### PR TITLE
chore: prepare v0.32.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,15 +204,16 @@ jobs:
 
           Holon ${GITHUB_REF_NAME} is part of the Rust runtime line. The Rust runtime is now the main \`holon\` binary.
 
-          This patch release hardens scheduler activation settlement and recovery: reducer-consumed duplicate TaskResult messages now terminalize with explicit reducer-only Turn evidence, unsettled scheduler claims are reconciled through bounded one-shot recovery that quarantines poison claims while releasing execution lanes, and claims whose task waits were revoked fail closed through the same interrupt-and-quarantine path.
+          This release completes the canonical-only scheduler cutover. Holon no longer exposes the legacy scheduler selector or compatibility protocol, and runtime recovery now derives authority exclusively from primary execution facts.
+
+          The database upgrade removes obsolete scheduler authority and control schema through a transactional, idempotent, fail-closed migration. Back up the database before upgrading. After migration, rollback to v0.31.1 requires restoring the pre-migration database backup; old binaries must not open the migrated database.
 
           Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64.
 
           ## Changes
 
-          - Terminalize reducer-consumed duplicate/suppressed TaskResult messages with explicit reducer-only terminal Turns instead of fabricated provider or assistant evidence, and settle replayed task-restart messages idempotently ([#2601](https://github.com/holon-run/holon/pull/2601)).
-          - Reconcile unsettled scheduler claims through a shared pure planner across bootstrap, online settlement failure, and scheduler-recovery debug: replay is bounded to one fenced recovery generation, repeated or ambiguous poison claims are interrupted and quarantined with durable audit evidence while execution lanes are released, and unsettled/quarantined claim counts surface through agent status and metrics ([#2602](https://github.com/holon-run/holon/pull/2602)).
-          - Quarantine claims with revoked task waits: a cancelled exact task wait is treated as negative continuation authority and converged through the canonical interrupt-and-quarantine planner, with exact \`--message-id\` scheduler-recovery targeting plus claim age, lane-blocking, and health diagnostics ([#2603](https://github.com/holon-run/holon/pull/2603)).
+          - Retire the legacy scheduler runtime, selector, compatibility protocol, mirror-based recovery paths, and dual-engine release acceptance. Explicit legacy scheduler configuration now fails at startup instead of being ignored or silently falling back ([#2605](https://github.com/holon-run/holon/pull/2605)).
+          - Safely remove obsolete scheduler authority/control tables, triggers, and indexes while retaining primary execution facts and approved immutable audit evidence. The migration refuses active or unsettled legacy state and preserves recovery report/apply/report fixed-point behavior ([#2606](https://github.com/holon-run/holon/pull/2606)).
 
           ## Install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.31.1"
+version = "0.32.0"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Status and compatibility
 
 Holon is under active development. The current recommended release is
-[`v0.31.1`](https://github.com/holon-run/holon/releases/tag/v0.31.1).
+[`v0.32.0`](https://github.com/holon-run/holon/releases/tag/v0.32.0).
 
 The current project focus remains the Rust runtime: agent lifecycle, queues,
 WaitFor/wake, tasks, WorkItems, trust boundaries, local workspaces, and

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -105,7 +105,7 @@ waitable, delegable, and deliverable.
 ## Status and compatibility
 
 The current recommended release is
-[`v0.31.1`](https://github.com/holon-run/holon/releases/tag/v0.31.1).
+[`v0.32.0`](https://github.com/holon-run/holon/releases/tag/v0.32.0).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project maintains

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -8656,7 +8656,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.31.1"
+    "version": "0.32.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -3226,8 +3226,6 @@ export interface components {
                 };
                 /** Format: uint32 */
                 runtime_max_output_tokens: number;
-                /** @enum {string} */
-                scheduler: "legacy" | "canonical";
                 unknown_model_fallback_configured: boolean;
                 vision_default?: string | null;
                 web_search: {
@@ -3336,8 +3334,6 @@ export interface components {
                 };
                 /** Format: uint32 */
                 runtime_max_output_tokens: number;
-                /** @enum {string} */
-                scheduler: "legacy" | "canonical";
                 unknown_model_fallback_configured: boolean;
                 vision_default?: string | null;
                 web_search: {


### PR DESCRIPTION
Minor release preparation for **v0.32.0**, covering the canonical-only scheduler cutover and forward-only obsolete scheduler schema migration landed since v0.31.1:

- #2605 — remove the public legacy scheduler selector/runtime/protocol/recovery dual track and fail closed on explicit legacy configuration
- #2606 — transactionally and idempotently remove obsolete scheduler authority/control schema while retaining primary facts and approved immutable audit evidence

## Changes

- `Cargo.toml` / `Cargo.lock`: version → 0.32.0
- `docs/website/reference/openapi.json` and generated web types: snapshots refreshed for the canonical-only public contract
- `README.md` / `docs/website/README.md`: recommended release link → v0.32.0
- `.github/workflows/release.yml`: release notes updated with the canonical-only cutover and migration/rollback boundary

## Upgrade boundary

Back up the database before upgrading. The v0.32.0 migration is forward-only: after migration, rollback to v0.31.1 requires restoring the pre-migration database backup. Old binaries must not open the migrated database. Explicit legacy scheduler configuration now fails at startup rather than being ignored or silently falling back.

## Verification

Local verification passed:

- `make snapshots-check`
- `make transport-types-check`
- `make fmt-check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test runtime_db --lib`
- `make docker-smoke`
- `make docker-e2e-scheduler-required`

After this PR is merged, the pre-tag Release E2E will run with `release_tag=v0.32.0` and `previous_image=0.31.1`; the tag will only be pushed after its attestation passes.
