### PR TITLE
fix: terminalize reducer-consumed messages

### DIFF
--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -647,6 +647,13 @@ All terminal tools lower into the same runtime settlement command:
 - reducer-only completion; and
 - explicit continuation or pause.
 
+A claimed message that completes through a reducer-only path still produces a
+terminal `TurnRecord` for that activation. Duplicate, already-delivered, or
+policy-suppressed input may omit provider, assistant-round, token-usage, and
+delivery evidence, but it must not use an absent terminal Turn to mean
+success. Queue `Processed`, the terminal Turn, and execution settlement commit
+atomically.
+
 A WorkItem-bound activation must include one WorkItem disposition.
 
 ### Missing Settlement

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -263,6 +263,7 @@ pub async fn run_once_with_host(
 
     let mut candidate_completion: Option<CandidateCompletion> = None;
     let mut observed_new_task_ids = HashSet::<String>::new();
+    let mut observed_terminal_final_text: Option<String> = None;
 
     let final_candidate = loop {
         let state = session.runtime.agent_state().await?;
@@ -293,20 +294,26 @@ pub async fn run_once_with_host(
         } else {
             None
         };
-        let terminal_final_text_observed = state
+        let latest_terminal_final_text = state
             .last_turn_terminal
             .as_ref()
             .filter(|record| record.turn_index > baseline.turn_index)
             .and_then(|record| record.last_assistant_message.as_ref())
-            .is_some_and(|text| !text.trim().is_empty());
+            .map(|text| text.trim())
+            .filter(|text| !text.is_empty());
+        if let Some(text) = latest_terminal_final_text {
+            observed_terminal_final_text = Some(text.to_string());
+        }
+        let terminal_final_text_observed = observed_terminal_final_text.is_some()
+            || poll_view.operator_visible_assistant_text_observed;
 
         let waiting_for_active_tasks = request.wait_for_tasks && !active_new_task_ids.is_empty();
         let candidate_status = if poll_view.runtime_error && foreground_idle {
             Some((RunFinalStatus::Failed, None))
-        } else if terminal_within_max_turns
-            && (matches!(terminal_status, Some((RunFinalStatus::Failed, _)))
-                || (terminal_final_text_observed
-                    && matches!(terminal_status, Some((RunFinalStatus::Completed, _)))))
+        } else if (matches!(terminal_status, Some((RunFinalStatus::Failed, _)))
+            && terminal_within_max_turns)
+            || (terminal_final_text_observed
+                && matches!(terminal_status, Some((RunFinalStatus::Completed, _))))
         {
             if waiting_for_active_tasks {
                 None
@@ -399,6 +406,7 @@ pub async fn run_once_with_host(
         &queued_message,
         final_status,
         waiting_reason,
+        observed_terminal_final_text,
         final_state,
         final_view,
     )
@@ -590,6 +598,7 @@ impl CandidateCompletion {
 struct RunPollView {
     new_task_ids: Vec<String>,
     turn_terminal_observed: bool,
+    operator_visible_assistant_text_observed: bool,
     runtime_error: bool,
     activity_signature: PollActivitySignature,
 }
@@ -612,6 +621,15 @@ async fn collect_run_poll_view(
         .rev()
         .take_while(|event| !baseline.event_ids.contains(&event.id))
         .any(|event| event.kind == "runtime_error");
+    let operator_visible_assistant_text_observed = events
+        .iter()
+        .rev()
+        .take_while(|event| !baseline.event_ids.contains(&event.id))
+        .any(|event| {
+            event.kind == "assistant_round_recorded"
+                && event.data["visibility"] == "operator_visible"
+                && event.data["has_text"].as_bool() == Some(true)
+        });
 
     let mut new_task_ids = latest_tasks
         .iter()
@@ -646,6 +664,7 @@ async fn collect_run_poll_view(
             .last_turn_terminal
             .as_ref()
             .is_some_and(|record| record.turn_index > baseline.turn_index),
+        operator_visible_assistant_text_observed,
         runtime_error,
         activity_signature,
     })
@@ -834,6 +853,7 @@ async fn build_response(
     queued_message: &MessageEnvelope,
     final_status: RunFinalStatus,
     waiting_reason: Option<WaitingReason>,
+    observed_terminal_final_text: Option<String>,
     final_state: crate::types::AgentState,
     view: RunView,
 ) -> Result<RunOnceResponse> {
@@ -916,7 +936,12 @@ async fn build_response(
     } else {
         None
     };
-    let raw_final_text = raw_final_text(&final_state, baseline, final_status);
+    let raw_final_text = observed_terminal_final_text
+        .or(latest_operator_visible_assistant_text(
+            runtime,
+            &view.new_events,
+        )?)
+        .or_else(|| raw_final_text(&final_state, baseline, final_status));
     let new_briefs = runtime
         .storage()
         .read_recent_briefs(usize::MAX)?
@@ -1128,6 +1153,39 @@ fn latest_run_model_state(
     }
 
     (requested_model, active_model, fallback_active)
+}
+
+fn latest_operator_visible_assistant_text(
+    runtime: &crate::runtime::RuntimeHandle,
+    events: &[AuditEvent],
+) -> Result<Option<String>> {
+    for event in events.iter().rev().filter(|event| {
+        event.kind == "assistant_round_recorded"
+            && event.data["visibility"] == "operator_visible"
+            && event.data["has_text"].as_bool() == Some(true)
+    }) {
+        let Some(entry_id) = event.data["assistant_round_id"].as_str() else {
+            continue;
+        };
+        let Some(entry) = runtime.storage().read_transcript_entry_by_id(entry_id)? else {
+            continue;
+        };
+        let Some(blocks) = entry.data["blocks"].as_array() else {
+            continue;
+        };
+        let text = blocks
+            .iter()
+            .filter(|block| block["type"] == "text")
+            .filter_map(|block| block["text"].as_str())
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        if !text.is_empty() {
+            return Ok(Some(text));
+        }
+    }
+    Ok(None)
 }
 
 fn raw_final_text(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5738,14 +5738,11 @@ impl RuntimeHandle {
                         }),
                     )],
                     true,
-                    terminal_transition.as_ref(),
+                    Some(&terminal_transition),
                 )
                 .await?;
-                self.maybe_supersede_queued_provider_recovery(
-                    &message,
-                    terminal_transition.as_ref(),
-                )
-                .await?;
+                self.maybe_supersede_queued_provider_recovery(&message, Some(&terminal_transition))
+                    .await?;
             }
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4331,6 +4331,24 @@ impl RuntimeHandle {
         } else {
             None
         };
