### PR TITLE
feat: observer-sync S0 contract skeleton (DTOs, capability evaluator, fixtures)

### DIFF
--- a/docs/implementation-decisions/104-agent-canonical-projection-v1-boundary.md
+++ b/docs/implementation-decisions/104-agent-canonical-projection-v1-boundary.md
@@ -1,0 +1,30 @@
+# AgentCanonicalProjection v1 field boundary
+
+Source: `docs/rfcs/observer-sync-agent-summary-and-read-markers.md` (S0
+contract slice). `AgentCanonicalProjection` is the payload of the per-Agent
+projection snapshot and is anchored to one `snapshot_through_seq` consistency
+boundary.
+
+v1 carries compact current state only:
+
+- the `GET /api/agents/list` entry shape (lifecycle, posture, waiting, model);
+- a current WorkItem anchor (`id`, `state`, `plan_status`, canonical
+  `revision`, `updated_at`);
+- conversation revision anchors (`latest_message_id`,
+  `latest_transcript_entry_id`) for record families that have no per-record
+  revision counter;
+- latest Brief identity with bounded preview (512 UTF-8 bytes) and immutable
+  `created_event_seq` linkage;
+- hydration tombstones and hydration references keyed by
+  `(record_kind, record_id)`.
+
+v1 explicitly excludes verbose timelines, full transcript/message history, and
+full Brief text. Those remain behind the retained event pages and the batch
+record APIs. This keeps the snapshot a bootstrap/recovery baseline for the
+compact projection instead of a second conversation API; unbounded history and
+anchor pagination stay a separate future contract.
+
+OpenAPI keeps the embedded agent entry as a conservative baseline object
+(`AgentListEntry`) until the agents/list DTO stabilizes under a named schema;
+the Rust DTO reuses the concrete `AgentListEntry` type so fixtures round-trip
+the real wire shape.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -97,6 +97,62 @@
         "title": "AddSkillRequest",
         "type": "object"
       },
