### PR TITLE
test: cover interrupted schema 47 upgrades

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -318,6 +318,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 - <<'PY'
+          import hashlib
           import json
           import os
           from pathlib import Path
@@ -358,6 +359,66 @@ jobs:
               raise SystemExit("Scheduler coverage image digest does not match summary")
           if coverage_report["profile"] != "scheduler-required":
               raise SystemExit("Scheduler coverage profile is not scheduler-required")
+          interrupted_case = next(
+              (
+                  result
+                  for result in summary["case_results"]
+                  if result["base_id"] == "runtime-upgrade-interrupted-schema47"
+              ),
+              None,
+          )
+          if interrupted_case is None or interrupted_case["status"] != "pass":
+              raise SystemExit(
+                  "Interrupted schema 47 previous-image upgrade case did not pass"
+              )
+          recovery_path = Path(
+              "target/docker-e2e/release-core/"
+              "runtime-upgrade-interrupted-schema47/"
+              "upgrade-schema47-recovery-attestation.json"
+          )
+          recovery = json.loads(recovery_path.read_text())
+          recovery_dir = recovery_path.parent
+          old_snapshot_path = recovery_dir / "upgrade-schema47-old-runtime-db.json"
+          migrated_snapshot_path = (
+              recovery_dir / "upgrade-schema47-migrated-runtime-db.json"
+          )
+          old_snapshot_sha256 = hashlib.sha256(
+              old_snapshot_path.read_bytes()
+          ).hexdigest()
+          migrated_snapshot_sha256 = hashlib.sha256(
+              migrated_snapshot_path.read_bytes()
+          ).hexdigest()
+          old_snapshot = json.loads(old_snapshot_path.read_text())
+          migrated_snapshot = json.loads(migrated_snapshot_path.read_text())
+          report_before = recovery.get("report_before", {})
+          apply = recovery.get("apply", {})
+          report_after = recovery.get("report_after", {})
+          if (
+              recovery["previous_schema_revision"]
+              != old_snapshot.get("schema_revision")
+              or recovery["candidate_schema_revision"]
+              != migrated_snapshot.get("schema_revision")
+              or recovery["candidate_schema_revision"] < 47
+              or recovery["candidate_schema_revision"]
+              <= recovery["previous_schema_revision"]
+              or len(recovery["affected_agents"]) < 2
+              or recovery.get("old_snapshot_sha256") != old_snapshot_sha256
+              or recovery.get("migrated_snapshot_sha256")
+              != migrated_snapshot_sha256
+              or not report_before.get("before", {}).get("blockers")
+              or report_before.get("report_errors")
+              or not apply.get("apply", {}).get("changed")
+              or apply.get("after", {}).get("blockers")
+              or apply.get("report_errors")
+              or report_after.get("before", {}).get("blockers")
+              or report_after.get("after", {}).get("blockers")
+              or report_after.get("report_errors")
+              or report_after.get("reports")
+          ):
+              raise SystemExit(
+                  f"Interrupted schema 47 recovery evidence is invalid: {recovery}"
+              )
+          recovery_sha256 = hashlib.sha256(recovery_path.read_bytes()).hexdigest()
           attestation = {
               "schema_version": 1,
               "release_tag": os.environ["RELEASE_TAG"],
@@ -377,6 +438,16 @@ jobs:
               "scheduler_acceptance": scheduler_report,
               "scheduler_coverage": coverage_report,
               "scheduler_live_canary": canary_report,
+              "interrupted_schema47_upgrade": {
+                  "case": interrupted_case,
+                  "evidence_path": str(recovery_path),
+                  "evidence_sha256": recovery_sha256,
+                  "previous_schema_revision": recovery["previous_schema_revision"],
+                  "candidate_schema_revision": recovery["candidate_schema_revision"],
+                  "affected_agents": recovery["affected_agents"],
+                  "old_snapshot_sha256": recovery["old_snapshot_sha256"],
+                  "migrated_snapshot_sha256": recovery["migrated_snapshot_sha256"],
+              },
               "summary_path": str(summary_path),
               "scheduler_acceptance_path": str(scheduler_report_path),
               "scheduler_coverage_path": str(coverage_report_path),

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -2456,14 +2456,6 @@ def run_runtime_upgrade_interrupted_schema47_case(
         matching,
         "previous image did not retain open agent-lifecycle and WorkItem attempts",
     )
-    for row in matching:
-        payload = json.loads(row["payload_json"])
-        if (
-            row["agent_id"] == lifecycle_agent
-            and payload.get("binding", {}).get("kind") == "agent_lifecycle"
-        ):
-            lifecycle_agent = row["agent_id"]
-            break
     harness.crash()
     prompt_thread.join(timeout=35)
     work_item_thread.join(timeout=35)
@@ -5429,7 +5421,7 @@ def main(argv: list[str] | None = None) -> int:
         selected,
         scheduler_matrix=args.scheduler_matrix,
     )
-    if not args.skip_build and any(
+    if any(
         case.get("provider_mode", profile.get("provider_mode", "live")) == "stub"
         for case, _ in expanded_cases
     ):

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -242,7 +242,9 @@ def merged_runtime_config(
         models = merged.setdefault("models", {})
         require(isinstance(models, dict), "config models must be a JSON object")
         catalog = models.setdefault("catalog", {})
-        require(isinstance(catalog, dict), "config models.catalog must be a JSON object")
+        require(
+            isinstance(catalog, dict), "config models.catalog must be a JSON object"
+        )
         catalog[model] = dict(model_runtime_override)
     return merged
 
@@ -263,8 +265,7 @@ def provider_base_url_env(model: str) -> str:
         )
         return override
     fragment = "".join(
-        character.upper() if character.isalnum() else "_"
-        for character in provider
+        character.upper() if character.isalnum() else "_" for character in provider
     )
     return f"HOLON_{fragment}_BASE_URL"
 
@@ -464,14 +465,14 @@ class CaseHarness:
             "set -euo pipefail; "
             "rss_kb=$(awk '/^VmRSS:/{print $2}' /proc/1/status); "
             "fd_count=$(find /proc/1/fd -maxdepth 1 -type l | wc -l); "
-            "printf '{\"rss_kb\":%s,\"fd_count\":%s,\"state_files\":[' "
-            "\"${rss_kb:-0}\" \"$fd_count\"; "
+            'printf \'{"rss_kb":%s,"fd_count":%s,"state_files":[\' '
+            '"${rss_kb:-0}" "$fd_count"; '
             "first=1; for path in /var/lib/holon/state/runtime.sqlite*; do "
-            "[ -e \"$path\" ] || continue; "
-            "size=$(stat -c %s \"$path\"); "
-            "name=$(basename \"$path\"); "
+            '[ -e "$path" ] || continue; '
+            'size=$(stat -c %s "$path"); '
+            'name=$(basename "$path"); '
             "[ $first -eq 1 ] || printf ','; first=0; "
-            "printf '{\"name\":\"%s\",\"bytes\":%s}' \"$name\" \"$size\"; "
+            'printf \'{"name":"%s","bytes":%s}\' "$name" "$size"; '
             "done; printf ']}'",
             check=False,
             timeout=15,
@@ -542,6 +543,22 @@ class CaseHarness:
             objective,
         )
 
+    def seed_scheduler_recovery_fixture(
+        self,
+        label: str,
+        *,
+        agent: str,
+        objective: str,
+    ) -> dict[str, Any]:
+        return self.offline_debug(
+            label,
+            "scheduler-recovery-fixture",
+            "--agent",
+            agent,
+            "--objective",
+            objective,
+        )
+
     def initialize_workspace(self) -> None:
         self.workspace_parent.mkdir(parents=True, exist_ok=True)
         self.workspace_parent.chmod(0o777)
@@ -568,7 +585,9 @@ class CaseHarness:
         if self.docker("network", "inspect", self.network, check=False).returncode != 0:
             self.docker("network", "create", self.network)
         if self.provider_mode == "stub":
-            require(bool(self.stub_scenario), "stub provider mode requires stub_scenario")
+            require(
+                bool(self.stub_scenario), "stub provider mode requires stub_scenario"
+            )
             stub_state = self.docker(
                 "inspect",
                 "--format",
@@ -619,9 +638,8 @@ class CaseHarness:
             )
             self.runtime_env["OPENAI_API_KEY"] = "deterministic-test-key"
         if (
-            (self.runtime_config or self.model_runtime_override)
-            and not self._model_runtime_override_seeded
-        ):
+            self.runtime_config or self.model_runtime_override
+        ) and not self._model_runtime_override_seeded:
             config = merged_runtime_config(
                 self.runtime_config,
                 self.model,
@@ -751,7 +769,7 @@ class CaseHarness:
         self.stop()
         self.start(wait_idle=wait_idle)
 
-    def crash_restart(self, *, wait_idle: bool = True) -> None:
+    def crash(self) -> None:
         # Kill the container directly with SIGKILL.  This avoids the
         # SIGSTOP/SIGKILL race where the daemon could detect child-process
         # death and record a terminal TaskResult before being stopped.
@@ -799,6 +817,9 @@ class CaseHarness:
             check=False,
         )
         self.base_url = ""
+
+    def crash_restart(self, *, wait_idle: bool = True) -> None:
+        self.crash()
         self.start(wait_idle=wait_idle)
 
     def restart_with_image(self, image: str, *, wait_idle: bool = True) -> None:
@@ -885,7 +906,10 @@ class CaseHarness:
         )
         status = json.loads(result.stdout)
         write_json(self.evidence / "stub-status.json", status)
-        require(status.get("complete") is True, f"stub transcript was not fully consumed: {status}")
+        require(
+            status.get("complete") is True,
+            f"stub transcript was not fully consumed: {status}",
+        )
         require(
             status.get("extra_requests") == 0,
             f"stub received requests after transcript exhaustion: {status}",
@@ -1075,7 +1099,9 @@ class CaseHarness:
                 item for item in items if objective_marker in item.get("objective", "")
             ]
             if len(matches) > 1:
-                write_json(self.evidence / f"{label}-duplicate-work-items.json", matches)
+                write_json(
+                    self.evidence / f"{label}-duplicate-work-items.json", matches
+                )
                 self.capture_context(f"{label}-duplicate")
                 raise AssertionError(
                     f"multiple WorkItems matched {objective_marker}: "
@@ -1106,7 +1132,9 @@ class CaseHarness:
                 item for item in items if objective_marker in item.get("objective", "")
             ]
             if len(matches) > 1:
-                write_json(self.evidence / f"{label}-duplicate-work-items.json", matches)
+                write_json(
+                    self.evidence / f"{label}-duplicate-work-items.json", matches
+                )
                 self.capture_context(f"{label}-duplicate")
                 raise AssertionError(
                     f"multiple WorkItems matched {objective_marker}: "
@@ -1121,8 +1149,7 @@ class CaseHarness:
                 )
             if (
                 len(matches) == 1
-                and matches[0].get("scheduling_state")
-                == expected_scheduling_state
+                and matches[0].get("scheduling_state") == expected_scheduling_state
             ):
                 write_json(self.evidence / f"{label}-work-items.json", items)
                 return matches[0]
@@ -1205,9 +1232,7 @@ class CaseHarness:
         while True:
             page = self.request(
                 "GET",
-                self.agent_path(
-                    f"events?limit={limit}&order=asc&after_seq={cursor}"
-                ),
+                self.agent_path(f"events?limit={limit}&order=asc&after_seq={cursor}"),
             )
             events.extend(page["events"])
             newest_seq = page.get("newest_seq")
@@ -1283,10 +1308,8 @@ class CaseHarness:
         deadline = time.monotonic() + self.timeout_seconds
         last_state = before
         baseline_failure_at = (
-            (before["agent"]["agent"].get("last_runtime_failure") or {}).get(
-                "occurred_at"
-            )
-        )
+            before["agent"]["agent"].get("last_runtime_failure") or {}
+        ).get("occurred_at")
         target_turn_id: str | None = None
         target_turn_index: int | None = None
         event_poll_cursor = baseline_event_seq
@@ -1324,8 +1347,7 @@ class CaseHarness:
                     event.get("payload", {}).get("message_id") == message_id
                     or (
                         target_turn_id is not None
-                        and event.get("payload", {}).get("turn_id")
-                        == target_turn_id
+                        and event.get("payload", {}).get("turn_id") == target_turn_id
                     )
                 )
             ]
@@ -1347,8 +1369,7 @@ class CaseHarness:
                     for event in phase_events
                     if event.get("type") == "turn_terminal"
                     and target_turn_id is not None
-                    and event.get("payload", {}).get("turn_id")
-                    == target_turn_id
+                    and event.get("payload", {}).get("turn_id") == target_turn_id
                 ),
                 None,
             )
@@ -1404,9 +1425,7 @@ class CaseHarness:
     ) -> list[dict[str, Any]]:
         events = self.events(f"{label}-tool-check")
         turn_indexes = {
-            event["payload"].get("turn_id"): int(
-                event["payload"].get("turn_index", 0)
-            )
+            event["payload"].get("turn_id"): int(event["payload"].get("turn_index", 0))
             for event in events
             if event["type"] == "turn_started"
         }
@@ -1445,13 +1464,14 @@ class CaseHarness:
         runtime_failures = [
             event
             for event in events
-            if event["type"] == "runtime_error"
-            and in_scope(event)
+            if event["type"] == "runtime_error" and in_scope(event)
         ]
         if runtime_failures:
             failure = runtime_failures[-1]["payload"]
             source_chain = failure.get("source_chain") or []
