### PR TITLE
fix: fail closed on invalid previous release input

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -10,12 +10,11 @@ on:
         description: Intended release tag, for example v0.14.0.
         required: true
       previous_image:
-        description: Previous release image used by upgrade cases.
+        description: Full previous release image reference. Mutually exclusive with previous_ref; invalid references fail.
         required: false
       previous_ref:
-        description: Git tag of the previous release. Used to build the previous image when previous_image is not published.
+        description: Git tag used to build the previous image when previous_image is omitted.
         required: false
-        default: v0.30.0
       model:
         description: Real model route.
         required: false
@@ -133,11 +132,32 @@ jobs:
           PREVIOUS_REF: ${{ inputs.previous_ref }}
         run: |
           set -euo pipefail
-          if [ -n "${PREVIOUS_IMAGE_INPUT}" ] \
-            && docker manifest inspect "${PREVIOUS_IMAGE_INPUT}" >/dev/null 2>&1; then
-            echo "image=${PREVIOUS_IMAGE_INPUT}" >> "$GITHUB_OUTPUT"
+          if [ -n "${PREVIOUS_IMAGE_INPUT}" ] && [ -n "${PREVIOUS_REF}" ]; then
+            echo "previous_image and previous_ref are mutually exclusive" >&2
+            exit 1
+          fi
+          if [ -n "${PREVIOUS_IMAGE_INPUT}" ]; then
+            echo "Resolving previous release from explicit image: ${PREVIOUS_IMAGE_INPUT}"
+            if ! docker manifest inspect "${PREVIOUS_IMAGE_INPUT}" >/dev/null; then
+              echo "previous_image is not a resolvable container image: ${PREVIOUS_IMAGE_INPUT}" >&2
+              exit 1
+            fi
+            {
+              echo "image=${PREVIOUS_IMAGE_INPUT}"
+              echo "source=previous_image"
+              echo "ref="
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          if [ -z "${PREVIOUS_REF}" ]; then
+            echo "one of previous_image or previous_ref is required" >&2
+            exit 1
+          fi
+          if [[ ! "${PREVIOUS_REF}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "previous_ref must be a release tag such as v0.31.1: ${PREVIOUS_REF}" >&2
+            exit 1
+          fi
+          echo "Building previous release image from release assets for ${PREVIOUS_REF}"
           version="${PREVIOUS_REF#v}"
           workdir="$(mktemp -d)"
           trap 'rm -rf "${workdir}"' EXIT
@@ -177,7 +197,11 @@ jobs:
           DOCKERFILE
           tag="holon-e2e-previous:${version}"
           docker build --tag "${tag}" "${workdir}"
-          echo "image=${tag}" >> "$GITHUB_OUTPUT"
+          {
+            echo "image=${tag}"
+            echo "source=previous_ref"
+            echo "ref=${PREVIOUS_REF}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run release core E2E
         env:
@@ -238,6 +262,7 @@ jobs:
         run: |
           python3 - <<'PY'
           import json
+          import os
           from pathlib import Path
 
           summary = json.loads(
@@ -260,6 +285,9 @@ jobs:
               f"- Status: **{summary['status']}**",
               f"- Candidate: `{summary['image']['ref']}`",
               f"- Git SHA: `{summary['git_sha']}`",
+              f"- Previous release image: `{os.environ['PREVIOUS_IMAGE']}`",
+              f"- Previous release source: `{os.environ['PREVIOUS_SOURCE']}`",
+              f"- Previous release ref: `{os.environ['PREVIOUS_REF'] or 'n/a'}`",
               f"- Deterministic scheduler gate: **{scheduler_report['status']}**",
               f"- Scheduler live canary: **{canary['status'] if canary else 'missing'}**",
               f"- Runtime schema revision: `{scheduler_report['runtime_schema_revision']}`",
@@ -277,10 +305,14 @@ jobs:
               lines.append(
                   f"| `{case['id']}` | {case['status']} | {case['duration_seconds']}s |"
               )
-          Path(__import__("os").environ["GITHUB_STEP_SUMMARY"]).write_text(
+          Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text(
               "\n".join(lines) + "\n"
           )
           PY
+        env:
+          PREVIOUS_IMAGE: ${{ steps.previous.outputs.image }}
+          PREVIOUS_SOURCE: ${{ steps.previous.outputs.source }}
+          PREVIOUS_REF: ${{ steps.previous.outputs.ref }}
 
       - name: Write release E2E attestation
         run: |
@@ -337,6 +369,11 @@ jobs:
               "model_route": summary["model_route"],
               "image": summary["image"],
               "image_digest": summary["image_digest"],
+              "previous_release": {
+                  "image": os.environ["PREVIOUS_IMAGE"],
+                  "source": os.environ["PREVIOUS_SOURCE"],
+                  "ref": os.environ["PREVIOUS_REF"] or None,
+              },
               "scheduler_acceptance": scheduler_report,
               "scheduler_coverage": coverage_report,
               "scheduler_live_canary": canary_report,
@@ -355,6 +392,9 @@ jobs:
         env:
           CANDIDATE_REF: ${{ inputs.candidate_ref }}
           CANDIDATE_SHA: ${{ needs.candidate.outputs.sha }}
+          PREVIOUS_IMAGE: ${{ steps.previous.outputs.image }}
+          PREVIOUS_SOURCE: ${{ steps.previous.outputs.source }}
+          PREVIOUS_REF: ${{ steps.previous.outputs.ref }}
           RELEASE_TAG: ${{ inputs.release_tag }}
 
       - name: Prepare safe evidence upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,14 @@ jobs:
              and .status == "pass"
              and (.image.ref | contains("@sha256:"))
              and (.model_route | length > 0)
+             and (.previous_release.image | type == "string" and length > 0)
+             and (
+               (.previous_release.source == "previous_image"
+                and .previous_release.ref == null)
+               or
+               (.previous_release.source == "previous_ref"
+                and (.previous_release.ref | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")))
+             )
              and .scheduler_acceptance.schema_version == 1
              and .scheduler_acceptance.status == "pass"
              and .scheduler_acceptance.git_sha == $sha

--- a/docs/release.md
+++ b/docs/release.md
@@ -18,7 +18,13 @@ from a commit whose crate version is `0.13.0`.
 
 Before creating the tag:
 
-1. Run the `Release E2E` workflow with the candidate commit and intended tag.
+1. Run the `Release E2E` workflow with the candidate commit, intended tag, and
+   exactly one previous-release source:
+   - `previous_image`: a full, resolvable container image reference; or
+   - `previous_ref`: a release tag such as `v0.31.1`, used to build an image
+     from that release's verified Linux binary asset.
+   The workflow fails rather than falling back when an explicit image is
+   invalid, when both inputs are set, or when neither input is set.
 2. Select the protected `release-e2e` environment approval.
 3. Confirm the uploaded `summary.json`, JUnit report, and secret scan all pass.
 4. Record the successful workflow run and candidate digest in the release
@@ -84,7 +90,8 @@ Before pushing the tag, verify:
 - the public GHCR tags promote the verified candidate digest rather than
   rebuilding a new image
 - when an upgrade case is available, it used the current recommended release
-  image as `previous_image`
+  through exactly one of `previous_image` or `previous_ref`, and the attestation
+  records the resolved image and source
 - the host real-data upgrade verification passed for the previous release ->
   candidate pair (`scripts/upgrade-verify-realdata/README.md`): migration,
   preservation, and cross-upgrade memory recall with a real model

--- a/docs/testing/docker-acceptance.md
+++ b/docs/testing/docker-acceptance.md
@@ -233,6 +233,12 @@ jobs:
    scheduler-tagged cases with `--scheduler-matrix` in one attested runner
    invocation.
 
+The manual dispatch must provide exactly one previous-release source.
+`previous_image` is a full container image reference and is validated without
+fallback; `previous_ref` is a release tag used to download the checksummed Linux
+binary and build the local upgrade image. The resolved image, source kind, and
+release ref are recorded in the run summary and attestation.
+
 The E2E job has read-only repository/package permissions and cannot publish a
 GitHub release, promote `latest`, or update Homebrew. Evidence is retained as a
 workflow artifact. Its attestation embeds the machine-readable scheduler

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -302,6 +302,47 @@ class DockerE2ERunnerTests(unittest.TestCase):
             self.assertNotIn("HOLON_E2E_PROVIDER_ENV_FILE", job_env)
             self.assertNotIn("HOLON_E2E_PROVIDER_CONFIG_FILE", job_env)
 
+    def test_release_workflow_fails_closed_for_previous_release_inputs(self) -> None:
+        release = (ROOT / ".github/workflows/release-e2e.yml").read_text()
+        inputs = release.split("    inputs:\n", 1)[1].split("\npermissions:", 1)[0]
+        prepare = release.split(
+            "      - name: Prepare previous release image\n", 1
+        )[1].split("      - name:", 1)[0]
+
+        self.assertNotIn("default: v0.30.0", inputs)
+        self.assertIn(
+            "previous_image and previous_ref are mutually exclusive",
+            prepare,
+        )
+        self.assertIn(
+            'if ! docker manifest inspect "${PREVIOUS_IMAGE_INPUT}"',
+            prepare,
+        )
+        self.assertIn(
+            "previous_image is not a resolvable container image",
+            prepare,
+        )
+        self.assertIn(
+            "one of previous_image or previous_ref is required",
+            prepare,
+        )
+        self.assertIn("source=previous_image", prepare)
+        self.assertIn("source=previous_ref", prepare)
+        self.assertIn('"previous_release": {', release)
+        self.assertIn('"image": os.environ["PREVIOUS_IMAGE"]', release)
+        self.assertIn('"source": os.environ["PREVIOUS_SOURCE"]', release)
+        self.assertIn('"ref": os.environ["PREVIOUS_REF"] or None', release)
+        publish = (ROOT / ".github/workflows/release.yml").read_text()
+        self.assertIn(".previous_release.image", publish)
+        self.assertIn(
+            '.previous_release.source == "previous_image"',
+            publish,
+        )
+        self.assertIn(
+            '.previous_release.source == "previous_ref"',
+            publish,
+        )
+
     def test_scheduler_required_profile_selects_all_stub_cases(self) -> None:
         profile = runner.resolve_profile(self.manifest, "scheduler-required")
         selected = runner.select_cases(


### PR DESCRIPTION
## 摘要

- `previous_image` 与 `previous_ref` 改为互斥且至少提供一个，避免无效显式镜像静默回退到默认 release ref
- `previous_image` 必须能够被 Docker 解析；`previous_ref` 明确构建对应 release binary fallback image
- 在 Release E2E summary/attestation 中记录实际 previous release 的 image、source 与 ref，并在 release workflow 中验证 provenance
- 更新发布文档和 workflow 静态回归测试

## 原因

此前传入 `previous_image=0.31.1` 时，Docker 无法将其解析为完整镜像引用，workflow 随后静默回退到默认 `previous_ref=v0.30.0`，导致 gate 虽成功但并未验证计划中的 `v0.31.1 → v0.32.0` 升级路径。

## 验证

- `python3 tests/test_docker_e2e_runner.py`
- `python3 scripts/docker-e2e.py --validate-manifest`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- PyYAML 解析 `.github/workflows/release-e2e.yml` 与 `.github/workflows/release.yml`
- `git diff --check`