+      "AgentCanonicalProjection": {
+        "additionalProperties": false,
+        "description": "First concrete AgentCanonicalProjection: compact current state plus stable revision anchors only. Deliberately excludes verbose timelines and full transcript/message history (see docs/implementation-decisions/104-agent-canonical-projection-v1-boundary.md).",
+        "properties": {
+          "agent": {
+            "$ref": "#/components/schemas/AgentListEntry"
+          },
+          "conversation": {
+            "$ref": "#/components/schemas/ConversationRevisionAnchors"
+          },
+          "current_work_item": {
+            "description": "Current WorkItem anchor; null when the Agent has no current WorkItem.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AgentWorkItemAnchor"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hydration_references": {
+            "description": "Records referenced by the projection but still resolvable through the batch record APIs.",
+            "items": {
+              "$ref": "#/components/schemas/AgentHydrationKey"
+            },
+            "type": "array"
+          },
+          "hydration_tombstones": {
+            "description": "Records deleted at or before the snapshot boundary; they terminate pending hydration without fetching a record that no longer exists.",
+            "items": {
+              "$ref": "#/components/schemas/AgentHydrationKey"
+            },
+            "type": "array"
+          },
+          "latest_brief": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AgentLatestBrief"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "agent",
+          "current_work_item",
+          "conversation",
+          "latest_brief",
+          "hydration_tombstones",
+          "hydration_references"
+        ],
+        "type": "object"
+      },
       "AgentDeletionResponse": {
         "properties": {
           "created": {
@@ -439,6 +495,221 @@
           "identity"
         ],
         "title": "AgentDeletionStatusResponse",
+        "type": "object"
+      },
+      "AgentEventWindow": {
+        "additionalProperties": false,
+        "description": "Committed event window for one Agent inside one snapshot read view. Values come from a committed database view, never from an in-memory watcher or a sequence allocator.",
+        "properties": {
+          "event_head_seq": {
+            "description": "Greatest committed event_seq visible in the response read view.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "oldest_retained_seq": {
+            "description": "First raw event still replayable in that view; null when the Agent has no events (event_head_seq = 0).",
+            "oneOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "event_head_seq",
+          "oldest_retained_seq"
+        ],
+        "type": "object"
+      },
+      "AgentHydrationKey": {
+        "additionalProperties": false,
+        "description": "Identifies one canonical record for hydration termination (tombstone) or batch resolution (reference).",
+        "properties": {
+          "record_id": {
+            "type": "string"
+          },
+          "record_kind": {
+            "enum": [
+              "message",
+              "brief",
+              "transcript_entry"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_kind",
+          "record_id"
+        ],
+        "type": "object"
+      },
+      "AgentLatestBrief": {
+        "additionalProperties": false,
+        "description": "Latest Brief anchor derived from canonical Brief storage, not a second UI-summary table.",
+        "properties": {
+          "brief_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "created_event_seq": {
+            "description": "Immutable brief_created event linkage; null when the Brief cannot be linked to a unique retained event. Null-linked Briefs do not participate in exact unread calculation.",
+            "oneOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "preview": {
+            "description": "Bounded to 512 UTF-8 bytes. Full Brief content remains available from the canonical Brief APIs.",
+            "maxLength": 512,
+            "type": "string"
+          }
+        },
+        "required": [
+          "brief_id",
+          "created_event_seq",
+          "created_at",
+          "preview"
+        ],
+        "type": "object"
+      },
+      "AgentListEntry": {
+        "additionalProperties": true,
+        "description": "Public Agent entry, same shape as GET /api/agents/list response entries. Baseline object schema until the agents/list DTO stabilizes under a named schema.",
+        "type": "object"
+      },
+      "AgentProjectionSnapshot": {
+        "additionalProperties": false,
+        "description": "Per-Agent canonical projection snapshot at one consistency boundary (RFC: observer sync). Served by GET /api/agents/{agent_id}/projection-snapshot only while the agents.projection-snapshot.v1 capability is advertised.",
+        "properties": {
+          "agent_id": {
+            "type": "string"
+          },
+          "contract_version": {
+            "const": 1,
+            "type": "integer"
+          },
+          "event_head_seq": {
+            "description": "May exceed snapshot_through_seq; names a committed event available through the event page. Clients replay (snapshot_through_seq, event_head_seq] and later events.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "event_log_epoch": {
+            "type": "string"
+          },
+          "oldest_retained_seq": {
+            "oneOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "projection": {
+            "$ref": "#/components/schemas/AgentCanonicalProjection"
+          },
+          "runtime_id": {
+            "type": "string"
+          },
+          "snapshot_through_seq": {
+            "description": "Every event with event_seq <= snapshot_through_seq that affects current canonical state is already reflected in the projection or its revision anchors.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "visibility_scope_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "contract_version",
+          "runtime_id",
+          "event_log_epoch",
+          "visibility_scope_id",
+          "agent_id",
+          "snapshot_through_seq",
+          "event_head_seq",
+          "oldest_retained_seq",
+          "projection"
+        ],
+        "type": "object"
+      },
+      "AgentRosterEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "$ref": "#/components/schemas/AgentListEntry"
+          },
+          "event_window": {
+            "$ref": "#/components/schemas/AgentEventWindow"
+          },
+          "latest_brief": {
+            "description": "Latest canonical Brief; null when the Agent has no Brief yet.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AgentLatestBrief"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "agent",
+          "event_window",
+          "latest_brief"
+        ],
+        "type": "object"
+      },
+      "AgentRosterSnapshot": {
+        "additionalProperties": false,
+        "description": "Authoritative roster snapshot (RFC: observer sync). All-or-nothing membership with per-Agent event windows and latest Brief anchors. Served by GET /api/agents/snapshot only while the agents.roster-snapshot.v1 capability is advertised; route registration alone is never sufficient.",
+        "properties": {
+          "agents": {
+            "description": "Active public Agents visible to the caller in one committed read view. Private child Agents are never included. A failure to assemble one Agent fails the whole response.",
+            "items": {
+              "$ref": "#/components/schemas/AgentRosterEntry"
+            },
+            "type": "array"
+          },
+          "contract_version": {
+            "const": 1,
+            "type": "integer"
+          },
+          "event_log_epoch": {
+            "description": "Current event log epoch; a changed value means historical event continuity is intentionally reset.",
+            "type": "string"
+          },
+          "runtime_id": {
+            "description": "Stable public identity of the runtime installation. Distinguishes a replaced server at the same URL from an ordinary restart. Not a secret.",
+            "type": "string"
+          },
+          "visibility_scope_id": {
+            "description": "Server-generated scope id derived from stable runtime identity, resolved authority, normalized visibility entitlement, and policy generation. Never contains credentials or tokens.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "contract_version",
+          "runtime_id",
+          "event_log_epoch",
+          "visibility_scope_id",
+          "agents"
+        ],
         "type": "object"
       },
       "AgentStateSnapshotDto": {
@@ -1987,6 +2258,37 @@
         "title": "AgentStateSnapshotDto",
         "type": "object"
       },
+      "AgentWorkItemAnchor": {
+        "additionalProperties": false,
+        "properties": {
+          "plan_status": {
+            "type": "string"
+          },
+          "revision": {
+            "description": "Canonical WorkItem revision at the snapshot boundary.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "state": {
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "work_item_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "work_item_id",
+          "state",
+          "plan_status",
+          "revision",
+          "updated_at"
+        ],
+        "type": "object"
+      },
       "AttachWorkspaceRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
@@ -2351,6 +2653,37 @@
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
         "type": "object"
       },
+      "ConversationRevisionAnchors": {
+        "additionalProperties": false,
+        "description": "Latest-record anchors for conversation families whose canonical records carry no per-record revision counter. Always present; null fields mean the family has no record at the boundary.",
+        "properties": {
+          "latest_message_id": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "latest_transcript_entry_id": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "latest_message_id",
+          "latest_transcript_entry_id"
+        ],
+        "type": "object"
+      },
       "CreateAgentRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
@@ -2426,6 +2759,55 @@
       "CreateWorkItemRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "CursorNotFoundError": {
+        "additionalProperties": true,
+        "description": "Rich cursor_not_found body for event pages and SSE. event_log_epoch, oldest_retained_seq, and event_head_seq must come from one committed read view so clients can distinguish a retained-prefix gap from an epoch change and select the correct reset path.",
+        "properties": {
+          "after_seq": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "code": {
+            "const": "cursor_not_found",
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          },
+          "event_head_seq": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "event_log_epoch": {
+            "type": "string"
+          },
+          "ok": {
+            "const": false,
+            "type": "boolean"
+          },
+          "oldest_retained_seq": {
+            "oneOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "ok",
+          "error",
+          "code",
+          "after_seq",
+          "event_log_epoch",
+          "oldest_retained_seq",
+          "event_head_seq"
+        ],
         "type": "object"
       },
       "DebugPromptRequest": {
@@ -4124,6 +4506,14 @@
         ],
         "title": "PickWorkItemResponse",
         "type": "object"
+      },
+      "ProjectionEffect": {
+        "description": "Additive top-level StreamEventEnvelope classification shared by event pages and SSE. The runtime event registry is the source of truth; legacy or otherwise unclassified events default conservatively to display_invalidation. Emitted only while events.projection-effect.v1 is advertised; introducing the field increments the envelope contract version.",
+        "enum": [
+          "none",
+          "display_invalidation"
+        ],
+        "type": "string"
       },
       "ReconcileSkillRequest": {
         "properties": {

--- a/src/http/agents.rs
+++ b/src/http/agents.rs
@@ -135,6 +135,23 @@ fn normalize_search_agent_ids(
     Ok(normalized)
 }
 
+/// Legacy control-plane capabilities plus the observer-sync capabilities
+/// evaluated from durable verification results. Until a verification source
+/// exists the evaluator keeps all observer-sync capabilities disabled.
+fn handshake_capabilities() -> Vec<&'static str> {
+    let mut capabilities = vec![
+        "agents.list",
+        "agents.state",
+        "agents.events",
+        "agents.control",
+        "tui.remote",
+    ];
+    capabilities.extend(advertised_observer_sync_capabilities(
+        &ObserverSyncCapabilityVerification::default(),
+    ));
+    capabilities
+}
+
 pub async fn handshake(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -151,13 +168,7 @@ pub async fn handshake(
             "mode": if state.require_control_token { "bearer" } else { "local" },
             "required": state.require_control_token,
         },
-        "capabilities": [
-            "agents.list",
-            "agents.state",
-            "agents.events",
-            "agents.control",
-            "tui.remote"
-        ],
+        "capabilities": handshake_capabilities(),
         "runtime": {
             "default_agent": config.default_agent_id,
             "workspace_dir": config.workspace_dir,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -97,6 +97,10 @@ mod control;
 mod events;
 mod ingress;
 mod jobs;
+// S0 contract skeleton: DTOs/fixtures/capability evaluator are exercised by
+// unit tests now and wired into handlers by the S2/S4/S5 slices.
+#[cfg_attr(not(test), allow(dead_code))]
+mod observer_sync;
 mod projection_gate;
 mod skills;
 mod state;
@@ -107,6 +111,9 @@ mod web;
 mod workspace_files;
 
 // Re-export shared helpers used across submodules.
+pub(crate) use observer_sync::{
+    advertised_observer_sync_capabilities, ObserverSyncCapabilityVerification,
+};
 pub(crate) use projection_gate::{
     ProjectionFailure, ProjectionGate, ProjectionGateError, ProjectionKey,
 };

--- a/src/http/observer_sync.rs
+++ b/src/http/observer_sync.rs
@@ -1,0 +1,396 @@
+//! Observer-sync HTTP contract skeleton.
+//!
+//! Implements the contract surface of
+//! `docs/rfcs/observer-sync-agent-summary-and-read-markers.md` (S0):
+//! snapshot DTOs, projection-effect classification, the rich cursor error
+//! shape, and the capability evaluator. The snapshot endpoints are
+//! intentionally not registered yet: a capability is advertised only after
+//! its durable verification succeeds, and until a verification source exists
+//! (S1+) the evaluator keeps all four capabilities disabled.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::types::{AgentListEntry, WorkItemPlanStatus, WorkItemState};
+
+pub(crate) const ROSTER_SNAPSHOT_CAPABILITY: &str = "agents.roster-snapshot.v1";
+pub(crate) const PROJECTION_SNAPSHOT_CAPABILITY: &str = "agents.projection-snapshot.v1";
+pub(crate) const PROJECTION_EFFECT_CAPABILITY: &str = "events.projection-effect.v1";
+pub(crate) const ATOMIC_BRIEF_CREATED_EVENT_CAPABILITY: &str = "briefs.atomic-created-event.v1";
+
+pub(crate) const AGENT_ROSTER_SNAPSHOT_CONTRACT_VERSION: u32 = 1;
+pub(crate) const AGENT_PROJECTION_SNAPSHOT_CONTRACT_VERSION: u32 = 1;
+
+/// Upper bound for `AgentLatestBrief::preview`, in UTF-8 bytes.
+pub(crate) const LATEST_BRIEF_PREVIEW_MAX_UTF8_BYTES: usize = 512;
+
+/// Durable verification results required before any observer-sync capability
+/// may be advertised. Each field is the outcome of a stored verification
+/// against the current runtime database, not a route or schema existence
+/// check. S1 introduces the verification source; until then every capability
+/// stays disabled.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ObserverSyncCapabilityVerification {
+    /// Stable `runtime_id` and current `event_log_epoch` are persisted and
+    /// survived the latest reopen check.
+    pub(crate) runtime_identity_stable: bool,
+    /// Agent identity reservation/tombstones are durable; same-epoch
+    /// `agent_id` reuse is impossible.
+    pub(crate) agent_identity_reserved: bool,
+    /// Roster snapshot consistent read view, authorization, all-or-nothing
+    /// failure, and limit tests passed for this database.
+    pub(crate) roster_snapshot_verified: bool,
+    /// Per-Agent projection snapshot consistency boundary and fault tests
+    /// passed for this database.
+    pub(crate) projection_snapshot_verified: bool,
+    /// Every served event family is classified in the event registry
+    /// inventory (page, SSE, and history).
+    pub(crate) event_projection_effect_complete: bool,
+    /// Every Brief publication path commits record plus unique
+    /// `brief_created` event atomically (or via durable outbox) and the
+    /// historical backfill is unambiguous.
+    pub(crate) brief_atomic_linkage_verified: bool,
+}
+
+/// Evaluates the four observer-sync capabilities independently. Snapshot
+/// capabilities additionally require stable runtime and Agent identity
+/// verification because their responses anchor browser cache partitions to
+/// `(runtime_id, visibility_scope_id, event_log_epoch)`.
+pub(crate) fn advertised_observer_sync_capabilities(
+    verification: &ObserverSyncCapabilityVerification,
+) -> Vec<&'static str> {
+    let mut capabilities = Vec::new();
+    if verification.runtime_identity_stable
+        && verification.agent_identity_reserved
+        && verification.roster_snapshot_verified
+    {
+        capabilities.push(ROSTER_SNAPSHOT_CAPABILITY);
+    }
+    if verification.runtime_identity_stable
+        && verification.agent_identity_reserved
+        && verification.projection_snapshot_verified
+    {
+        capabilities.push(PROJECTION_SNAPSHOT_CAPABILITY);
+    }
+    if verification.event_projection_effect_complete {
+        capabilities.push(PROJECTION_EFFECT_CAPABILITY);
+    }
+    if verification.brief_atomic_linkage_verified {
+        capabilities.push(ATOMIC_BRIEF_CREATED_EVENT_CAPABILITY);
+    }
+    capabilities
+}
+
+/// Authoritative roster snapshot for membership, authorization visibility,
+/// and per-Agent event-window anchors. All-or-nothing: a failure to assemble
+/// one Agent fails the whole response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct AgentRosterSnapshot {
+    pub(crate) contract_version: u32,
+    /// Stable public identity of the runtime installation. Distinguishes a
+    /// replaced server from an ordinary restart. Not a secret.
+    pub(crate) runtime_id: String,
+    pub(crate) event_log_epoch: String,
+    pub(crate) visibility_scope_id: String,
+    /// Active public Agents visible to the caller. Private child Agents are
+    /// never included.
+    pub(crate) agents: Vec<AgentRosterEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct AgentRosterEntry {
+    /// Same entry shape as `GET /api/agents/list`.
+    pub(crate) agent: AgentListEntry,
+    pub(crate) event_window: AgentEventWindow,
+    /// Latest canonical Brief; `null` when the Agent has no Brief yet.
+    pub(crate) latest_brief: Option<AgentLatestBrief>,
+}
+
+/// Committed event window for one Agent inside the snapshot read view. Both
+/// values must come from the same committed database view, never from an
+/// in-memory watcher or a sequence allocator.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct AgentEventWindow {
+    /// Greatest committed `event_seq` visible in the response read view.
+    pub(crate) event_head_seq: u64,
+    /// First raw event still replayable in that view; `null` when the Agent
+    /// has no events (`event_head_seq = 0`).
+    pub(crate) oldest_retained_seq: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct AgentLatestBrief {
+    pub(crate) brief_id: String,
+    /// `brief_created` event sequence linkage. `null` when the Brief cannot
+    /// be linked to a unique retained event; such Briefs do not participate
+    /// in exact unread calculation.
+    pub(crate) created_event_seq: Option<u64>,
+    pub(crate) created_at: DateTime<Utc>,
+    /// Bounded preview, at most `LATEST_BRIEF_PREVIEW_MAX_UTF8_BYTES`
+    /// UTF-8 bytes. Full text remains available from the Brief APIs.
+    pub(crate) preview: String,
+}
+
+/// Per-Agent canonical projection snapshot at one consistency boundary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct AgentProjectionSnapshot {
+    pub(crate) contract_version: u32,
+    pub(crate) runtime_id: String,
+    pub(crate) event_log_epoch: String,
+    pub(crate) visibility_scope_id: String,
+    pub(crate) agent_id: String,
+    /// Every event with `event_seq <= snapshot_through_seq` that affects the
+    /// current canonical state is already reflected in `projection`.
+    pub(crate) snapshot_through_seq: u64,
+    /// May be greater than `snapshot_through_seq`; names a committed event
+    /// available through the event page.
+    pub(crate) event_head_seq: u64,
+    pub(crate) oldest_retained_seq: Option<u64>,
+    pub(crate) projection: AgentCanonicalProjection,
+}
+
+/// First concrete `AgentCanonicalProjection`: compact current state plus
+/// stable revision anchors only. It deliberately excludes verbose timelines
+/// and full transcript/message history (see
+/// `docs/implementation-decisions/104-agent-canonical-projection-v1-boundary.md`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct AgentCanonicalProjection {
+    /// Lifecycle, posture, and compact card facts.
+    pub(crate) agent: AgentListEntry,
+    /// Current focused/open WorkItem anchor; `null` when none exists.
+    pub(crate) current_work_item: Option<AgentWorkItemAnchor>,
+    pub(crate) conversation: ConversationRevisionAnchors,
+    pub(crate) latest_brief: Option<AgentLatestBrief>,
+    /// Records deleted at or before the snapshot boundary. They terminate
+    /// pending hydration without fetching a record that no longer exists.
+    #[serde(default)]
+    pub(crate) hydration_tombstones: Vec<AgentHydrationKey>,
+    /// Records referenced by the projection but still resolvable through the
+    /// batch record APIs.
+    #[serde(default)]
+    pub(crate) hydration_references: Vec<AgentHydrationKey>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct AgentWorkItemAnchor {
+    pub(crate) work_item_id: String,
+    pub(crate) state: WorkItemState,
+    pub(crate) plan_status: WorkItemPlanStatus,
+    /// Canonical WorkItem revision at the snapshot boundary.
+    pub(crate) revision: u64,
+    pub(crate) updated_at: DateTime<Utc>,
+}
+
+/// Latest-record anchors for conversation families whose canonical records
+/// carry no per-record revision counter. Combined with replayed events they
+/// let a client decide whether a local record is current at the boundary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ConversationRevisionAnchors {
+    pub(crate) latest_message_id: Option<String>,
+    pub(crate) latest_transcript_entry_id: Option<String>,
+}
+
+/// Identifies one canonical record for hydration termination or resolution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct AgentHydrationKey {
+    pub(crate) record_kind: ObserverSyncRecordKind,
+    pub(crate) record_id: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ObserverSyncRecordKind {
+    Message,
+    Brief,
+    TranscriptEntry,
+}
+
+/// Additive `StreamEventEnvelope` classification published by event pages
+/// and SSE once `events.projection-effect.v1` is enabled. The runtime event
+/// registry is the source of truth; legacy or otherwise unclassified events
+/// default conservatively to `DisplayInvalidation`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ProjectionEffect {
+    /// Does not affect the Web projection; never blocks readiness.
+    None,
+    /// Invalidates display state derived from the referenced record; blocks
+    /// projection readiness until resolved.
+    DisplayInvalidation,
+}
+
+/// Rich `cursor_not_found` body for event pages and SSE. `event_log_epoch`,
+/// `oldest_retained_seq`, and `event_head_seq` must come from one committed
+/// read view so clients can distinguish a retained-prefix gap from an epoch
+/// change and select the correct reset path.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct RichCursorNotFoundError {
+    pub(crate) ok: bool,
+    pub(crate) error: String,
+    pub(crate) code: String,
+    pub(crate) after_seq: u64,
+    pub(crate) event_log_epoch: String,
+    pub(crate) oldest_retained_seq: Option<u64>,
+    pub(crate) event_head_seq: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    const FIXTURE_DIR: &str = "tests/fixtures/observer_sync";
+
+    fn load_fixture(name: &str) -> Value {
+        let path = format!("{FIXTURE_DIR}/{name}");
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("failed to read {path}: {err}"));
+        serde_json::from_str(&raw).unwrap_or_else(|err| panic!("invalid fixture {path}: {err}"))
+    }
+
+    fn assert_round_trip<T: serde::de::DeserializeOwned + Serialize>(name: &str) -> T {
+        let fixture = load_fixture(name);
+        let parsed: T = serde_json::from_value(fixture.clone())
+            .unwrap_or_else(|err| panic!("fixture {name} failed to deserialize: {err}"));
+        let serialized = serde_json::to_value(&parsed)
+            .unwrap_or_else(|err| panic!("fixture {name} failed to serialize: {err}"));
+        assert_eq!(serialized, fixture, "fixture {name} does not round-trip");
+        parsed
+    }
+
+    #[test]
+    fn evaluator_disables_all_capabilities_without_verification() {
+        let advertised = advertised_observer_sync_capabilities(&Default::default());
+        assert!(advertised.is_empty());
+    }
+
+    #[test]
+    fn evaluator_requires_identity_prerequisites_for_snapshot_capabilities() {
+        let verification = ObserverSyncCapabilityVerification {
+            roster_snapshot_verified: true,
+            projection_snapshot_verified: true,
+            brief_atomic_linkage_verified: true,
+            event_projection_effect_complete: true,
+            ..Default::default()
+        };
+        let advertised = advertised_observer_sync_capabilities(&verification);
+        assert!(!advertised.contains(&ROSTER_SNAPSHOT_CAPABILITY));
+        assert!(!advertised.contains(&PROJECTION_SNAPSHOT_CAPABILITY));
+        assert!(advertised.contains(&PROJECTION_EFFECT_CAPABILITY));
+        assert!(advertised.contains(&ATOMIC_BRIEF_CREATED_EVENT_CAPABILITY));
+    }
+
+    #[test]
+    fn evaluator_advertises_capabilities_independently() {
+        let verification = ObserverSyncCapabilityVerification {
+            runtime_identity_stable: true,
+            agent_identity_reserved: true,
+            roster_snapshot_verified: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            advertised_observer_sync_capabilities(&verification),
+            vec![ROSTER_SNAPSHOT_CAPABILITY]
+        );
+
+        let verification = ObserverSyncCapabilityVerification {
+            runtime_identity_stable: true,
+            agent_identity_reserved: true,
+            projection_snapshot_verified: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            advertised_observer_sync_capabilities(&verification),
+            vec![PROJECTION_SNAPSHOT_CAPABILITY]
+        );
+    }
+
+    #[test]
+    fn roster_snapshot_fixture_round_trips() {
+        let snapshot: AgentRosterSnapshot = assert_round_trip("agent_roster_snapshot.json");
+        assert_eq!(
+            snapshot.contract_version,
+            AGENT_ROSTER_SNAPSHOT_CONTRACT_VERSION
+        );
+        for entry in &snapshot.agents {
+            assert_brief_preview_bounded(entry.latest_brief.as_ref());
+        }
+    }
+
+    #[test]
+    fn projection_snapshot_fixture_round_trips() {
+        let snapshot: AgentProjectionSnapshot = assert_round_trip("agent_projection_snapshot.json");
+        assert_eq!(
+            snapshot.contract_version,
+            AGENT_PROJECTION_SNAPSHOT_CONTRACT_VERSION
+        );
+        assert_brief_preview_bounded(snapshot.projection.latest_brief.as_ref());
+    }
+
+    #[test]
+    fn cursor_not_found_fixture_round_trips() {
+        let error: RichCursorNotFoundError = assert_round_trip("cursor_not_found_error.json");
+        assert!(!error.ok);
+        assert_eq!(error.code, "cursor_not_found");
+    }
+
+    #[test]
+    fn projection_effect_serializes_rfc_values() {
+        assert_eq!(
+            serde_json::to_value(ProjectionEffect::None).unwrap(),
+            Value::String("none".into())
+        );
+        assert_eq!(
+            serde_json::to_value(ProjectionEffect::DisplayInvalidation).unwrap(),
+            Value::String("display_invalidation".into())
+        );
+        assert_eq!(
+            serde_json::from_value::<ProjectionEffect>(Value::String("none".into())).unwrap(),
+            ProjectionEffect::None
+        );
+        assert_eq!(
+            serde_json::from_value::<ProjectionEffect>(Value::String(
+                "display_invalidation".into()
+            ))
+            .unwrap(),
+            ProjectionEffect::DisplayInvalidation
+        );
+    }
+
+    #[test]
+    fn openapi_registers_observer_sync_schemas_without_routes() {
+        let api = crate::openapi::generate_openapi_json();
+        let schemas = api["components"]["schemas"].as_object().unwrap();
+        for name in [
+            "AgentRosterSnapshot",
+            "AgentRosterEntry",
+            "AgentEventWindow",
+            "AgentLatestBrief",
+            "AgentProjectionSnapshot",
+            "AgentCanonicalProjection",
+            "AgentWorkItemAnchor",
+            "ConversationRevisionAnchors",
+            "AgentHydrationKey",
+            "ProjectionEffect",
+            "CursorNotFoundError",
+        ] {
+            assert!(schemas.contains_key(name), "missing schema {name}");
+        }
+        let paths = api["paths"].as_object().unwrap();
+        // S0 registers no snapshot routes: route existence must never be
+        // mistaken for capability support.
+        assert!(!paths.contains_key("/api/agents/snapshot"));
+        assert!(!paths.contains_key("/api/agents/{agent_id}/projection-snapshot"));
+    }
+
+    fn assert_brief_preview_bounded(latest_brief: Option<&AgentLatestBrief>) {
+        let Some(brief) = latest_brief else {
+            return;
+        };
+        assert!(
+            brief.preview.len() <= LATEST_BRIEF_PREVIEW_MAX_UTF8_BYTES,
+            "preview exceeds {} UTF-8 bytes",
+            LATEST_BRIEF_PREVIEW_MAX_UTF8_BYTES
+        );
+    }
+}

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -811,6 +811,230 @@ fn component_schemas() -> Value {
         "SyncTemplateRemoteSourcesRequest".into(),
         component_schema::<SyncTemplateRemoteSourcesRequest>(),
     );
