### PR TITLE
fix: validate release version output contract

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -24,6 +24,8 @@ jobs:
     env:
       RELEASE_VERSION: ${{ inputs.version || 'v0.13.0' }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download release asset
         run: |
           set -euo pipefail
@@ -48,4 +50,4 @@ jobs:
           expected="${RELEASE_VERSION#v}"
           actual="$(./smoke/holon --version)"
           echo "$actual"
-          test "$actual" = "holon ${expected}"
+          scripts/verify-release-version.sh "$expected" "$actual"

--- a/scripts/verify-release-version.sh
+++ b/scripts/verify-release-version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "usage: $0 <version> <version-output>" >&2
+  exit 2
+fi
+
+expected_version="$1"
+actual="$2"
+prefix="holon ${expected_version} ("
+
+if [[ "$actual" != "$prefix"*")" ]]; then
+  echo "unexpected version output: $actual" >&2
+  exit 1
+fi
+
+commit_sha="${actual#"$prefix"}"
+commit_sha="${commit_sha%")"}"
+if [[ ! "$commit_sha" =~ ^[0-9a-f]{7,40}$ ]]; then
+  echo "unexpected commit SHA in version output: $actual" >&2
+  exit 1
+fi

--- a/tests/release_version_contract.rs
+++ b/tests/release_version_contract.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn verifier() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/verify-release-version.sh")
+}
+
+fn verify(version: &str, output: &str) -> bool {
+    Command::new(verifier())
+        .args([version, output])
+        .status()
+        .expect("run release version verifier")
+        .success()
+}
+
+#[test]
+fn accepts_version_output_with_commit_sha() {
+    assert!(verify("0.32.0", "holon 0.32.0 (df561ad)"));
+    assert!(verify(
+        "0.32.0",
+        "holon 0.32.0 (df561adf277c2bfb3db74f69468207a6ef8b9e62)"
+    ));
+}
+
+#[test]
+fn rejects_stale_or_malformed_version_output() {
+    for output in [
+        "holon 0.32.0",
+        "holon 0.31.1 (df561ad)",
+        "holon 0.32.0 (df561ad-dirty)",
+        "holon 0.32.0 (DF561AD)",
+        "holon 0.32.0 (123456)",
+    ] {
+        assert!(!verify("0.32.0", output), "{output}");
+    }
+}


### PR DESCRIPTION
## Summary

- 更新 `Release Smoke` 的版本输出断言，接受当前公开契约 `holon <version> (<commit-sha>)`
- 验证版本必须与目标 release 一致，commit SHA 必须为 7–40 位小写十六进制
- 增加独立脚本和 Rust 集成测试，覆盖有效输出及旧格式、错误版本、dirty/大写/过短 SHA

## Context

v0.32.0 已发布，release binary 的 `--version` 输出包含构建 commit SHA。现有 smoke 仍按旧的 `holon <version>` 精确字符串断言，因此资产下载、校验和与 Ubuntu 22.04 执行均成功后，最终版本检查错误失败。

本修复不改写已发布 tag。合并后将从 `main` 手动运行 `Release Smoke`，验证现有 v0.32.0 release assets。

## Verification

- `docker run --rm --user 0 -v "$PWD:/repo:ro" -w /repo rhysd/actionlint:1.7.9 -shellcheck= .github/workflows/release-smoke.yml`
- `shellcheck scripts/verify-release-version.sh`
- `cargo fmt --all -- --check`
- `cargo test --test release_version_contract`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