+        let terminal_source_turn = if replay_source.is_none() {
+            if let Some(message) = message {
+                if let Some(source_turn_id) = normalized_turn_id(message.turn_id.as_deref()) {
+                    self.inner
+                        .runtime_db
+                        .turn_records()
+                        .by_id(Some(&message.agent_id), &source_turn_id)?
+                        .filter(|turn| turn.terminal.is_some())
+                        .map(|turn| (source_turn_id, turn))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         let canonical_execution_binding = match &execution_admission_provenance {
             ExecutionAdmissionProvenance::Canonical { activation_id, .. } => {
                 let message = message.ok_or_else(|| {
@@ -4406,7 +4424,7 @@ impl RuntimeHandle {
         let state = {
             let mut guard = self.inner.agent.lock().await;
             guard.state.turn_index += 1;
-            let turn_id = if replay_source.is_some() {
+            let turn_id = if replay_source.is_some() || terminal_source_turn.is_some() {
                 crate::ids::turn_id()
             } else {
                 message

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -275,12 +275,12 @@ impl RuntimeHandle {
             }
         }
 
-        if terminal_transition
-            .as_ref()
-            .is_some_and(|transition| transition.prepared_work_item_completion.is_some())
-        {
-            return Ok(terminal_transition.expect("checked prepared completion"));
-        }
+        terminal_transition = match terminal_transition {
+            Some(transition) if transition.prepared_work_item_completion.is_some() => {
+                return Ok(transition);
+            }
+            transition => transition,
+        };
 
         if let Some(resolution) = continuation_resolution.as_ref() {
             self.persist_last_continuation(resolution).await?;

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -195,6 +195,24 @@ impl RuntimeHandle {
             ..
         } = plan;
         let model_reentry = scheduler_decision.model_reentry;
+        let reducer_only_dispatch = match message.kind {
+            MessageKind::OperatorPrompt
+            | MessageKind::WebhookEvent
+            | MessageKind::CallbackEvent
+            | MessageKind::TimerTick
+            | MessageKind::SystemTick
+            | MessageKind::ChannelEvent
+            | MessageKind::InternalFollowup => !model_reentry,
+            MessageKind::TaskStatus
+            | MessageKind::Control
+            | MessageKind::BriefAck
+            | MessageKind::BriefResult => true,
+            MessageKind::TaskResult => false,
+        };
+        if reducer_only_dispatch {
+            self.begin_reducer_only_turn(&message, execution_admission_provenance.clone())
+                .await?;
+        }
         let task = task?;
         let mut terminal_transition = None;
         let mut reducer_only_reason = None;

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -168,12 +168,10 @@ impl RuntimeHandle {
         plan: MessageDispatchPlan,
         scheduler_decision: &scheduler::SchedulerDecision,
     ) -> Result<()> {
-        if let Some(transition) = self
+        let transition = self
             .process_message_with_plan_deferred(message, plan, scheduler_decision)
-            .await?
-        {
-            self.persist_terminal_transition(&transition).await?;
-        }
+            .await?;
+        self.persist_terminal_transition(&transition).await?;
         Ok(())
     }
 
@@ -182,7 +180,7 @@ impl RuntimeHandle {
         mut message: MessageEnvelope,
         plan: MessageDispatchPlan,
         scheduler_decision: &scheduler::SchedulerDecision,
-    ) -> Result<Option<turn::TurnTerminalTransition>> {
+    ) -> Result<turn::TurnTerminalTransition> {
         message.normalize_admission_fields();
         self.inner.storage.append_event(&AuditEvent::typed(
             RuntimeEventKind::MessageProcessingStarted,
@@ -199,6 +197,7 @@ impl RuntimeHandle {
         let model_reentry = scheduler_decision.model_reentry;
         let task = task?;
         let mut terminal_transition = None;
+        let mut reducer_only_reason = None;
         if let Some(trigger) = continuation_trigger.as_ref() {
             self.record_continuation_trigger_received(&message, trigger, &prior_closure)
                 .await?;
@@ -240,23 +239,27 @@ impl RuntimeHandle {
                         )
                         .await?,
                     );
+                } else {
+                    reducer_only_reason = Some("reducer_only/model_reentry_suppressed");
                 }
             }
             MessageKind::TaskStatus => {
                 let task = task.ok_or_else(|| anyhow!("task status message should parse task"))?;
                 self.reduce_task_status_message(task).await?;
+                reducer_only_reason = Some("reducer_only/task_status");
             }
             MessageKind::TaskResult => {
                 let task = task.ok_or_else(|| anyhow!("task result message should parse task"))?;
-                terminal_transition = self
-                    .reduce_task_result_message_deferred(
+                terminal_transition = Some(
+                    self.reduce_task_result_message_deferred(
                         &message,
                         task,
                         model_reentry,
                         continuation_resolution.as_ref(),
                         execution_admission_provenance,
                     )
-                    .await?;
+                    .await?,
+                );
             }
             MessageKind::Control => {
                 let action = match &message.body {
@@ -265,15 +268,18 @@ impl RuntimeHandle {
                     _ => return Err(anyhow!("unknown control action")),
                 };
                 self.control(action).await?;
+                reducer_only_reason = Some("reducer_only/control");
             }
-            MessageKind::BriefAck | MessageKind::BriefResult => {}
+            MessageKind::BriefAck | MessageKind::BriefResult => {
+                reducer_only_reason = Some("reducer_only/brief_notification");
+            }
         }
 
         if terminal_transition
             .as_ref()
             .is_some_and(|transition| transition.prepared_work_item_completion.is_some())
         {
-            return Ok(terminal_transition);
+            return Ok(terminal_transition.expect("checked prepared completion"));
         }
 
         if let Some(resolution) = continuation_resolution.as_ref() {
@@ -336,7 +342,15 @@ impl RuntimeHandle {
         ))?;
 
         info!("processed message {}", message.id);
-        Ok(terminal_transition)
+        match terminal_transition {
+            Some(transition) => Ok(transition),
+            None => {
+                self.build_reducer_only_terminal_transition(
+                    reducer_only_reason.unwrap_or("reducer_only/message_consumed"),
+                )
+                .await
+            }
+        }
     }
 
     async fn refresh_current_work_item_refs(

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -525,14 +525,20 @@ impl RuntimeHandle {
         execution_admission_provenance: ExecutionAdmissionProvenance,
     ) -> Result<turn::TurnTerminalTransition> {
         if should_ignore_task_update(self.inner.runtime_db.tasks().latest(&task.id)?, &task) {
+            self.begin_reducer_only_turn(message, execution_admission_provenance)
+                .await?;
             return self
                 .build_reducer_only_terminal_transition("reducer_only/duplicate_task_result")
                 .await;
         }
-        self.persist_task_transition(&task, "task_result_received")
-            .await?;
         let parent_turn_already_delivered =
             task_result_parent_turn_already_delivered(&self.inner.storage, &task)?;
+        if !model_reentry || parent_turn_already_delivered {
+            self.begin_reducer_only_turn(message, execution_admission_provenance.clone())
+                .await?;
+        }
+        self.persist_task_transition(&task, "task_result_received")
+            .await?;
 
         let task_status_label = match task.status {
             TaskStatus::Completed => "completed",

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -503,7 +503,7 @@ impl RuntimeHandle {
             continuation_resolution,
             Some(&task),
         )?;
-        if let Some(transition) = self
+        let transition = self
             .reduce_task_result_message_deferred(
                 message,
                 task,
@@ -511,10 +511,8 @@ impl RuntimeHandle {
                 continuation_resolution,
                 execution_admission_provenance,
             )
-            .await?
-        {
-            self.persist_terminal_transition(&transition).await?;
-        }
+            .await?;
+        self.persist_terminal_transition(&transition).await?;
         Ok(())
     }
 
@@ -525,9 +523,11 @@ impl RuntimeHandle {
         model_reentry: bool,
         continuation_resolution: Option<&ContinuationResolution>,
         execution_admission_provenance: ExecutionAdmissionProvenance,
-    ) -> Result<Option<turn::TurnTerminalTransition>> {
+    ) -> Result<turn::TurnTerminalTransition> {
         if should_ignore_task_update(self.inner.runtime_db.tasks().latest(&task.id)?, &task) {
-            return Ok(None);
+            return self
+                .build_reducer_only_terminal_transition("reducer_only/duplicate_task_result")
+                .await;
         }
         self.persist_task_transition(&task, "task_result_received")
             .await?;
@@ -580,7 +580,7 @@ impl RuntimeHandle {
                     },
                 )
                 .await?;
-            return Ok(Some(transition));
+            return Ok(transition);
         } else if !model_reentry {
             if emit_result_brief {
                 let brief = brief::make_result(&message.agent_id, message, result_text);
@@ -597,7 +597,12 @@ impl RuntimeHandle {
                 }),
             ))?;
         }
-        Ok(None)
+        self.build_reducer_only_terminal_transition(if parent_turn_already_delivered {
+            "reducer_only/parent_turn_already_delivered"
+        } else {
+            "reducer_only/task_result_without_model_reentry"
+        })
+        .await
     }
 }
 
@@ -1123,12 +1128,18 @@ mod tests {
             .unwrap()
             .iter()
             .any(|event| event.kind == "stale_task_result_rejoin_suppressed"));
-        assert!(runtime
+        let terminal = runtime
             .agent_state()
             .await
             .unwrap()
             .last_turn_terminal
-            .is_none());
+            .expect("suppressed TaskResult should still complete its reducer-only turn");
+        assert_eq!(terminal.kind, TurnTerminalKind::Completed);
+        assert_eq!(
+            terminal.reason.as_deref(),
+            Some("reducer_only/parent_turn_already_delivered")
+        );
+        assert!(terminal.last_assistant_message.is_none());
     }
 
     #[tokio::test]

--- a/src/runtime/tests/message_dispatch.rs
+++ b/src/runtime/tests/message_dispatch.rs
@@ -11,8 +11,9 @@ use super::support::*;
 use crate::domain::scheduler::ScenarioMode;
 use crate::types::{
     AuthorityClass, ClosureDecision, ClosureOutcome, ExecutionAdmissionProvenance, MessageBody,
-    MessageKind, MessageOrigin, Priority, RuntimePosture,
+    MessageKind, MessageOrigin, Priority, RuntimePosture, TurnTerminalKind, TurnTerminalSummary,
 };
+use chrono::Utc;
 
 fn task_metadata() -> serde_json::Value {
     serde_json::json!({
@@ -316,6 +317,65 @@ async fn dispatch_brief_result_is_noop() {
         .process_message_with_plan(msg, plan, &decision)
         .await
         .expect("BriefResult dispatch should not error");
+}
+
+#[tokio::test]
+async fn reducer_only_dispatch_preserves_parent_turn_identity() {
+    let (_dir, _ws, runtime) = fresh_runtime().await;
+    let mut parent = crate::types::TurnRecord::new("default", "turn-parent", 1);
+    parent.terminal = Some(TurnTerminalSummary {
+        kind: TurnTerminalKind::Completed,
+        reason: Some("parent_completed".into()),
+        completed_at: Utc::now(),
+        duration_ms: 1,
+    });
+    runtime.storage().append_turn(&parent).unwrap();
+
+    let mut msg = message_of_kind(
+        MessageKind::BriefAck,
+        MessageBody::Text { text: "ack".into() },
+    );
+    msg.turn_id = Some(parent.turn_id.clone());
+    let plan = runtime
+        .build_message_dispatch_plan(
+            &msg,
+            closure_decision(),
+            &runtime.agent_state().await.unwrap(),
+        )
+        .unwrap();
+    let decision =
+        scheduler::SchedulerDecision::new(scheduler::SchedulerDecisionKind::Noop, "test_brief_ack");
+
+    runtime
+        .process_message_with_plan(msg.clone(), plan, &decision)
+        .await
+        .expect("reducer-only dispatch should use a distinct terminal turn");
+
+    assert_eq!(
+        runtime.storage().read_turn_by_id(&parent.turn_id).unwrap(),
+        Some(parent)
+    );
+    let reducer_turn = runtime
+        .inner
+        .runtime_db
+        .turn_records()
+        .recent_for_agent("default", 10)
+        .unwrap()
+        .into_iter()
+        .find(|turn| {
+            turn.terminal.as_ref().is_some_and(|terminal| {
+                terminal.reason.as_deref() == Some("reducer_only/brief_notification")
+            })
+        })
+        .expect("reducer-only message should have a matching turn");
+    assert_ne!(reducer_turn.turn_id, "turn-parent");
+    assert_eq!(
+        reducer_turn
+            .terminal
+            .as_ref()
+            .and_then(|terminal| terminal.reason.as_deref()),
+        Some("reducer_only/brief_notification")
+    );
 }
 
 #[tokio::test]

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1948,9 +1948,66 @@ async fn late_terminal_task_result_for_completed_work_item_settles_without_model
         }
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
     }
-    runner.abort();
 
     assert_eq!(provider.call_count().await, 0);
+    let terminal_turn = runtime
+        .inner
+        .runtime_db
+        .turn_records()
+        .recent_for_agent("default", 10)
+        .unwrap()
+        .into_iter()
+        .find(|turn| {
+            turn.terminal.as_ref().is_some_and(|terminal| {
+                terminal.reason.as_deref() == Some("reducer_only/task_result_without_model_reentry")
+            })
+        })
+        .expect("suppressed TaskResult should persist a matching terminal Turn");
+    assert_eq!(
+        terminal_turn
+            .terminal
+            .as_ref()
+            .map(|terminal| terminal.kind.clone()),
+        Some(TurnTerminalKind::Completed)
+    );
+    assert!(terminal_turn.produced_brief_ids.is_empty());
+
+    let operator = runtime
+        .enqueue(trusted_operator_prompt(
+            None,
+            "continue after late task result",
+        ))
+        .await
+        .unwrap();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        if runner.is_finished() {
+            panic!(
+                "runtime exited before processing the following operator prompt: {:?}",
+                (&mut runner).await
+            );
+        }
+        let processed = runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.message_id == operator.id)
+            .is_some_and(|entry| entry.status == QueueEntryStatus::Processed);
+        if processed {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "operator prompt remained blocked after TaskResult settlement"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    runner.abort();
+
+    assert_eq!(provider.call_count().await, 1);
     let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
     assert!(events.iter().any(|event| {
         event.kind == "task_result_received" && event.data["task_id"] == "task-late-child-result"

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1909,10 +1909,19 @@ async fn late_terminal_task_result_for_completed_work_item_settles_without_model
         .complete_work_item(work_item.id.clone(), Vec::new())
         .await
         .unwrap();
+    let mut parent_turn = crate::types::TurnRecord::new("default", "turn-parent-completed", 1);
+    parent_turn.terminal = Some(crate::types::TurnTerminalSummary {
+        kind: TurnTerminalKind::Completed,
+        reason: Some("parent_completed".into()),
+        completed_at: Utc::now(),
+        duration_ms: 1,
+    });
+    runtime.storage().append_turn(&parent_turn).unwrap();
     let mut result = task_result_message("task-late-child-result").with_admission(
         MessageDeliverySurface::TaskRejoin,
         AdmissionContext::RuntimeOwned,
     );
+    result.turn_id = Some(parent_turn.turn_id.clone());
     result.metadata = Some(serde_json::json!({
         "task_id": "task-late-child-result",
         "task_kind": "child_agent_task",
@@ -1971,6 +1980,14 @@ async fn late_terminal_task_result_for_completed_work_item_settles_without_model
         Some(TurnTerminalKind::Completed)
     );
     assert!(terminal_turn.produced_brief_ids.is_empty());
+    assert_ne!(terminal_turn.turn_id, parent_turn.turn_id);
+    assert_eq!(
+        runtime
+            .storage()
+            .read_turn_by_id(&parent_turn.turn_id)
+            .unwrap(),
+        Some(parent_turn)
+    );
 
     let operator = runtime
         .enqueue(trusted_operator_prompt(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1979,7 +1979,13 @@ async fn late_terminal_task_result_for_completed_work_item_settles_without_model
             .map(|terminal| terminal.kind.clone()),
         Some(TurnTerminalKind::Completed)
     );
-    assert!(terminal_turn.produced_brief_ids.is_empty());
+    assert_eq!(terminal_turn.produced_brief_ids.len(), 1);
+    let result_briefs = runtime
+        .storage()
+        .read_briefs_by_ids(&terminal_turn.produced_brief_ids)
+        .unwrap();
+    assert_eq!(result_briefs.len(), 1);
+    assert_eq!(result_briefs[0].kind, BriefKind::Result);
     assert_ne!(terminal_turn.turn_id, parent_turn.turn_id);
     assert_eq!(
         runtime

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -179,6 +179,37 @@ fn render_operator_interjection_text(message: &MessageEnvelope) -> String {
 }
 
 impl RuntimeHandle {
+    pub(super) async fn build_reducer_only_terminal_transition(
+        &self,
+        reason: impl Into<String>,
+    ) -> Result<TurnTerminalTransition> {
+        let terminal = {
+            let guard = self.inner.agent.lock().await;
+            let turn_id = guard
+                .state
+                .current_turn_id
+                .clone()
+                .filter(|turn_id| !turn_id.trim().is_empty())
+                .unwrap_or_else(crate::ids::turn_id);
+            TurnTerminalRecord {
+                turn_id,
+                turn_index: guard.state.turn_index,
+                kind: TurnTerminalKind::Completed,
+                reason: Some(reason.into()),
+                last_assistant_message: None,
+                checkpoint: None,
+                completed_at: chrono::Utc::now(),
+                duration_ms: 0,
+            }
+        };
+        Ok(TurnTerminalTransition {
+            turn_record: self.build_turn_record(&terminal).await?,
+            terminal,
+            prepared_work_item_completion: None,
+            terminal_tool_executions: Vec::new(),
+        })
+    }
+
     pub(super) async fn build_turn_record(
         &self,
         terminal: &TurnTerminalRecord,

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -23,8 +23,8 @@ use crate::config::ModelRouteRef;
 use crate::provider::{ModelBlock, ToolResultBlock};
 use crate::tool::{spec::ToolResultEnvelope, ToolCall};
 use crate::types::{
-    AuditEvent, BriefKind, Citation, MessageEnvelope, TurnRecord, TurnTerminalKind,
-    TurnTerminalRecord, TurnTerminalSummary, TurnTriggerSummary,
+    AuditEvent, BriefKind, Citation, ExecutionAdmissionProvenance, MessageEnvelope, TurnRecord,
+    TurnTerminalKind, TurnTerminalRecord, TurnTerminalSummary, TurnTriggerSummary,
 };
 
 use super::{message_dispatch::message_text, RuntimeHandle};
@@ -179,6 +179,22 @@ fn render_operator_interjection_text(message: &MessageEnvelope) -> String {
 }
 
 impl RuntimeHandle {
+    pub(super) async fn begin_reducer_only_turn(
+        &self,
+        message: &MessageEnvelope,
+        execution_admission_provenance: ExecutionAdmissionProvenance,
+    ) -> Result<()> {
+        let (operator_binding_id, operator_reply_route_id) =
+            Self::operator_transport_from_message(message);
+        self.begin_interactive_turn_with_provenance(
+            Some(message),
+            operator_binding_id.as_deref(),
+            operator_reply_route_id.as_deref(),
+            execution_admission_provenance,
+        )
+        .await
+    }
+
     pub(super) async fn build_reducer_only_terminal_transition(
         &self,
         reason: impl Into<String>,


### PR DESCRIPTION
## Summary

- replace the ambiguous `Option<TurnTerminalTransition>` reducer success contract with an explicit outcome
- write reducer-only terminal Turns for duplicate/suppressed TaskResult paths without fabricating provider, assistant, usage, or brief evidence
- preserve canonical `Processed requires matching terminal Turn` validation and settle replayed task-restart messages idempotently
- cover the production failure shape and verify that the next operator message remains claimable
- document the claimed-message terminal evidence contract

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib` (2733 passed, 0 failed, 1 ignored)

## Scope

This is PR 1 of #2598. It intentionally does not add the unified online/bootstrap/debug reconciler, bounded replay, quarantine, poison-message lane release, production deployment, or production data repair planned for PR 2.

Part of #2598.
