### PR TITLE
fix: make schema 47 recovery reach global fixed point

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -583,10 +583,12 @@ pub enum DebugCommands {
     },
     #[command(about = "Inspect scheduler bootstrap recovery candidates without applying repairs")]
     SchedulerRecovery {
-        #[arg(long)]
+        #[arg(long, conflicts_with = "all_affected")]
         agent: Option<String>,
-        #[arg(long)]
+        #[arg(long, conflicts_with = "all_affected")]
         message_id: Option<String>,
+        #[arg(long)]
+        all_affected: bool,
         #[arg(long)]
         json: bool,
         #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1492,6 +1492,7 @@ mod tests {
                 DebugCommands::SchedulerRecovery {
                     agent,
                     message_id,
+                    all_affected,
                     json,
                     apply,
                     no_backup,
@@ -1502,9 +1503,53 @@ mod tests {
         };
         assert_eq!(agent.as_deref(), Some("pm"));
         assert!(message_id.is_none());
+        assert!(!all_affected);
         assert!(json);
         assert!(!apply);
         assert!(!no_backup);
+    }
+
+    #[test]
+    fn debug_scheduler_recovery_all_affected_conflicts_with_selectors() {
+        let cli = Cli::parse_from([
+            "holon",
+            "debug",
+            "scheduler-recovery",
+            "--all-affected",
+            "--json",
+        ]);
+        let Commands::Debug {
+            command:
+                DebugCommands::SchedulerRecovery {
+                    agent,
+                    message_id,
+                    all_affected,
+                    json,
+                    apply,
+                    no_backup,
+                },
+        } = cli.command
+        else {
+            panic!("expected debug scheduler-recovery command");
+        };
+        assert!(agent.is_none());
+        assert!(message_id.is_none());
+        assert!(all_affected);
+        assert!(json);
+        assert!(!apply);
+        assert!(!no_backup);
+
+        for selector in [["--agent", "pm"], ["--message-id", "message-1"]] {
+            assert!(Cli::try_parse_from([
+                "holon",
+                "debug",
+                "scheduler-recovery",
+                "--all-affected",
+                selector[0],
+                selector[1],
+            ])
+            .is_err());
+        }
     }
 
     #[test]
@@ -2536,10 +2581,19 @@ async fn handle_debug_command(config: AppConfig, command: DebugCommands) -> Resu
         DebugCommands::SchedulerRecovery {
             agent,
             message_id,
+            all_affected,
             json,
             apply,
             no_backup,
-        } => print_scheduler_recovery_report(&config, agent, message_id, json, apply, no_backup),
+        } => print_scheduler_recovery_report(
+            &config,
+            agent,
+            message_id,
+            all_affected,
+            json,
+            apply,
+            no_backup,
+        ),
         DebugCommands::SchedulerRecoveryFixture {
             agent,
             objective,
@@ -2608,15 +2662,23 @@ fn print_scheduler_recovery_report(
     config: &AppConfig,
     agent: Option<String>,
     message_id: Option<String>,
+    all_affected: bool,
     json: bool,
     apply: bool,
     no_backup: bool,
 ) -> Result<()> {
-    let agent_id = agent.unwrap_or_else(|| config.default_agent_id.clone());
     let runtime_db = RuntimeDb::open_for_scheduler_recovery(
         config.runtime_db_path(),
         config.runtime_db_lock_path(),
     )?;
+    let _maintenance_lock = apply
+        .then(|| RuntimeDbLock::try_lock(config.runtime_db_maintenance_lock_path()))
+        .transpose()
+        .context("scheduler recovery apply requires holon serve to be stopped")?;
+    if all_affected {
+        return print_all_scheduler_recovery_reports(config, &runtime_db, json, apply, no_backup);
+    }
+    let agent_id = agent.unwrap_or_else(|| config.default_agent_id.clone());
     let storage = AppStorage::new_for_agent(
         config.agent_root_dir().join(&agent_id),
         agent_id.clone(),
@@ -2626,8 +2688,6 @@ fn print_scheduler_recovery_report(
     filter_scheduler_recovery_report(&mut report, message_id.as_deref(), true)?;
     let mut apply_result = None;
     if apply {
-        let _maintenance_lock = RuntimeDbLock::try_lock(config.runtime_db_maintenance_lock_path())
-            .context("scheduler recovery apply requires holon serve to be stopped")?;
         let backup_policy = if no_backup {
             holon::runtime::SchedulerRecoveryBackupPolicy::SkipApproved
         } else {
@@ -2711,6 +2771,126 @@ fn print_scheduler_recovery_report(
             candidate.eligible,
             candidate.reason,
         );
+    }
+    Ok(())
+}
+
+fn print_all_scheduler_recovery_reports(
+    config: &AppConfig,
+    runtime_db: &RuntimeDb,
+    json: bool,
+    apply: bool,
+    no_backup: bool,
+) -> Result<()> {
+    let before = runtime_db.retired_scheduler_cleanup_inventory()?;
+    let agent_ids = before.affected_agents();
+    let mut storages = Vec::with_capacity(agent_ids.len());
+    let mut reports = Vec::with_capacity(agent_ids.len());
+    let mut report_errors = Vec::new();
+    for agent_id in &agent_ids {
+        let storage = AppStorage::new_for_agent(
+            config.agent_root_dir().join(agent_id),
+            agent_id.clone(),
+            runtime_db.clone(),
+        )?;
+        match holon::runtime::scheduler_recovery_report(&storage, runtime_db, agent_id) {
+            Ok(report) => reports.push(Some(report)),
+            Err(error) => {
+                report_errors.push(serde_json::json!({
+                    "agent_id": agent_id,
+                    "error": format!("{error:#}"),
+                }));
+                reports.push(None);
+            }
+        }
+        storages.push(storage);
+    }
+
+    let mut changed = 0;
+    let mut backup_path = None;
+    let mut fallback_results = Vec::new();
+    if apply && !before.is_fixed_point() {
+        if !no_backup {
+            backup_path = Some(runtime_db.create_scheduler_recovery_backup()?);
+        }
+        for ((storage, report), agent_id) in storages.iter().zip(&reports).zip(&agent_ids) {
+            let Some(report) = report else {
+                continue;
+            };
+            changed += holon::runtime::apply_scheduler_recovery_plan_with_backup_policy(
+                storage,
+                runtime_db,
+                agent_id,
+                report,
+                holon::runtime::SchedulerRecoveryBackupPolicy::SkipApproved,
+            )?
+            .0;
+        }
+        let after_exact = runtime_db.retired_scheduler_cleanup_inventory()?;
+        for result in
+            runtime_db.apply_retired_scheduler_cleanup_fallbacks(&after_exact.affected_agents())?
+        {
+            changed += usize::from(!result.actions.is_empty());
+            fallback_results.push(result);
+        }
+    }
+
+    let after = runtime_db.retired_scheduler_cleanup_inventory()?;
+    if json {
+        print_json(&serde_json::json!({
+            "before": before,
+            "reports": reports,
+            "report_errors": report_errors,
+            "apply": apply.then(|| serde_json::json!({
+                "changed": changed,
+                "backup_path": backup_path,
+                "backup_policy": if no_backup { "skip_approved" } else { "required" },
+                "backup_created": backup_path.is_some(),
+                "fallback_results": fallback_results,
+            })),
+            "after": after,
+        }))?;
+    } else {
+        println!(
+            "Scheduler recovery affected agents={} blockers={}",
+            agent_ids.join(","),
+            before.blockers.len()
+        );
+        for (agent_id, report) in agent_ids.iter().zip(&reports) {
+            if let Some(report) = report {
+                println!(
+                    "- {}: candidates={} task_result_claims={} continuations={}",
+                    report.agent_id,
+                    report.candidates.len(),
+                    report.task_result_claim_recoveries.len(),
+                    report.continuation_reconciliations.len(),
+                );
+            } else {
+                println!(
+                    "- {agent_id}: exact recovery report unavailable; typed fallback required"
+                );
+            }
+        }
+        if apply {
+            println!(
+                "- applied recovery changes={} fallbacks={} backup={}",
+                changed,
+                fallback_results.len(),
+                backup_path
+                    .as_ref()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|| "not-created".into())
+            );
+        }
+        println!("- remaining blockers={}", after.blockers.len());
+    }
+    if apply && !after.is_fixed_point() {
+        return Err(anyhow!(
+            "scheduler recovery did not reach the retired scheduler cleanup fixed point: \
+             remaining_blockers={} affected_agents={}",
+            after.blockers.len(),
+            after.affected_agents().join(",")
+        ));
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2830,7 +2830,7 @@ fn print_all_scheduler_recovery_reports(
         for result in
             runtime_db.apply_retired_scheduler_cleanup_fallbacks(&after_exact.affected_agents())?
         {
-            changed += usize::from(!result.actions.is_empty());
+            changed += result.actions.len();
             fallback_results.push(result);
         }
     }

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -19,6 +19,7 @@ use crate::domain::{
     },
 };
 use crate::runtime_db::evidence::content_hash;
+use crate::runtime_db::retired_scheduler_cleanup::retired_scheduler_cleanup_inventory;
 use crate::types::{AgentState, MessageEnvelope, TaskRecord, WaitConditionRecord, WorkItemRecord};
 
 pub struct Migration {
@@ -70,43 +71,19 @@ fn migrate_retired_scheduler_schema(
     migration: &Migration,
 ) -> Result<()> {
     let transaction = connection.transaction()?;
-    let open_attempts: i64 = transaction.query_row(
-        "SELECT COUNT(*) FROM execution_protocol_attempts
-         WHERE lifecycle_state = 'open'",
-        [],
-        |row| row.get(0),
-    )?;
-    let in_flight_work_items: i64 = transaction.query_row(
-        "SELECT COUNT(*) FROM execution_protocol_work_items
-         WHERE lifecycle_state = 'in_flight'",
-        [],
-        |row| row.get(0),
-    )?;
-    let dequeued_queue_entries: i64 = transaction.query_row(
-        "SELECT COUNT(*) FROM queue_entries WHERE status = 'dequeued'",
-        [],
-        |row| row.get(0),
-    )?;
-    if open_attempts > 0 || in_flight_work_items > 0 || dequeued_queue_entries > 0 {
-        let mut affected_agents = transaction.prepare(
-            "SELECT agent_id FROM execution_protocol_attempts WHERE lifecycle_state = 'open'
-             UNION
-             SELECT agent_id FROM execution_protocol_work_items WHERE lifecycle_state = 'in_flight'
-             UNION
-             SELECT agent_id FROM queue_entries WHERE status = 'dequeued'
-             ORDER BY agent_id",
-        )?;
-        let affected_agents = affected_agents
-            .query_map([], |row| row.get::<_, String>(0))?
-            .collect::<rusqlite::Result<Vec<_>>>()?
-            .join(",");
+    let inventory = retired_scheduler_cleanup_inventory(&transaction)?;
+    if !inventory.is_fixed_point() {
+        let open_attempts = inventory.open_execution_attempts();
+        let in_flight_work_items = inventory.in_flight_execution_work_items();
+        let dequeued_queue_entries = inventory.dequeued_queue_entries();
+        let affected_agents = inventory.affected_agents().join(",");
         bail!(
             "retired scheduler schema migration requires a recovery fixed point: \
              open_execution_attempts={open_attempts}, \
              in_flight_execution_work_items={in_flight_work_items}, \
              dequeued_queue_entries={dequeued_queue_entries}, \
              affected_agents={affected_agents}; \
-             stop holon, then run `holon debug scheduler-recovery --agent <affected-agent>` \
+             stop holon, then run `holon debug scheduler-recovery --all-affected` \
              report/apply/report and retry (v0.31.1 remains the supported rollback binary)"
         );
     }

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -15,6 +15,7 @@ pub mod evidence;
 pub mod migrations;
 pub mod repositories;
 pub mod retention;
+pub mod retired_scheduler_cleanup;
 pub mod storage_domain;
 pub(crate) mod transitions;
 pub mod types;
@@ -32,6 +33,11 @@ pub use crate::runtime_db::index_outbox::{
 pub use crate::runtime_db::retention::{
     RuntimeDbCompactReport, RuntimeDbRetentionPolicy, RuntimeDbRetentionReport,
     RuntimeDbRetentionTableReport,
+};
+pub use crate::runtime_db::retired_scheduler_cleanup::{
+    RetiredSchedulerCleanupBlocker, RetiredSchedulerCleanupBlockerKind,
+    RetiredSchedulerCleanupInventory, RetiredSchedulerFallbackAction,
+    RetiredSchedulerFallbackActionKind, RetiredSchedulerFallbackResult,
 };
 pub use crate::runtime_db::storage_domain::{ExpectedStorageDomain, StorageDomainSnapshot};
 pub use crate::runtime_db::types::{
@@ -367,6 +373,10 @@ impl RuntimeDb {
         Ok(backup_path)
     }
 
+    pub fn create_scheduler_recovery_backup(&self) -> Result<PathBuf> {
+        self.create_verified_backup("scheduler-recovery")
+    }
+
     pub fn transaction<T>(&self, f: impl FnMut(&Transaction<'_>) -> Result<T>) -> Result<T> {
         self.writer.append_wait(f)
     }
@@ -398,6 +408,39 @@ impl RuntimeDb {
     pub fn current_schema_version(&self) -> Result<i64> {
         let connection = self.connection()?;
         current_schema_version(&connection)
+    }
+
+    pub fn retired_scheduler_cleanup_inventory(&self) -> Result<RetiredSchedulerCleanupInventory> {
+        let connection = self.connection()?;
+        retired_scheduler_cleanup::retired_scheduler_cleanup_inventory(&connection)
+    }
+
+    pub fn apply_retired_scheduler_cleanup_fallback(
+        &self,
+        agent_id: &str,
+    ) -> Result<RetiredSchedulerFallbackResult> {
+        self.apply_retired_scheduler_cleanup_fallbacks(&[agent_id.to_string()])
+            .map(|mut results| {
+                results
+                    .pop()
+                    .expect("one fallback result is returned for one agent")
+            })
+    }
+
+    pub fn apply_retired_scheduler_cleanup_fallbacks(
+        &self,
+        agent_ids: &[String],
+    ) -> Result<Vec<RetiredSchedulerFallbackResult>> {
+        self.transaction(|tx| {
+            agent_ids
+                .iter()
+                .map(|agent_id| {
+                    retired_scheduler_cleanup::apply_retired_scheduler_cleanup_fallback(
+                        tx, agent_id,
+                    )
+                })
+                .collect()
+        })
     }
 
     pub fn work_items(&self) -> WorkItemRepository<'_> {

--- a/src/runtime_db/retired_scheduler_cleanup.rs
+++ b/src/runtime_db/retired_scheduler_cleanup.rs
@@ -1,0 +1,387 @@
+use std::collections::BTreeSet;
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::Utc;
+use rusqlite::{Connection, OptionalExtension, Transaction};
+use serde::Serialize;
+
+use crate::domain::execution_protocol::{
+    self, CommandResult, ConversationOutcome, ExecutionAttemptState, ExecutionBinding,
+    ExecutionOutcome, ExecutionOutcomeRecord, WorkItemExecutionState, WorkItemOutcome,
+};
+use crate::ids;
+use crate::runtime_db::evidence::{append_audit_event_tx, append_message_tx};
+use crate::runtime_db::repositories::upsert_queue_entry_tx;
+use crate::runtime_db::transitions::execution_protocol_repository::{
+    load_state_unchecked_tx, persist_state_tx,
+};
+use crate::types::{
+    AuditEvent, AuthorityClass, MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority,
+    QueueEntryRecord, QueueEntryStatus,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetiredSchedulerCleanupBlockerKind {
+    OpenExecutionAttempt,
+    InFlightExecutionWorkItem,
+    DequeuedQueueEntry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RetiredSchedulerCleanupBlocker {
+    pub kind: RetiredSchedulerCleanupBlockerKind,
+    pub agent_id: String,
+    pub record_id: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct RetiredSchedulerCleanupInventory {
+    pub blockers: Vec<RetiredSchedulerCleanupBlocker>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetiredSchedulerFallbackActionKind {
+    InterruptOpenExecutionAttempt,
+    ResumeInFlightExecutionWorkItem,
+    QuarantineDequeuedQueueEntry,
+    EnqueueAgentRecoveryEvent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RetiredSchedulerFallbackAction {
+    pub kind: RetiredSchedulerFallbackActionKind,
+    pub record_id: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RetiredSchedulerFallbackResult {
+    pub agent_id: String,
+    pub recovery_message_id: Option<String>,
+    pub protected_message_ids: Vec<String>,
+    pub actions: Vec<RetiredSchedulerFallbackAction>,
+}
+
+impl RetiredSchedulerCleanupInventory {
+    pub fn is_fixed_point(&self) -> bool {
+        self.blockers.is_empty()
+    }
+
+    pub fn open_execution_attempts(&self) -> usize {
+        self.count(RetiredSchedulerCleanupBlockerKind::OpenExecutionAttempt)
+    }
+
+    pub fn in_flight_execution_work_items(&self) -> usize {
+        self.count(RetiredSchedulerCleanupBlockerKind::InFlightExecutionWorkItem)
+    }
+
+    pub fn dequeued_queue_entries(&self) -> usize {
+        self.count(RetiredSchedulerCleanupBlockerKind::DequeuedQueueEntry)
+    }
+
+    pub fn affected_agents(&self) -> Vec<String> {
+        self.blockers
+            .iter()
+            .map(|blocker| blocker.agent_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    fn count(&self, kind: RetiredSchedulerCleanupBlockerKind) -> usize {
+        self.blockers
+            .iter()
+            .filter(|blocker| blocker.kind == kind)
+            .count()
+    }
+}
+
+pub(crate) fn retired_scheduler_cleanup_inventory(
+    connection: &Connection,
+) -> Result<RetiredSchedulerCleanupInventory> {
+    let mut blockers = Vec::new();
+    collect_blockers(
+        connection,
+        "SELECT agent_id, attempt_id
+         FROM execution_protocol_attempts
+         WHERE lifecycle_state = 'open'
+         ORDER BY agent_id, attempt_id",
+        RetiredSchedulerCleanupBlockerKind::OpenExecutionAttempt,
+        &mut blockers,
+    )?;
+    collect_blockers(
+        connection,
+        "SELECT agent_id, work_item_id
+         FROM execution_protocol_work_items
+         WHERE lifecycle_state = 'in_flight'
+         ORDER BY agent_id, work_item_id",
+        RetiredSchedulerCleanupBlockerKind::InFlightExecutionWorkItem,
+        &mut blockers,
+    )?;
+    collect_blockers(
+        connection,
+        "SELECT agent_id, message_id
+         FROM queue_entries
+         WHERE status = 'dequeued'
+         ORDER BY agent_id, message_id",
+        RetiredSchedulerCleanupBlockerKind::DequeuedQueueEntry,
+        &mut blockers,
+    )?;
+    Ok(RetiredSchedulerCleanupInventory { blockers })
+}
+
+fn collect_blockers(
+    connection: &Connection,
+    sql: &str,
+    kind: RetiredSchedulerCleanupBlockerKind,
+    blockers: &mut Vec<RetiredSchedulerCleanupBlocker>,
+) -> Result<()> {
+    let mut statement = connection.prepare(sql)?;
+    blockers.extend(
+        statement
+            .query_map([], |row| {
+                Ok(RetiredSchedulerCleanupBlocker {
+                    kind,
+                    agent_id: row.get(0)?,
+                    record_id: row.get(1)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?,
+    );
+    Ok(())
+}
+
+pub(crate) fn apply_retired_scheduler_cleanup_fallback(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+) -> Result<RetiredSchedulerFallbackResult> {
+    let inventory = retired_scheduler_cleanup_inventory(tx)?;
+    let blockers = inventory
+        .blockers
+        .into_iter()
+        .filter(|blocker| blocker.agent_id == agent_id)
+        .collect::<Vec<_>>();
+    if blockers.is_empty() {
+        return Ok(RetiredSchedulerFallbackResult {
+            agent_id: agent_id.to_string(),
+            recovery_message_id: None,
+            protected_message_ids: Vec::new(),
+            actions: Vec::new(),
+        });
+    }
+
+    let mut state = load_state_unchecked_tx(tx, agent_id)
+        .with_context(|| format!("loading damaged execution partition for agent {agent_id}"))?;
+    let now = Utc::now();
+    let now_text = now.to_rfc3339();
+    let recovery_message_id = ids::message_id();
+    let mut protected_message_ids = BTreeSet::new();
+    let mut actions = Vec::new();
+
+    for attempt in state
+        .attempts
+        .values()
+        .filter(|attempt| attempt.state == ExecutionAttemptState::Open)
+    {
+        if let Some(message_id) = attempt.source_message_id.as_deref() {
+            require_message_evidence(tx, agent_id, message_id)?;
+            protected_message_ids.insert(message_id.to_string());
+        }
+    }
+    for blocker in blockers
+        .iter()
+        .filter(|blocker| blocker.kind == RetiredSchedulerCleanupBlockerKind::DequeuedQueueEntry)
+    {
+        require_message_evidence(tx, agent_id, &blocker.record_id)?;
+        protected_message_ids.insert(blocker.record_id.clone());
+    }
+
+    for work_item in state
+        .work_items
+        .values_mut()
+        .filter(|record| matches!(record.state, WorkItemExecutionState::InFlight { .. }))
+    {
+        let generation = work_item
+            .generation()
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("WorkItem recovery generation overflow"))?;
+        work_item.state = WorkItemExecutionState::Runnable {
+            generation,
+            recovery_ref: Some(recovery_message_id.clone()),
+        };
+    }
+    for blocker in blockers.iter().filter(|blocker| {
+        blocker.kind == RetiredSchedulerCleanupBlockerKind::InFlightExecutionWorkItem
+    }) {
+        actions.push(RetiredSchedulerFallbackAction {
+            kind: RetiredSchedulerFallbackActionKind::ResumeInFlightExecutionWorkItem,
+            record_id: blocker.record_id.clone(),
+            reason: "retired_scheduler_cleanup_released_in_flight_work_item".into(),
+        });
+    }
+
+    let open_attempt_ids = state
+        .attempts
+        .values()
+        .filter(|attempt| attempt.state == ExecutionAttemptState::Open)
+        .map(|attempt| attempt.attempt_id.clone())
+        .collect::<Vec<_>>();
+    for attempt_id in open_attempt_ids {
+        let attempt = state
+            .attempts
+            .get(&attempt_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("open execution attempt disappeared from recovery state"))?;
+        let outcome_id = format!("retired-scheduler-cleanup:{attempt_id}");
+        let outcome = ExecutionOutcomeRecord {
+            outcome_id: outcome_id.clone(),
+            attempt_id: attempt_id.clone(),
+            outcome: match attempt.binding {
+                ExecutionBinding::WorkItem { .. } => {
+                    ExecutionOutcome::WorkItem(WorkItemOutcome::Interrupted {
+                        reason: "retired_scheduler_cleanup".into(),
+                    })
+                }
+                ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. } => {
+                    ExecutionOutcome::Conversation(ConversationOutcome::Interrupted {
+                        reason: "retired_scheduler_cleanup".into(),
+                    })
+                }
+                ExecutionBinding::Command => {
+                    ExecutionOutcome::Command(CommandResult::Quarantined {
+                        reason: "retired_scheduler_cleanup".into(),
+                    })
+                }
+            },
+            created_at: now_text.clone(),
+        };
+        let attempt = state
+            .attempts
+            .get_mut(&attempt_id)
+            .expect("attempt was read from the same state");
+        attempt.state = ExecutionAttemptState::Interrupted;
+        attempt.terminal_outcome_id = Some(outcome_id.clone());
+        attempt.terminal_at = Some(now_text.clone());
+        state.outcomes.insert(outcome_id, outcome);
+        actions.push(RetiredSchedulerFallbackAction {
+            kind: RetiredSchedulerFallbackActionKind::InterruptOpenExecutionAttempt,
+            record_id: attempt_id,
+            reason: "retired_scheduler_cleanup_interrupted_unrecoverable_attempt".into(),
+        });
+    }
+    execution_protocol::assert_invariants(&state).map_err(|error| {
+        anyhow!("retired scheduler fallback could not repair execution partition: {error}")
+    })?;
+    persist_state_tx(tx, &state)?;
+
+    let mut dequeued = tx.prepare(
+        "SELECT payload_json
+         FROM queue_entries
+         WHERE agent_id = ?1 AND status = 'dequeued'
+         ORDER BY message_id",
+    )?;
+    let dequeued = dequeued
+        .query_map([agent_id], |row| row.get::<_, String>(0))?
+        .map(|payload| {
+            serde_json::from_str::<QueueEntryRecord>(&payload?)
+                .context("decoding dequeued queue entry for retired scheduler fallback")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    for mut entry in dequeued {
+        entry.status = QueueEntryStatus::Quarantined;
+        entry.updated_at = now;
+        upsert_queue_entry_tx(tx, &entry)?;
+        actions.push(RetiredSchedulerFallbackAction {
+            kind: RetiredSchedulerFallbackActionKind::QuarantineDequeuedQueueEntry,
+            record_id: entry.message_id,
+            reason: "retired_scheduler_cleanup_side_effect_unknown".into(),
+        });
+    }
+
+    let protected_message_ids = protected_message_ids.into_iter().collect::<Vec<_>>();
+    actions.push(RetiredSchedulerFallbackAction {
+        kind: RetiredSchedulerFallbackActionKind::EnqueueAgentRecoveryEvent,
+        record_id: recovery_message_id.clone(),
+        reason: "retired_scheduler_cleanup_requires_agent_reconciliation".into(),
+    });
+    let mut recovery_message = MessageEnvelope::new(
+        agent_id,
+        MessageKind::InternalFollowup,
+        MessageOrigin::System {
+            subsystem: "scheduler_recovery".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Json {
+            value: serde_json::json!({
+                "kind": "retired_scheduler_cleanup_recovery",
+                "recovery_message_id": recovery_message_id,
+                "protected_message_ids": protected_message_ids,
+                "actions": actions,
+                "instruction": "Inspect the protected original messages and resume or reconcile interrupted work.",
+            }),
+        },
+    );
+    recovery_message.id = recovery_message_id.clone();
+    for message_id in &protected_message_ids {
+        recovery_message
+            .source_refs
+            .insert(message_id.clone(), format!("message:{message_id}"));
+    }
+    let (recovery_message, _) = append_message_tx(tx, &recovery_message)?;
+    upsert_queue_entry_tx(
+        tx,
+        &QueueEntryRecord {
+            message_id: recovery_message.id.clone(),
+            agent_id: agent_id.to_string(),
+            priority: Priority::Next,
+            status: QueueEntryStatus::Queued,
+            created_at: recovery_message.created_at,
+            updated_at: recovery_message.created_at,
+        },
+    )?;
+    append_audit_event_tx(
+        tx,
+        Some(agent_id),
+        &AuditEvent::legacy(
+            "retired_scheduler_cleanup_fallback_applied",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "recovery_message_id": recovery_message.id,
+                "protected_message_ids": protected_message_ids,
+                "actions": actions,
+            }),
+        ),
+    )?;
+
+    Ok(RetiredSchedulerFallbackResult {
+        agent_id: agent_id.to_string(),
+        recovery_message_id: Some(recovery_message.id),
+        protected_message_ids,
+        actions,
+    })
+}
+
+fn require_message_evidence(tx: &Transaction<'_>, agent_id: &str, message_id: &str) -> Result<()> {
+    let payload = tx
+        .query_row(
+            "SELECT payload_json FROM messages WHERE evidence_id = ?1",
+            [message_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .ok_or_else(|| {
+            anyhow!(
+                "retired scheduler fallback cannot preserve source message {message_id}; \
+                 refusing automatic recovery"
+            )
+        })?;
+    let message: MessageEnvelope = serde_json::from_str(&payload)
+        .with_context(|| format!("decoding protected source message {message_id}"))?;
+    if message.id != message_id || message.agent_id != agent_id {
+        bail!("retired scheduler fallback source message identity mismatch for {message_id}");
+    }
+    Ok(())
+}

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -1639,7 +1639,7 @@ INSERT INTO scheduler_rollout_command_results (
             assert!(
                 error
                     .to_string()
-                    .contains("run `holon debug scheduler-recovery --agent <affected-agent>`"),
+                    .contains("run `holon debug scheduler-recovery --all-affected`"),
                 "{error:#}"
             );
             assert!(
@@ -1668,6 +1668,388 @@ INSERT INTO scheduler_rollout_command_results (
                 );
             }
         }
+        Ok(())
+    }
+
+    #[test]
+    fn retired_scheduler_cleanup_fallback_preserves_input_and_reaches_fixed_point() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        prepare_pre_execution_protocol_claim(
+            &db,
+            "agent-a",
+            "work-a",
+            "message-a",
+            "activation-a",
+        )?;
+        let original_message = db
+            .messages()
+            .recent(Some("agent-a"), usize::MAX)?
+            .into_iter()
+            .find(|message| message.id == "message-a")
+            .expect("operator message exists");
+        drop(db);
+        downgrade_before_execution_protocol(&db_path)?;
+        restore_pre_execution_protocol_work_demand(&db_path, "agent-a", "work-a")?;
+        {
+            let mut connection = open_connection(&db_path)?;
+            migrate_through(&mut connection, 46)?;
+        }
+
+        let db = RuntimeDb::open_for_scheduler_recovery(&db_path, &lock_path)?;
+        assert_eq!(db.retired_scheduler_cleanup_inventory()?.blockers.len(), 3);
+        let result = db.apply_retired_scheduler_cleanup_fallback("agent-a")?;
+        assert_eq!(result.protected_message_ids, vec!["message-a".to_string()]);
+        assert!(result.recovery_message_id.is_some());
+        assert!(db.retired_scheduler_cleanup_inventory()?.is_fixed_point());
+
+        let messages = db.messages().recent(Some("agent-a"), usize::MAX)?;
+        assert_eq!(
+            messages.iter().find(|message| message.id == "message-a"),
+            Some(&original_message)
+        );
+        let recovery_message = messages
+            .iter()
+            .find(|message| Some(message.id.as_str()) == result.recovery_message_id.as_deref())
+            .expect("fallback enqueues an agent recovery event");
+        assert_eq!(
+            recovery_message.kind,
+            crate::types::MessageKind::InternalFollowup
+        );
+        let crate::types::MessageBody::Json { value } = &recovery_message.body else {
+            panic!("recovery event must use a typed JSON body");
+        };
+        assert_eq!(
+            value["actions"]
+                .as_array()
+                .expect("recovery actions are an array")
+                .len(),
+            result.actions.len()
+        );
+        assert_eq!(
+            value["actions"]
+                .as_array()
+                .expect("recovery actions are an array")
+                .last()
+                .and_then(|action| action["kind"].as_str()),
+            Some("enqueue_agent_recovery_event")
+        );
+        assert_eq!(
+            db.queue_entries()
+                .latest("message-a")?
+                .expect("original queue entry exists")
+                .status,
+            QueueEntryStatus::Quarantined
+        );
+        assert_eq!(
+            db.queue_entries()
+                .latest(&recovery_message.id)?
+                .expect("recovery queue entry exists")
+                .status,
+            QueueEntryStatus::Queued
+        );
+        let state = db
+            .transitions()
+            .load_execution_protocol_state_if_initialized("agent-a")?
+            .expect("execution partition exists");
+        assert!(matches!(
+            state
+                .attempts
+                .get("activation-a")
+                .expect("attempt remains durable")
+                .state,
+            crate::domain::execution_protocol::ExecutionAttemptState::Interrupted
+        ));
+        assert!(matches!(
+            state
+                .work_items
+                .get("work-a")
+                .expect("WorkItem remains durable")
+                .state,
+            WorkItemExecutionState::Runnable {
+                recovery_ref: Some(_),
+                ..
+            }
+        ));
+        drop(db);
+
+        RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 47);
+        Ok(())
+    }
+
+    #[test]
+    fn retired_scheduler_cleanup_fallback_refuses_missing_source_message() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        prepare_pre_execution_protocol_claim(
+            &db,
+            "agent-a",
+            "work-a",
+            "message-a",
+            "activation-a",
+        )?;
+        drop(db);
+        downgrade_before_execution_protocol(&db_path)?;
+        restore_pre_execution_protocol_work_demand(&db_path, "agent-a", "work-a")?;
+        {
+            let mut connection = open_connection(&db_path)?;
+            migrate_through(&mut connection, 46)?;
+            connection.execute("DELETE FROM messages WHERE message_id = 'message-a'", [])?;
+        }
+
+        let db = RuntimeDb::open_for_scheduler_recovery(&db_path, &lock_path)?;
+        let before = db.retired_scheduler_cleanup_inventory()?;
+        let error = db
+            .apply_retired_scheduler_cleanup_fallback("agent-a")
+            .expect_err("fallback must protect missing operator input");
+        assert!(
+            error
+                .to_string()
+                .contains("cannot preserve source message message-a"),
+            "{error:#}"
+        );
+        assert_eq!(db.retired_scheduler_cleanup_inventory()?, before);
+        Ok(())
+    }
+
+    #[test]
+    fn retired_scheduler_cleanup_fallback_handles_partial_execution_facts() -> Result<()> {
+        for (case, damage_sql, expected_blockers) in [
+            (
+                "missing_attempt",
+                "DELETE FROM execution_protocol_attempts
+                 WHERE agent_id = 'agent-a' AND attempt_id = 'activation-a'",
+                2,
+            ),
+            (
+                "isolated_queue",
+                "DELETE FROM execution_protocol_attempts
+                 WHERE agent_id = 'agent-a' AND attempt_id = 'activation-a';
+                 DELETE FROM execution_protocol_work_items
+                 WHERE agent_id = 'agent-a' AND work_item_id = 'work-a'",
+                1,
+            ),
+            (
+                "bare_in_flight_work_item",
+                "DELETE FROM execution_protocol_attempts
+                 WHERE agent_id = 'agent-a' AND attempt_id = 'activation-a';
+                 DELETE FROM queue_entries
+                 WHERE agent_id = 'agent-a' AND message_id = 'message-a'",
+                1,
+            ),
+        ] {
+            let (_temp_dir, db_path, lock_path) = temp_paths()?;
+            let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+            prepare_pre_execution_protocol_claim(
+                &db,
+                "agent-a",
+                "work-a",
+                "message-a",
+                "activation-a",
+            )?;
+            drop(db);
+            downgrade_before_execution_protocol(&db_path)?;
+            restore_pre_execution_protocol_work_demand(&db_path, "agent-a", "work-a")?;
+            {
+                let mut connection = open_connection(&db_path)?;
+                migrate_through(&mut connection, 46)?;
+                connection.execute_batch(damage_sql)?;
+            }
+
+            let db = RuntimeDb::open_for_scheduler_recovery(&db_path, &lock_path)?;
+            assert_eq!(
+                db.retired_scheduler_cleanup_inventory()?.blockers.len(),
+                expected_blockers,
+                "{case}"
+            );
+            let result = db.apply_retired_scheduler_cleanup_fallback("agent-a")?;
+            assert!(
+                !result.actions.is_empty(),
+                "{case} must produce typed recovery actions"
+            );
+            assert!(
+                db.retired_scheduler_cleanup_inventory()?.is_fixed_point(),
+                "{case} must reach the migration fixed point"
+            );
+            assert!(
+                result.recovery_message_id.is_some(),
+                "{case} must wake the agent for reconciliation"
+            );
+            drop(db);
+
+            RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+            assert_eq!(
+                current_schema_version(&open_connection(&db_path)?)?,
+                47,
+                "{case}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn retired_scheduler_cleanup_fallback_repairs_nonreciprocal_execution_facts() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        prepare_pre_execution_protocol_claim(
+            &db,
+            "agent-a",
+            "work-a",
+            "message-a",
+            "activation-a",
+        )?;
+        drop(db);
+        downgrade_before_execution_protocol(&db_path)?;
+        restore_pre_execution_protocol_work_demand(&db_path, "agent-a", "work-a")?;
+        {
+            let mut connection = open_connection(&db_path)?;
+            migrate_through(&mut connection, 46)?;
+            let payload = connection.query_row(
+                "SELECT payload_json
+                 FROM execution_protocol_work_items
+                 WHERE agent_id = 'agent-a' AND work_item_id = 'work-a'",
+                [],
+                |row| row.get::<_, String>(0),
+            )?;
+            let mut record: WorkItemExecutionRecord = serde_json::from_str(&payload)?;
+            record.state = WorkItemExecutionState::InFlight {
+                generation: record.generation(),
+                attempt_id: "missing-attempt".into(),
+            };
+            connection.execute(
+                "UPDATE execution_protocol_work_items
+                 SET payload_json = ?1
+                 WHERE agent_id = 'agent-a' AND work_item_id = 'work-a'",
+                [serde_json::to_string(&record)?],
+            )?;
+        }
+
+        let db = RuntimeDb::open_for_scheduler_recovery(&db_path, &lock_path)?;
+        assert_eq!(db.retired_scheduler_cleanup_inventory()?.blockers.len(), 3);
+        let result = db.apply_retired_scheduler_cleanup_fallback("agent-a")?;
+        assert!(result.actions.iter().any(|action| {
+            action.kind
+                == crate::runtime_db::RetiredSchedulerFallbackActionKind::ResumeInFlightExecutionWorkItem
+        }));
+        assert!(result.actions.iter().any(|action| {
+            action.kind
+                == crate::runtime_db::RetiredSchedulerFallbackActionKind::InterruptOpenExecutionAttempt
+        }));
+        assert!(db.retired_scheduler_cleanup_inventory()?.is_fixed_point());
+        drop(db);
+
+        RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 47);
+        Ok(())
+    }
+
+    #[test]
+    fn retired_scheduler_cleanup_fallback_converges_for_multiple_agents() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        for suffix in ["a", "b"] {
+            prepare_pre_execution_protocol_claim(
+                &db,
+                &format!("agent-{suffix}"),
+                &format!("work-{suffix}"),
+                &format!("message-{suffix}"),
+                &format!("activation-{suffix}"),
+            )?;
+        }
+        drop(db);
+        downgrade_before_execution_protocol(&db_path)?;
+        for suffix in ["a", "b"] {
+            restore_pre_execution_protocol_work_demand(
+                &db_path,
+                &format!("agent-{suffix}"),
+                &format!("work-{suffix}"),
+            )?;
+        }
+        {
+            let mut connection = open_connection(&db_path)?;
+            migrate_through(&mut connection, 46)?;
+        }
+
+        let db = RuntimeDb::open_for_scheduler_recovery(&db_path, &lock_path)?;
+        let before = db.retired_scheduler_cleanup_inventory()?;
+        assert_eq!(
+            before.affected_agents(),
+            vec!["agent-a".to_string(), "agent-b".to_string()]
+        );
+        assert_eq!(before.blockers.len(), 6);
+        for agent_id in before.affected_agents() {
+            let first = db.apply_retired_scheduler_cleanup_fallback(&agent_id)?;
+            assert!(!first.actions.is_empty());
+        }
+        assert!(db.retired_scheduler_cleanup_inventory()?.is_fixed_point());
+        for agent_id in ["agent-a", "agent-b"] {
+            let message_count = db.messages().recent(Some(agent_id), usize::MAX)?.len();
+            let second = db.apply_retired_scheduler_cleanup_fallback(agent_id)?;
+            assert!(
+                second.actions.is_empty(),
+                "repeated fallback must be a fixed point for {agent_id}"
+            );
+            assert!(second.recovery_message_id.is_none());
+            assert_eq!(
+                db.messages().recent(Some(agent_id), usize::MAX)?.len(),
+                message_count,
+                "fixed-point apply must not enqueue another recovery event for {agent_id}"
+            );
+        }
+        drop(db);
+
+        RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 47);
+        Ok(())
+    }
+
+    #[test]
+    fn retired_scheduler_cleanup_fallbacks_are_atomic_across_agents() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        for suffix in ["a", "b"] {
+            prepare_pre_execution_protocol_claim(
+                &db,
+                &format!("agent-{suffix}"),
+                &format!("work-{suffix}"),
+                &format!("message-{suffix}"),
+                &format!("activation-{suffix}"),
+            )?;
+        }
+        drop(db);
+        downgrade_before_execution_protocol(&db_path)?;
+        for suffix in ["a", "b"] {
+            restore_pre_execution_protocol_work_demand(
+                &db_path,
+                &format!("agent-{suffix}"),
+                &format!("work-{suffix}"),
+            )?;
+        }
+        {
+            let mut connection = open_connection(&db_path)?;
+            migrate_through(&mut connection, 46)?;
+            connection.execute("DELETE FROM messages WHERE message_id = 'message-b'", [])?;
+        }
+
+        let db = RuntimeDb::open_for_scheduler_recovery(&db_path, &lock_path)?;
+        let before = db.retired_scheduler_cleanup_inventory()?;
+        let agent_a_messages = db.messages().recent(Some("agent-a"), usize::MAX)?;
+        let error = db
+            .apply_retired_scheduler_cleanup_fallbacks(&before.affected_agents())
+            .expect_err("one unprotected operator input must abort the global fallback");
+        assert!(
+            error
+                .to_string()
+                .contains("cannot preserve source message message-b"),
+            "{error:#}"
+        );
+        assert_eq!(db.retired_scheduler_cleanup_inventory()?, before);
+        assert_eq!(
+            db.messages().recent(Some("agent-a"), usize::MAX)?,
+            agent_a_messages,
+            "the first agent must roll back when a later agent cannot be recovered"
+        );
         Ok(())
     }
 

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -1164,14 +1164,11 @@ fn stored_outcome_matches(existing: &str, outcome: &ExecutionOutcomeRecord) -> R
     Ok(existing == *outcome)
 }
 
-pub(super) fn load_state_tx(
+pub(crate) fn load_state_unchecked_tx(
     tx: &Transaction<'_>,
     agent_id: &str,
 ) -> Result<ExecutionProtocolState> {
-    if !partition_exists_tx(tx, agent_id)? {
-        bail!("execution protocol partition for agent {agent_id} is not initialized");
-    }
-    let state = ExecutionProtocolState {
+    Ok(ExecutionProtocolState {
         agent_id: agent_id.to_owned(),
         attempts: load_payload_map(
             tx,
@@ -1191,7 +1188,17 @@ pub(super) fn load_state_tx(
              FROM execution_protocol_outcomes WHERE agent_id = ?1",
             agent_id,
         )?,
-    };
+    })
+}
+
+pub(super) fn load_state_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+) -> Result<ExecutionProtocolState> {
+    if !partition_exists_tx(tx, agent_id)? {
+        bail!("execution protocol partition for agent {agent_id} is not initialized");
+    }
+    let state = load_state_unchecked_tx(tx, agent_id)?;
     execution_protocol::assert_invariants(&state)
         .map_err(|error| anyhow!("stored execution protocol state is invalid: {error}"))?;
     Ok(state)

--- a/src/runtime_db/transitions/execution_protocol_repository.rs
+++ b/src/runtime_db/transitions/execution_protocol_repository.rs
@@ -1164,6 +1164,10 @@ fn stored_outcome_matches(existing: &str, outcome: &ExecutionOutcomeRecord) -> R
     Ok(existing == *outcome)
 }
 
+/// Loads execution-protocol rows without requiring a partition marker or
+/// asserting cross-row invariants.
+///
+/// Repair callers must restore and assert those invariants before committing.
 pub(crate) fn load_state_unchecked_tx(
     tx: &Transaction<'_>,
     agent_id: &str,

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -855,6 +855,16 @@
         "required": false
       },
       {
+        "long": "all-affected",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
         "long": "apply",
         "short": null,
         "default_value": null,


### PR DESCRIPTION
## Summary

- centralize migration 47's retired-scheduler blocker inventory in a typed, shared preflight
- add `scheduler-recovery --all-affected` so one offline run can recover every affected agent
- prefer canonical typed recovery when facts are complete, and use an explicit availability-first fallback for malformed or orphaned blockers
- preserve original operator input, emit agent-visible recovery events, and require a global fixed point before a successful apply
- keep backup, rollback, predecessor-schema, and unsupported-schema behavior fail-closed

## Context

PR #2610 breaks the bootstrap deadlock by allowing the current binary's offline recovery command to open schema 46 without first applying migration 47. That bridge is necessary, but recovery previously covered only blockers with complete canonical facts. Orphaned queue entries, open attempts, bare in-flight work items, and non-reciprocal execution facts could remain after a successful command and permanently block migration 47.

This PR makes the migration preflight and recovery planner consume the same typed blocker inventory. An apply succeeds only when the full database reaches the schema 47 cleanup fixed point.

The fallback is intentionally availability-first: when an execution cannot be reconstructed precisely, it is explicitly interrupted and converted into recoverable agent-visible state instead of requiring manual SQLite edits. It does not extend support below the published schema floor.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
- `make snapshots-check`

Coverage includes typed inventory parity, read-only planning, `--all-affected`, multi-agent atomicity, missing attempt/queue facts, bare in-flight work items, non-reciprocal facts, operator-input preservation, recovery-event creation, rollback/backup semantics, and post-apply fixed-point enforcement.