### PR TITLE
fix: reconcile unsettled scheduler claims

### DIFF
--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -654,6 +654,36 @@ delivery evidence, but it must not use an absent terminal Turn to mean
 success. Queue `Processed`, the terminal Turn, and execution settlement commit
 atomically.
 
+### Unsettled Claim Reconciliation
+
+`Processed` without a matching terminal Turn remains a protocol conflict. The
+runtime represents it as a typed `ExecutionSettlementConflict`, not a string
+matched error and not permission to weaken the terminal evidence invariant.
+
+Bootstrap recovery, online settlement conflict handling, and
+`debug scheduler-recovery` inspect/apply use the same durable-facts planner.
+For a dequeued claim the planner chooses one of:
+
+- settle from a matching terminal Turn;
+- interrupt and requeue when exact source, owner, and revision fences prove
+  replay is safe;
+- interrupt and quarantine when replay evidence is ambiguous or the claim is
+  already a recovery attempt; or
+- no-op when the claim already converged.
+
+Automatic replay is bounded to one recovery generation. A second failure for
+the same recovery chain is not requeued again. Quarantine atomically records an
+interrupted execution outcome and `QueueEntryStatus::Quarantined`, preserves
+the message and attempt as audit evidence, releases the agent execution lane,
+and permits the next operator message to be claimed. Quarantine never rewrites
+unknown work as `Processed`.
+
+Every automatic decision emits durable `unsettled_claim_reconciled` evidence
+with the decision, reason, and recovery generation. Runtime diagnostics count
+missing terminal conflicts, unsettled-claim recoveries, and poison-message
+quarantines. The debug recovery projection exposes the same decision and
+generation used by apply.
+
 A WorkItem-bound activation must include one WorkItem disposition.
 
 ### Missing Settlement

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -35,6 +35,12 @@ static SCHEDULER_POLL_STOPPED: MetricAccumulator = MetricAccumulator::new("sched
 static SCHEDULER_POLL_SHUTDOWN: MetricAccumulator =
     MetricAccumulator::new("scheduler.poll.shutdown");
 static SCHEDULER_POLL_SKIPPED: MetricAccumulator = MetricAccumulator::new("scheduler.poll.skipped");
+static SCHEDULER_MISSING_TERMINAL_TURN: MetricAccumulator =
+    MetricAccumulator::new("scheduler.missing_terminal_turn_detected");
+static SCHEDULER_UNSETTLED_CLAIM_RECOVERY: MetricAccumulator =
+    MetricAccumulator::new("scheduler.unsettled_claim_recovery");
+static SCHEDULER_POISON_MESSAGE_QUARANTINED: MetricAccumulator =
+    MetricAccumulator::new("scheduler.poison_message_quarantined");
 
 // Turn lifecycle
 static TURN_TOTAL: MetricAccumulator = MetricAccumulator::new("turn.total");
@@ -225,6 +231,21 @@ pub fn record_scheduler_poll(outcome: &'static str, elapsed: Duration) {
     process_started_at();
     SCHEDULER_POLL_ALL.record(elapsed, None);
     scheduler_poll_accumulator(outcome).record(elapsed, None);
+}
+
+pub fn record_missing_terminal_turn_detected() {
+    process_started_at();
+    SCHEDULER_MISSING_TERMINAL_TURN.record(Duration::ZERO, None);
+}
+
+pub fn record_unsettled_claim_recovery() {
+    process_started_at();
+    SCHEDULER_UNSETTLED_CLAIM_RECOVERY.record(Duration::ZERO, None);
+}
+
+pub fn record_poison_message_quarantined() {
+    process_started_at();
+    SCHEDULER_POISON_MESSAGE_QUARANTINED.record(Duration::ZERO, None);
 }
 
 // Turn lifecycle recording
@@ -455,6 +476,9 @@ pub fn performance_snapshot() -> PerformanceDiagnosticsSnapshot {
             SCHEDULER_POLL_STOPPED.snapshot(false),
             SCHEDULER_POLL_SHUTDOWN.snapshot(false),
             SCHEDULER_POLL_SKIPPED.snapshot(false),
+            SCHEDULER_MISSING_TERMINAL_TURN.snapshot(false),
+            SCHEDULER_UNSETTLED_CLAIM_RECOVERY.snapshot(false),
+            SCHEDULER_POISON_MESSAGE_QUARANTINED.snapshot(false),
         ],
         turn: vec![
             TURN_TOTAL.snapshot(false),

--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -8,6 +8,18 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ExecutionSettlementConflict {
+    #[error(
+        "execution attempt {attempt_id} cannot settle message {message_id} as processed without a matching terminal Turn"
+    )]
+    MissingTerminalTurn {
+        attempt_id: String,
+        message_id: String,
+        owner_work_item_id: Option<String>,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecutionProtocolState {
     pub agent_id: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2663,11 +2663,13 @@ fn print_scheduler_recovery_report(
     }
     for candidate in report.task_result_claim_recoveries {
         println!(
-            "- task_result_claim:{} attempt={} work_item={} eligible={} reason={} target={:?}",
+            "- task_result_claim:{} attempt={} work_item={} eligible={} decision={} generation={} reason={} target={:?}",
             candidate.message_id,
             candidate.activation_id,
             candidate.work_item_id,
             candidate.eligible,
+            candidate.recovery_decision,
+            candidate.recovery_generation,
             candidate.reason,
             candidate
                 .proposed_queue_entry

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -24,6 +24,7 @@ mod tasks;
 #[cfg(test)]
 mod test_util;
 mod turn;
+mod unsettled_claim;
 mod waiting;
 pub(crate) mod workspace;
 pub(crate) mod workspace_control;
@@ -1258,12 +1259,14 @@ fn execution_protocol_settlement_transition_from_facts(
         terminal_turn,
     )?;
     let Some(terminal_turn) = matching_terminal_turn else {
-        return Err(anyhow!(
-            "execution attempt {} cannot settle message {} as processed without a matching \
-             terminal Turn",
-            attempt.attempt_id,
-            record.message_id
-        ));
+        return Err(
+            crate::domain::execution_protocol::ExecutionSettlementConflict::MissingTerminalTurn {
+                attempt_id: attempt.attempt_id.clone(),
+                message_id: record.message_id.clone(),
+                owner_work_item_id: owner_work_item_id.map(ToString::to_string),
+            }
+            .into(),
+        );
     };
 
     let outcome = match &attempt.binding {
@@ -1467,6 +1470,14 @@ fn execution_protocol_settlement_transition_from_facts(
             })],
         },
     )
+}
+
+fn execution_settlement_conflict(error: &anyhow::Error) -> bool {
+    error.chain().any(|source| {
+        source
+            .downcast_ref::<crate::domain::execution_protocol::ExecutionSettlementConflict>()
+            .is_some()
+    })
 }
 
 fn execution_attempt_for_message<'a>(
@@ -1709,6 +1720,8 @@ fn scheduler_task_result_claim_recovery_candidates(
                 expected_queue_entry: None,
                 eligible: false,
                 reason: "task_result_claim_evidence_incomplete".into(),
+                recovery_decision: "no_op".into(),
+                recovery_generation: u32::from(attempt.recovery_of_attempt_id.is_some()),
                 evidence: vec![
                     format!("work_item:{work_item_id}"),
                     format!("open_execution_attempt:{}", attempt.attempt_id),
@@ -1727,6 +1740,38 @@ fn scheduler_task_result_claim_recovery_candidates(
                 candidate.reason = "message_missing".into();
                 return Ok(candidate);
             };
+            let decision =
+                unsettled_claim::plan_unsettled_claim(&unsettled_claim::UnsettledClaimFacts {
+                    queue_status: entry.status.clone(),
+                    attempt_state: attempt.state,
+                    terminal_turn_completed: None,
+                    replay_is_exactly_fenced: true,
+                    recovery_of_attempt_id: attempt.recovery_of_attempt_id.clone(),
+                });
+            if let unsettled_claim::UnsettledClaimDecision::InterruptAndQuarantine { reason } =
+                decision
+            {
+                let mut proposed_entry = entry.clone();
+                proposed_entry.status = QueueEntryStatus::Quarantined;
+                proposed_entry.updated_at = Utc::now();
+                candidate.eligible = true;
+                candidate.reason = reason.into();
+                candidate.recovery_decision = "interrupt_and_quarantine".into();
+                candidate.evidence.push("recovery_generation=1".to_string());
+                candidate.proposed_queue_entry = Some(proposed_entry);
+                candidate.expected_queue_entry = Some(entry.clone());
+                candidate.proposed_command = Some(
+                    crate::domain::execution_protocol::ExecutionProtocolCommand::Interrupt(
+                        crate::domain::execution_protocol::InterruptExecution {
+                            attempt_id: attempt.attempt_id.clone(),
+                            outcome_id: format!("outcome:interrupted:{}", attempt.attempt_id),
+                            reason: reason.into(),
+                            interrupted_at: Utc::now().to_rfc3339(),
+                        },
+                    ),
+                );
+                return Ok(candidate);
+            }
             let recovery = exact_task_result_claim_recovery(
                 storage,
                 runtime_db,
@@ -1752,6 +1797,7 @@ fn scheduler_task_result_claim_recovery_candidates(
             proposed_entry.updated_at = Utc::now();
             candidate.eligible = true;
             candidate.reason = reason.into();
+            candidate.recovery_decision = "interrupt_and_requeue".into();
             candidate.evidence.push(format!(
                 "durable_work_item_revision:{}",
                 runtime_db
@@ -1790,6 +1836,8 @@ pub struct SchedulerTaskResultClaimRecoveryCandidate {
     pub expected_queue_entry: Option<QueueEntryRecord>,
     pub eligible: bool,
     pub reason: String,
+    pub recovery_decision: String,
+    pub recovery_generation: u32,
     pub evidence: Vec<String>,
     pub proposed_queue_entry: Option<QueueEntryRecord>,
     pub proposed_command: Option<crate::domain::execution_protocol::ExecutionProtocolCommand>,
@@ -2875,7 +2923,11 @@ fn apply_scheduler_recovery_plan_with_options(
             .commit_queue_with_execution_protocol(
                 &crate::runtime_db::transitions::QueueTransitionCommand {
                     agent_id: agent_id.to_string(),
-                    operation: crate::runtime_db::transitions::QueueOperation::Requeue,
+                    operation: if proposed_entry.status == QueueEntryStatus::Queued {
+                        crate::runtime_db::transitions::QueueOperation::Requeue
+                    } else {
+                        crate::runtime_db::transitions::QueueOperation::Settle
+                    },
                     mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
                         expected: expected_entry.clone(),
                         record: proposed_entry.clone(),
@@ -2905,6 +2957,12 @@ fn apply_scheduler_recovery_plan_with_options(
                 },
             )?;
         applied |= commit.applied;
+        if commit.applied {
+            crate::diagnostics::record_unsettled_claim_recovery();
+            if proposed_entry.status == QueueEntryStatus::Quarantined {
+                crate::diagnostics::record_poison_message_quarantined();
+            }
+        }
     }
     if !continuation_reconciliation.is_empty() {
         let audit_events = report
@@ -5696,29 +5754,39 @@ impl RuntimeHandle {
                         }
                         state
                     };
-                    self.commit_queue_terminal_settlement_with_evidence(
-                        QueueEntryRecord {
-                            message_id: message.id.clone(),
-                            agent_id: message.agent_id.clone(),
-                            priority: message.priority.clone(),
-                            status: queue_status,
-                            created_at: message.created_at,
-                            updated_at: Utc::now(),
-                        },
-                        audit_events,
-                        true,
-                        Some(&terminal_transition),
-                        Some(committed_state),
-                        failure_artifacts
-                            .as_ref()
-                            .map(|artifacts| vec![artifacts.transcript.clone()])
-                            .unwrap_or_default(),
-                        failure_artifacts
-                            .as_ref()
-                            .map(|artifacts| vec![artifacts.brief.clone()])
-                            .unwrap_or_default(),
-                    )
-                    .await?;
+                    let settlement = self
+                        .commit_queue_terminal_settlement_with_evidence(
+                            QueueEntryRecord {
+                                message_id: message.id.clone(),
+                                agent_id: message.agent_id.clone(),
+                                priority: message.priority.clone(),
+                                status: queue_status,
+                                created_at: message.created_at,
+                                updated_at: Utc::now(),
+                            },
+                            audit_events,
+                            true,
+                            Some(&terminal_transition),
+                            Some(committed_state),
+                            failure_artifacts
+                                .as_ref()
+                                .map(|artifacts| vec![artifacts.transcript.clone()])
+                                .unwrap_or_default(),
+                            failure_artifacts
+                                .as_ref()
+                                .map(|artifacts| vec![artifacts.brief.clone()])
+                                .unwrap_or_default(),
+                        )
+                        .await;
+                    if let Err(error) = settlement {
+                        if execution_settlement_conflict(&error) {
+                            crate::diagnostics::record_missing_terminal_turn_detected();
+                            if self.recover_scheduler_bootstrap_claims().await? > 0 {
+                                continue;
+                            }
+                        }
+                        return Err(error);
+                    }
                     let failed_state = {
                         let mut guard = self.inner.agent.lock().await;
                         guard.current_run_abort = None;
@@ -5738,27 +5806,37 @@ impl RuntimeHandle {
                     guard.state.clone()
                 };
                 self.append_state_changed_events(&processed_state)?;
-                self.commit_queue_terminal_settlement(
-                    QueueEntryRecord {
-                        message_id: message.id.clone(),
-                        agent_id: message.agent_id.clone(),
-                        priority: message.priority.clone(),
-                        status: QueueEntryStatus::Processed,
-                        created_at: message.created_at,
-                        updated_at: Utc::now(),
-                    },
-                    vec![AuditEvent::legacy(
-                        "queue_entry_settled",
-                        serde_json::json!({
-                            "message_id": message.id,
-                            "message_kind": message.kind,
-                            "status": QueueEntryStatus::Processed,
-                        }),
-                    )],
-                    true,
-                    Some(&terminal_transition),
-                )
-                .await?;
+                let settlement = self
+                    .commit_queue_terminal_settlement(
+                        QueueEntryRecord {
+                            message_id: message.id.clone(),
+                            agent_id: message.agent_id.clone(),
+                            priority: message.priority.clone(),
+                            status: QueueEntryStatus::Processed,
+                            created_at: message.created_at,
+                            updated_at: Utc::now(),
+                        },
+                        vec![AuditEvent::legacy(
+                            "queue_entry_settled",
+                            serde_json::json!({
+                                "message_id": message.id,
+                                "message_kind": message.kind,
+                                "status": QueueEntryStatus::Processed,
+                            }),
+                        )],
+                        true,
+                        Some(&terminal_transition),
+                    )
+                    .await;
+                if let Err(error) = settlement {
+                    if execution_settlement_conflict(&error) {
+                        crate::diagnostics::record_missing_terminal_turn_detected();
+                        if self.recover_scheduler_bootstrap_claims().await? > 0 {
+                            continue;
+                        }
+                    }
+                    return Err(error);
+                }
                 self.maybe_supersede_queued_provider_recovery(&message, Some(&terminal_transition))
                     .await?;
             }
@@ -5932,12 +6010,14 @@ impl RuntimeHandle {
                     continue;
                 }
             };
-            let task_result_recovery = if let Some(work_item_id) = work_item_id.as_deref() {
-                let work_queue_claim = matches!(
+            let work_queue_claim = work_item_id.as_deref().is_some_and(|work_item_id| {
+                matches!(
                     (&message.kind, &message.origin),
                     (MessageKind::SystemTick, MessageOrigin::System { subsystem })
                         if subsystem == "work_queue"
-                ) && message.work_item_id.as_deref() == Some(work_item_id);
+                ) && message.work_item_id.as_deref() == Some(work_item_id)
+            });
+            let task_result_recovery = if let Some(work_item_id) = work_item_id.as_deref() {
                 let task_result_recovery = exact_task_result_claim_recovery(
                     &self.inner.storage,
                     &self.inner.runtime_db,
@@ -5974,6 +6054,78 @@ impl RuntimeHandle {
                     terminal.kind == crate::types::TurnTerminalKind::Completed
                 })
             });
+            let canonical_first_attempt = attempt.attempt_id
+                == scheduler_executor::canonical_activation_id(&entry.message_id);
+            let decision =
+                unsettled_claim::plan_unsettled_claim(&unsettled_claim::UnsettledClaimFacts {
+                    queue_status: entry.status.clone(),
+                    attempt_state: attempt.state,
+                    terminal_turn_completed: terminal_turn.map(|_| terminal_is_completed),
+                    replay_is_exactly_fenced: task_result_recovery.is_some()
+                        || work_queue_claim
+                        || canonical_first_attempt,
+                    recovery_of_attempt_id: attempt.recovery_of_attempt_id.clone(),
+                });
+            if let unsettled_claim::UnsettledClaimDecision::InterruptAndQuarantine { reason } =
+                decision
+            {
+                entry.status = QueueEntryStatus::Quarantined;
+                entry.updated_at = self.now();
+                let message_id = entry.message_id.clone();
+                let execution_protocol = execution_protocol_settlement_transition_from_facts(
+                    &self.inner.storage,
+                    &self.inner.runtime_db,
+                    &entry,
+                    terminal_turn,
+                )?;
+                let commit = self
+                    .inner
+                    .runtime_db
+                    .transitions()
+                    .commit_queue_with_execution_protocol(
+                        &crate::runtime_db::transitions::QueueTransitionCommand {
+                            agent_id: agent_id.clone(),
+                            operation: crate::runtime_db::transitions::QueueOperation::Settle,
+                            mutation:
+                                crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                                    expected: expected_entry,
+                                    record: entry,
+                                },
+                            scheduler_claim_work_item: None,
+                            agent_state: None,
+                            message_evidence: Vec::new(),
+                            transcript_entries: Vec::new(),
+                            turn_record: terminal_turn.cloned(),
+                            audit_events: vec![AuditEvent::legacy(
+                                "unsettled_claim_reconciled",
+                                serde_json::json!({
+                                    "agent_id": agent_id,
+                                    "message_id": message_id,
+                                    "activation_id": activation_id,
+                                    "work_item_id": work_item_id,
+                                    "decision": "interrupt_and_quarantine",
+                                    "reason": reason,
+                                    "recovery_generation": usize::from(
+                                        attempt.recovery_of_attempt_id.is_some()
+                                    ),
+                                    "provenance": "bootstrap_reconciliation",
+                                }),
+                            )],
+                            notify_scheduler: true,
+                            fault: self.take_transition_fault(),
+                            brief_evidence: Vec::new(),
+                        },
+                        &execution_protocol,
+                    )?;
+                if commit.applied {
+                    recovered += 1;
+                    crate::diagnostics::record_unsettled_claim_recovery();
+                    crate::diagnostics::record_poison_message_quarantined();
+                }
+                drop(guard);
+                self.apply_transition_commit(commit).await;
+                continue;
+            }
             if attempt.state == crate::domain::execution_protocol::ExecutionAttemptState::Open
                 && terminal_turn.is_none()
                 && task_result_recovery.is_some()
@@ -6021,6 +6173,7 @@ impl RuntimeHandle {
                     )?;
                 if commit.applied {
                     recovered += 1;
+                    crate::diagnostics::record_unsettled_claim_recovery();
                     guard.restore_bootstrap_replay_message(&self.inner.storage, &message)?;
                 }
                 drop(guard);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -6072,12 +6072,23 @@ impl RuntimeHandle {
                 entry.status = QueueEntryStatus::Quarantined;
                 entry.updated_at = self.now();
                 let message_id = entry.message_id.clone();
-                let execution_protocol = execution_protocol_settlement_transition_from_facts(
-                    &self.inner.storage,
-                    &self.inner.runtime_db,
-                    &entry,
-                    terminal_turn,
-                )?;
+                let execution_protocol =
+                    crate::runtime_db::transitions::ExecutionProtocolTransition {
+                        bootstrap: None,
+                        commands: vec![
+                            crate::domain::execution_protocol::ExecutionProtocolCommand::Interrupt(
+                                crate::domain::execution_protocol::InterruptExecution {
+                                    attempt_id: attempt.attempt_id.clone(),
+                                    outcome_id: format!(
+                                        "outcome:interrupted:{}",
+                                        attempt.attempt_id
+                                    ),
+                                    reason: reason.into(),
+                                    interrupted_at: entry.updated_at.to_rfc3339(),
+                                },
+                            ),
+                        ],
+                    };
                 let commit = self
                     .inner
                     .runtime_db
@@ -6105,7 +6116,7 @@ impl RuntimeHandle {
                                     "work_item_id": work_item_id,
                                     "decision": "interrupt_and_quarantine",
                                     "reason": reason,
-                                    "recovery_generation": usize::from(
+                                    "recovery_generation": u32::from(
                                         attempt.recovery_of_attempt_id.is_some()
                                     ),
                                     "provenance": "bootstrap_reconciliation",

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1772,6 +1772,20 @@ fn scheduler_task_result_claim_recovery_candidates(
                 );
                 return Ok(candidate);
             }
+            if let unsettled_claim::UnsettledClaimDecision::QuarantineSettled { reason } = decision
+            {
+                let mut proposed_entry = entry.clone();
+                proposed_entry.status = QueueEntryStatus::Quarantined;
+                proposed_entry.updated_at = Utc::now();
+                candidate.eligible = true;
+                candidate.reason = reason.into();
+                candidate.recovery_decision = "quarantine_settled".into();
+                candidate.evidence.push("recovery_generation=1".to_string());
+                candidate.proposed_queue_entry = Some(proposed_entry);
+                candidate.expected_queue_entry = Some(entry.clone());
+                candidate.proposed_command = None;
+                return Ok(candidate);
+            }
             let recovery = exact_task_result_claim_recovery(
                 storage,
                 runtime_db,
@@ -6066,6 +6080,61 @@ impl RuntimeHandle {
                         || canonical_first_attempt,
                     recovery_of_attempt_id: attempt.recovery_of_attempt_id.clone(),
                 });
+            if let unsettled_claim::UnsettledClaimDecision::QuarantineSettled { reason } = decision
+            {
+                entry.status = QueueEntryStatus::Quarantined;
+                entry.updated_at = self.now();
+                let message_id = entry.message_id.clone();
+                let execution_protocol =
+                    crate::runtime_db::transitions::ExecutionProtocolTransition::default();
+                let commit = self
+                    .inner
+                    .runtime_db
+                    .transitions()
+                    .commit_queue_with_execution_protocol(
+                        &crate::runtime_db::transitions::QueueTransitionCommand {
+                            agent_id: agent_id.clone(),
+                            operation: crate::runtime_db::transitions::QueueOperation::Settle,
+                            mutation:
+                                crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                                    expected: expected_entry,
+                                    record: entry,
+                                },
+                            scheduler_claim_work_item: None,
+                            agent_state: None,
+                            message_evidence: Vec::new(),
+                            transcript_entries: Vec::new(),
+                            turn_record: terminal_turn.cloned(),
+                            audit_events: vec![AuditEvent::legacy(
+                                "unsettled_claim_reconciled",
+                                serde_json::json!({
+                                    "agent_id": agent_id,
+                                    "message_id": message_id,
+                                    "activation_id": activation_id,
+                                    "work_item_id": work_item_id,
+                                    "decision": "quarantine_settled",
+                                    "reason": reason,
+                                    "recovery_generation": u32::from(
+                                        attempt.recovery_of_attempt_id.is_some()
+                                    ),
+                                    "provenance": "bootstrap_reconciliation",
+                                }),
+                            )],
+                            notify_scheduler: true,
+                            fault: self.take_transition_fault(),
+                            brief_evidence: Vec::new(),
+                        },
+                        &execution_protocol,
+                    )?;
+                if commit.applied {
+                    recovered += 1;
+                    crate::diagnostics::record_unsettled_claim_recovery();
+                    crate::diagnostics::record_poison_message_quarantined();
+                }
+                drop(guard);
+                self.apply_transition_commit(commit).await;
+                continue;
+            }
             if let unsettled_claim::UnsettledClaimDecision::InterruptAndQuarantine { reason } =
                 decision
             {

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -2762,6 +2762,97 @@ async fn bootstrap_recovers_unadvanced_task_result_claim_but_diagnostic_apply_do
 }
 
 #[tokio::test]
+async fn bootstrap_quarantines_repeated_task_result_claim_recovery() {
+    use crate::domain::execution_protocol::ExecutionAttemptState;
+
+    let fixture = stale_task_result_claim_fixture("task-bootstrap-bounded-recovery").await;
+    let mut state = fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("TaskResult fixture execution partition");
+    state
+        .attempts
+        .get_mut(&fixture.attempt_id)
+        .expect("TaskResult fixture attempt")
+        .recovery_of_attempt_id = Some("attempt:prior-recovery".into());
+    fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &state))
+        .unwrap();
+
+    assert_eq!(
+        fixture
+            .runtime
+            .recover_scheduler_bootstrap_claims()
+            .await
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        fixture
+            .runtime
+            .recover_scheduler_bootstrap_claims()
+            .await
+            .unwrap(),
+        0
+    );
+    let recovered = fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("recovered execution partition");
+    assert_eq!(
+        recovered.attempts[&fixture.attempt_id].state,
+        ExecutionAttemptState::Interrupted
+    );
+    assert_eq!(
+        fixture
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&fixture.result.id)
+            .unwrap()
+            .expect("quarantined TaskResult")
+            .status,
+        QueueEntryStatus::Quarantined
+    );
+    let event = fixture
+        .runtime
+        .inner
+        .storage
+        .read_recent_events(100)
+        .unwrap()
+        .into_iter()
+        .find(|event| {
+            event.kind == "unsettled_claim_reconciled"
+                && event
+                    .data
+                    .get("message_id")
+                    .and_then(|value| value.as_str())
+                    == Some(fixture.result.id.as_str())
+        })
+        .expect("bounded recovery should emit durable reconciliation evidence");
+    assert_eq!(
+        event.data.get("decision").and_then(|value| value.as_str()),
+        Some("interrupt_and_quarantine")
+    );
+    assert_eq!(
+        event.data.get("reason").and_then(|value| value.as_str()),
+        Some("bounded_replay_exhausted")
+    );
+}
+
+#[tokio::test]
 async fn scheduler_recovery_task_result_claim_is_atomic_fenced_and_idempotent() {
     use crate::domain::execution_protocol::{ExecutionAttemptState, WorkItemExecutionState};
     use crate::runtime_db::transitions::TransitionFaultPoint;
@@ -2942,6 +3033,82 @@ async fn scheduler_recovery_task_result_claim_is_atomic_fenced_and_idempotent() 
             .unwrap()
             .unwrap(),
         before_queue
+    );
+}
+
+#[tokio::test]
+async fn scheduler_recovery_quarantines_repeated_task_result_claim() {
+    use crate::domain::execution_protocol::ExecutionAttemptState;
+
+    let fixture = stale_task_result_claim_fixture("task-debug-bounded-recovery").await;
+    let mut state = fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("TaskResult fixture execution partition");
+    state
+        .attempts
+        .get_mut(&fixture.attempt_id)
+        .expect("TaskResult fixture attempt")
+        .recovery_of_attempt_id = Some("attempt:prior-recovery".into());
+    fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &state))
+        .unwrap();
+
+    let report = isolated_task_result_claim_report(&fixture.runtime);
+    let [candidate] = report.task_result_claim_recoveries.as_slice() else {
+        panic!("expected one repeated TaskResult claim candidate: {report:#?}");
+    };
+    assert!(candidate.eligible);
+    assert_eq!(candidate.reason, "bounded_replay_exhausted");
+    assert_eq!(
+        candidate
+            .proposed_queue_entry
+            .as_ref()
+            .map(|entry| entry.status.clone()),
+        Some(QueueEntryStatus::Quarantined)
+    );
+
+    assert_eq!(
+        apply_scheduler_recovery_plan_with_backup_policy(
+            &fixture.runtime.inner.storage,
+            &fixture.runtime.inner.runtime_db,
+            "default",
+            &report,
+            SchedulerRecoveryBackupPolicy::SkipApproved,
+        )
+        .unwrap(),
+        (1, None)
+    );
+    let recovered = fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("recovered execution partition");
+    assert_eq!(
+        recovered.attempts[&fixture.attempt_id].state,
+        ExecutionAttemptState::Interrupted
+    );
+    assert_eq!(
+        fixture
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&fixture.result.id)
+            .unwrap()
+            .expect("quarantined TaskResult")
+            .status,
+        QueueEntryStatus::Quarantined
     );
 }
 
@@ -6382,7 +6549,7 @@ async fn restarted_interrupted_unbound_operator_prompt_does_not_block_resent_pro
         .into_iter()
         .find(|entry| entry.message_id == first.id)
         .map(|entry| entry.status);
-    assert_eq!(recovered_first_status, Some(QueueEntryStatus::Aborted));
+    assert_eq!(recovered_first_status, Some(QueueEntryStatus::Quarantined));
     let second = runtime
         .enqueue(trusted_operator_prompt(None, "resent operator prompt"))
         .await
@@ -6640,6 +6807,9 @@ async fn canonical_processed_settlement_without_terminal_turn_fails_closed() {
         )
         .await
         .unwrap_err();
+    assert!(error
+        .downcast_ref::<crate::domain::execution_protocol::ExecutionSettlementConflict>()
+        .is_some());
     assert!(error
         .to_string()
         .contains("without a matching terminal Turn"));

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -2850,6 +2850,17 @@ async fn bootstrap_quarantines_repeated_task_result_claim_recovery() {
         event.data.get("reason").and_then(|value| value.as_str()),
         Some("bounded_replay_exhausted")
     );
+    let attempt = &recovered.attempts[&fixture.attempt_id];
+    assert!(matches!(
+        &recovered.outcomes[attempt
+            .terminal_outcome_id
+            .as_deref()
+            .expect("quarantine should persist interruption evidence")]
+        .outcome,
+        crate::domain::execution_protocol::ExecutionOutcome::WorkItem(
+            crate::domain::execution_protocol::WorkItemOutcome::Interrupted { reason }
+        ) if reason == "bounded_replay_exhausted"
+    ));
 }
 
 #[tokio::test]