-            detail = source_chain[0] if source_chain else failure.get("error", "unknown")
+            detail = (
+                source_chain[0] if source_chain else failure.get("error", "unknown")
+            )
             raise AssertionError(
                 f"runtime failure occurred in {label}: "
                 f"{failure.get('domain', 'unknown')}: {detail}"
@@ -1459,8 +1479,7 @@ class CaseHarness:
         failures = [
             event
             for event in events
-            if event["type"] == "tool_execution_failed"
-            and in_scope(event)
+            if event["type"] == "tool_execution_failed" and in_scope(event)
         ]
         require(not failures, f"tool failures occurred in {label}: {failures}")
         return [
@@ -1505,7 +1524,9 @@ class CaseHarness:
                 },
             )
             return events
-        require(not missing, f"{label} missing successful tools {missing}; got {actual}")
+        require(
+            not missing, f"{label} missing successful tools {missing}; got {actual}"
+        )
         require(
             not forbidden_actual,
             f"{label} used forbidden tools {forbidden_actual}; got {actual}",
@@ -1641,6 +1662,83 @@ class CaseHarness:
         write_json(self.evidence / f"{label}-runtime-db.json", snapshot)
         return snapshot
 
+    def offline_runtime_db_snapshot(self, label: str) -> dict[str, Any]:
+        snapshot_dir = self.evidence / f"{label}-runtime-state"
+        if snapshot_dir.exists():
+            shutil.rmtree(snapshot_dir)
+        snapshot_dir.mkdir(parents=True)
+        self.docker(
+            "run",
+            "--rm",
+            "--user",
+            "0:0",
+            "--volume",
+            f"{self.volume}:/var/lib/holon:ro",
+            "--volume",
+            f"{snapshot_dir}:/snapshot",
+            "--entrypoint",
+            "bash",
+            self.image,
+            "-lc",
+            "set -euo pipefail; cp /var/lib/holon/state/runtime.sqlite* /snapshot/",
+        )
+        database = snapshot_dir / "runtime.sqlite"
+        require(database.is_file(), "offline runtime database snapshot is missing")
+        connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+        connection.row_factory = sqlite3.Row
+        try:
+            tables = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                )
+            }
+            snapshot = {
+                "integrity_check": connection.execute(
+                    "PRAGMA integrity_check"
+                ).fetchone()[0],
+                "schema_revision": connection.execute(
+                    "SELECT COALESCE(MAX(version), 0) FROM schema_migrations"
+                ).fetchone()[0],
+                "tables": sorted(tables),
+                "messages": sqlite_rows(
+                    connection,
+                    "SELECT message_id, agent_id, work_item_id, kind, payload_json "
+                    "FROM messages ORDER BY created_at",
+                ),
+                "queue_entries": sqlite_rows(
+                    connection,
+                    "SELECT message_id, agent_id, status, payload_json "
+                    "FROM queue_entries ORDER BY created_at, updated_at",
+                ),
+                "execution_protocol_attempts": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, attempt_id, lifecycle_state, terminal_outcome_id, "
+                    "payload_json FROM execution_protocol_attempts "
+                    "ORDER BY agent_id, attempt_id",
+                ),
+                "execution_protocol_work_items": sqlite_rows(
+                    connection,
+                    "SELECT agent_id, work_item_id, generation, lifecycle_state, "
+                    "payload_json FROM execution_protocol_work_items "
+                    "ORDER BY agent_id, work_item_id",
+                ),
+                "migration_baselines": (
+                    sqlite_rows(
+                        connection,
+                        "SELECT baseline_id, source_version, target_version, "
+                        "covered_versions_json, schema_fingerprint "
+                        "FROM schema_migration_baselines",
+                    )
+                    if "schema_migration_baselines" in tables
+                    else []
+                ),
+            }
+        finally:
+            connection.close()
+        write_json(self.evidence / f"{label}-runtime-db.json", snapshot)
+        return snapshot
+
     def upgrade_db_snapshot(self, label: str, marker: str) -> dict[str, Any]:
         snapshot_dir = self.evidence / f"{label}-runtime-state"
         if snapshot_dir.exists():
