### PR TITLE
fix: accept previous release schema in upgrade E2E

### DIFF
--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -2183,7 +2183,16 @@ def run_runtime_case(harness: CaseHarness, case: dict[str, Any]) -> None:
     require(assistant_rounds, "marker assistant round is missing from transcript")
 
 
-def run_runtime_upgrade_v030_case(
+def require_previous_schema_revision(snapshot: dict[str, Any]) -> int:
+    revision = snapshot["schema_revision"]
+    require(
+        isinstance(revision, int) and revision > 0,
+        f"previous release produced an invalid schema revision: {snapshot}",
+    )
+    return revision
+
+
+def run_runtime_upgrade_previous_release_case(
     harness: CaseHarness, case: dict[str, Any]
 ) -> None:
     require(
@@ -2206,10 +2215,7 @@ def run_runtime_upgrade_v030_case(
         old_snapshot["integrity_check"] == "ok",
         f"old database is invalid: {old_snapshot}",
     )
-    require(
-        old_snapshot["schema_revision"] == 25,
-        f"previous release did not produce schema 25: {old_snapshot}",
-    )
+    old_schema_revision = require_previous_schema_revision(old_snapshot)
     require(
         old_snapshot["messages"] and old_snapshot["briefs"],
         f"previous release did not persist the marker: {old_snapshot}",
@@ -2225,7 +2231,7 @@ def run_runtime_upgrade_v030_case(
         f"migrated database is invalid: {migrated}",
     )
     require(
-        migrated["schema_revision"] > old_snapshot["schema_revision"],
+        migrated["schema_revision"] > old_schema_revision,
         f"candidate did not advance the schema: {migrated}",
     )
     require(
@@ -4219,7 +4225,7 @@ def run_scheduler_checkpoint_replay_case(
 
 CASE_RUNNERS = {
     "runtime-auth-model-delivery": run_runtime_case,
-    "runtime-upgrade-v030": run_runtime_upgrade_v030_case,
+    "runtime-upgrade-v030": run_runtime_upgrade_previous_release_case,
     "memory-agent-home-persistence": run_memory_case,
     "workspace-restart-lifecycle": run_workspace_case,
     "workitem-wait-restart-complete": run_workitem_case,

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -2184,7 +2184,7 @@ def run_runtime_case(harness: CaseHarness, case: dict[str, Any]) -> None:
 
 
 def require_previous_schema_revision(snapshot: dict[str, Any]) -> int:
-    revision = snapshot["schema_revision"]
+    revision = snapshot.get("schema_revision")
     require(
         isinstance(revision, int) and revision > 0,
         f"previous release produced an invalid schema revision: {snapshot}",

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -78,7 +78,7 @@
       "requires_previous_image": true,
       "provider_mode": "stub",
       "stub_scenario": "runtime-upgrade-v030",
-      "description": "Run v0.30.0 against a shared volume, persist one agent turn, upgrade the same database to the candidate, verify baseline provenance and preserved data, then complete a new agent turn.",
+      "description": "Run the previous release against a shared volume, persist one agent turn, upgrade the same database to the candidate, verify baseline provenance and preserved data, then complete a new agent turn.",
       "phases": [
         {
           "id": "old-release",

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -39,11 +39,12 @@ class DockerE2ERunnerTests(unittest.TestCase):
         )
 
     def test_previous_schema_revision_rejects_invalid_revision(self) -> None:
-        with self.assertRaisesRegex(
-            AssertionError,
-            "previous release produced an invalid schema revision",
-        ):
-            runner.require_previous_schema_revision({"schema_revision": 0})
+        for snapshot in ({"schema_revision": 0}, {}):
+            with self.subTest(snapshot=snapshot), self.assertRaisesRegex(
+                AssertionError,
+                "previous release produced an invalid schema revision",
+            ):
+                runner.require_previous_schema_revision(snapshot)
 
     def setUp(self) -> None:
         self.manifest = json.loads(runner.DEFAULT_MANIFEST.read_text())

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -28,6 +28,23 @@ STUB_SPEC.loader.exec_module(stub)
 
 
 class DockerE2ERunnerTests(unittest.TestCase):
+    def test_previous_schema_revision_accepts_supported_release_schemas(self) -> None:
+        self.assertEqual(
+            runner.require_previous_schema_revision({"schema_revision": 25}),
+            25,
+        )
+        self.assertEqual(
+            runner.require_previous_schema_revision({"schema_revision": 46}),
+            46,
+        )
+
+    def test_previous_schema_revision_rejects_invalid_revision(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            "previous release produced an invalid schema revision",
+        ):
+            runner.require_previous_schema_revision({"schema_revision": 0})
+
     def setUp(self) -> None:
         self.manifest = json.loads(runner.DEFAULT_MANIFEST.read_text())
         runner.validate_manifest(self.manifest)


### PR DESCRIPTION
## Summary

- remove the Release E2E upgrade gate's hard-coded v0.30.0/schema 25 assumption
- accept any valid positive previous-release schema revision while preserving the requirement that the candidate advances the schema
- keep the stable `runtime-upgrade-v030` scenario ID for attestation compatibility, but update its user-facing description
- cover both schema 25 and v0.31.1's schema 46 in unit tests

## Why

Release E2E run 31978421758 used `previous_image=0.31.1` correctly, but failed before migration because the runner asserted that the previous database must be schema 25. v0.31.1 correctly produced schema 46, so the gate had retained an obsolete v0.30.0-specific precondition.

## Verification

- `python3 -m unittest discover -s tests -p 'test_docker_e2e_runner.py'` (76 passed)
- `python3 scripts/docker-e2e.py --validate-manifest`
- `python3 -m py_compile scripts/docker_e2e/runner.py tests/test_docker_e2e_runner.py`
- `git diff --check`
- real upgrade case using `ghcr.io/holon-run/holon:0.31.1` and the immutable v0.32.0 candidate digest from run 31978421758: `PASS runtime-upgrade-v030`
