### PR TITLE
fix: 支持 Ubuntu 22.04 Linux 发布产物

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,6 +1,12 @@
 name: Release Smoke
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: Release tag to smoke test.
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -18,7 +24,7 @@ permissions:
 jobs:
   linux-asset:
     name: Linux asset
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       RELEASE_VERSION: ${{ inputs.version || 'v0.13.0' }}
     steps:

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -13,10 +13,6 @@ on:
         description: Release tag to smoke test.
         required: false
         default: v0.13.0
-  pull_request:
-    branches: [main]
-    paths:
-      - ".github/workflows/release-smoke.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          # Keep the official GNU/Linux binary compatible with glibc 2.35.
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             asset: holon-linux-amd64
           - os: macos-latest
@@ -216,7 +217,7 @@ jobs:
 
           The database upgrade removes obsolete scheduler authority and control schema through a transactional, idempotent, fail-closed migration. Back up the database before upgrading. After migration, rollback to v0.31.1 requires restoring the pre-migration database backup; old binaries must not open the migrated database.
 
-          Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64.
+          Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64. The Linux amd64 binary supports Ubuntu 22.04 or newer (glibc 2.35 or newer).
 
           ## Changes
 
@@ -282,6 +283,15 @@ jobs:
           fi
           git commit -m "Update Holon formula for ${GITHUB_REF_NAME}"
           git push origin main
+
+  smoke:
+    name: Smoke published release
+    needs: release
+    uses: ./.github/workflows/release-smoke.yml
+    with:
+      version: ${{ github.ref_name }}
+    permissions:
+      contents: read
 
   container:
     name: Publish container image

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ holon --help
 
 You can also download prebuilt binaries for Linux amd64, macOS amd64, and macOS
 arm64 from [GitHub Releases](https://github.com/holon-run/holon/releases/latest).
+The Linux amd64 binary supports Ubuntu 22.04 or newer (glibc 2.35 or newer).
 
 The examples below assume `holon` is installed on `PATH`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -74,6 +74,7 @@ holon --help
 
 也可以从 [GitHub Releases](https://github.com/holon-run/holon/releases/latest)
 下载 Linux amd64、macOS amd64 和 macOS arm64 预编译二进制。
+Linux amd64 二进制支持 Ubuntu 22.04 或更新版本（glibc 2.35 或更新版本）。
 
 下文示例假设 `holon` 已在 `PATH` 中。
 


### PR DESCRIPTION
## 概要

- 将官方 Linux amd64 GNU release artifact 的构建 runner 固定为 Ubuntu 22.04 / glibc 2.35 基线
- 将发布后的 Linux artifact smoke test 固定在 Ubuntu 22.04，并由 release workflow 自动调用
- 在 release notes 与中英文 README 中明确最低支持版本：Ubuntu 22.04 或更新版本（glibc 2.35 或更新版本）

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `actionlint` 1.7.9（两个修改的 workflow 均通过）
- 在 Ubuntu 22.04 / glibc 2.35 容器中构建 release binary 并运行 `holon --version`
- `readelf --version-info` 显示该验证产物最高要求 `GLIBC_2.34`

Closes #2302
