### PR TITLE
fix: quarantine claims with revoked task waits

### DIFF
--- a/docs/rfcs/agent-activation-settlement-and-dispatch.md
+++ b/docs/rfcs/agent-activation-settlement-and-dispatch.md
@@ -667,9 +667,19 @@ For a dequeued claim the planner chooses one of:
 - settle from a matching terminal Turn;
 - interrupt and requeue when exact source, owner, and revision fences prove
   replay is safe;
+- interrupt and quarantine when an exact cancelled task wait proves that the
+  result's continuation authority was revoked;
 - interrupt and quarantine when replay evidence is ambiguous or the claim is
   already a recovery attempt; or
 - no-op when the claim already converged.
+
+An exact cancelled task wait is negative authority evidence, not incomplete
+evidence and not replay authority. The runtime must never restore that wait,
+replay its `TaskResult`, or mark the claim `Processed`; bootstrap, online
+settlement conflict handling, and debug recovery all use
+`task_result_wait_cancelled` for the canonical interrupt-and-quarantine
+decision. Missing, duplicate, or identity-mismatched waits remain ambiguous and
+fail closed.
 
 Automatic replay is bounded to one recovery generation. A second failure for
 the same recovery chain is not requeued again. Quarantine atomically records an
@@ -682,7 +692,14 @@ Every automatic decision emits durable `unsettled_claim_reconciled` evidence
 with the decision, reason, and recovery generation. Runtime diagnostics count
 missing terminal conflicts, unsettled-claim recoveries, and poison-message
 quarantines. The debug recovery projection exposes the same decision and