@@ -1721,9 +1819,7 @@ def sqlite_rows(
 def require_processed_queue_entries(
     queue_entries: list[dict[str, Any]], message_ids: set[str]
 ) -> None:
-    matching = [
-        row for row in queue_entries if row.get("message_id") in message_ids
-    ]
+    matching = [row for row in queue_entries if row.get("message_id") in message_ids]
     require(
         len(matching) == len(message_ids)
         and all(row.get("status") == "processed" for row in matching),
@@ -1830,8 +1926,7 @@ def require_scheduler_wait_terminal(
         require(
             any(
                 event.get("disposition") == "triggered"
-                and event.get("external_trigger_id")
-                == callback_external_trigger_id
+                and event.get("external_trigger_id") == callback_external_trigger_id
                 for event in callback_events
             ),
             f"canonical {wait_kind} wait lacked callback trigger evidence: "
@@ -1897,8 +1992,7 @@ def require_execution_attempt_chain(
         (row, attempt)
         for row, attempt in attempts
         if attempt.get("source_message_id") in lifecycle_message_ids
-        and attempt.get("binding")
-        == {"kind": "agent_lifecycle", "agent_id": agent_id}
+        and attempt.get("binding") == {"kind": "agent_lifecycle", "agent_id": agent_id}
     ]
     require(
         len(lifecycle_attempts) == len(lifecycle_message_ids)
@@ -2169,11 +2263,11 @@ def run_runtime_case(harness: CaseHarness, case: dict[str, Any]) -> None:
     ]
     require(len(matching) == 1, f"expected one marker brief: {matching}")
 
-    transcript = harness.request(
-        "GET", harness.agent_path("transcript?limit=200")
-    )
+    transcript = harness.request("GET", harness.agent_path("transcript?limit=200"))
     write_json(harness.evidence / "runtime-delivery-transcript.json", transcript)
-    entries = transcript if isinstance(transcript, list) else transcript.get("entries", [])
+    entries = (
+        transcript if isinstance(transcript, list) else transcript.get("entries", [])
+    )
     assistant_rounds = [
         entry
         for entry in entries
@@ -2243,9 +2337,7 @@ def run_runtime_upgrade_previous_release_case(
         and old_message_ids.issubset(
             {row["message_id"] for row in migrated["messages"]}
         )
-        and old_brief_ids.issubset(
-            {row["evidence_id"] for row in migrated["briefs"]}
-        ),
+        and old_brief_ids.issubset({row["evidence_id"] for row in migrated["briefs"]}),
         f"release data was not preserved: old={old_snapshot}, migrated={migrated}",
     )
 
@@ -2265,6 +2357,234 @@ def run_runtime_upgrade_previous_release_case(
         final_snapshot["messages"] and final_snapshot["briefs"],
         f"upgraded agent did not persist the new marker: {final_snapshot}",
     )
+
+
+def run_runtime_upgrade_interrupted_schema47_case(
+    harness: CaseHarness, case: dict[str, Any]
+) -> None:
+    require(bool(harness.previous_image), f"{case['id']} requires --previous-image")
+    harness.runtime_env["HOLON_SCHEDULER_ACCEPTANCE_FIXTURES"] = "true"
+    candidate_image = harness.image
+    lifecycle_marker = f"UPGRADE-SCHEMA47-LIFECYCLE-{secrets.token_hex(6)}"
+    candidate_marker = f"UPGRADE-SCHEMA47-CANDIDATE-{secrets.token_hex(6)}"
+    work_item_agent = f"upgrade-worker-{secrets.token_hex(4)}"
+    work_item_bootstrap_marker = f"UPGRADE-SCHEMA47-BOOTSTRAP-{secrets.token_hex(6)}"
+    work_item_objective = f"UPGRADE-SCHEMA47-WORKITEM-{secrets.token_hex(6)}"
+    prompt_error: list[str] = []
+    work_item_error: list[str] = []
+
+    harness.image = str(harness.previous_image)
+    harness.initialize_workspace()
+    harness.start()
+    lifecycle_agent = harness.agent_id
+    created_work_item_agent = harness.request(
+        "POST",
+        f"/api/control/agents/{urllib.parse.quote(work_item_agent, safe='')}/create",
+        {
+            "authority_class": "operator_instruction",
+            "template": None,
+        },
+    )
+    write_json(
+        harness.evidence / "upgrade-schema47-workitem-agent.json",
+        created_work_item_agent,
+    )
+    harness.agent_id = work_item_agent
+    try:
+        harness.prompt(
+            "upgrade-schema47-workitem-bootstrap",
+            f"Reply with exactly {work_item_bootstrap_marker}.",
+        )
+    finally:
+        harness.agent_id = lifecycle_agent
+    work_item_path = (
+        "/api/control/agents/"
+        f"{urllib.parse.quote(work_item_agent, safe='')}/work-items"
+    )
+
+    def block_work_item_turn() -> None:
+        try:
+            created = harness.request(
+                "POST",
+                work_item_path,
+                {"objective": work_item_objective},
+            )
+            write_json(
+                harness.evidence / "upgrade-schema47-workitem-created.json",
+                created,
+            )
+        except Exception as error:
+            work_item_error.append(str(error))
+
+    work_item_thread = threading.Thread(target=block_work_item_turn, daemon=True)
+    work_item_thread.start()
+
+    def block_lifecycle_turn() -> None:
+        try:
+            harness.prompt(
+                "upgrade-schema47-lifecycle",
+                case["phases"][0]["prompt"].format(marker=lifecycle_marker),
+            )
+        except Exception as error:
+            prompt_error.append(str(error))
+
+    prompt_thread = threading.Thread(target=block_lifecycle_turn, daemon=True)
+    prompt_thread.start()
+    deadline = time.monotonic() + harness.timeout_seconds
+    old_live: dict[str, Any] | None = None
+    matching: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        old_live = harness.runtime_db_snapshot("upgrade-schema47-open-attempt")
+        matching = [
+            row
+            for row in old_live["execution_protocol_attempts"]
+            if row["lifecycle_state"] == "open"
+        ]
+        binding_kinds = {
+            json.loads(row["payload_json"]).get("binding", {}).get("kind")
+            for row in matching
+        }
+        matching_agents = {row["agent_id"] for row in matching}
+        if {"agent_lifecycle", "work_item"}.issubset(binding_kinds) and {
+            lifecycle_agent,
+            work_item_agent,
+        }.issubset(matching_agents):
+            break
+        matching = []
+        time.sleep(0.5)
+    require(
+        matching,
+        "previous image did not retain open agent-lifecycle and WorkItem attempts",
+    )
+    for row in matching:
+        payload = json.loads(row["payload_json"])
+        if (
+            row["agent_id"] == lifecycle_agent
+            and payload.get("binding", {}).get("kind") == "agent_lifecycle"
+        ):
+            lifecycle_agent = row["agent_id"]
+            break
+    harness.crash()
+    prompt_thread.join(timeout=35)
+    work_item_thread.join(timeout=35)
+    require(
+        not prompt_thread.is_alive() and not work_item_thread.is_alive(),
+        "interrupted previous-image requests did not terminate after SIGKILL",
+    )
+    old_snapshot = harness.offline_runtime_db_snapshot("upgrade-schema47-old")
+    require(
+        old_snapshot["integrity_check"] == "ok", f"old database invalid: {old_snapshot}"
+    )
+    previous_schema_revision = require_previous_schema_revision(old_snapshot)
+    open_attempt_agents = {
+        row["agent_id"]
+        for row in old_snapshot["execution_protocol_attempts"]
+        if row["lifecycle_state"] == "open"
+    }
+    require(
+        {lifecycle_agent, work_item_agent}.issubset(open_attempt_agents),
+        f"multi-agent blockers were not retained: {old_snapshot}",
+    )
+
+    harness.image = candidate_image
+    report = harness.offline_debug(
+        "upgrade-schema47-report-before",
+        "scheduler-recovery",
+        "--all-affected",
+    )
+    apply = harness.offline_debug(
+        "upgrade-schema47-apply",
+        "scheduler-recovery",
+        "--all-affected",
+        "--apply",
+    )
+    fixed_point = harness.offline_debug(
+        "upgrade-schema47-report-after",
+        "scheduler-recovery",
+        "--all-affected",
+    )
+    harness.start()
+    before_turn = int(
+        harness.state("upgrade-schema47-before-candidate")["agent"]["agent"][
+            "turn_index"
+        ]
+    )
+    harness.prompt(
+        "upgrade-schema47-candidate",
+        case["phases"][1]["prompt"].format(marker=candidate_marker),
+    )
+    after_turn = int(
+        harness.state("upgrade-schema47-after-candidate")["agent"]["agent"][
+            "turn_index"
+        ]
+    )
+    require(
+        after_turn > before_turn,
+        "schema 47 candidate did not complete a new canonical turn",
+    )
+    candidate_snapshot = harness.upgrade_db_snapshot(
+        "upgrade-schema47-candidate", candidate_marker
+    )
+    require(
+        candidate_snapshot["messages"] and candidate_snapshot["briefs"],
+        f"schema 47 candidate did not persist the new marker: {candidate_snapshot}",
+    )
+    harness.stop()
+    migrated = harness.offline_runtime_db_snapshot("upgrade-schema47-migrated")
+    candidate_schema_revision = migrated.get("schema_revision")
+    require(
+        migrated["integrity_check"] == "ok"
+        and isinstance(candidate_schema_revision, int)
+        and candidate_schema_revision >= 47
+        and candidate_schema_revision > previous_schema_revision,
+        "candidate did not migrate beyond the previous release at schema 47 or "
+        f"newer: previous={previous_schema_revision}, candidate={migrated}",
+    )
+    retired_tables = {
+        "scheduler_agent_slots",
+        "scheduler_waits",
+        "scheduler_work_demands",
+    }
+    require(
+        retired_tables.isdisjoint(migrated["tables"]),
+        f"retired scheduler tables remain after migration: {migrated['tables']}",
+    )
+    require(
+        len(migrated["migration_baselines"]) == 1,
+        f"schema migration baseline is missing: {migrated}",
+    )
+    require(
+        not [
+            row
+            for row in migrated["execution_protocol_attempts"]
+            if row["lifecycle_state"] == "open"
+        ],
+        f"recovery did not reach the execution fixed point: {migrated}",
+    )
+    old_evidence = harness.evidence / "upgrade-schema47-old-runtime-db.json"
+    migrated_evidence = harness.evidence / "upgrade-schema47-migrated-runtime-db.json"
+    write_json(
+        harness.evidence / "upgrade-schema47-recovery-attestation.json",
+        {
+            "schema_version": 1,
+            "previous_schema_revision": previous_schema_revision,
+            "candidate_schema_revision": candidate_schema_revision,
+            "affected_agents": sorted(open_attempt_agents),
+            "report_before": report,
+            "apply": apply,
+            "report_after": fixed_point,
+            "old_snapshot_sha256": hashlib.sha256(
+                old_evidence.read_bytes()
+            ).hexdigest(),
+            "migrated_snapshot_sha256": hashlib.sha256(
+                migrated_evidence.read_bytes()
+            ).hexdigest(),
+            "prompt_error_after_sigkill": prompt_error,
+            "work_item_error_after_sigkill": work_item_error,
+        },
+    )
+    # Leave the candidate running for the runner's common final context capture.
+    harness.start()
 
 
 def run_memory_case(harness: CaseHarness, case: dict[str, Any]) -> None:
@@ -2295,9 +2615,7 @@ def run_memory_case(harness: CaseHarness, case: dict[str, Any]) -> None:
         message_id=harness.prompt_scope("memory-search")["message_id"],
     )
     search_event = next(
-        event
-        for event in events
-        if event["payload"].get("tool_name") == "MemorySearch"
+        event for event in events if event["payload"].get("tool_name") == "MemorySearch"
     )
     search_result = result_value(harness.tool_detail(search_event, "memory-search"))
     matches = [
@@ -2312,9 +2630,7 @@ def run_memory_case(harness: CaseHarness, case: dict[str, Any]) -> None:
         f"MemorySearch result omitted source_ref: {matches[0]}",
     )
     get_event = next(
-        event
-        for event in events
-        if event["payload"].get("tool_name") == "MemoryGet"
+        event for event in events if event["payload"].get("tool_name") == "MemoryGet"
     )
     get_result = memory_value(
         result_value(harness.tool_detail(get_event, "memory-get"))
@@ -2347,9 +2663,7 @@ def run_memory_case(harness: CaseHarness, case: dict[str, Any]) -> None:
         message_id=harness.prompt_scope("memory-recover")["message_id"],
     )
     recovered_get = next(
-        event
-        for event in events
-        if event["payload"].get("tool_name") == "MemoryGet"
+        event for event in events if event["payload"].get("tool_name") == "MemoryGet"
     )
     recovered = memory_value(
         result_value(harness.tool_detail(recovered_get, "memory-recover-get"))
@@ -2562,8 +2876,7 @@ def run_workitem_case(harness: CaseHarness, case: dict[str, Any]) -> None:
     require(
         len(completed.get("todo_list", [])) == 3
         and all(
-            todo["state"] == "completed"
-            for todo in completed.get("todo_list", [])
+            todo["state"] == "completed" for todo in completed.get("todo_list", [])
         ),
         f"WorkItem todos were not all completed: {completed}",
     )
@@ -2625,8 +2938,7 @@ def recovered_retry_ticks(
     return [
         tick
         for tick in recovered_ticks
-        if tick["status"] == "processed"
-        and tick["idempotency_key"] in failed_keys
+        if tick["status"] == "processed" and tick["idempotency_key"] in failed_keys
     ]
 
 
@@ -2701,9 +3013,7 @@ def run_scheduler_task_wait_resume_case(
             "UpdateWorkItem",
             "CompleteWorkItem",
         ],
-        message_id=harness.prompt_scope("scheduler-task-wait-seed")[
-            "message_id"
-        ],
+        message_id=harness.prompt_scope("scheduler-task-wait-seed")["message_id"],
     )
     work_item_id = item["id"]
     result_brief_id = item.get("result_brief_id")
@@ -2762,7 +3072,11 @@ def run_scheduler_task_wait_resume_case(
         harness,
         snapshot,
         work_item_id=work_item_id,
-        expected_source_kinds=("work_item_continuation", "task_result", "triggered_wait"),
+        expected_source_kinds=(
+            "work_item_continuation",
+            "task_result",
+            "triggered_wait",
+        ),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-task-wait-seed")["message_id"]
         },
@@ -3207,7 +3521,9 @@ def run_scheduler_external_wait_resume_case(
     )
     work_item_id = item["id"]
     require(item["state"] == "completed", f"WorkItem not completed: {item}")
-    require(item["id"] == waiting["id"], "external wait-resume changed WorkItem identity")
+    require(
+        item["id"] == waiting["id"], "external wait-resume changed WorkItem identity"
+    )
     result_brief_id = item.get("result_brief_id")
     require(
         isinstance(result_brief_id, str) and result_brief_id,
@@ -3232,7 +3548,11 @@ def run_scheduler_external_wait_resume_case(
     harness.assert_tools(
         "scheduler-external-resume",
         baseline,
-        [name for name in required if name not in {"CreateWorkItem", "PickWorkItem", "WaitFor"}],
+        [
+            name
+            for name in required
+            if name not in {"CreateWorkItem", "PickWorkItem", "WaitFor"}
+        ],
         forbidden + ["CreateWorkItem", "PickWorkItem", "WaitFor"],
         turn_ids=resume_turn_ids,
     )
@@ -3319,7 +3639,9 @@ def run_scheduler_operator_wait_resume_case(
     )
     work_item_id = item["id"]
     require(item["state"] == "completed", f"WorkItem not completed: {item}")
-    require(item["id"] == waiting["id"], "operator wait-resume changed WorkItem identity")
+    require(
+        item["id"] == waiting["id"], "operator wait-resume changed WorkItem identity"
+    )
     result_brief_id = item.get("result_brief_id")
     require(
         isinstance(result_brief_id, str) and result_brief_id,
@@ -3340,7 +3662,11 @@ def run_scheduler_operator_wait_resume_case(
     harness.assert_tools(
         "scheduler-operator-resume",
         baseline,
-        [name for name in required if name not in {"CreateWorkItem", "PickWorkItem", "WaitFor"}],
+        [
+            name
+            for name in required
+            if name not in {"CreateWorkItem", "PickWorkItem", "WaitFor"}
+        ],
         forbidden + ["CreateWorkItem", "PickWorkItem", "WaitFor"],
         turn_ids=resume_turn_ids,
     )
@@ -3445,9 +3771,7 @@ def run_scheduler_concurrent_claim_fencing_case(
         baseline,
         ["CreateWorkItem", "PickWorkItem", "WaitFor"],
         forbidden + ["GetWorkItem", "UpdateWorkItem", "CompleteWorkItem"],
-        message_id=harness.prompt_scope("scheduler-concurrent-create")[
-            "message_id"
-        ],
+        message_id=harness.prompt_scope("scheduler-concurrent-create")["message_id"],
     )
     work_item_a_id = item_a["id"]
     work_item_b_id = item_b["id"]
@@ -3474,9 +3798,7 @@ def run_scheduler_concurrent_claim_fencing_case(
             f"WorkItem {letter} brief mismatch: {brief}",
         )
     snapshot = harness.runtime_db_snapshot("scheduler-concurrent")
-    messages_by_id = {
-        row["message_id"]: row for row in snapshot["messages"]
-    }
+    messages_by_id = {row["message_id"]: row for row in snapshot["messages"]}
     a_turn_ids = {
         row["turn_id"]
         for row in snapshot["turn_records"]
@@ -3631,18 +3953,14 @@ def run_scheduler_operator_interject_during_wait_case(
         baseline,
         ["CreateWorkItem", "PickWorkItem", "WaitFor"],
         forbidden + ["GetWorkItem", "UpdateWorkItem", "CompleteWorkItem"],
-        message_id=harness.prompt_scope("scheduler-interject-create")[
-            "message_id"
-        ],
+        message_id=harness.prompt_scope("scheduler-interject-create")["message_id"],
     )
     harness.assert_tools(
         "scheduler-interject-b-create",
         baseline,
         ["CreateWorkItem"],
         forbidden + ["PickWorkItem", "WaitFor", "CompleteWorkItem"],
-        message_id=harness.prompt_scope("scheduler-interject-b-create")[
-            "message_id"
-        ],
+        message_id=harness.prompt_scope("scheduler-interject-b-create")["message_id"],
     )
     work_item_a_id = item_a["id"]
     work_item_b_id = item_b["id"]
@@ -3770,9 +4088,7 @@ def run_scheduler_compaction_continuity_case(
         expected_scheduling_state="waiting_operator",
         label="scheduler-compaction-waiting",
     )
-    stimulus_snapshot = harness.runtime_db_snapshot(
-        "scheduler-compaction-stimulus"
-    )
+    stimulus_snapshot = harness.runtime_db_snapshot("scheduler-compaction-stimulus")
     require_turn_local_compaction(
         stimulus_snapshot,
         label="scheduler-compaction",
@@ -3795,13 +4111,13 @@ def run_scheduler_compaction_continuity_case(
         baseline,
         ["CreateWorkItem", "PickWorkItem", "WaitFor"],
         forbidden + ["GetWorkItem", "UpdateWorkItem", "CompleteWorkItem"],
-        message_id=harness.prompt_scope("scheduler-compaction-create")[
-            "message_id"
-        ],
+        message_id=harness.prompt_scope("scheduler-compaction-create")["message_id"],
     )
     work_item_id = item["id"]
     require(item["state"] == "completed", f"WorkItem not completed: {item}")
-    require(item["id"] == waiting["id"], "compaction wait-resume changed WorkItem identity")
+    require(
+        item["id"] == waiting["id"], "compaction wait-resume changed WorkItem identity"
+    )
     result_brief_id = item.get("result_brief_id")
     require(
         isinstance(result_brief_id, str) and result_brief_id,
@@ -3922,9 +4238,7 @@ def run_scheduler_worktree_isolation_case(
         baseline,
         required,
         forbidden,
-        message_id=harness.prompt_scope("scheduler-worktree-lifecycle")[
-            "message_id"
-        ],
+        message_id=harness.prompt_scope("scheduler-worktree-lifecycle")["message_id"],
     )
     work_item_id = item["id"]
     require(item["state"] == "completed", f"WorkItem not completed: {item}")
@@ -4011,9 +4325,7 @@ def run_scheduler_spawn_agent_supervision_case(
         baseline,
         required,
         forbidden,
-        message_id=harness.prompt_scope("scheduler-spawn-and-complete")[
-            "message_id"
-        ],
+        message_id=harness.prompt_scope("scheduler-spawn-and-complete")["message_id"],
     )
     work_item_id = item["id"]
     require(item["state"] == "completed", f"WorkItem not completed: {item}")
@@ -4036,8 +4348,7 @@ def run_scheduler_spawn_agent_supervision_case(
     spawn_detail = harness.tool_detail(spawn_event, "scheduler-spawn")
     spawn_result = result_value(spawn_detail)
     require(
-        isinstance(spawn_result.get("agent_id"), str)
-        and spawn_result["agent_id"],
+        isinstance(spawn_result.get("agent_id"), str) and spawn_result["agent_id"],
         f"SpawnAgent result missing agent_id: {spawn_result}",
     )
     task_handle = spawn_result.get("task_handle") or {}
@@ -4124,9 +4435,7 @@ def run_scheduler_checkpoint_replay_case(
     restarted_a = next(
         item for item in restarted_items if item["id"] == waiting_a["id"]
     )
-    restarted_b = next(
-        item for item in restarted_items if item["id"] == item_b["id"]
-    )
+    restarted_b = next(item for item in restarted_items if item["id"] == item_b["id"])
     require(
         restarted_a.get("scheduling_state") == "waiting_external",
         f"WorkItem A did not survive restart in waiting state: {restarted_a}",
@@ -4222,10 +4531,12 @@ def run_scheduler_checkpoint_replay_case(
     )
 
 
-
 CASE_RUNNERS = {
     "runtime-auth-model-delivery": run_runtime_case,
     "runtime-upgrade-v030": run_runtime_upgrade_previous_release_case,
+    "runtime-upgrade-interrupted-schema47": (
+        run_runtime_upgrade_interrupted_schema47_case
+    ),
     "memory-agent-home-persistence": run_memory_case,
     "workspace-restart-lifecycle": run_workspace_case,
     "workitem-wait-restart-complete": run_workitem_case,
@@ -4327,6 +4638,18 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
                 isinstance(case["requires_previous_image"], bool),
                 f"{case_id} requires_previous_image must be boolean",
             )
+        result_schema_revision_snapshot = case.get(
+            "result_schema_revision_snapshot"
+        )
+        require(
+            result_schema_revision_snapshot is None
+            or (
+                isinstance(result_schema_revision_snapshot, str)
+                and result_schema_revision_snapshot
+                and "/" not in result_schema_revision_snapshot
+            ),
+            f"{case_id} result_schema_revision_snapshot must be a file label",
+        )
         coverage_ids = case.get("coverage_ids", [])
         require(
             isinstance(coverage_ids, list)
@@ -4341,12 +4664,13 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
         )
         if provider_mode == "stub":
             require(
-                isinstance(case.get("stub_scenario"), str)
-                and case["stub_scenario"],
+                isinstance(case.get("stub_scenario"), str) and case["stub_scenario"],
                 f"{case_id} stub provider mode requires stub_scenario",
             )
         runtime_env = case.get("runtime_env", {})
-        require(isinstance(runtime_env, dict), f"{case_id} runtime_env must be an object")
+        require(
+            isinstance(runtime_env, dict), f"{case_id} runtime_env must be an object"
+        )
         require(
             "HOLON_SCHEDULER" not in runtime_env,
             f"{case_id} must not configure the retired HOLON_SCHEDULER selector",
@@ -4425,9 +4749,7 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
     known_case_ids = {case["id"] for case in cases}
     cases_by_id = {case["id"]: case for case in cases}
     known_coverage_ids = {
-        coverage_id
-        for case in cases
-        for coverage_id in case.get("coverage_ids", [])
+        coverage_id for case in cases for coverage_id in case.get("coverage_ids", [])
     }
     for profile_id, profile in profiles.items():
         profile_case_ids = profile.get("case_ids", [])
@@ -4475,9 +4797,7 @@ def select_cases(
     return selected
 
 
-def resolve_profile(
-    manifest: dict[str, Any], profile_id: str | None
-) -> dict[str, Any]:
+def resolve_profile(manifest: dict[str, Any], profile_id: str | None) -> dict[str, Any]:
     if profile_id is None:
         return {
             "gate_kind": "suite",
@@ -4607,7 +4927,8 @@ def collect_case_metrics(evidence: Path) -> dict[str, Any]:
                 provider_rounds += 1
                 payload = event.get("payload", {})
                 provider_attempts += len(
-                    (payload.get("provider_attempt_timeline") or {}).get("attempts") or []
+                    (payload.get("provider_attempt_timeline") or {}).get("attempts")
+                    or []
                 )
                 usage = payload.get("token_usage") or {}
                 for key in token_usage:
@@ -4637,7 +4958,31 @@ def collect_case_metrics(evidence: Path) -> dict[str, Any]:
     }
 
 
-def collect_case_schema_revision(evidence: Path) -> int | None:
+def collect_case_schema_revision(
+    evidence: Path,
+    result_snapshot: str | None = None,
+) -> int | None:
+    if result_snapshot is not None:
+        path = evidence / f"{result_snapshot}-runtime-db.json"
+        require(
+            path.is_file(),
+            f"result schema revision snapshot is missing for case "
+            f"{evidence.name}: {path.name}",
+        )
+        try:
+            value = json.loads(path.read_text()).get("schema_revision")
+        except (OSError, json.JSONDecodeError) as error:
+            raise AssertionError(
+                f"result schema revision snapshot is invalid for case "
+                f"{evidence.name}: {path.name}: {error}"
+            ) from error
+        require(
+            isinstance(value, int),
+            f"result schema revision snapshot has no revision for case "
+            f"{evidence.name}: {path.name}",
+        )
+        return value
+
     revisions = set()
     for path in evidence.glob("*-runtime-db.json"):
         try:
@@ -4695,7 +5040,9 @@ def scheduler_acceptance_report(
         )
     for engine in SCHEDULER_ENGINES:
         results = [
-            result for result in scheduler_results if result["scheduler_engine"] == engine
+            result
+            for result in scheduler_results
+            if result["scheduler_engine"] == engine
         ]
         coverage_counts: dict[str, int] = {}
         for result in results:
@@ -4806,10 +5153,19 @@ def scheduler_coverage_report(
         if coverage_id in required_coverage_ids
         and len(evidence_ids) != len(SCHEDULER_ENGINES)
     }
-    failed = sorted(result["id"] for result in case_results if result["status"] != "pass")
+    failed = sorted(
+        result["id"] for result in case_results if result["status"] != "pass"
+    )
     return {
         "schema_version": SCHEDULER_COVERAGE_REPORT_SCHEMA_VERSION,
-        "status": "pass" if not missing and not invalid_counts and not failed and secret_scan_status == "pass" else "fail",
+        "status": (
+            "pass"
+            if not missing
+            and not invalid_counts
+            and not failed
+            and secret_scan_status == "pass"
+            else "fail"
+        ),
         "git_sha": run_record["git_sha"],
         "image_digest": run_record["image_digest"],
         "manifest_sha256": run_record["manifest_sha256"],
@@ -4915,7 +5271,9 @@ def write_junit(path: Path, cases: list[dict[str, Any]], duration: float) -> Non
             },
         )
         if case["status"] != "pass":
-            failure = ElementTree.SubElement(node, "failure", {"message": case["error"]})
+            failure = ElementTree.SubElement(
+                node, "failure", {"message": case["error"]}
+            )
             failure.text = case["error"]
     ElementTree.indent(suite)
     ElementTree.ElementTree(suite).write(path, encoding="unicode", xml_declaration=True)
@@ -4927,7 +5285,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--image-digest")
     parser.add_argument("--previous-image")
     parser.add_argument("--model")
-    parser.add_argument("--suite", choices=["core", "extended", "published"], default="core")
+    parser.add_argument(
+        "--suite", choices=["core", "extended", "published"], default="core"
+    )
     parser.add_argument("--case", action="append", dest="cases")
     parser.add_argument("--tag", action="append", default=[])
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
@@ -4983,9 +5343,7 @@ def main(argv: list[str] | None = None) -> int:
     model = args.model or first_env(
         "HOLON_E2E_MODEL", "HOLON_LIVE_MODEL", default=DEFAULT_MODEL
     )
-    raw_names = first_env(
-        "HOLON_E2E_CREDENTIAL_ENVS", "HOLON_LIVE_CREDENTIAL_ENVS"
-    )
+    raw_names = first_env("HOLON_E2E_CREDENTIAL_ENVS", "HOLON_LIVE_CREDENTIAL_ENVS")
     credential_envs = [name.strip() for name in raw_names.split(",") if name.strip()]
     env_file, config_file = provider_file_paths(args.env_file, args.config_file)
     runtime_config = load_runtime_config(config_file)
@@ -4999,7 +5357,9 @@ def main(argv: list[str] | None = None) -> int:
         credential_envs = [inferred]
     if requires_model:
         for name in credential_envs:
-            require(name in os.environ, f"required credential environment {name} is unset")
+            require(
+                name in os.environ, f"required credential environment {name} is unset"
+            )
     else:
         credential_envs = []
         env_file = None
@@ -5032,9 +5392,8 @@ def main(argv: list[str] | None = None) -> int:
     started_monotonic = time.monotonic()
     git_sha = run(["git", "rev-parse", "HEAD"]).stdout.strip()
     identity = image_identity(image)
-    image_digest = (
-        args.image_digest
-        or next(iter(identity.get("repo_digests") or []), None)
+    image_digest = args.image_digest or next(
+        iter(identity.get("repo_digests") or []), None
     )
     run_record = {
         "schema_version": EVIDENCE_SCHEMA_VERSION,
@@ -5070,7 +5429,7 @@ def main(argv: list[str] | None = None) -> int:
         selected,
         scheduler_matrix=args.scheduler_matrix,
     )
-    if any(
+    if not args.skip_build and any(
         case.get("provider_mode", profile.get("provider_mode", "live")) == "stub"
         for case, _ in expanded_cases
     ):
@@ -5181,7 +5540,10 @@ def main(argv: list[str] | None = None) -> int:
             "duration_seconds": round(time.monotonic() - case_started, 3),
             "cleanup": cleanup_result["status"],
             "cleanup_errors": cleanup_result["errors"],
-            "schema_revision": collect_case_schema_revision(harness.evidence),
+            "schema_revision": collect_case_schema_revision(
+                harness.evidence,
+                case.get("result_schema_revision_snapshot"),
+            ),
             "coverage_ids": case.get("coverage_ids", []),
             **collect_case_metrics(harness.evidence),
         }

--- a/tests/e2e/docker/manifest.json
+++ b/tests/e2e/docker/manifest.json
@@ -95,6 +95,32 @@
       ]
     },
     {
+      "id": "runtime-upgrade-interrupted-schema47",
+      "tier": "core",
+      "tags": ["runtime", "upgrade", "migration", "recovery", "multi-agent"],
+      "timeout_seconds": 300,
+      "requires_model": false,
+      "requires_previous_image": true,
+      "provider_mode": "stub",
+      "stub_scenario": "runtime-upgrade-interrupted-schema47",
+      "result_schema_revision_snapshot": "upgrade-schema47-migrated",
+      "description": "Interrupt a previous-image agent-lifecycle activation, add a second agent with an in-flight WorkItem, recover all affected agents with the candidate, migrate schema 46 to 47, and attest the fixed point.",
+      "phases": [
+        {
+          "id": "previous-image-interrupted",
+          "prompt": "Keep this turn active for the release interruption checkpoint {marker}.",
+          "required_tools": [],
+          "forbidden_tools": []
+        },
+        {
+          "id": "candidate",
+          "prompt": "Reply with the exact marker {marker}.",
+          "required_tools": [],
+          "forbidden_tools": []
+        }
+      ]
+    },
+    {
       "id": "memory-agent-home-persistence",
       "tier": "core",
       "tags": ["memory", "agent-home", "restart", "persistence"],

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -11,6 +11,7 @@ CALLBACK_CAPABILITY_PATTERN = re.compile(
 )
 SCENARIOS = (
     "runtime-upgrade-v030",
+    "runtime-upgrade-interrupted-schema47",
     "scheduler-task-wait",
     "scheduler-provider-retry",
     "scheduler-multi",
@@ -24,6 +25,7 @@ SCENARIOS = (
     "scheduler-checkpoint",
 )
 
+
 def redact_evidence(value: Any) -> Any:
     if isinstance(value, dict):
         return {key: redact_evidence(item) for key, item in value.items()}
@@ -33,14 +35,33 @@ def redact_evidence(value: Any) -> Any:
         return CALLBACK_CAPABILITY_PATTERN.sub(r"\1<redacted>", value)
     return value
 
+
 def response(items: list[dict[str, Any]], rid: str) -> dict[str, Any]:
-    return {"id": rid, "status": "completed", "usage": {"input_tokens": 100, "output_tokens": 10}, "output": items}
+    return {
+        "id": rid,
+        "status": "completed",
+        "usage": {"input_tokens": 100, "output_tokens": 10},
+        "output": items,
+    }
+
 
 def text_item(text: str) -> dict[str, Any]:
-    return {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": text}]}
+    return {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": text}],
+    }
+
 
 def call_item(cid: str, name: str, args: dict[str, Any]) -> dict[str, Any]:
-    return {"type": "function_call", "id": f"fc_{cid}", "call_id": cid, "name": name, "arguments": json.dumps(args, separators=(",", ":"))}
+    return {
+        "type": "function_call",
+        "id": f"fc_{cid}",
+        "call_id": cid,
+        "name": name,
+        "arguments": json.dumps(args, separators=(",", ":")),
+    }
+
 
 class Scenario:
     def __init__(self, name: str) -> None:
@@ -52,6 +73,8 @@ class Scenario:
         self.current_input_text = ""
         self.extra_requests = 0
         self.lock = threading.Lock()
+        self.interrupted_schema47_seen = False
+        self.interrupted_schema47_kinds: set[str] = set()
 
     def observe(self, request: dict[str, Any]) -> str:
         raw = json.dumps(request, ensure_ascii=False)
@@ -68,23 +91,38 @@ class Scenario:
             if execution_root_id not in self.execution_root_ids:
                 self.execution_root_ids.append(execution_root_id)
         for key, pattern in {
-            "multi_a": r"SCHEDULER-MULTI-A-[0-9a-f]+", "multi_b": r"SCHEDULER-MULTI-B-[0-9a-f]+",
-            "multi_complete_a": r"SCHEDULER-MULTI-COMPLETE-A-[0-9a-f]+", "multi_complete_b": r"SCHEDULER-MULTI-COMPLETE-B-[0-9a-f]+",
-            "external": r"SCHEDULER-EXTERNAL-WAIT-[0-9a-f]+", "external_complete": r"SCHEDULER-EXTERNAL-COMPLETE-[0-9a-f]+",
-            "operator": r"SCHEDULER-OPERATOR-WAIT-[0-9a-f]+", "operator_complete": r"SCHEDULER-OPERATOR-COMPLETE-[0-9a-f]+",
-            "task": r"SCHEDULER-TASK-WAIT-[0-9a-f]+", "task_result": r"SCHEDULER-TASK-RESULT-[0-9a-f]+",
+            "multi_a": r"SCHEDULER-MULTI-A-[0-9a-f]+",
+            "multi_b": r"SCHEDULER-MULTI-B-[0-9a-f]+",
+            "multi_complete_a": r"SCHEDULER-MULTI-COMPLETE-A-[0-9a-f]+",
+            "multi_complete_b": r"SCHEDULER-MULTI-COMPLETE-B-[0-9a-f]+",
+            "external": r"SCHEDULER-EXTERNAL-WAIT-[0-9a-f]+",
+            "external_complete": r"SCHEDULER-EXTERNAL-COMPLETE-[0-9a-f]+",
+            "operator": r"SCHEDULER-OPERATOR-WAIT-[0-9a-f]+",
+            "operator_complete": r"SCHEDULER-OPERATOR-COMPLETE-[0-9a-f]+",
+            "task": r"SCHEDULER-TASK-WAIT-[0-9a-f]+",
+            "task_result": r"SCHEDULER-TASK-RESULT-[0-9a-f]+",
             "task_complete": r"SCHEDULER-TASK-WAIT-COMPLETE-[0-9a-f]+",
-            "provider": r"SCHEDULER-PROVIDER-RETRY-[0-9a-f]+", "provider_complete": r"SCHEDULER-PROVIDER-RETRY-COMPLETE-[0-9a-f]+",
-            "concurrent_a": r"SCHEDULER-CONCURRENT-A-[0-9a-f]+", "concurrent_b": r"SCHEDULER-CONCURRENT-B-[0-9a-f]+",
-            "concurrent_complete_a": r"SCHEDULER-CONCURRENT-COMPLETE-A-[0-9a-f]+", "concurrent_complete_b": r"SCHEDULER-CONCURRENT-COMPLETE-B-[0-9a-f]+",
-            "interject_a": r"SCHEDULER-INTERJECT-A-[0-9a-f]+", "interject_b": r"SCHEDULER-INTERJECT-B-[0-9a-f]+",
-            "interject_complete_a": r"SCHEDULER-INTERJECT-COMPLETE-A-[0-9a-f]+", "interject_complete_b": r"SCHEDULER-INTERJECT-COMPLETE-B-[0-9a-f]+",
-            "compaction": r"SCHEDULER-COMPACTION-[0-9a-f]+", "compaction_complete": r"SCHEDULER-COMPACTION-COMPLETE-[0-9a-f]+",
-            "worktree": r"SCHEDULER-WORKTREE-[0-9a-f]+", "worktree_complete": r"SCHEDULER-WORKTREE-COMPLETE-[0-9a-f]+",
-            "spawn": r"SCHEDULER-SPAWN-[0-9a-f]+", "spawn_complete": r"SCHEDULER-SPAWN-COMPLETE-[0-9a-f]+",
+            "provider": r"SCHEDULER-PROVIDER-RETRY-[0-9a-f]+",
+            "provider_complete": r"SCHEDULER-PROVIDER-RETRY-COMPLETE-[0-9a-f]+",
+            "concurrent_a": r"SCHEDULER-CONCURRENT-A-[0-9a-f]+",
+            "concurrent_b": r"SCHEDULER-CONCURRENT-B-[0-9a-f]+",
+            "concurrent_complete_a": r"SCHEDULER-CONCURRENT-COMPLETE-A-[0-9a-f]+",
+            "concurrent_complete_b": r"SCHEDULER-CONCURRENT-COMPLETE-B-[0-9a-f]+",
+            "interject_a": r"SCHEDULER-INTERJECT-A-[0-9a-f]+",
+            "interject_b": r"SCHEDULER-INTERJECT-B-[0-9a-f]+",
+            "interject_complete_a": r"SCHEDULER-INTERJECT-COMPLETE-A-[0-9a-f]+",
+            "interject_complete_b": r"SCHEDULER-INTERJECT-COMPLETE-B-[0-9a-f]+",
+            "compaction": r"SCHEDULER-COMPACTION-[0-9a-f]+",
+            "compaction_complete": r"SCHEDULER-COMPACTION-COMPLETE-[0-9a-f]+",
+            "worktree": r"SCHEDULER-WORKTREE-[0-9a-f]+",
+            "worktree_complete": r"SCHEDULER-WORKTREE-COMPLETE-[0-9a-f]+",
+            "spawn": r"SCHEDULER-SPAWN-[0-9a-f]+",
+            "spawn_complete": r"SCHEDULER-SPAWN-COMPLETE-[0-9a-f]+",
             "spawn_child": r"SCHEDULER-SPAWN-CHILD-[0-9a-f]+",
-            "checkpoint_a": r"SCHEDULER-REPLAY-A-[0-9a-f]+", "checkpoint_b": r"SCHEDULER-REPLAY-B-[0-9a-f]+",
-            "checkpoint_complete_a": r"SCHEDULER-REPLAY-COMPLETE-A-[0-9a-f]+", "checkpoint_complete_b": r"SCHEDULER-REPLAY-COMPLETE-B-[0-9a-f]+",
+            "checkpoint_a": r"SCHEDULER-REPLAY-A-[0-9a-f]+",
+            "checkpoint_b": r"SCHEDULER-REPLAY-B-[0-9a-f]+",
+            "checkpoint_complete_a": r"SCHEDULER-REPLAY-COMPLETE-A-[0-9a-f]+",
+            "checkpoint_complete_b": r"SCHEDULER-REPLAY-COMPLETE-B-[0-9a-f]+",
             "branch": r"e2e-worktree-[0-9a-f]+",
             "callback": r"docker-e2e:[0-9a-f]+",
         }.items():
@@ -108,13 +146,30 @@ class Scenario:
                 return text.rsplit(marker, 1)[1]
         return ""
 
-    def call(self, name: str, args: dict[str, Any], text: str | None = None) -> tuple[int, dict[str, Any]]:
+    def call(
+        self, name: str, args: dict[str, Any], text: str | None = None
+    ) -> tuple[int, dict[str, Any]]:
         cid = f"{self.name}-{self.phase}-{name.lower()}"
         self.phase += 1
         items = ([text_item(text)] if text else []) + [call_item(cid, name, args)]
         return 200, response(items, f"resp_{cid}")
 
     def consume(self, request: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        if self.name == "runtime-upgrade-interrupted-schema47":
+            raw = self.observe(request)
+            if "UPGRADE-SCHEMA47-LIFECYCLE-" in raw:
+                self.interrupted_schema47_kinds.add("agent_lifecycle")
+                self.interrupted_schema47_seen = True
+                threading.Event().wait(300)
+            if "UPGRADE-SCHEMA47-WORKITEM-" in raw:
+                self.interrupted_schema47_kinds.add("work_item")
+                self.interrupted_schema47_seen = True
+                threading.Event().wait(300)
+            markers = re.findall(r"UPGRADE-SCHEMA47-CANDIDATE-[0-9a-f]+", raw)
+            return 200, response(
+                [text_item(markers[-1] if markers else "Recovered schema 47 runtime.")],
+                "resp_runtime_upgrade_interrupted_schema47",
+            )
         with self.lock:
             raw = self.observe(request)
             if request.get("instructions") == "Reply with exactly OK.":
@@ -138,7 +193,9 @@ class Scenario:
                 in current_input
                 and "This is the first run of Holon" in current_input
             ):
-                return 200, response([text_item("Deterministic Holon test runtime ready.")], "resp_intro")
+                return 200, response(
+                    [text_item("Deterministic Holon test runtime ready.")], "resp_intro"
+                )
             if self.name == "runtime-upgrade-v030":
                 # Serialized history carries the earlier phase marker, so the
                 # current prompt's marker is the last occurrence in the payload.
@@ -189,15 +246,39 @@ class Scenario:
 
     def multi(self) -> tuple[int, dict[str, Any]]:
         if self.phase == 0:
-            return self.call("CreateWorkItem", {"objective": self.markers.get("multi_a", "SCHEDULER-MULTI-A"), "plan_status": "ready", "todo_list": [{"text": "seed-a", "state": "completed"}, {"text": "complete-a", "state": "pending"}]})
+            return self.call(
+                "CreateWorkItem",
+                {
+                    "objective": self.markers.get("multi_a", "SCHEDULER-MULTI-A"),
+                    "plan_status": "ready",
+                    "todo_list": [
+                        {"text": "seed-a", "state": "completed"},
+                        {"text": "complete-a", "state": "pending"},
+                    ],
+                },
+            )
         if self.phase == 1:
-            return self.call("CreateWorkItem", {"objective": self.markers.get("multi_b", "SCHEDULER-MULTI-B"), "plan_status": "ready", "todo_list": [{"text": "seed-b", "state": "completed"}, {"text": "complete-b", "state": "pending"}]})
+            return self.call(
+                "CreateWorkItem",
+                {
+                    "objective": self.markers.get("multi_b", "SCHEDULER-MULTI-B"),
+                    "plan_status": "ready",
+                    "todo_list": [
+                        {"text": "seed-b", "state": "completed"},
+                        {"text": "complete-b", "state": "pending"},
+                    ],
+                },
+            )
         if self.phase == 2:
             self.phase += 1
-            return 200, response([text_item("Created two deterministic WorkItems.")], "resp_multi_seeded")
+            return 200, response(
+                [text_item("Created two deterministic WorkItems.")], "resp_multi_seeded"
+            )
         index = 0 if self.phase < 7 else 1
         if len(self.work_ids) <= index:
-            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
         wid = self.work_ids[index]
         if self.phase == 7 and (
             "[trigger:system_tick]" not in self.current_input_text
@@ -216,10 +297,30 @@ class Scenario:
                 "resp_multi_first_complete",
             )
         steps = {
-            3: ("AgentGet", {}), 4: ("ListWorkItems", {"filter": "current", "include_todo_list": True}),
-            5: ("UpdateWorkItem", {"work_item_id": wid, "todo_list": [{"text": "seed-a", "state": "completed"}, {"text": "complete-a", "state": "completed"}]}),
-            7: ("GetWorkspaceState", {}), 8: ("ListWorkItems", {"filter": "current", "include_todo_list": True}),
-            9: ("UpdateWorkItem", {"work_item_id": wid, "todo_list": [{"text": "seed-b", "state": "completed"}, {"text": "complete-b", "state": "completed"}]}),
+            3: ("AgentGet", {}),
+            4: ("ListWorkItems", {"filter": "current", "include_todo_list": True}),
+            5: (
+                "UpdateWorkItem",
+                {
+                    "work_item_id": wid,
+                    "todo_list": [
+                        {"text": "seed-a", "state": "completed"},
+                        {"text": "complete-a", "state": "completed"},
+                    ],
+                },
+            ),
+            7: ("GetWorkspaceState", {}),
+            8: ("ListWorkItems", {"filter": "current", "include_todo_list": True}),
+            9: (
+                "UpdateWorkItem",
+                {
+                    "work_item_id": wid,
+                    "todo_list": [
+                        {"text": "seed-b", "state": "completed"},
+                        {"text": "complete-b", "state": "completed"},
+                    ],
+                },
+            ),
         }
         if self.phase in steps:
             return self.call(*steps[self.phase])
@@ -233,27 +334,59 @@ class Scenario:
                 "multi_b"
             ].replace("SCHEDULER-MULTI-B-", "SCHEDULER-MULTI-COMPLETE-B-")
             return self.call("CompleteWorkItem", {"work_item_id": wid}, completion)
-        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+        return 409, {
+            "error": {"type": "transcript_exhausted", "message": str(self.phase)}
+        }
 
     def wait(
         self, marker_key: str, todo_prefix: str, wake: str
     ) -> tuple[int, dict[str, Any]]:
         if self.phase == 0:
-            return self.call("CreateWorkItem", {"objective": self.markers.get(marker_key, f"SCHEDULER-{marker_key.upper()}-WAIT"), "plan_status": "ready", "todo_list": [{"text": f"{todo_prefix}-wait", "state": "pending"}, {"text": f"{todo_prefix}-complete", "state": "pending"}]})
+            return self.call(
+                "CreateWorkItem",
+                {
+                    "objective": self.markers.get(
+                        marker_key, f"SCHEDULER-{marker_key.upper()}-WAIT"
+                    ),
+                    "plan_status": "ready",
+                    "todo_list": [
+                        {"text": f"{todo_prefix}-wait", "state": "pending"},
+                        {"text": f"{todo_prefix}-complete", "state": "pending"},
+                    ],
+                },
+            )
         if not self.work_ids:
-            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
         wid = self.work_ids[0]
         if self.phase == 1:
             return self.call("PickWorkItem", {"work_item_id": wid})
         if self.phase == 2:
-            args: dict[str, Any] = {"wake": wake, "reason": f"deterministic {marker_key} wait"}
+            args: dict[str, Any] = {
+                "wake": wake,
+                "reason": f"deterministic {marker_key} wait",
+            }
             if wake == "external":
-                args["resource"] = self.markers.get("callback", "docker-e2e:deterministic")
+                args["resource"] = self.markers.get(
+                    "callback", "docker-e2e:deterministic"
+                )
             return self.call("WaitFor", args)
         if self.phase == 3:
-            return self.call("GetWorkItem", {"work_item_id": wid, "include_todo_list": True})
+            return self.call(
+                "GetWorkItem", {"work_item_id": wid, "include_todo_list": True}
+            )
         if self.phase == 4:
-            return self.call("UpdateWorkItem", {"work_item_id": wid, "todo_list": [{"text": f"{todo_prefix}-wait", "state": "completed"}, {"text": f"{todo_prefix}-complete", "state": "completed"}]})
+            return self.call(
+                "UpdateWorkItem",
+                {
+                    "work_item_id": wid,
+                    "todo_list": [
+                        {"text": f"{todo_prefix}-wait", "state": "completed"},
+                        {"text": f"{todo_prefix}-complete", "state": "completed"},
+                    ],
+                },
+            )
         if self.phase == 5:
             completion = self.markers.get(f"{marker_key}_complete") or self.markers[
                 marker_key
@@ -262,7 +395,9 @@ class Scenario:
                 f"SCHEDULER-{marker_key.upper()}-COMPLETE-",
             )
             return self.call("CompleteWorkItem", {"work_item_id": wid}, completion)
-        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+        return 409, {
+            "error": {"type": "transcript_exhausted", "message": str(self.phase)}
+        }
 
     def task_wait(self) -> tuple[int, dict[str, Any]]:
         if self.phase == 0:
@@ -284,7 +419,9 @@ class Scenario:
                 "resp_task_wait_created",
             )
         if not self.work_ids:
-            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
         wid = self.work_ids[0]
         if self.phase == 2:
             marker = self.markers.get("task_result", "SCHEDULER-TASK-RESULT")
@@ -298,7 +435,9 @@ class Scenario:
             )
         if self.phase == 3:
             if not self.task_ids:
-                return 409, {"error": {"type": "missing_task_id", "message": str(self.phase)}}
+                return 409, {
+                    "error": {"type": "missing_task_id", "message": str(self.phase)}
+                }
             return self.call(
                 "WaitFor",
                 {
@@ -317,7 +456,9 @@ class Scenario:
                 "WaitFor",
                 {
                     "wake": "external",
-                    "resource": self.markers.get("callback", "docker-e2e:deterministic"),
+                    "resource": self.markers.get(
+                        "callback", "docker-e2e:deterministic"
+                    ),
                     "reason": "deterministic external completion",
                 },
             )
@@ -338,11 +479,15 @@ class Scenario:
                 {"work_item_id": wid},
                 self.markers.get("task_complete", "SCHEDULER-TASK-WAIT-COMPLETE"),
             )
-        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+        return 409, {
+            "error": {"type": "transcript_exhausted", "message": str(self.phase)}
+        }
 
     def provider_retry(self) -> tuple[int, dict[str, Any]]:
         if not self.work_ids:
-            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
         wid = self.work_ids[0]
         if self.phase == 0:
             return self.call(
@@ -357,7 +502,9 @@ class Scenario:
                     "provider_complete", "SCHEDULER-PROVIDER-RETRY-COMPLETE"
                 ),
             )
-        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+        return 409, {
+            "error": {"type": "transcript_exhausted", "message": str(self.phase)}
+        }
 
     def concurrent(self) -> tuple[int, dict[str, Any]]:
         if self.phase == 0:
@@ -373,7 +520,9 @@ class Scenario:
                 },
             )
         if not self.work_ids:
-            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
         if self.phase == 1:
             return self.call("PickWorkItem", {"work_item_id": self.work_ids[0]})
         if self.phase == 2:
@@ -388,7 +537,9 @@ class Scenario:
                 },
             )
         if len(self.work_ids) < 2:
-            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
         if self.phase == 3:
             return self.call(
                 "ListWorkItems",
@@ -409,13 +560,14 @@ class Scenario:
             return self.call(
                 "CompleteWorkItem",
                 {"work_item_id": self.work_ids[1]},
-                self.markers.get(
-                    "concurrent_complete_b", "concurrent-complete-b"
-                ),
+                self.markers.get("concurrent_complete_b", "concurrent-complete-b"),
             )
         if self.phase == 6:
             marker = self.markers.get("concurrent_a", "SCHEDULER-CONCURRENT-A")
-            if "[trigger:" not in self.current_input_text or marker not in self.current_input_text:
+            if (
+                "[trigger:" not in self.current_input_text
+                or marker not in self.current_input_text
+            ):
                 self.phase += 1
                 return 200, response(
                     [text_item("Completed deterministic concurrent WorkItem B.")],
@@ -442,20 +594,18 @@ class Scenario:
             return self.call(
                 "CompleteWorkItem",
                 {"work_item_id": self.work_ids[0]},
-                self.markers.get(
-                    "concurrent_complete_a", "concurrent-complete-a"
-                ),
+                self.markers.get("concurrent_complete_a", "concurrent-complete-a"),
             )
-        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+        return 409, {
+            "error": {"type": "transcript_exhausted", "message": str(self.phase)}
+        }
 
     def compaction(self) -> tuple[int, dict[str, Any]]:
         if self.phase == 0:
             return self.call(
                 "CreateWorkItem",
                 {
-                    "objective": self.markers.get(
-                        "compaction", "SCHEDULER-COMPACTION"
-                    ),
+                    "objective": self.markers.get("compaction", "SCHEDULER-COMPACTION"),
                     "plan_status": "ready",
                     "todo_list": [
                         {"text": "compaction-wait", "state": "pending"},
@@ -475,7 +625,7 @@ class Scenario:
                 "ExecCommand",
                 {
                     "cmd": (
-                        "i=0; while [ \"$i\" -lt 16000 ]; do "
+                        'i=0; while [ "$i" -lt 16000 ]; do '
                         f"printf 'compaction-payload-{self.phase}-%04d\\n' \"$i\"; "
                         "i=$((i+1)); done"
                     ),
@@ -532,7 +682,9 @@ class Scenario:
                 },
             )
         if not self.work_ids:
-            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
         if self.phase == 1:
             return self.call("PickWorkItem", {"work_item_id": self.work_ids[0]})
         if self.phase == 2:
@@ -564,7 +716,9 @@ class Scenario:
                 f"resp_{prefix}_interject_created",
             )
         if len(self.work_ids) < 2:
-            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
         if self.phase == 5:
             return self.call(
                 "ListWorkItems",
@@ -615,7 +769,9 @@ class Scenario:
                 {"work_item_id": self.work_ids[0]},
                 self.markers.get(f"{prefix}_complete_a", f"{prefix}-complete-a"),
             )
-        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+        return 409, {
+            "error": {"type": "transcript_exhausted", "message": str(self.phase)}
+        }
 
     def worktree(self) -> tuple[int, dict[str, Any]]:
         if self.phase == 0:
@@ -631,7 +787,9 @@ class Scenario:
                 },
             )
         if not self.work_ids:
-            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
         wid = self.work_ids[0]
         if self.phase == 1:
             return self.call("PickWorkItem", {"work_item_id": wid})
@@ -639,7 +797,12 @@ class Scenario:
             return self.call("GetWorkspaceState", {})
         if self.phase == 3:
             if not self.workspace_ids:
-                return 409, {"error": {"type": "missing_workspace_id", "message": str(self.phase)}}
+                return 409, {
+                    "error": {
+                        "type": "missing_workspace_id",
+                        "message": str(self.phase),
+                    }
+                }
             return self.call(
                 "CreateWorktree",
                 {
@@ -656,7 +819,12 @@ class Scenario:
             )
         if self.phase == 7:
             if not self.execution_root_ids:
-                return 409, {"error": {"type": "missing_execution_root_id", "message": str(self.phase)}}
+                return 409, {
+                    "error": {
+                        "type": "missing_execution_root_id",
+                        "message": str(self.phase),
+                    }
+                }
             return self.call(
                 "RemoveWorktree",
                 {
@@ -681,7 +849,9 @@ class Scenario:
                 {"work_item_id": wid},
                 self.markers.get("worktree_complete", "SCHEDULER-WORKTREE-COMPLETE"),
             )
-        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+        return 409, {
+            "error": {"type": "transcript_exhausted", "message": str(self.phase)}
+        }
 
     def spawn(self) -> tuple[int, dict[str, Any]]:
         if self.phase == 0:
@@ -697,7 +867,9 @@ class Scenario:
                 },
             )
         if not self.work_ids:
-            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
         wid = self.work_ids[0]
         if self.phase == 1:
             return self.call("PickWorkItem", {"work_item_id": wid})
@@ -717,7 +889,9 @@ class Scenario:
             )
         if self.phase == 3:
             if not self.task_ids:
-                return 409, {"error": {"type": "missing_task_id", "message": str(self.phase)}}
+                return 409, {
+                    "error": {"type": "missing_task_id", "message": str(self.phase)}
+                }
             return self.call("TaskStatus", {"task_id": self.task_ids[-1]})
         if self.phase == 4:
             return self.call(
@@ -736,7 +910,9 @@ class Scenario:
                 {"work_item_id": wid},
                 self.markers.get("spawn_complete", "SCHEDULER-SPAWN-COMPLETE"),
             )
-        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+        return 409, {
+            "error": {"type": "transcript_exhausted", "message": str(self.phase)}
+        }
 
     def checkpoint(self) -> tuple[int, dict[str, Any]]:
         if self.phase in {0, 1}:
@@ -765,13 +941,17 @@ class Scenario:
                 "resp_checkpoint_created",
             )
         if len(self.work_ids) < 2:
-            return 409, {"error": {"type": "missing_work_item_id", "message": str(self.phase)}}
+            return 409, {
+                "error": {"type": "missing_work_item_id", "message": str(self.phase)}
+            }
         if self.phase == 4:
             return self.call(
                 "WaitFor",
                 {
                     "wake": "external",
-                    "resource": self.markers.get("callback", "docker-e2e:deterministic"),
+                    "resource": self.markers.get(
+                        "callback", "docker-e2e:deterministic"
+                    ),
                     "reason": "deterministic checkpoint wait",
                 },
             )
@@ -829,11 +1009,14 @@ class Scenario:
                     "checkpoint_complete_a", "SCHEDULER-REPLAY-COMPLETE-A"
                 ),
             )
-        return 409, {"error": {"type": "transcript_exhausted", "message": str(self.phase)}}
+        return 409, {
+            "error": {"type": "transcript_exhausted", "message": str(self.phase)}
+        }
 
     def expected_phase(self) -> int:
         return {
             "runtime-upgrade-v030": 2,
+            "runtime-upgrade-interrupted-schema47": 0,
             "scheduler-task-wait": 10,
             "scheduler-provider-retry": 3,
             "scheduler-multi": 12,
@@ -848,6 +1031,15 @@ class Scenario:
         }[self.name]
 
     def status(self) -> dict[str, Any]:
+        if self.name == "runtime-upgrade-interrupted-schema47":
+            return {
+                "scenario": self.name,
+                "phase": 0,
+                "expected_phase": 0,
+                "extra_requests": 0,
+                "complete": self.interrupted_schema47_kinds
+                == {"agent_lifecycle", "work_item"},
+            }
         expected = self.expected_phase()
         return {
             "scenario": self.name,
@@ -857,34 +1049,68 @@ class Scenario:
             "complete": self.phase == expected and self.extra_requests == 0,
         }
 
+
 def make_handler(scenario: Scenario, log: Path) -> type[BaseHTTPRequestHandler]:
     class Handler(BaseHTTPRequestHandler):
         def send_json(self, status: int, value: dict[str, Any]) -> None:
             body = json.dumps(value, separators=(",", ":")).encode()
-            self.send_response(status); self.send_header("Content-Type", "application/json"); self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body)
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
         def do_GET(self) -> None:
-            self.send_json(200, {"status": "ok"}) if self.path == "/healthz" else self.send_json(200, scenario.status()) if self.path == "/status" else self.send_json(404, {"error": {"type": "not_found"}})
+            (
+                self.send_json(200, {"status": "ok"})
+                if self.path == "/healthz"
+                else (
+                    self.send_json(200, scenario.status())
+                    if self.path == "/status"
+                    else self.send_json(404, {"error": {"type": "not_found"}})
+                )
+            )
+
         def do_POST(self) -> None:
             if self.path != "/v1/responses":
-                self.send_json(404, {"error": {"type": "not_found"}}); return
+                self.send_json(404, {"error": {"type": "not_found"}})
+                return
             try:
-                request = json.loads(self.rfile.read(int(self.headers.get("Content-Length", "0"))))
-                if not isinstance(request, dict): raise ValueError
+                request = json.loads(
+                    self.rfile.read(int(self.headers.get("Content-Length", "0")))
+                )
+                if not isinstance(request, dict):
+                    raise ValueError
             except (ValueError, json.JSONDecodeError):
-                self.send_json(400, {"error": {"type": "invalid_json"}}); return
+                self.send_json(400, {"error": {"type": "invalid_json"}})
+                return
             log.parent.mkdir(parents=True, exist_ok=True)
             with log.open("a") as stream:
                 stream.write(
                     json.dumps(redact_evidence(request), separators=(",", ":")) + "\n"
                 )
             self.send_json(*scenario.consume(request))
-        def log_message(self, format: str, *args: Any) -> None: return
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
     return Handler
 
+
 def main() -> None:
-    parser = argparse.ArgumentParser(); parser.add_argument("--listen", default="0.0.0.0"); parser.add_argument("--port", type=int, default=8080); parser.add_argument("--scenario", required=True, choices=SCENARIOS); parser.add_argument("--request-log", type=Path, default=Path("/data/stub-requests.jsonl")); args = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--listen", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument("--scenario", required=True, choices=SCENARIOS)
+    parser.add_argument(
+        "--request-log", type=Path, default=Path("/data/stub-requests.jsonl")
+    )
+    args = parser.parse_args()
     scenario = Scenario(args.scenario)
-    ThreadingHTTPServer((args.listen, args.port), make_handler(scenario, args.request_log)).serve_forever()
+    ThreadingHTTPServer(
+        (args.listen, args.port), make_handler(scenario, args.request_log)
+    ).serve_forever()
+
 
 if __name__ == "__main__":
     main()

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -158,12 +158,14 @@ class Scenario:
         if self.name == "runtime-upgrade-interrupted-schema47":
             raw = self.observe(request)
             if "UPGRADE-SCHEMA47-LIFECYCLE-" in raw:
-                self.interrupted_schema47_kinds.add("agent_lifecycle")
-                self.interrupted_schema47_seen = True
+                with self.lock:
+                    self.interrupted_schema47_kinds.add("agent_lifecycle")
+                    self.interrupted_schema47_seen = True
                 threading.Event().wait(300)
             if "UPGRADE-SCHEMA47-WORKITEM-" in raw:
-                self.interrupted_schema47_kinds.add("work_item")
-                self.interrupted_schema47_seen = True
+                with self.lock:
+                    self.interrupted_schema47_kinds.add("work_item")
+                    self.interrupted_schema47_seen = True
                 threading.Event().wait(300)
             markers = re.findall(r"UPGRADE-SCHEMA47-CANDIDATE-[0-9a-f]+", raw)
             return 200, response(
@@ -1032,13 +1034,17 @@ class Scenario:
 
     def status(self) -> dict[str, Any]:
         if self.name == "runtime-upgrade-interrupted-schema47":
+            with self.lock:
+                complete = self.interrupted_schema47_kinds == {
+                    "agent_lifecycle",
+                    "work_item",
+                }
             return {
                 "scenario": self.name,
                 "phase": 0,
                 "expected_phase": 0,
                 "extra_requests": 0,
-                "complete": self.interrupted_schema47_kinds
-                == {"agent_lifecycle", "work_item"},
+                "complete": complete,
             }
         expected = self.expected_phase()
         return {

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -8,6 +8,8 @@ import copy
 import os
 import subprocess
 import tempfile
+import threading
+import time
 import unittest
 import urllib.error
 from pathlib import Path
@@ -28,6 +30,11 @@ STUB_SPEC.loader.exec_module(stub)
 
 
 class DockerE2ERunnerTests(unittest.TestCase):
+    def test_skip_build_covers_candidate_and_stub_images(self) -> None:
+        source = inspect.getsource(runner.main)
+        self.assertIn("if not args.skip_build:", source)
+        self.assertIn("if not args.skip_build and any(", source)
+
     def test_previous_schema_revision_accepts_supported_release_schemas(self) -> None:
         self.assertEqual(
             runner.require_previous_schema_revision({"schema_revision": 25}),
@@ -40,9 +47,12 @@ class DockerE2ERunnerTests(unittest.TestCase):
 
     def test_previous_schema_revision_rejects_invalid_revision(self) -> None:
         for snapshot in ({"schema_revision": 0}, {}):
-            with self.subTest(snapshot=snapshot), self.assertRaisesRegex(
-                AssertionError,
-                "previous release produced an invalid schema revision",
+            with (
+                self.subTest(snapshot=snapshot),
+                self.assertRaisesRegex(
+                    AssertionError,
+                    "previous release produced an invalid schema revision",
+                ),
             ):
                 runner.require_previous_schema_revision(snapshot)
 
@@ -59,6 +69,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
             [
                 "runtime-auth-model-delivery",
                 "runtime-upgrade-v030",
+                "runtime-upgrade-interrupted-schema47",
                 "memory-agent-home-persistence",
                 "workspace-restart-lifecycle",
                 "workitem-wait-restart-complete",
@@ -287,17 +298,15 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertIn("HOLON_E2E_PROVIDER_CONFIG_FILE:", nightly)
         self.assertNotIn("HOLON_E2E_CONFIG_FILE:", nightly)
         for workflow in (ci, nightly, release):
-            live_step = workflow.split(
-                "      - name: Run scheduler live canary\n", 1
-            )[1].split("      - name:", 1)[0]
+            live_step = workflow.split("      - name: Run scheduler live canary\n", 1)[
+                1
+            ].split("      - name:", 1)[0]
             self.assertNotIn("HOLON_E2E_PROVIDER_CONFIG_FILE", live_step)
             self.assertIn("config_file=/tmp/holon-e2e-config.json", live_step)
-        nightly_job_env = nightly.split("  nightly:\n", 1)[1].split(
-            "    steps:\n", 1
-        )[0]
-        release_job_env = release.split("  core:\n", 1)[1].split(
-            "    steps:\n", 1
-        )[0]
+        nightly_job_env = nightly.split("  nightly:\n", 1)[1].split("    steps:\n", 1)[
+            0
+        ]
+        release_job_env = release.split("  core:\n", 1)[1].split("    steps:\n", 1)[0]
         for job_env in (nightly_job_env, release_job_env):
             self.assertNotIn("HOLON_E2E_PROVIDER_ENV_FILE", job_env)
             self.assertNotIn("HOLON_E2E_PROVIDER_CONFIG_FILE", job_env)
@@ -305,9 +314,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
     def test_release_workflow_fails_closed_for_previous_release_inputs(self) -> None:
         release = (ROOT / ".github/workflows/release-e2e.yml").read_text()
         inputs = release.split("    inputs:\n", 1)[1].split("\npermissions:", 1)[0]
-        prepare = release.split(
-            "      - name: Prepare previous release image\n", 1
-        )[1].split("      - name:", 1)[0]
+        prepare = release.split("      - name: Prepare previous release image\n", 1)[
+            1
+        ].split("      - name:", 1)[0]
 
         self.assertNotIn("default: v0.30.0", inputs)
         self.assertIn(
@@ -332,6 +341,42 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertIn('"image": os.environ["PREVIOUS_IMAGE"]', release)
         self.assertIn('"source": os.environ["PREVIOUS_SOURCE"]', release)
         self.assertIn('"ref": os.environ["PREVIOUS_REF"] or None', release)
+        self.assertIn('"runtime-upgrade-interrupted-schema47"', release)
+        self.assertIn('"interrupted_schema47_upgrade": {', release)
+        self.assertIn('"evidence_sha256": recovery_sha256', release)
+        self.assertIn(
+            'recovery["previous_schema_revision"]\n'
+            '              != old_snapshot.get("schema_revision")',
+            release,
+        )
+        self.assertIn(
+            'recovery["candidate_schema_revision"]\n'
+            '              != migrated_snapshot.get("schema_revision")',
+            release,
+        )
+        self.assertIn('recovery["candidate_schema_revision"] < 47', release)
+        self.assertIn(
+            'recovery["candidate_schema_revision"]\n'
+            '              <= recovery["previous_schema_revision"]',
+            release,
+        )
+        self.assertIn(
+            'recovery.get("old_snapshot_sha256") != old_snapshot_sha256',
+            release,
+        )
+        self.assertIn(
+            'recovery.get("migrated_snapshot_sha256")',
+            release,
+        )
+        self.assertIn("!= migrated_snapshot_sha256", release)
+        self.assertIn(
+            'not report_before.get("before", {}).get("blockers")',
+            release,
+        )
+        self.assertIn('not apply.get("apply", {}).get("changed")', release)
+        self.assertIn('apply.get("after", {}).get("blockers")', release)
+        self.assertIn('report_after.get("before", {}).get("blockers")', release)
+        self.assertIn('report_after.get("reports")', release)
         publish = (ROOT / ".github/workflows/release.yml").read_text()
         self.assertIn(".previous_release.image", publish)
         self.assertIn(
@@ -362,15 +407,11 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertEqual([case["id"] for case in selected], expected)
         self.assertEqual(profile["required_coverage_ids"], expected)
         self.assertTrue(all(case.get("stub_scenario") for case in selected))
-        self.assertTrue(
-            all(case["timeout_seconds"] <= 120 for case in selected)
-        )
+        self.assertTrue(all(case["timeout_seconds"] <= 120 for case in selected))
 
     def test_manifest_rejects_live_canary_with_strict_tools(self) -> None:
         invalid = json.loads(json.dumps(self.manifest))
-        invalid["profiles"]["scheduler-live-canary"][
-            "tool_assertion_mode"
-        ] = "strict"
+        invalid["profiles"]["scheduler-live-canary"]["tool_assertion_mode"] = "strict"
         with self.assertRaisesRegex(
             AssertionError,
             "live canary must observe tool assertions",
@@ -438,7 +479,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
             ],
         )
 
-    def test_collect_case_metrics_deduplicates_overlapping_event_snapshots(self) -> None:
+    def test_collect_case_metrics_deduplicates_overlapping_event_snapshots(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             evidence = Path(directory)
             events = [
@@ -462,12 +505,8 @@ class DockerE2ERunnerTests(unittest.TestCase):
                     },
                 },
             ]
-            (evidence / "first-events.json").write_text(
-                json.dumps({"events": events})
-            )
-            (evidence / "second-events.json").write_text(
-                json.dumps({"events": events})
-            )
+            (evidence / "first-events.json").write_text(json.dumps({"events": events}))
+            (evidence / "second-events.json").write_text(json.dumps({"events": events}))
 
             metrics = runner.collect_case_metrics(evidence)
 
@@ -476,6 +515,34 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertEqual(metrics["provider_attempts"], 2)
         self.assertEqual(metrics["provider_retries"], 1)
         self.assertEqual(metrics["token_usage"]["total_tokens"], 5)
+
+    def test_collect_case_schema_revision_uses_declared_result_snapshot(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = Path(directory)
+            (evidence / "old-runtime-db.json").write_text(
+                json.dumps({"schema_revision": 46})
+            )
+            (evidence / "migrated-runtime-db.json").write_text(
+                json.dumps({"schema_revision": 47})
+            )
+
+            revision = runner.collect_case_schema_revision(evidence, "migrated")
+
+        self.assertEqual(revision, 47)
+
+    def test_collect_case_schema_revision_requires_declared_result_snapshot(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = Path(directory)
+
+            with self.assertRaisesRegex(
+                AssertionError,
+                "result schema revision snapshot is missing",
+            ):
+                runner.collect_case_schema_revision(evidence, "migrated")
 
     def test_scheduler_coverage_reports_missing_and_duplicate_ids(self) -> None:
         report = runner.scheduler_coverage_report(
@@ -571,11 +638,32 @@ class DockerE2ERunnerTests(unittest.TestCase):
         )
         self.assertEqual(scenario.phase, 0)
         status, response = scenario.consume(
-            {"input": [{"type": "message", "content": [{"type": "input_text", "text": "SCHEDULER-EXTERNAL-WAIT-abcd SCHEDULER-EXTERNAL-COMPLETE-abcd docker-e2e:abcd"}]}]}
+            {
+                "input": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "SCHEDULER-EXTERNAL-WAIT-abcd SCHEDULER-EXTERNAL-COMPLETE-abcd docker-e2e:abcd",
+                            }
+                        ],
+                    }
+                ]
+            }
         )
         self.assertEqual(status, 200)
         self.assertEqual(response["output"][0]["name"], "CreateWorkItem")
-        status, response = scenario.consume({"input": [{"type": "function_call_output", "output": "{\"work_item\":{\"id\":\"work_0123456789abcde\"}}"}]})
+        status, response = scenario.consume(
+            {
+                "input": [
+                    {
+                        "type": "function_call_output",
+                        "output": '{"work_item":{"id":"work_0123456789abcde"}}',
+                    }
+                ]
+            }
+        )
         self.assertEqual(status, 200)
         self.assertEqual(response["output"][0]["name"], "PickWorkItem")
         scenario.phase = 6
@@ -778,57 +866,142 @@ class DockerE2ERunnerTests(unittest.TestCase):
         )
         for case in selected:
             scenario = stub.Scenario(case["stub_scenario"])
-            self.assertGreater(scenario.expected_phase(), 0)
+            if case["stub_scenario"] == "runtime-upgrade-interrupted-schema47":
+                self.assertEqual(scenario.expected_phase(), 0)
+            else:
+                self.assertGreater(scenario.expected_phase(), 0)
+
+    def test_interrupted_schema47_stub_attests_both_blocked_request_kinds(self) -> None:
+        scenario = stub.Scenario("runtime-upgrade-interrupted-schema47")
+        workers = []
+        for marker in (
+            "UPGRADE-SCHEMA47-LIFECYCLE-deadbeef",
+            "UPGRADE-SCHEMA47-WORKITEM-deadbeef",
+        ):
+            request = {
+                "input": [{"content": [{"text": marker}]}],
+            }
+            worker = threading.Thread(
+                target=scenario.consume,
+                args=(request,),
+                daemon=True,
+            )
+            worker.start()
+            workers.append(worker)
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline and not scenario.status()["complete"]:
+            time.sleep(0.01)
+
+        self.assertTrue(scenario.interrupted_schema47_seen)
+        self.assertTrue(scenario.status()["complete"])
 
     def test_openai_stub_required_scenarios_reach_exact_completion(self) -> None:
         expected_calls = {
             "scheduler-task-wait": [
-                "CreateWorkItem", "ExecCommand", "WaitFor", "GetWorkItem",
-                "WaitFor", "GetWorkItem", "UpdateWorkItem", "CompleteWorkItem",
+                "CreateWorkItem",
+                "ExecCommand",
+                "WaitFor",
+                "GetWorkItem",
+                "WaitFor",
+                "GetWorkItem",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
             ],
             "scheduler-provider-retry": ["ListWorkItems", "CompleteWorkItem"],
             "scheduler-multi": [
-                "CreateWorkItem", "CreateWorkItem", "AgentGet", "ListWorkItems",
-                "UpdateWorkItem", "CompleteWorkItem", "GetWorkspaceState",
-                "ListWorkItems", "UpdateWorkItem", "CompleteWorkItem",
+                "CreateWorkItem",
+                "CreateWorkItem",
+                "AgentGet",
+                "ListWorkItems",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
+                "GetWorkspaceState",
+                "ListWorkItems",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
             ],
             "scheduler-external": [
-                "CreateWorkItem", "PickWorkItem", "WaitFor", "GetWorkItem",
-                "UpdateWorkItem", "CompleteWorkItem",
+                "CreateWorkItem",
+                "PickWorkItem",
+                "WaitFor",
+                "GetWorkItem",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
             ],
             "scheduler-operator": [
-                "CreateWorkItem", "PickWorkItem", "WaitFor", "GetWorkItem",
-                "UpdateWorkItem", "CompleteWorkItem",
+                "CreateWorkItem",
+                "PickWorkItem",
+                "WaitFor",
+                "GetWorkItem",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
             ],
             "scheduler-concurrent": [
-                "CreateWorkItem", "PickWorkItem", "WaitFor",
-                "ListWorkItems", "UpdateWorkItem", "CompleteWorkItem",
-                "GetWorkItem", "UpdateWorkItem", "CompleteWorkItem",
+                "CreateWorkItem",
+                "PickWorkItem",
+                "WaitFor",
+                "ListWorkItems",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
+                "GetWorkItem",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
             ],
             "scheduler-interject": [
-                "CreateWorkItem", "PickWorkItem", "WaitFor", "CreateWorkItem",
-                "ListWorkItems", "UpdateWorkItem", "CompleteWorkItem",
-                "GetWorkItem", "UpdateWorkItem", "CompleteWorkItem",
+                "CreateWorkItem",
+                "PickWorkItem",
+                "WaitFor",
+                "CreateWorkItem",
+                "ListWorkItems",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
+                "GetWorkItem",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
             ],
             "scheduler-compaction": [
-                "CreateWorkItem", "PickWorkItem", "ExecCommand", "ExecCommand",
-                "ExecCommand", "WaitFor", "GetWorkItem", "UpdateWorkItem",
+                "CreateWorkItem",
+                "PickWorkItem",
+                "ExecCommand",
+                "ExecCommand",
+                "ExecCommand",
+                "WaitFor",
+                "GetWorkItem",
+                "UpdateWorkItem",
                 "CompleteWorkItem",
             ],
             "scheduler-worktree": [
-                "CreateWorkItem", "PickWorkItem", "GetWorkspaceState",
-                "CreateWorktree", "GetWorkspaceState", "SwitchWorkspace",
-                "GetWorkspaceState", "RemoveWorktree", "GetWorkspaceState",
-                "UpdateWorkItem", "CompleteWorkItem",
+                "CreateWorkItem",
+                "PickWorkItem",
+                "GetWorkspaceState",
+                "CreateWorktree",
+                "GetWorkspaceState",
+                "SwitchWorkspace",
+                "GetWorkspaceState",
+                "RemoveWorktree",
+                "GetWorkspaceState",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
             ],
             "scheduler-spawn": [
-                "CreateWorkItem", "PickWorkItem", "SpawnAgent", "TaskStatus",
-                "UpdateWorkItem", "CompleteWorkItem",
+                "CreateWorkItem",
+                "PickWorkItem",
+                "SpawnAgent",
+                "TaskStatus",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
             ],
             "scheduler-checkpoint": [
-                "CreateWorkItem", "CreateWorkItem", "ListWorkItems", "WaitFor",
-                "ListWorkItems", "UpdateWorkItem", "CompleteWorkItem",
-                "GetWorkItem", "UpdateWorkItem", "CompleteWorkItem",
+                "CreateWorkItem",
+                "CreateWorkItem",
+                "ListWorkItems",
+                "WaitFor",
+                "ListWorkItems",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
+                "GetWorkItem",
+                "UpdateWorkItem",
+                "CompleteWorkItem",
             ],
         }
         transcript = (
@@ -866,10 +1039,12 @@ class DockerE2ERunnerTests(unittest.TestCase):
             "git_worktree_root:deterministic"
         )
         request = {
-            "input": [{
-                "type": "message",
-                "content": [{"type": "input_text", "text": transcript}],
-            }]
+            "input": [
+                {
+                    "type": "message",
+                    "content": [{"type": "input_text", "text": transcript}],
+                }
+            ]
         }
         for name, expected in expected_calls.items():
             scenario = stub.Scenario(name)
@@ -967,9 +1142,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
         self.assertEqual(runner.memory_value(memory), memory)
 
     def test_evidence_redacts_callback_capability(self) -> None:
-        value = {
-            "url": "http://localhost/api/callbacks/wake/cb_secret-capability"
-        }
+        value = {"url": "http://localhost/api/callbacks/wake/cb_secret-capability"}
         redacted = runner.redact_evidence(value)
         self.assertEqual(
             redacted["url"],
@@ -1091,8 +1264,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
 
             failure = json.loads(
                 (
-                    harness.evidence
-                    / "scheduler-runtime-state-copy-failure.json"
+                    harness.evidence / "scheduler-runtime-state-copy-failure.json"
                 ).read_text()
             )
             self.assertEqual(failure["status"], "timeout")
@@ -1102,6 +1274,39 @@ class DockerE2ERunnerTests(unittest.TestCase):
             )
             self.assertEqual(failure["stdout"], "partial")
             self.assertEqual(failure["stderr"], "daemon stalled")
+
+    def test_offline_runtime_db_snapshot_can_write_host_evidence_directory(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            harness = runner.CaseHarness(
+                case_id="offline-snapshot-user-test",
+                image="holon:test",
+                model="deepseek/deepseek-v4-flash",
+                credential_envs=[],
+                env_file=None,
+                runtime_env={},
+                evidence_root=Path(directory),
+                timeout_seconds=1,
+                keep=False,
+            )
+            docker_args: tuple[str, ...] | None = None
+
+            def capture_docker(
+                *args: str, **_: object
+            ) -> subprocess.CompletedProcess[str]:
+                nonlocal docker_args
+                docker_args = args
+                raise RuntimeError("stop after command capture")
+
+            harness.docker = capture_docker
+            with self.assertRaisesRegex(RuntimeError, "command capture"):
+                harness.offline_runtime_db_snapshot("scheduler")
+
+            self.assertIsNotNone(docker_args)
+            assert docker_args is not None
+            user_index = docker_args.index("--user")
+            self.assertEqual(docker_args[user_index + 1], "0:0")
 
     def test_docker_circuit_breaker_opens_after_consecutive_timeouts(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -1182,10 +1387,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 include_conversation=False,
             )
             self.assertTrue(
-                any(
-                    "events?limit=300&order=asc&after_seq=12" in path
-                    for path in paths
-                )
+                any("events?limit=300&order=asc&after_seq=12" in path for path in paths)
             )
             self.assertFalse(any("/briefs?" in path for path in paths))
             self.assertFalse(any("/transcript?" in path for path in paths))
@@ -1248,7 +1450,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 keep=False,
             )
 
-            def fake_docker(*args: str, **_: object) -> subprocess.CompletedProcess[str]:
+            def fake_docker(
+                *args: str, **_: object
+            ) -> subprocess.CompletedProcess[str]:
                 if args[:2] == ("volume", "inspect"):
                     return subprocess.CompletedProcess(["docker", *args], 0, "", "")
                 return subprocess.CompletedProcess(["docker", *args], 1, "", "")
@@ -1641,13 +1845,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
         )
         task_wait = selected[0]
         self.assertEqual(len(task_wait["phases"]), 1)
-        self.assertIn(
-            "ExecCommand", task_wait["phases"][0]["required_tools"]
-        )
+        self.assertIn("ExecCommand", task_wait["phases"][0]["required_tools"])
         self.assertIn("WaitFor", task_wait["phases"][0]["required_tools"])
-        self.assertNotIn(
-            "PickWorkItem", task_wait["phases"][0]["required_tools"]
-        )
+        self.assertNotIn("PickWorkItem", task_wait["phases"][0]["required_tools"])
         for case in selected:
             self.assertNotIn(
                 "HOLON_SCHEDULER_ACCEPTANCE_FIXTURES",
@@ -1730,6 +1930,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
             [
                 ("runtime-auth-model-delivery", None),
                 ("runtime-upgrade-v030", None),
+                ("runtime-upgrade-interrupted-schema47", None),
                 ("memory-agent-home-persistence", None),
                 ("workspace-restart-lifecycle", None),
                 ("workitem-wait-restart-complete", None),
@@ -1780,9 +1981,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
             )
             self.assertEqual(len(case["phases"]), 1)
         compaction = next(
-            case
-            for case in selected
-            if case["id"] == "scheduler-compaction-continuity"
+            case for case in selected if case["id"] == "scheduler-compaction-continuity"
         )
         self.assertEqual(
             compaction["model_runtime_override"],
@@ -1846,7 +2045,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
             ["canonical"],
         )
 
-    def test_scheduler_acceptance_report_rejects_duplicate_canonical_coverage(self) -> None:
+    def test_scheduler_acceptance_report_rejects_duplicate_canonical_coverage(
+        self,
+    ) -> None:
         run_record = {
             "git_sha": "abc123",
             "image": {"ref": "holon:test", "id": None, "repo_digests": []},
@@ -1876,7 +2077,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
             {diagnostic["code"] for diagnostic in report["diagnostics"]},
         )
 
-    def test_scheduler_acceptance_report_distinguishes_missing_schema_evidence(self) -> None:
+    def test_scheduler_acceptance_report_distinguishes_missing_schema_evidence(
+        self,
+    ) -> None:
         run_record = {
             "git_sha": "abc123",
             "image": {"ref": "holon:test", "id": None, "repo_digests": []},
@@ -2025,7 +2228,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
         )
         self.assertEqual(waits[0]["status"], "resolved")
 
-    def test_canonical_activation_oracle_distinguishes_lifecycle_and_work_item(self) -> None:
+    def test_canonical_activation_oracle_distinguishes_lifecycle_and_work_item(
+        self,
+    ) -> None:
         harness = type(
             "CanonicalHarness",
             (),
@@ -2086,9 +2291,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 {
                     "agent_id": "default",
                     "outcome_id": "outcome-lifecycle",
-                    "payload_json": json.dumps(
-                        {"attempt_id": "attempt-lifecycle"}
-                    ),
+                    "payload_json": json.dumps({"attempt_id": "attempt-lifecycle"}),
                 },
                 {
                     "agent_id": "default",
@@ -2228,9 +2431,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
                         event,
                         {
                             "kind": "provider_round_completed",
-                            "data_json": json.dumps(
-                                {"data": {"compression_epoch": 1}}
-                            ),
+                            "data_json": json.dumps({"data": {"compression_epoch": 1}}),
                         },
                     ]
                 },
@@ -2315,13 +2516,9 @@ class DockerE2ERunnerTests(unittest.TestCase):
             wait_id="wait-1",
         )
 
-        resume = json.loads(
-            snapshot["execution_protocol_attempts"][1]["payload_json"]
-        )
+        resume = json.loads(snapshot["execution_protocol_attempts"][1]["payload_json"])
         resume["source"]["identity"]["wait_id"] = "other-wait"
-        snapshot["execution_protocol_attempts"][1]["payload_json"] = json.dumps(
-            resume
-        )
+        snapshot["execution_protocol_attempts"][1]["payload_json"] = json.dumps(resume)
         with self.assertRaisesRegex(
             AssertionError,
             "wait-resume attempt mismatch",
@@ -2420,9 +2617,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
 
     def test_runtime_model_route_rejects_unconfirmed_provider(self) -> None:
         harness = self._route_oracle_harness("dashscope-token-plan/qwen-3.7")
-        with self.assertRaisesRegex(
-            AssertionError, "model catalog did not confirm"
-        ):
+        with self.assertRaisesRegex(AssertionError, "model catalog did not confirm"):
             runner.require_runtime_model_route(
                 harness,
                 "runtime default",

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -30,10 +30,11 @@ STUB_SPEC.loader.exec_module(stub)
 
 
 class DockerE2ERunnerTests(unittest.TestCase):
-    def test_skip_build_covers_candidate_and_stub_images(self) -> None:
+    def test_skip_build_only_covers_candidate_image(self) -> None:
         source = inspect.getsource(runner.main)
         self.assertIn("if not args.skip_build:", source)
-        self.assertIn("if not args.skip_build and any(", source)
+        self.assertIn("if any(", source)
+        self.assertNotIn("if not args.skip_build and any(", source)
 
     def test_previous_schema_revision_accepts_supported_release_schemas(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## 概要

- 新增真实 previous-image `v0.31.1`（schema 46）到 candidate（schema 47）的 interrupted-upgrade Release E2E
- 在旧镜像中制造跨两个 Agent 的中断 `agent_lifecycle` / WorkItem activation，验证 candidate 启动前 fail-closed、`scheduler-recovery --all-affected --apply` 全局恢复及迁移后的 fixed point
- 保全并校验旧库/迁移后库快照、受影响 Agent 集合、recovery report/apply/report 结果及 SHA-256 artifact attestation
- 将该场景加入 release core gate，并扩展 OpenAI stub 与 runner 单测覆盖多 Agent bootstrap、立即 continue system tick 和恢复后新 turn

## 运行时契约

本 PR 不改变生产运行时逻辑；它为 #2611 的 schema 47 长期恢复契约增加 previous-release artifact 级发布证明，确保真实旧 binary 制造的中断状态可由 candidate 恢复并继续工作。

## 验证

- `python3 tests/test_docker_e2e_runner.py`（82 tests）
- `python3 -m py_compile scripts/docker_e2e/runner.py tests/e2e/docker/openai_stub/server.py`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `python3 scripts/docker-e2e.py --skip-build --image holon-schema47-prb:candidate --previous-image holon-schema47-prb:previous-v0.31.1 --case runtime-upgrade-interrupted-schema47 --evidence-dir /tmp/holon-schema47-prb-submit-1786950472`
  - `PASS runtime-upgrade-interrupted-schema47`