+    schemas.insert(
+        "AgentRosterSnapshot".into(),
+        json!({
+            "type": "object",
+            "description": "Authoritative roster snapshot (RFC: observer sync). All-or-nothing membership with per-Agent event windows and latest Brief anchors. Served by GET /api/agents/snapshot only while the agents.roster-snapshot.v1 capability is advertised; route registration alone is never sufficient.",
+            "properties": {
+                "contract_version": { "type": "integer", "const": 1 },
+                "runtime_id": { "type": "string", "description": "Stable public identity of the runtime installation. Distinguishes a replaced server at the same URL from an ordinary restart. Not a secret." },
+                "event_log_epoch": { "type": "string", "description": "Current event log epoch; a changed value means historical event continuity is intentionally reset." },
+                "visibility_scope_id": { "type": "string", "description": "Server-generated scope id derived from stable runtime identity, resolved authority, normalized visibility entitlement, and policy generation. Never contains credentials or tokens." },
+                "agents": {
+                    "type": "array",
+                    "description": "Active public Agents visible to the caller in one committed read view. Private child Agents are never included. A failure to assemble one Agent fails the whole response.",
+                    "items": { "$ref": "#/components/schemas/AgentRosterEntry" }
+                }
+            },
+            "required": ["contract_version", "runtime_id", "event_log_epoch", "visibility_scope_id", "agents"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
+        "AgentRosterEntry".into(),
+        json!({
+            "type": "object",
+            "properties": {
+                "agent": { "$ref": "#/components/schemas/AgentListEntry" },
+                "event_window": { "$ref": "#/components/schemas/AgentEventWindow" },
+                "latest_brief": {
+                    "oneOf": [
+                        { "$ref": "#/components/schemas/AgentLatestBrief" },
+                        { "type": "null" }
+                    ],
+                    "description": "Latest canonical Brief; null when the Agent has no Brief yet."
+                }
+            },
+            "required": ["agent", "event_window", "latest_brief"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
+        "AgentListEntry".into(),
+        json!({
+            "type": "object",
+            "description": "Public Agent entry, same shape as GET /api/agents/list response entries. Baseline object schema until the agents/list DTO stabilizes under a named schema.",
+            "additionalProperties": true
+        }),
+    );
+    schemas.insert(
+        "AgentEventWindow".into(),
+        json!({
+            "type": "object",
+            "description": "Committed event window for one Agent inside one snapshot read view. Values come from a committed database view, never from an in-memory watcher or a sequence allocator.",
+            "properties": {
+                "event_head_seq": { "type": "integer", "minimum": 0, "description": "Greatest committed event_seq visible in the response read view." },
+                "oldest_retained_seq": {
+                    "oneOf": [
+                        { "type": "integer", "minimum": 0 },
+                        { "type": "null" }
+                    ],
+                    "description": "First raw event still replayable in that view; null when the Agent has no events (event_head_seq = 0)."
+                }
+            },
+            "required": ["event_head_seq", "oldest_retained_seq"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
+        "AgentLatestBrief".into(),
+        json!({
+            "type": "object",
+            "description": "Latest Brief anchor derived from canonical Brief storage, not a second UI-summary table.",
+            "properties": {
+                "brief_id": { "type": "string" },
+                "created_event_seq": {
+                    "oneOf": [
+                        { "type": "integer", "minimum": 0 },
+                        { "type": "null" }
+                    ],
+                    "description": "Immutable brief_created event linkage; null when the Brief cannot be linked to a unique retained event. Null-linked Briefs do not participate in exact unread calculation."
+                },
+                "created_at": { "type": "string", "format": "date-time" },
+                "preview": { "type": "string", "maxLength": 512, "description": "Bounded to 512 UTF-8 bytes. Full Brief content remains available from the canonical Brief APIs." }
+            },
+            "required": ["brief_id", "created_event_seq", "created_at", "preview"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
+        "AgentProjectionSnapshot".into(),
+        json!({
+            "type": "object",
+            "description": "Per-Agent canonical projection snapshot at one consistency boundary (RFC: observer sync). Served by GET /api/agents/{agent_id}/projection-snapshot only while the agents.projection-snapshot.v1 capability is advertised.",
+            "properties": {
+                "contract_version": { "type": "integer", "const": 1 },
+                "runtime_id": { "type": "string" },
+                "event_log_epoch": { "type": "string" },
+                "visibility_scope_id": { "type": "string" },
+                "agent_id": { "type": "string" },
+                "snapshot_through_seq": { "type": "integer", "minimum": 0, "description": "Every event with event_seq <= snapshot_through_seq that affects current canonical state is already reflected in the projection or its revision anchors." },
+                "event_head_seq": { "type": "integer", "minimum": 0, "description": "May exceed snapshot_through_seq; names a committed event available through the event page. Clients replay (snapshot_through_seq, event_head_seq] and later events." },
+                "oldest_retained_seq": {
+                    "oneOf": [
+                        { "type": "integer", "minimum": 0 },
+                        { "type": "null" }
+                    ]
+                },
+                "projection": { "$ref": "#/components/schemas/AgentCanonicalProjection" }
+            },
+            "required": ["contract_version", "runtime_id", "event_log_epoch", "visibility_scope_id", "agent_id", "snapshot_through_seq", "event_head_seq", "oldest_retained_seq", "projection"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
+        "AgentCanonicalProjection".into(),
+        json!({
+            "type": "object",
+            "description": "First concrete AgentCanonicalProjection: compact current state plus stable revision anchors only. Deliberately excludes verbose timelines and full transcript/message history (see docs/implementation-decisions/104-agent-canonical-projection-v1-boundary.md).",
+            "properties": {
+                "agent": { "$ref": "#/components/schemas/AgentListEntry" },
+                "current_work_item": {
+                    "oneOf": [
+                        { "$ref": "#/components/schemas/AgentWorkItemAnchor" },
+                        { "type": "null" }
+                    ],
+                    "description": "Current WorkItem anchor; null when the Agent has no current WorkItem."
+                },
+                "conversation": { "$ref": "#/components/schemas/ConversationRevisionAnchors" },
+                "latest_brief": {
+                    "oneOf": [
+                        { "$ref": "#/components/schemas/AgentLatestBrief" },
+                        { "type": "null" }
+                    ]
+                },
+                "hydration_tombstones": {
+                    "type": "array",
+                    "description": "Records deleted at or before the snapshot boundary; they terminate pending hydration without fetching a record that no longer exists.",
+                    "items": { "$ref": "#/components/schemas/AgentHydrationKey" }
+                },
+                "hydration_references": {
+                    "type": "array",
+                    "description": "Records referenced by the projection but still resolvable through the batch record APIs.",
+                    "items": { "$ref": "#/components/schemas/AgentHydrationKey" }
+                }
+            },
+            "required": ["agent", "current_work_item", "conversation", "latest_brief", "hydration_tombstones", "hydration_references"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
+        "AgentWorkItemAnchor".into(),
+        json!({
+            "type": "object",
+            "properties": {
+                "work_item_id": { "type": "string" },
+                "state": { "type": "string" },
+                "plan_status": { "type": "string" },
+                "revision": { "type": "integer", "minimum": 0, "description": "Canonical WorkItem revision at the snapshot boundary." },
+                "updated_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["work_item_id", "state", "plan_status", "revision", "updated_at"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
+        "ConversationRevisionAnchors".into(),
+        json!({
+            "type": "object",
+            "description": "Latest-record anchors for conversation families whose canonical records carry no per-record revision counter. Always present; null fields mean the family has no record at the boundary.",
+            "properties": {
+                "latest_message_id": {
+                    "oneOf": [{ "type": "string" }, { "type": "null" }]
+                },
+                "latest_transcript_entry_id": {
+                    "oneOf": [{ "type": "string" }, { "type": "null" }]
+                }
+            },
+            "required": ["latest_message_id", "latest_transcript_entry_id"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
+        "AgentHydrationKey".into(),
+        json!({
+            "type": "object",
+            "description": "Identifies one canonical record for hydration termination (tombstone) or batch resolution (reference).",
+            "properties": {
+                "record_kind": { "type": "string", "enum": ["message", "brief", "transcript_entry"] },
+                "record_id": { "type": "string" }
+            },
+            "required": ["record_kind", "record_id"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
+        "ProjectionEffect".into(),
+        json!({
+            "type": "string",
+            "enum": ["none", "display_invalidation"],
+            "description": "Additive top-level StreamEventEnvelope classification shared by event pages and SSE. The runtime event registry is the source of truth; legacy or otherwise unclassified events default conservatively to display_invalidation. Emitted only while events.projection-effect.v1 is advertised; introducing the field increments the envelope contract version."
+        }),
+    );
+    schemas.insert(
+        "CursorNotFoundError".into(),
+        json!({
+            "type": "object",
+            "description": "Rich cursor_not_found body for event pages and SSE. event_log_epoch, oldest_retained_seq, and event_head_seq must come from one committed read view so clients can distinguish a retained-prefix gap from an epoch change and select the correct reset path.",
+            "properties": {
+                "ok": { "type": "boolean", "const": false },
+                "error": { "type": "string" },
+                "code": { "type": "string", "const": "cursor_not_found" },
+                "after_seq": { "type": "integer", "minimum": 0 },
+                "event_log_epoch": { "type": "string" },
+                "oldest_retained_seq": {
+                    "oneOf": [
+                        { "type": "integer", "minimum": 0 },
+                        { "type": "null" }
+                    ]
+                },
+                "event_head_seq": { "type": "integer", "minimum": 0 }
+            },
+            "required": ["ok", "error", "code", "after_seq", "event_log_epoch", "oldest_retained_seq", "event_head_seq"],
+            "additionalProperties": true
+        }),
+    );
     for name in [
         "EnqueueRequest",
         "IncomingOrigin",

--- a/tests/fixtures/observer_sync/agent_projection_snapshot.json
+++ b/tests/fixtures/observer_sync/agent_projection_snapshot.json
@@ -1,0 +1,72 @@
+{
+  "contract_version": 1,
+  "runtime_id": "rt_example_installation",
+  "event_log_epoch": "epoch_2026_08_18_example",
+  "visibility_scope_id": "scope_public_local_example",
+  "agent_id": "worker-a",
+  "snapshot_through_seq": 120,
+  "event_head_seq": 128,
+  "oldest_retained_seq": 4,
+  "projection": {
+    "agent": {
+      "identity": {
+        "agent_id": "worker-a",
+        "kind": "named",
+        "visibility": "public",
+        "ownership": "self_owned",
+        "profile_preset": "public_named",
+        "status": "active",
+        "is_default_agent": false
+      },
+      "status": "awake_idle",
+      "scheduling_posture": {
+        "posture": "waiting_for_external",
+        "reason": "awaiting_external_change",
+        "work_item_id": "work_example_current"
+      },
+      "lifecycle": {
+        "accepts_external_messages": true
+      },
+      "pending": 0,
+      "model": {
+        "source": "runtime_default",
+        "runtime_default_model": "example-provider@default/example-model",
+        "effective_model": "example-provider@default/example-model",
+        "fallback_active": false
+      }
+    },
+    "current_work_item": {
+      "work_item_id": "work_example_current",
+      "state": "open",
+      "plan_status": "ready",
+      "revision": 7,
+      "updated_at": "2026-08-18T06:39:30Z"
+    },
+    "conversation": {
+      "latest_message_id": "msg_0192_example",
+      "latest_transcript_entry_id": "te_0192_example"
+    },
+    "latest_brief": {
+      "brief_id": "brief_0192_example",
+      "created_event_seq": 120,
+      "created_at": "2026-08-18T06:40:00Z",
+      "preview": "Example bounded brief preview."
+    },
+    "hydration_tombstones": [
+      {
+        "record_kind": "message",
+        "record_id": "msg_0181_deleted_example"
+      }
+    ],
+    "hydration_references": [
+      {
+        "record_kind": "brief",
+        "record_id": "brief_0192_example"
+      },
+      {
+        "record_kind": "transcript_entry",
+        "record_id": "te_0192_example"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/observer_sync/agent_roster_snapshot.json
+++ b/tests/fixtures/observer_sync/agent_roster_snapshot.json
@@ -1,0 +1,79 @@
+{
+  "contract_version": 1,
+  "runtime_id": "rt_example_installation",
+  "event_log_epoch": "epoch_2026_08_18_example",
+  "visibility_scope_id": "scope_public_local_example",
+  "agents": [
+    {
+      "agent": {
+        "identity": {
+          "agent_id": "worker-a",
+          "kind": "named",
+          "visibility": "public",
+          "ownership": "self_owned",
+          "profile_preset": "public_named",
+          "status": "active",
+          "is_default_agent": false
+        },
+        "status": "awake_idle",
+        "scheduling_posture": {
+          "posture": "waiting_for_external",
+          "reason": "awaiting_external_change"
+        },
+        "lifecycle": {
+          "accepts_external_messages": true
+        },
+        "pending": 0,
+        "model": {
+          "source": "runtime_default",
+          "runtime_default_model": "example-provider@default/example-model",
+          "effective_model": "example-provider@default/example-model",
+          "fallback_active": false
+        }
+      },
+      "event_window": {
+        "event_head_seq": 128,
+        "oldest_retained_seq": 4
+      },
+      "latest_brief": {
+        "brief_id": "brief_0192_example",
+        "created_event_seq": 120,
+        "created_at": "2026-08-18T06:40:00Z",
+        "preview": "Example bounded brief preview."
+      }
+    },
+    {
+      "agent": {
+        "identity": {
+          "agent_id": "worker-b",
+          "kind": "named",
+          "visibility": "public",
+          "ownership": "self_owned",
+          "profile_preset": "public_named",
+          "status": "active",
+          "is_default_agent": false
+        },
+        "status": "booting",
+        "scheduling_posture": {
+          "posture": "unknown",
+          "reason": "posture projection unavailable"
+        },
+        "lifecycle": {
+          "accepts_external_messages": true
+        },
+        "pending": 0,
+        "model": {
+          "source": "runtime_default",
+          "runtime_default_model": "example-provider@default/example-model",
+          "effective_model": "example-provider@default/example-model",
+          "fallback_active": false
+        }
+      },
+      "event_window": {
+        "event_head_seq": 0,
+        "oldest_retained_seq": null
+      },
+      "latest_brief": null
+    }
+  ]
+}

--- a/tests/fixtures/observer_sync/cursor_not_found_error.json
+++ b/tests/fixtures/observer_sync/cursor_not_found_error.json
@@ -1,0 +1,9 @@
+{
+  "ok": false,
+  "error": "after_seq 12 was not found in the replay window",
+  "code": "cursor_not_found",
+  "after_seq": 12,
+  "event_log_epoch": "epoch_2026_08_18_example",
+  "oldest_retained_seq": 40,
+  "event_head_seq": 128
+}

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -2033,6 +2033,18 @@ export interface components {
                 skill?: string | null;
             };
         };
+        /** @description First concrete AgentCanonicalProjection: compact current state plus stable revision anchors only. Deliberately excludes verbose timelines and full transcript/message history (see docs/implementation-decisions/104-agent-canonical-projection-v1-boundary.md). */
+        AgentCanonicalProjection: {
+            agent: components["schemas"]["AgentListEntry"];
+            conversation: components["schemas"]["ConversationRevisionAnchors"];
+            /** @description Current WorkItem anchor; null when the Agent has no current WorkItem. */
+            current_work_item: components["schemas"]["AgentWorkItemAnchor"] | null;
+            /** @description Records referenced by the projection but still resolvable through the batch record APIs. */
+            hydration_references: components["schemas"]["AgentHydrationKey"][];
+            /** @description Records deleted at or before the snapshot boundary; they terminate pending hydration without fetching a record that no longer exists. */
+            hydration_tombstones: components["schemas"]["AgentHydrationKey"][];
+            latest_brief: components["schemas"]["AgentLatestBrief"] | null;
+        };
         /** AgentDeletionResponse */
         AgentDeletionResponse: {
             created: boolean;
@@ -2116,6 +2128,67 @@ export interface components {
                 /** Format: date-time */
                 updated_at: string;
             } | null;
+        };
+        /** @description Committed event window for one Agent inside one snapshot read view. Values come from a committed database view, never from an in-memory watcher or a sequence allocator. */
+        AgentEventWindow: {
+            /** @description Greatest committed event_seq visible in the response read view. */
+            event_head_seq: number;
+            /** @description First raw event still replayable in that view; null when the Agent has no events (event_head_seq = 0). */
+            oldest_retained_seq: number | null;
+        };
+        /** @description Identifies one canonical record for hydration termination (tombstone) or batch resolution (reference). */
+        AgentHydrationKey: {
+            record_id: string;
+            /** @enum {string} */
+            record_kind: "message" | "brief" | "transcript_entry";
+        };
+        /** @description Latest Brief anchor derived from canonical Brief storage, not a second UI-summary table. */
+        AgentLatestBrief: {
+            brief_id: string;
+            /** Format: date-time */
+            created_at: string;
+            /** @description Immutable brief_created event linkage; null when the Brief cannot be linked to a unique retained event. Null-linked Briefs do not participate in exact unread calculation. */
+            created_event_seq: number | null;
+            /** @description Bounded to 512 UTF-8 bytes. Full Brief content remains available from the canonical Brief APIs. */
+            preview: string;
+        };
+        /** @description Public Agent entry, same shape as GET /api/agents/list response entries. Baseline object schema until the agents/list DTO stabilizes under a named schema. */
+        AgentListEntry: {
+            [key: string]: unknown;
+        };
+        /** @description Per-Agent canonical projection snapshot at one consistency boundary (RFC: observer sync). Served by GET /api/agents/{agent_id}/projection-snapshot only while the agents.projection-snapshot.v1 capability is advertised. */
+        AgentProjectionSnapshot: {
+            agent_id: string;
+            /** @constant */
+            contract_version: 1;
+            /** @description May exceed snapshot_through_seq; names a committed event available through the event page. Clients replay (snapshot_through_seq, event_head_seq] and later events. */
+            event_head_seq: number;
+            event_log_epoch: string;
+            oldest_retained_seq: number | null;
+            projection: components["schemas"]["AgentCanonicalProjection"];
+            runtime_id: string;
+            /** @description Every event with event_seq <= snapshot_through_seq that affects current canonical state is already reflected in the projection or its revision anchors. */
+            snapshot_through_seq: number;
+            visibility_scope_id: string;
+        };
+        AgentRosterEntry: {
+            agent: components["schemas"]["AgentListEntry"];
+            event_window: components["schemas"]["AgentEventWindow"];
+            /** @description Latest canonical Brief; null when the Agent has no Brief yet. */
+            latest_brief: components["schemas"]["AgentLatestBrief"] | null;
+        };
+        /** @description Authoritative roster snapshot (RFC: observer sync). All-or-nothing membership with per-Agent event windows and latest Brief anchors. Served by GET /api/agents/snapshot only while the agents.roster-snapshot.v1 capability is advertised; route registration alone is never sufficient. */
+        AgentRosterSnapshot: {
+            /** @description Active public Agents visible to the caller in one committed read view. Private child Agents are never included. A failure to assemble one Agent fails the whole response. */
+            agents: components["schemas"]["AgentRosterEntry"][];
+            /** @constant */
+            contract_version: 1;
+            /** @description Current event log epoch; a changed value means historical event continuity is intentionally reset. */
+            event_log_epoch: string;
+            /** @description Stable public identity of the runtime installation. Distinguishes a replaced server at the same URL from an ordinary restart. Not a secret. */
+            runtime_id: string;
+            /** @description Server-generated scope id derived from stable runtime identity, resolved authority, normalized visibility entitlement, and policy generation. Never contains credentials or tokens. */
+            visibility_scope_id: string;
         };
         /** AgentStateSnapshotDto */
         AgentStateSnapshotDto: {
@@ -2495,6 +2568,15 @@ export interface components {
                 }[];
             };
         };
+        AgentWorkItemAnchor: {
+            plan_status: string;
+            /** @description Canonical WorkItem revision at the snapshot boundary. */
+            revision: number;
+            state: string;
+            /** Format: date-time */
+            updated_at: string;
+            work_item_id: string;
+        };
         /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
         AttachWorkspaceRequest: {
             [key: string]: unknown;
@@ -2610,6 +2692,11 @@ export interface components {
         ControlWakeRequest: {
             [key: string]: unknown;
         };
+        /** @description Latest-record anchors for conversation families whose canonical records carry no per-record revision counter. Always present; null fields mean the family has no record at the boundary. */
+        ConversationRevisionAnchors: {
+            latest_message_id: string | null;
+            latest_transcript_entry_id: string | null;
+        };
         /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
         CreateAgentRequest: {
             [key: string]: unknown;
@@ -2635,6 +2722,20 @@ export interface components {
         };
         /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
         CreateWorkItemRequest: {
+            [key: string]: unknown;
+        };
+        /** @description Rich cursor_not_found body for event pages and SSE. event_log_epoch, oldest_retained_seq, and event_head_seq must come from one committed read view so clients can distinguish a retained-prefix gap from an epoch change and select the correct reset path. */
+        CursorNotFoundError: {
+            after_seq: number;
+            /** @constant */
+            code: "cursor_not_found";
+            error: string;
+            event_head_seq: number;
+            event_log_epoch: string;
+            /** @constant */
+            ok: false;
+            oldest_retained_seq: number | null;
+        } & {
             [key: string]: unknown;
         };
         /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
@@ -3142,6 +3243,11 @@ export interface components {
                 }[];
             };
         };
+        /**
+         * @description Additive top-level StreamEventEnvelope classification shared by event pages and SSE. The runtime event registry is the source of truth; legacy or otherwise unclassified events default conservatively to display_invalidation. Emitted only while events.projection-effect.v1 is advertised; introducing the field increments the envelope contract version.
+         * @enum {string}
+         */
+        ProjectionEffect: "none" | "display_invalidation";
         /** ReconcileSkillRequest */
         ReconcileSkillRequest: {
             name?: string | null;


### PR DESCRIPTION
## Summary

S0 slice of the observer-sync RFC implementation plan (`docs/rfcs/observer-sync-agent-summary-and-read-markers.md`): fix the HTTP contract surface before any endpoint or storage work lands.

Runtime concept changed: **capability advertisement is now an evaluated result, not a hardcoded list**, and the snapshot/cursor contracts exist as reviewable DTO + OpenAPI schemas while remaining unregistered and unadvertised.

## Changes

- **`src/http/observer_sync.rs` (new)**: contract skeleton for
  - `AgentRosterSnapshot` / `AgentRosterEntry` / `AgentEventWindow` / `AgentLatestBrief`
  - `AgentProjectionSnapshot` + first concrete `AgentCanonicalProjection` v1 (`AgentWorkItemAnchor`, `ConversationRevisionAnchors`, hydration tombstones/references)
  - `ProjectionEffect { none, display_invalidation }`
  - rich `RichCursorNotFoundError` shape (`event_log_epoch` / `oldest_retained_seq` / `event_head_seq`)
  - four capability constants (`agents.roster-snapshot.v1`, `agents.projection-snapshot.v1`, `events.projection-effect.v1`, `briefs.atomic-created-event.v1`) plus `ObserverSyncCapabilityVerification` and one evaluator. Snapshot capabilities additionally require stable runtime/Agent identity verification.
- **Handshake** now appends the evaluator result; with no verification source yet the evaluator keeps all four capabilities disabled, so advertised capabilities are unchanged.
- **OpenAPI**: hand-written component schemas for the new contracts (explicit nullability, 512 UTF-8 byte brief preview bound, `additionalProperties: false`); **no new route paths are registered** — route existence must never be mistaken for capability support.
- **Fixtures** `tests/fixtures/observer_sync/*.json` with unit tests: fixture↔DTO round-trip, evaluator prerequisite matrix, OpenAPI schema presence + snapshot-route absence assertions.
- **Decision note** `docs/implementation-decisions/104-agent-canonical-projection-v1-boundary.md`: v1 carries compact current state and revision anchors only; no verbose timelines or full history (that stays behind event pages and batch APIs).
- Refreshed `docs/website/reference/openapi.json` and regenerated `web-gui/app/src/runtime/generated/openapi.ts` (`make transport-types`).

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib http::observer_sync` (8 passed)
- `cargo test --test openapi_snapshot --test http_route_snapshot`
- `make transport-types-check`

Follow-up slices (S1 identity/epoch/capability gate, S2 projection-effect + rich cursor errors, S4/S5 snapshot endpoints) will wire these contracts into real handlers; each capability stays disabled until its durable verification passes.