-generation used by apply.
+generation used by apply. Operators may constrain both inspect and apply to one
+TaskResult claim with `--message-id`; the selector must match exactly one
+candidate and does not override eligibility.
+
+Every retained dequeued TaskResult claim also reports its age, whether it still
+blocks the execution lane, and a `recoverable` or `unhealthy` health class.
+Ambiguous claims remain fail-closed and ineligible, but they must be externally
+visible as unhealthy rather than silently represented as an ordinary no-op.
 
 A WorkItem-bound activation must include one WorkItem disposition.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -586,6 +586,8 @@ pub enum DebugCommands {
         #[arg(long)]
         agent: Option<String>,
         #[arg(long)]
+        message_id: Option<String>,
+        #[arg(long)]
         json: bool,
         #[arg(long)]
         apply: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1491,6 +1491,7 @@ mod tests {
             command:
                 DebugCommands::SchedulerRecovery {
                     agent,
+                    message_id,
                     json,
                     apply,
                     no_backup,
@@ -1500,6 +1501,7 @@ mod tests {
             panic!("expected debug scheduler-recovery command");
         };
         assert_eq!(agent.as_deref(), Some("pm"));
+        assert!(message_id.is_none());
         assert!(json);
         assert!(!apply);
         assert!(!no_backup);
@@ -1529,6 +1531,28 @@ mod tests {
         };
         assert!(apply);
         assert!(no_backup);
+    }
+
+    #[test]
+    fn debug_scheduler_recovery_command_parses_message_selector() {
+        let cli = Cli::parse_from([
+            "holon",
+            "debug",
+            "scheduler-recovery",
+            "--message-id",
+            "message:task-restart:task-1",
+        ]);
+        let Commands::Debug {
+            command:
+                DebugCommands::SchedulerRecovery {
+                    message_id, apply, ..
+                },
+        } = cli.command
+        else {
+            panic!("expected debug scheduler-recovery command");
+        };
+        assert_eq!(message_id.as_deref(), Some("message:task-restart:task-1"));
+        assert!(!apply);
     }
 
     #[test]
@@ -2513,10 +2537,11 @@ async fn handle_debug_command(config: AppConfig, command: DebugCommands) -> Resu
         }
         DebugCommands::SchedulerRecovery {
             agent,
+            message_id,
             json,
             apply,
             no_backup,
-        } => print_scheduler_recovery_report(&config, agent, json, apply, no_backup),
+        } => print_scheduler_recovery_report(&config, agent, message_id, json, apply, no_backup),
         DebugCommands::SchedulerRecoveryFixture {
             agent,
             objective,
@@ -2584,6 +2609,7 @@ async fn seed_scheduler_restart_fixture(
 fn print_scheduler_recovery_report(
     config: &AppConfig,
     agent: Option<String>,
+    message_id: Option<String>,
     json: bool,
     apply: bool,
     no_backup: bool,
@@ -2593,6 +2619,7 @@ fn print_scheduler_recovery_report(
     let storage = host.agent_storage(&agent_id)?;
     let mut report =
         holon::runtime::scheduler_recovery_report(&storage, host.runtime_db(), &agent_id)?;
+    filter_scheduler_recovery_report(&mut report, message_id.as_deref(), true)?;
     let mut apply_result = None;
     if apply {
         let _maintenance_lock = RuntimeDbLock::try_lock(config.runtime_db_maintenance_lock_path())
@@ -2613,6 +2640,7 @@ fn print_scheduler_recovery_report(
             backup_policy,
         ));
         report = holon::runtime::scheduler_recovery_report(&storage, host.runtime_db(), &agent_id)?;
+        filter_scheduler_recovery_report(&mut report, message_id.as_deref(), false)?;
     }
     if json {
         return print_json(&serde_json::json!({
@@ -2663,10 +2691,13 @@ fn print_scheduler_recovery_report(
     }
     for candidate in report.task_result_claim_recoveries {
         println!(
-            "- task_result_claim:{} attempt={} work_item={} eligible={} decision={} generation={} reason={} target={:?}",
+            "- task_result_claim:{} attempt={} work_item={} health={:?} lane_blocked={} age_seconds={} eligible={} decision={} generation={} reason={} target={:?}",
             candidate.message_id,
             candidate.activation_id,
             candidate.work_item_id,
+            candidate.health,
+            candidate.lane_blocked,
+            candidate.claim_age_seconds,
             candidate.eligible,
             candidate.recovery_decision,
             candidate.recovery_generation,
@@ -2694,6 +2725,33 @@ fn print_scheduler_recovery_report(
             candidate.reason,
         );
     }
+    Ok(())
+}
+
+fn filter_scheduler_recovery_report(
+    report: &mut holon::runtime::SchedulerRecoveryReport,
+    message_id: Option<&str>,
+    require_match: bool,
+) -> Result<()> {
+    let Some(message_id) = message_id else {
+        return Ok(());
+    };
+    let matching = report
+        .task_result_claim_recoveries
+        .iter()
+        .filter(|candidate| candidate.message_id == message_id)
+        .count();
+    if matching > 1 || (require_match && matching != 1) {
+        return Err(anyhow!(
+            "scheduler recovery selector `{message_id}` matched {matching} TaskResult claim candidates; expected exactly one"
+        ));
+    }
+    report.candidates.clear();
+    report.legacy_adoptions.clear();
+    report.continuation_reconciliations.clear();
+    report
+        .task_result_claim_recoveries
+        .retain(|candidate| candidate.message_id == message_id);
     Ok(())
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1755,6 +1755,8 @@ fn scheduler_task_result_claim_recovery_candidates(
                 queue_status: entry.status.clone(),
                 health: SchedulerUnsettledClaimHealth::Unhealthy,
                 lane_blocked: true,
+                // Queue entries currently expose the latest durable update, not a
+                // distinct claimed-at timestamp, so this is a diagnostic approximation.
                 claim_age_seconds: Utc::now()
                     .signed_duration_since(entry.updated_at)
                     .num_seconds()
@@ -6109,36 +6111,43 @@ impl RuntimeHandle {
                         if subsystem == "work_queue"
                 ) && message.work_item_id.as_deref() == Some(work_item_id)
             });
-            let (task_result_recovery, task_result_replay_fence) =
-                if let Some(work_item_id) = work_item_id.as_deref() {
-                    let task_result_recovery = exact_task_result_claim_recovery(
-                        &self.inner.storage,
-                        &self.inner.runtime_db,
-                        &message,
-                        &attempt,
-                        work_item_id,
-                        self.now(),
-                        TaskResultClaimRecoveryAuthority::RuntimeTerminatedBootstrap,
-                    )?;
-                    match task_result_recovery {
-                        TaskResultClaimRecovery::Replayable { transition, .. } => (
-                            Some(transition),
-                            unsettled_claim::ReplayFence::ExactReplayable,
-                        ),
-                        TaskResultClaimRecovery::Revoked { .. } => {
-                            (None, unsettled_claim::ReplayFence::Revoked)
-                        }
-                        TaskResultClaimRecovery::RequiresInactiveRuntime => {
-                            unreachable!("bootstrap authority permits equal-revision recovery")
-                        }
-                        TaskResultClaimRecovery::Ineligible { .. } if !work_queue_claim => continue,
-                        TaskResultClaimRecovery::Ineligible { .. } => {
-                            (None, unsettled_claim::ReplayFence::Ambiguous)
-                        }
+            let (task_result_recovery, task_result_replay_fence) = if let Some(work_item_id) =
+                work_item_id.as_deref()
+            {
+                let task_result_recovery = exact_task_result_claim_recovery(
+                    &self.inner.storage,
+                    &self.inner.runtime_db,
+                    &message,
+                    &attempt,
+                    work_item_id,
+                    self.now(),
+                    TaskResultClaimRecoveryAuthority::RuntimeTerminatedBootstrap,
+                )?;
+                match task_result_recovery {
+                    TaskResultClaimRecovery::Replayable { transition, .. } => (
+                        Some(transition),
+                        unsettled_claim::ReplayFence::ExactReplayable,
+                    ),
+                    TaskResultClaimRecovery::Revoked { .. } => {
+                        (None, unsettled_claim::ReplayFence::Revoked)
                     }
-                } else {
-                    (None, unsettled_claim::ReplayFence::Ambiguous)
-                };
+                    TaskResultClaimRecovery::RequiresInactiveRuntime => {
+                        tracing::error!(
+                            agent_id = %agent_id,
+                            message_id = %entry.message_id,
+                            activation_id = %activation_id,
+                            "bootstrap task-result recovery unexpectedly required an inactive runtime"
+                        );
+                        continue;
+                    }
+                    TaskResultClaimRecovery::Ineligible { .. } if !work_queue_claim => continue,
+                    TaskResultClaimRecovery::Ineligible { .. } => {
+                        (None, unsettled_claim::ReplayFence::Ambiguous)
+                    }
+                }
+            } else {
+                (None, unsettled_claim::ReplayFence::Ambiguous)
+            };
 
             let terminal_turn = turns.iter().find(|turn| {
                 turn.terminal.is_some()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1540,24 +1540,33 @@ fn exact_triggered_or_resolved_task_result_wait(
     })
 }
 
-fn exact_resolved_task_result_wait(
+fn exact_task_result_claim_wait(
     storage: &AppStorage,
     message: &MessageEnvelope,
     task_id: &str,
     work_item_id: &str,
 ) -> Result<Option<WaitConditionRecord>> {
     exact_task_result_wait_with_status(storage, message, task_id, work_item_id, |status| {
-        status == &WaitConditionStatus::Resolved
+        matches!(
+            status,
+            WaitConditionStatus::Resolved | WaitConditionStatus::Cancelled
+        )
     })
 }
 
 enum TaskResultClaimRecovery {
-    Eligible {
+    Replayable {
         transition: crate::runtime_db::transitions::ExecutionProtocolTransition,
         reason: &'static str,
     },
+    Revoked {
+        wait: WaitConditionRecord,
+        reason: &'static str,
+    },
     RequiresInactiveRuntime,
-    Ineligible,
+    Ineligible {
+        reason: &'static str,
+    },
 }
 
 #[derive(Clone, Copy)]
@@ -1585,7 +1594,9 @@ fn exact_task_result_claim_recovery(
         result_message_id,
     } = &attempt.source.identity
     else {
-        return Ok(TaskResultClaimRecovery::Ineligible);
+        return Ok(TaskResultClaimRecovery::Ineligible {
+            reason: "execution_source_not_task_result",
+        });
     };
     if result_message_id != &message.id
         || message.kind != MessageKind::TaskResult
@@ -1596,33 +1607,54 @@ fn exact_task_result_claim_recovery(
         || message.work_item_id.as_deref() != Some(work_item_id)
         || !matches!(&message.origin, MessageOrigin::Task { task_id: origin } if origin == task_id)
     {
-        return Ok(TaskResultClaimRecovery::Ineligible);
+        return Ok(TaskResultClaimRecovery::Ineligible {
+            reason: "task_result_message_identity_mismatch",
+        });
     }
     let Some(task) = storage.latest_task_record(task_id)? else {
-        return Ok(TaskResultClaimRecovery::Ineligible);
+        return Ok(TaskResultClaimRecovery::Ineligible {
+            reason: "task_result_task_missing",
+        });
     };
     let Ok(rejoin) = task.rejoin_fence() else {
-        return Ok(TaskResultClaimRecovery::Ineligible);
+        return Ok(TaskResultClaimRecovery::Ineligible {
+            reason: "task_result_rejoin_fence_missing",
+        });
     };
     if task.agent_id != message.agent_id
         || task.work_item_id.as_deref() != Some(work_item_id)
         || task.parent_message_id.as_deref() != Some(message.id.as_str())
         || attempt.admitted_fences.rejoin.as_ref() != Some(&rejoin)
     {
-        return Ok(TaskResultClaimRecovery::Ineligible);
+        return Ok(TaskResultClaimRecovery::Ineligible {
+            reason: "task_result_rejoin_identity_mismatch",
+        });
     }
-    let Some(wait) = exact_resolved_task_result_wait(storage, message, task_id, work_item_id)?
-    else {
-        return Ok(TaskResultClaimRecovery::Ineligible);
+    let Some(wait) = exact_task_result_claim_wait(storage, message, task_id, work_item_id)? else {
+        return Ok(TaskResultClaimRecovery::Ineligible {
+            reason: "task_result_wait_missing_or_ambiguous",
+        });
     };
+    if wait.status == WaitConditionStatus::Cancelled {
+        return Ok(TaskResultClaimRecovery::Revoked {
+            wait,
+            reason: "task_result_wait_cancelled",
+        });
+    }
     let Some(work_item) = runtime_db.work_items().latest(work_item_id)? else {
-        return Ok(TaskResultClaimRecovery::Ineligible);
+        return Ok(TaskResultClaimRecovery::Ineligible {
+            reason: "task_result_work_item_missing",
+        });
     };
     let Some(expected_source_revision) = attempt.admitted_fences.work_item_source_revision else {
-        return Ok(TaskResultClaimRecovery::Ineligible);
+        return Ok(TaskResultClaimRecovery::Ineligible {
+            reason: "task_result_work_item_revision_fence_missing",
+        });
     };
     if work_item.state != WorkItemState::Open || work_item.blocked_by.is_some() {
-        return Ok(TaskResultClaimRecovery::Ineligible);
+        return Ok(TaskResultClaimRecovery::Ineligible {
+            reason: "task_result_work_item_not_runnable",
+        });
     }
     let (command, reason) = match work_item.revision.cmp(&expected_source_revision) {
         std::cmp::Ordering::Greater => (
@@ -1673,9 +1705,13 @@ fn exact_task_result_claim_recovery(
                 "unadvanced_task_result_claim",
             )
         }
-        std::cmp::Ordering::Less => return Ok(TaskResultClaimRecovery::Ineligible),
+        std::cmp::Ordering::Less => {
+            return Ok(TaskResultClaimRecovery::Ineligible {
+                reason: "task_result_work_item_revision_regressed",
+            });
+        }
     };
-    Ok(TaskResultClaimRecovery::Eligible {
+    Ok(TaskResultClaimRecovery::Replayable {
         transition: crate::runtime_db::transitions::ExecutionProtocolTransition {
             bootstrap: None,
             commands: vec![command],
@@ -1717,6 +1753,12 @@ fn scheduler_task_result_claim_recovery_candidates(
                 activation_id: attempt.attempt_id.clone(),
                 work_item_id: work_item_id.clone(),
                 queue_status: entry.status.clone(),
+                health: SchedulerUnsettledClaimHealth::Unhealthy,
+                lane_blocked: true,
+                claim_age_seconds: Utc::now()
+                    .signed_duration_since(entry.updated_at)
+                    .num_seconds()
+                    .max(0) as u64,
                 expected_queue_entry: None,
                 eligible: false,
                 reason: "task_result_claim_evidence_incomplete".into(),
@@ -1740,12 +1782,43 @@ fn scheduler_task_result_claim_recovery_candidates(
                 candidate.reason = "message_missing".into();
                 return Ok(candidate);
             };
+            let recovery = exact_task_result_claim_recovery(
+                storage,
+                runtime_db,
+                &message,
+                attempt,
+                work_item_id,
+                Utc::now(),
+                TaskResultClaimRecoveryAuthority::Diagnostic,
+            )?;
+            let replay_fence = match &recovery {
+                TaskResultClaimRecovery::Replayable { .. }
+                | TaskResultClaimRecovery::RequiresInactiveRuntime => {
+                    unsettled_claim::ReplayFence::ExactReplayable
+                }
+                TaskResultClaimRecovery::Revoked { wait, reason } => {
+                    candidate.reason = (*reason).into();
+                    candidate
+                        .evidence
+                        .push(format!("cancelled_wait:{}", wait.id));
+                    unsettled_claim::ReplayFence::Revoked
+                }
+                TaskResultClaimRecovery::Ineligible { reason } => {
+                    candidate.reason = (*reason).into();
+                    unsettled_claim::ReplayFence::Ambiguous
+                }
+            };
+            if replay_fence == unsettled_claim::ReplayFence::Ambiguous
+                && attempt.recovery_of_attempt_id.is_none()
+            {
+                return Ok(candidate);
+            }
             let decision =
                 unsettled_claim::plan_unsettled_claim(&unsettled_claim::UnsettledClaimFacts {
                     queue_status: entry.status.clone(),
                     attempt_state: attempt.state,
                     terminal_turn_completed: None,
-                    replay_is_exactly_fenced: true,
+                    replay_fence,
                     recovery_of_attempt_id: attempt.recovery_of_attempt_id.clone(),
                 });
             if let unsettled_claim::UnsettledClaimDecision::InterruptAndQuarantine { reason } =
@@ -1755,6 +1828,7 @@ fn scheduler_task_result_claim_recovery_candidates(
                 proposed_entry.status = QueueEntryStatus::Quarantined;
                 proposed_entry.updated_at = Utc::now();
                 candidate.eligible = true;
+                candidate.health = SchedulerUnsettledClaimHealth::Recoverable;
                 candidate.reason = reason.into();
                 candidate.recovery_decision = "interrupt_and_quarantine".into();
                 candidate.evidence.push("recovery_generation=1".to_string());
@@ -1778,6 +1852,7 @@ fn scheduler_task_result_claim_recovery_candidates(
                 proposed_entry.status = QueueEntryStatus::Quarantined;
                 proposed_entry.updated_at = Utc::now();
                 candidate.eligible = true;
+                candidate.health = SchedulerUnsettledClaimHealth::Recoverable;
                 candidate.reason = reason.into();
                 candidate.recovery_decision = "quarantine_settled".into();
                 candidate.evidence.push("recovery_generation=1".to_string());
@@ -1786,22 +1861,14 @@ fn scheduler_task_result_claim_recovery_candidates(
                 candidate.proposed_command = None;
                 return Ok(candidate);
             }
-            let recovery = exact_task_result_claim_recovery(
-                storage,
-                runtime_db,
-                &message,
-                attempt,
-                work_item_id,
-                Utc::now(),
-                TaskResultClaimRecoveryAuthority::Diagnostic,
-            )?;
             let (transition, reason) = match recovery {
-                TaskResultClaimRecovery::Eligible { transition, reason } => (transition, reason),
+                TaskResultClaimRecovery::Replayable { transition, reason } => (transition, reason),
                 TaskResultClaimRecovery::RequiresInactiveRuntime => {
                     candidate.reason = "requires_inactive_runtime_recovery".into();
                     return Ok(candidate);
                 }
-                TaskResultClaimRecovery::Ineligible => return Ok(candidate),
+                TaskResultClaimRecovery::Revoked { .. }
+                | TaskResultClaimRecovery::Ineligible { .. } => return Ok(candidate),
             };
             let [command] = transition.commands.as_slice() else {
                 return Ok(candidate);
@@ -1810,6 +1877,7 @@ fn scheduler_task_result_claim_recovery_candidates(
             proposed_entry.status = QueueEntryStatus::Queued;
             proposed_entry.updated_at = Utc::now();
             candidate.eligible = true;
+            candidate.health = SchedulerUnsettledClaimHealth::Recoverable;
             candidate.reason = reason.into();
             candidate.recovery_decision = "interrupt_and_requeue".into();
             candidate.evidence.push(format!(
@@ -1847,6 +1915,9 @@ pub struct SchedulerTaskResultClaimRecoveryCandidate {
     pub activation_id: String,
     pub work_item_id: String,
     pub queue_status: QueueEntryStatus,
+    pub health: SchedulerUnsettledClaimHealth,
+    pub lane_blocked: bool,
+    pub claim_age_seconds: u64,
     pub expected_queue_entry: Option<QueueEntryRecord>,
     pub eligible: bool,
     pub reason: String,
@@ -1855,6 +1926,13 @@ pub struct SchedulerTaskResultClaimRecoveryCandidate {
     pub evidence: Vec<String>,
     pub proposed_queue_entry: Option<QueueEntryRecord>,
     pub proposed_command: Option<crate::domain::execution_protocol::ExecutionProtocolCommand>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchedulerUnsettledClaimHealth {
+    Recoverable,
+    Unhealthy,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -6031,27 +6109,36 @@ impl RuntimeHandle {
                         if subsystem == "work_queue"
                 ) && message.work_item_id.as_deref() == Some(work_item_id)
             });
-            let task_result_recovery = if let Some(work_item_id) = work_item_id.as_deref() {
-                let task_result_recovery = exact_task_result_claim_recovery(
-                    &self.inner.storage,
-                    &self.inner.runtime_db,
-                    &message,
-                    &attempt,
-                    work_item_id,
-                    self.now(),
-                    TaskResultClaimRecoveryAuthority::RuntimeTerminatedBootstrap,
-                )?;
-                match task_result_recovery {
-                    TaskResultClaimRecovery::Eligible { transition, .. } => Some(transition),
-                    TaskResultClaimRecovery::RequiresInactiveRuntime => {
-                        unreachable!("bootstrap authority permits equal-revision recovery")
+            let (task_result_recovery, task_result_replay_fence) =
+                if let Some(work_item_id) = work_item_id.as_deref() {
+                    let task_result_recovery = exact_task_result_claim_recovery(
+                        &self.inner.storage,
+                        &self.inner.runtime_db,
+                        &message,
+                        &attempt,
+                        work_item_id,
+                        self.now(),
+                        TaskResultClaimRecoveryAuthority::RuntimeTerminatedBootstrap,
+                    )?;
+                    match task_result_recovery {
+                        TaskResultClaimRecovery::Replayable { transition, .. } => (
+                            Some(transition),
+                            unsettled_claim::ReplayFence::ExactReplayable,
+                        ),
+                        TaskResultClaimRecovery::Revoked { .. } => {
+                            (None, unsettled_claim::ReplayFence::Revoked)
+                        }
+                        TaskResultClaimRecovery::RequiresInactiveRuntime => {
+                            unreachable!("bootstrap authority permits equal-revision recovery")
+                        }
+                        TaskResultClaimRecovery::Ineligible { .. } if !work_queue_claim => continue,
+                        TaskResultClaimRecovery::Ineligible { .. } => {
+                            (None, unsettled_claim::ReplayFence::Ambiguous)
+                        }
                     }
-                    TaskResultClaimRecovery::Ineligible if !work_queue_claim => continue,
-                    TaskResultClaimRecovery::Ineligible => None,
-                }
-            } else {
-                None
-            };
+                } else {
+                    (None, unsettled_claim::ReplayFence::Ambiguous)
+                };
 
             let terminal_turn = turns.iter().find(|turn| {
                 turn.terminal.is_some()
@@ -6075,9 +6162,15 @@ impl RuntimeHandle {
                     queue_status: entry.status.clone(),
                     attempt_state: attempt.state,
                     terminal_turn_completed: terminal_turn.map(|_| terminal_is_completed),
-                    replay_is_exactly_fenced: task_result_recovery.is_some()
-                        || work_queue_claim
-                        || canonical_first_attempt,
+                    replay_fence: if task_result_replay_fence
+                        == unsettled_claim::ReplayFence::Revoked
+                    {
+                        unsettled_claim::ReplayFence::Revoked
+                    } else if work_queue_claim || canonical_first_attempt {
+                        unsettled_claim::ReplayFence::ExactReplayable
+                    } else {
+                        task_result_replay_fence
+                    },
                     recovery_of_attempt_id: attempt.recovery_of_attempt_id.clone(),
                 });
             if let unsettled_claim::UnsettledClaimDecision::QuarantineSettled { reason } = decision

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -16,6 +16,126 @@ struct BlockingProvider {
     started: Arc<tokio::sync::Notify>,
 }
 
+#[tokio::test]
+async fn cancelled_task_result_wait_quarantines_open_claim_and_releases_lane() {
+    use crate::domain::execution_protocol::ExecutionAttemptState;
+
+    let fixture = cancelled_wait_task_result_claim_fixture("task-cancelled-wait-recovery").await;
+    let report = isolated_task_result_claim_report(&fixture.runtime);
+    let [candidate] = report.task_result_claim_recoveries.as_slice() else {
+        panic!("expected one cancelled-wait TaskResult claim candidate: {report:#?}");
+    };
+    assert!(candidate.eligible, "candidate: {candidate:#?}");
+    assert_eq!(candidate.health, SchedulerUnsettledClaimHealth::Recoverable);
+    assert!(candidate.lane_blocked);
+    assert_eq!(candidate.reason, "task_result_wait_cancelled");
+    assert_eq!(candidate.recovery_decision, "interrupt_and_quarantine");
+    assert!(candidate
+        .evidence
+        .iter()
+        .any(|evidence| evidence.starts_with("cancelled_wait:")));
+    assert_eq!(
+        candidate
+            .proposed_queue_entry
+            .as_ref()
+            .map(|entry| entry.status.clone()),
+        Some(QueueEntryStatus::Quarantined)
+    );
+
+    assert_eq!(
+        fixture
+            .runtime
+            .recover_scheduler_bootstrap_claims()
+            .await
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        fixture
+            .runtime
+            .recover_scheduler_bootstrap_claims()
+            .await
+            .unwrap(),
+        0
+    );
+    let recovered = fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .expect("recovered execution partition");
+    assert_eq!(
+        recovered.attempts[&fixture.attempt_id].state,
+        ExecutionAttemptState::Interrupted
+    );
+    assert!(matches!(
+        recovered.work_items[&fixture.work_item_id].state,
+        crate::domain::execution_protocol::WorkItemExecutionState::Runnable { .. }
+    ));
+    assert_eq!(
+        fixture
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&fixture.result.id)
+            .unwrap()
+            .expect("quarantined TaskResult")
+            .status,
+        QueueEntryStatus::Quarantined
+    );
+}
+
+#[tokio::test]
+async fn scheduler_recovery_apply_quarantines_cancelled_task_result_claim_atomically() {
+    let fixture = cancelled_wait_task_result_claim_fixture("task-cancelled-wait-debug-apply").await;
+    let report = isolated_task_result_claim_report(&fixture.runtime);
+    let [candidate] = report.task_result_claim_recoveries.as_slice() else {
+        panic!("expected one cancelled-wait TaskResult claim candidate: {report:#?}");
+    };
+    assert!(candidate.eligible);
+    assert_eq!(candidate.reason, "task_result_wait_cancelled");
+
+    assert_eq!(
+        apply_scheduler_recovery_plan_with_backup_policy(
+            &fixture.runtime.inner.storage,
+            &fixture.runtime.inner.runtime_db,
+            "default",
+            &report,
+            SchedulerRecoveryBackupPolicy::SkipApproved,
+        )
+        .unwrap(),
+        (1, None)
+    );
+    assert_eq!(
+        apply_scheduler_recovery_plan_with_backup_policy(
+            &fixture.runtime.inner.storage,
+            &fixture.runtime.inner.runtime_db,
+            "default",
+            &report,
+            SchedulerRecoveryBackupPolicy::SkipApproved,
+        )
+        .unwrap(),
+        (0, None)
+    );
+    let recovered = isolated_task_result_claim_report(&fixture.runtime);
+    assert!(recovered.task_result_claim_recoveries.is_empty());
+    assert_eq!(
+        fixture
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&fixture.result.id)
+            .unwrap()
+            .expect("quarantined TaskResult")
+            .status,
+        QueueEntryStatus::Quarantined
+    );
+}
+
 struct GatedFailingProvider {
     started: Arc<tokio::sync::Notify>,
     release: Arc<tokio::sync::Notify>,
@@ -2460,6 +2580,17 @@ struct StaleTaskResultClaimFixture {
 }
 
 async fn stale_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimFixture {
+    task_result_claim_fixture(task_id, false).await
+}
+
+async fn cancelled_wait_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimFixture {
+    task_result_claim_fixture(task_id, true).await
+}
+
+async fn task_result_claim_fixture(
+    task_id: &str,
+    cancel_wait_before_result: bool,
+) -> StaleTaskResultClaimFixture {
     use crate::domain::execution_protocol::{
         AdmittedFences, ExecutionAttempt, ExecutionAttemptState, ExecutionBinding, ExecutionOrigin,
         ExecutionPriority, ExecutionProtocolState, ExecutionProvenance, ExecutionSource,
@@ -2539,6 +2670,30 @@ async fn stale_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimF
     result.work_item_id = Some(work_item.id.clone());
     result.turn_id = Some(format!("turn-{task_id}-result"));
     terminal_task.parent_message_id = Some(result.id.clone());
+    if cancel_wait_before_result {
+        let mut wait = runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| {
+                condition.wake_sources.iter().any(|source| {
+                    matches!(source, WakeSource::TaskResult { task_id: source_task_id } if source_task_id == task_id)
+                })
+                    && condition.work_item_id.as_deref() == Some(work_item.id.as_str())
+            })
+            .expect("active TaskResult wait");
+        wait.status = WaitConditionStatus::Cancelled;
+        wait.updated_at = Utc::now();
+        wait.cancelled_at = Some(wait.updated_at);
+        wait.trigger_message_id = Some(result.id.clone());
+        runtime
+            .inner
+            .runtime_db
+            .wait_conditions()
+            .upsert(&wait)
+            .unwrap();
+    }
     assert!(!terminal_task.terminal_reentry());
     runtime
         .commit_terminal_task_result(&terminal_task, "task_completed", &result)
@@ -2705,6 +2860,8 @@ async fn bootstrap_recovers_unadvanced_task_result_claim_but_diagnostic_apply_do
         panic!("expected one unadvanced TaskResult claim candidate: {report:#?}");
     };
     assert!(!candidate.eligible);
+    assert_eq!(candidate.health, SchedulerUnsettledClaimHealth::Unhealthy);
+    assert!(candidate.lane_blocked);
     assert_eq!(candidate.reason, "requires_inactive_runtime_recovery");
     assert!(candidate.proposed_command.is_none());
 

--- a/src/runtime/unsettled_claim.rs
+++ b/src/runtime/unsettled_claim.rs
@@ -5,8 +5,15 @@ pub(crate) struct UnsettledClaimFacts {
     pub queue_status: QueueEntryStatus,
     pub attempt_state: ExecutionAttemptState,
     pub terminal_turn_completed: Option<bool>,
-    pub replay_is_exactly_fenced: bool,
+    pub replay_fence: ReplayFence,
     pub recovery_of_attempt_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReplayFence {
+    ExactReplayable,
+    Revoked,
+    Ambiguous,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,13 +53,18 @@ pub(crate) fn plan_unsettled_claim(facts: &UnsettledClaimFacts) -> UnsettledClai
             reason: "terminal_attempt_missing_terminal_turn",
         };
     }
-    // Recovery lineage takes precedence over a valid fence so one replay cannot recurse.
+    if facts.replay_fence == ReplayFence::Revoked {
+        return UnsettledClaimDecision::InterruptAndQuarantine {
+            reason: "task_result_wait_cancelled",
+        };
+    }
+    // Recovery lineage takes precedence over a replayable fence so one replay cannot recurse.
     if facts.recovery_of_attempt_id.is_some() {
         return UnsettledClaimDecision::InterruptAndQuarantine {
             reason: "bounded_replay_exhausted",
         };
     }
-    if facts.replay_is_exactly_fenced {
+    if facts.replay_fence == ReplayFence::ExactReplayable {
         return UnsettledClaimDecision::InterruptAndRequeue {
             reason: "exact_fence_replay",
         };
@@ -71,7 +83,7 @@ mod tests {
             queue_status: QueueEntryStatus::Dequeued,
             attempt_state: ExecutionAttemptState::Open,
             terminal_turn_completed: None,
-            replay_is_exactly_fenced: false,
+            replay_fence: ReplayFence::Ambiguous,
             recovery_of_attempt_id: None,
         }
     }
@@ -94,7 +106,7 @@ mod tests {
     fn exact_fence_allows_one_replay() {
         assert_eq!(
             plan_unsettled_claim(&UnsettledClaimFacts {
-                replay_is_exactly_fenced: true,
+                replay_fence: ReplayFence::ExactReplayable,
                 ..facts()
             }),
             UnsettledClaimDecision::InterruptAndRequeue {
@@ -107,7 +119,7 @@ mod tests {
     fn replay_attempt_is_quarantined_instead_of_looping() {
         assert_eq!(
             plan_unsettled_claim(&UnsettledClaimFacts {
-                replay_is_exactly_fenced: true,
+                replay_fence: ReplayFence::ExactReplayable,
                 recovery_of_attempt_id: Some("attempt:original".into()),
                 ..facts()
             }),
@@ -123,6 +135,20 @@ mod tests {
             plan_unsettled_claim(&facts()),
             UnsettledClaimDecision::InterruptAndQuarantine {
                 reason: "replay_fence_ambiguous",
+            }
+        );
+    }
+
+    #[test]
+    fn revoked_replay_authority_is_quarantined_even_for_recovery_attempt() {
+        assert_eq!(
+            plan_unsettled_claim(&UnsettledClaimFacts {
+                replay_fence: ReplayFence::Revoked,
+                recovery_of_attempt_id: Some("attempt:original".into()),
+                ..facts()
+            }),
+            UnsettledClaimDecision::InterruptAndQuarantine {
+                reason: "task_result_wait_cancelled",
             }
         );
     }

--- a/tests/scripted_agent_provider.rs
+++ b/tests/scripted_agent_provider.rs
@@ -159,9 +159,19 @@ async fn scripted_agent_provider_drives_tool_loop_and_captures_requests() -> Res
         .find(|result| result.tool_use_id == "agent-get-1")
         .expect("AgentGet result should be returned to the provider");
     assert!(!agent_get_result.is_error);
+    let agent_get_content: serde_json::Value = serde_json::from_str(&agent_get_result.content)?;
     assert!(
-        agent_get_result.content.contains("\"agent\""),
-        "AgentGet tool result should preserve the structured result envelope"
+        agent_get_content
+            .pointer("/result/agent")
+            .is_some_and(|value| value.is_object())
+            || (agent_get_content
+                .get("provider_projection_truncated")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+                && agent_get_content
+                    .get("output_ref")
+                    .is_some_and(|value| value.is_string())),
+        "AgentGet tool result should preserve either the full result or its canonical truncation receipt"
     );
 
     let state = runtime.agent_state().await?;

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -875,6 +875,13 @@
         "required": false
       },
       {
+        "long": "message-id",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
         "long": "no-backup",
         "short": null,
         "default_value": null,


### PR DESCRIPTION
## Summary

- classify an exact cancelled task wait as typed revoked continuation authority
- converge its lingering dequeued/open TaskResult claim through the canonical interrupt-and-quarantine planner used by bootstrap, online conflict handling, and debug recovery
- add exact `--message-id` scheduler-recovery targeting plus claim age, lane-blocking, and health diagnostics
- document the fail-closed boundary and add planner, runtime, fault-injection, CLI, and provider regressions

## Runtime contract

A cancelled exact task wait is negative authority evidence: the runtime must not restore the wait, replay the TaskResult, or mark the claim processed. The canonical recovery atomically interrupts the execution attempt, quarantines the queue entry, releases the execution lane, and records the shared `task_result_wait_cancelled` reason.

Missing, duplicate, or identity-mismatched wait evidence remains ambiguous and ineligible for automatic recovery.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- focused planner/runtime/CLI regressions
- `cargo test runtime::tests::runtime_state --lib`
- `cargo test --all-targets`: all relevant tests passed except one pre-existing timing-sensitive `sleep_only_completion_keeps_last_assistant_message_from_previous_round` timeout under the full concurrent suite; its immediate isolated rerun passed

## Operational boundary

This change does not deploy, restart services, mutate production data, or run recovery apply against production.