--- a/src/runtime/unsettled_claim.rs
+++ b/src/runtime/unsettled_claim.rs
@@ -1,0 +1,134 @@
+use crate::{domain::execution_protocol::ExecutionAttemptState, types::QueueEntryStatus};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UnsettledClaimFacts {
+    pub queue_status: QueueEntryStatus,
+    pub attempt_state: ExecutionAttemptState,
+    pub terminal_turn_completed: Option<bool>,
+    pub replay_is_exactly_fenced: bool,
+    pub recovery_of_attempt_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum UnsettledClaimDecision {
+    SettleFromTerminal {
+        queue_status: QueueEntryStatus,
+        reason: &'static str,
+    },
+    InterruptAndRequeue {
+        reason: &'static str,
+    },
+    InterruptAndQuarantine {
+        reason: &'static str,
+    },
+    NoopAlreadyConverged,
+}
+
+pub(crate) fn plan_unsettled_claim(facts: &UnsettledClaimFacts) -> UnsettledClaimDecision {
+    if facts.queue_status != QueueEntryStatus::Dequeued {
+        return UnsettledClaimDecision::NoopAlreadyConverged;
+    }
+    if let Some(completed) = facts.terminal_turn_completed {
+        return UnsettledClaimDecision::SettleFromTerminal {
+            queue_status: if completed {
+                QueueEntryStatus::Processed
+            } else {
+                QueueEntryStatus::Aborted
+            },
+            reason: "terminal_turn_settlement",
+        };
+    }
+    if facts.attempt_state != ExecutionAttemptState::Open {
+        return UnsettledClaimDecision::InterruptAndQuarantine {
+            reason: "terminal_attempt_missing_terminal_turn",
+        };
+    }
+    if facts.recovery_of_attempt_id.is_some() {
+        return UnsettledClaimDecision::InterruptAndQuarantine {
+            reason: "bounded_replay_exhausted",
+        };
+    }
+    if facts.replay_is_exactly_fenced {
+        return UnsettledClaimDecision::InterruptAndRequeue {
+            reason: "exact_fence_replay",
+        };
+    }
+    UnsettledClaimDecision::InterruptAndQuarantine {
+        reason: "replay_fence_ambiguous",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn facts() -> UnsettledClaimFacts {
+        UnsettledClaimFacts {
+            queue_status: QueueEntryStatus::Dequeued,
+            attempt_state: ExecutionAttemptState::Open,
+            terminal_turn_completed: None,
+            replay_is_exactly_fenced: false,
+            recovery_of_attempt_id: None,
+        }
+    }
+
+    #[test]
+    fn terminal_turn_settles_without_replay() {
+        assert_eq!(
+            plan_unsettled_claim(&UnsettledClaimFacts {
+                terminal_turn_completed: Some(true),
+                ..facts()
+            }),
+            UnsettledClaimDecision::SettleFromTerminal {
+                queue_status: QueueEntryStatus::Processed,
+                reason: "terminal_turn_settlement",
+            }
+        );
+    }
+
+    #[test]
+    fn exact_fence_allows_one_replay() {
+        assert_eq!(
+            plan_unsettled_claim(&UnsettledClaimFacts {
+                replay_is_exactly_fenced: true,
+                ..facts()
+            }),
+            UnsettledClaimDecision::InterruptAndRequeue {
+                reason: "exact_fence_replay",
+            }
+        );
+    }
+
+    #[test]
+    fn replay_attempt_is_quarantined_instead_of_looping() {
+        assert_eq!(
+            plan_unsettled_claim(&UnsettledClaimFacts {
+                replay_is_exactly_fenced: true,
+                recovery_of_attempt_id: Some("attempt:original".into()),
+                ..facts()
+            }),
+            UnsettledClaimDecision::InterruptAndQuarantine {
+                reason: "bounded_replay_exhausted",
+            }
+        );
+    }
+
+    #[test]
+    fn ambiguous_or_terminal_attempt_is_quarantined() {
+        assert_eq!(
+            plan_unsettled_claim(&facts()),
+            UnsettledClaimDecision::InterruptAndQuarantine {
+                reason: "replay_fence_ambiguous",
+            }
+        );
+        assert_eq!(
+            plan_unsettled_claim(&UnsettledClaimFacts {
+                attempt_state: ExecutionAttemptState::Interrupted,
+                ..facts()
+            }),
+            UnsettledClaimDecision::InterruptAndQuarantine {
+                reason: "terminal_attempt_missing_terminal_turn",
+            }
+        );
+    }
+}

--- a/src/runtime/unsettled_claim.rs
+++ b/src/runtime/unsettled_claim.rs
@@ -21,6 +21,9 @@ pub(crate) enum UnsettledClaimDecision {
     InterruptAndQuarantine {
         reason: &'static str,
     },
+    QuarantineSettled {
+        reason: &'static str,
+    },
     NoopAlreadyConverged,
 }
 
@@ -39,7 +42,7 @@ pub(crate) fn plan_unsettled_claim(facts: &UnsettledClaimFacts) -> UnsettledClai
         };
     }
     if facts.attempt_state != ExecutionAttemptState::Open {
-        return UnsettledClaimDecision::InterruptAndQuarantine {
+        return UnsettledClaimDecision::QuarantineSettled {
             reason: "terminal_attempt_missing_terminal_turn",
         };
     }
@@ -115,19 +118,23 @@ mod tests {
     }
 
     #[test]
-    fn ambiguous_or_terminal_attempt_is_quarantined() {
+    fn ambiguous_replay_is_interrupt_quarantined() {
         assert_eq!(
             plan_unsettled_claim(&facts()),
             UnsettledClaimDecision::InterruptAndQuarantine {
                 reason: "replay_fence_ambiguous",
             }
         );
+    }
+
+    #[test]
+    fn settled_attempt_without_terminal_is_quarantined() {
         assert_eq!(
             plan_unsettled_claim(&UnsettledClaimFacts {
                 attempt_state: ExecutionAttemptState::Interrupted,
                 ..facts()
             }),
-            UnsettledClaimDecision::InterruptAndQuarantine {
+            UnsettledClaimDecision::QuarantineSettled {
                 reason: "terminal_attempt_missing_terminal_turn",
             }
         );

--- a/src/runtime/unsettled_claim.rs
+++ b/src/runtime/unsettled_claim.rs
@@ -43,6 +43,7 @@ pub(crate) fn plan_unsettled_claim(facts: &UnsettledClaimFacts) -> UnsettledClai
             reason: "terminal_attempt_missing_terminal_turn",
         };
     }
+    // Recovery lineage takes precedence over a valid fence so one replay cannot recurse.
     if facts.recovery_of_attempt_id.is_some() {
         return UnsettledClaimDecision::InterruptAndQuarantine {
             reason: "bounded_replay_exhausted",


### PR DESCRIPTION
## Summary

- add a typed execution-settlement conflict and a shared pure unsettled-claim planner for bootstrap, online settlement failure, and scheduler-recovery debug flows
- bound automatic replay to one exactly fenced recovery generation, then quarantine repeated or ambiguous poison claims while preserving audit evidence and releasing the execution lane
- project unsettled/quarantined claim counts through agent status, add recovery/quarantine metrics, fault-injection and restart-idempotency coverage, and document the canonical contract in the activation settlement RFC

## Runtime contract

- does **not** relax `Processed` requiring a matching terminal Turn
- canonical first attempts and exact task-result/work-queue claims may replay once
- recovery attempts and ambiguous evidence are interrupted and quarantined rather than looping
- quarantine preserves durable queue/execution/audit evidence while allowing later operator messages to be claimed
- production deployment, daemon restart, and existing `holon-ops` data repair remain out of scope

## Verification

- `cargo test --lib` — 2740 passed, 1 ignored
- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2598
