### PR TITLE
docs: align scheduler contracts with canonical runtime

### DIFF
--- a/docs/rfc-implementation-notes/canonical-scheduler-activation-settlement-review.md
+++ b/docs/rfc-implementation-notes/canonical-scheduler-activation-settlement-review.md
@@ -8,6 +8,14 @@
 
 审计基线：`a0a4d8c8`，2026-08-01。
 
+> **当前状态（2026-08-18）：** 本文以下“当前实现形态”和“已采用的近期收缩”记录
+> 的是 unified execution protocol 切换前的历史审计基线。运行时已删除
+> `src/domain/scheduler_protocol.rs` 及其 slot/dispatch/WorkDemand/
+> missing-settlement 控制权，也不存在 legacy engine 或 runtime selector。当前契约以
+> [Scheduler–WorkItem Unified Execution Protocol](../rfcs/scheduler-work-item-unified-execution-protocol.md)
+> 和现行 runtime scheduler notes 为准。本文保留用于解释为何发生职责收缩，不应作为
+> 现行生产 authority 图读取。
+
 ## 结论摘要
 
 Canonical scheduler 不是一套应当整体废弃的方案。以下基础能力仍然具有明确的
@@ -34,10 +42,11 @@ settlement 表达该 attempt 的终态 outcome；运行资格、等待所有权�
 WorkItem/queue/wait 状态共同裁决。
 
 这不是立即删除 activation/settlement 的决定，也不是另起一套 scheduler 的提案。
-在新的简化设计被 RFC 明确之前，现有 canonical reducer 仍然是生产契约，修复必须
-继续遵守它的事务、幂等、fencing 和 provenance 边界。
+在当时新的简化设计被 RFC 明确之前，canonical reducer 仍是生产契约，修复必须
+遵守它的事务、幂等、fencing 和 provenance 边界。该过渡约束现已由 unified
+execution protocol 取代。
 
-## 当前实现形态
+## 历史实现形态
 
 ### 一个 snapshot 承载多组相互约束的事实
 
@@ -182,9 +191,10 @@ WorkItem、wait condition、agent state 和 queue projection，settlement builde
 读取这些事实。这意味着 canonical protocol 当前更像覆盖在已有 runtime lifecycle
 之上的控制层，而不是唯一状态机。
 
-这不等同于仍在运行两套 scheduler；accepted cutover RFC 已经要求一个进程只选择一个
-调度引擎。问题在于：即使只有 canonical engine，engine 内仍存在 protocol state 与
-operational state 的双向同步。只删除 rollout/shadow 控制面并不会自动消除这层重复。
+这在当时也不等同于同时运行两套 scheduler；进程只运行所选引擎。问题在于：即使只有
+canonical engine，engine 内仍存在 protocol state 与 operational state 的双向同步。
+后续删除 rollout/shadow 控制面本身并不会自动消除这层重复，因此最终还需要 unified
+execution protocol 收敛 authority。
 
 ### 7. Protocol conflict 会演化为 agent 不可用
 
@@ -307,7 +317,7 @@ owner 检查。
 
 Runtime loop 不应把普通 protocol rejection 无差别转成 agent restart。
 
-## 已采用的近期收缩
+## 当时已采用的近期收缩
 
 在不更换 scheduler、不修改持久化 schema 的前提下，近期实现先收缩最容易反复出错的
 lane 边界：
@@ -321,8 +331,8 @@ lane 边界：
   canonical partition 之外并产生诊断，不再阻止 agent 处理已经合法的 canonical work；
 - canonical prestate 损坏、存储错误和 missing-settlement recovery 仍然 fail closed。
 
-这是面向稳定性的有界修正，不代表 activation/settlement 的长期职责收缩已经完成。后续
-是否继续简化，应以生产 trace replay、restart drill 和 invariant 规模是否明显下降为依据。
+这是当时面向稳定性的有界修正；后续 unified execution protocol 和 canonical-only
+cutover 已完成长期职责收缩。下面的测试结果仍只代表该审计基线。
 
 ## 验证和测试缺口
 

--- a/docs/rfc-implementation-notes/runtime-scheduler-contract.md
+++ b/docs/rfc-implementation-notes/runtime-scheduler-contract.md
@@ -28,6 +28,12 @@ observability. See
 [scheduler spec](../website/spec/scheduler.md) and
 [implementation decision 098](../implementation-decisions/098-scheduler-protocol-transition-wraps-legacy-boundaries-atomically.md).
 
+The implementation-decision title records the historical migration boundary.
+The current `QueueTransitionCommand` contains only canonical queue, WorkItem,
+agent-state, message, transcript, Turn, audit, and brief mutations; it carries
+no legacy scheduler protocol payload. The runtime has no scheduler engine
+selector or legacy admission path.
+
 Canonical scheduler snapshots and ordinary queue/protocol transactions no
 longer load rollout manifests, preflights, per-scenario authority, expectations,
 or hard blockers. Migration 40 records that those tables are retired
@@ -41,6 +47,10 @@ its public export are gone, and runtime tests no longer configure historical
 scenario-authority rows. Published rollout, shadow-comparison, and semantic
 decision migrations remain immutable and are covered as upgrade compatibility
 schema.
+
+Published legacy scheduler command JSON shapes likewise remain only in
+migration parsing and tests that prove old databases can be read safely. They
+are not domain commands or runtime authority.
 
 `holon debug scheduler-recovery` reports retired rollout row counts and stale
 authoritative rows separately from typed canonical recovery candidates. The

--- a/docs/rfcs/scheduler-cutover-simplification.md
+++ b/docs/rfcs/scheduler-cutover-simplification.md
@@ -7,12 +7,13 @@ handle: rfc-scheduler-cutover-simplification
 
 # RFC: Scheduler Cutover Simplification
 
-> **Canonical-only amendment (2026-08-16):** the bounded compatibility window
-> ended after v0.31.1. The runtime now has one canonical scheduler. Legacy
-> rollback uses v0.31.1 with a pre-migration database backup. A redundant
-> `canonical` selector is accepted with a warning for one minor release;
-> `legacy` and unknown values fail startup. Schema deletion is delivered in a
-> separate follow-up migration.
+> **Canonical-only amendment (2026-08-18):** the bounded compatibility window
+> ended after v0.31.1. The runtime now has one canonical scheduler and no
+> scheduler engine selector. `HOLON_SCHEDULER` and the persisted
+> `runtime.scheduler` key are no longer runtime inputs. Legacy rollback uses
+> v0.31.1 with a pre-migration database backup. Published legacy wire and schema
+> shapes remain only where migration compatibility or historical diagnostics
+> require them.
 
 ## Summary
 
@@ -45,13 +46,13 @@ CI and release environments qualify one build
         operator makes one release decision
                     |
                     v
- process starts with legacy or canonical selected
+       process starts the canonical scheduler
                     |
                     v
        exactly one scheduler owns all admissions
                     |
                     v
- legacy and the temporary selector are deleted
+ legacy code and the temporary selector stay deleted
 ```
 
 Holon will not maintain a production path that:
@@ -82,11 +83,11 @@ This RFC also supersedes implementation notes or website text that describes:
 [Runtime Scheduler Contract](./runtime-scheduler-contract.md) remains the
 broader scheduler vocabulary and projection contract.
 
-## Current, Transition, And Target States
+## Historical Transition And Current State
 
-### Current state
+### Historical state on July 31, 2026
 
-As of July 31, 2026, startup exposes a temporary process-wide
+On July 31, 2026, startup exposed a temporary process-wide
 `legacy | canonical` selector. The selected engine is immutable for the process
 and the two engines do not shadow or compare each other in production.
 
@@ -98,7 +99,7 @@ export have been removed. `holon debug scheduler-recovery` retains a read-only
 summary of historical rollout rows so operators can distinguish compatibility
 data from canonical recovery candidates.
 
-### Transition state
+### Retired transition state
 
 The transition removes runtime rollout metadata from scheduler authority before
 performing destructive schema cleanup.
@@ -118,7 +119,7 @@ environment override > persisted configuration > canonical default
 
 This transition state is now retired by the canonical-only amendment above.
 
-The selector is:
+While it existed, the selector was:
 
 - parsed once during process startup;
 - immutable until process restart;
@@ -133,9 +134,9 @@ restored without reintroducing the deleted shadow and rollout systems. If that
 requires rebuilding a second large scheduler, Holon will remain canonical-only
 and use binary/database rollback instead.
 
-### Target state
+### Current canonical-only state
 
-The target runtime has:
+The runtime now has:
 
 - one canonical scheduler engine;
 - no scheduler engine selector;
@@ -147,8 +148,9 @@ The target runtime has:
   scheduler transactions; and
 - no schema whose rows can change scheduler authority at runtime.
 
-Historical tables may remain unread for one compatibility release before a
-later destructive migration removes them.
+Historical tables and wire shapes may remain only for published-migration
+compatibility or read-only diagnosis until a later destructive migration
+removes them.
 
 ## Preserved Canonical Contract
 
@@ -169,13 +171,14 @@ remain required:
 
 The simplification removes transition machinery, not safety invariants.
 
-## Engine Isolation
+## Historical Engine Isolation
 
-If the temporary selector is implemented, the engine choice occurs at the
-highest scheduler admission/execution boundary. Deep transition commands must
-not carry mode flags.
+This section records the isolation rule used during the retired compatibility
+window. It is not a current runtime mode or extension point. The engine choice
+occurred at the highest scheduler admission/execution boundary; deep transition
+commands did not carry mode flags.
 
-The two engines may share:
+The two historical engines could share:
 
 - message envelopes;
 - WorkItem, task, and wait persistence;
@@ -183,7 +186,7 @@ The two engines may share:
 - transcripts, briefs, delivery, and audit records; and
 - end-to-end scenarios and externally visible assertions.
 
-They must not, for the same production input:
+They could not, for the same production input:
 
 - both decide admission;
 - both reserve or consume scheduler ownership;
@@ -196,9 +199,10 @@ Comparison belongs in tests that run separate processes and databases. Tests
 compare user-visible behavior and durable invariants, not byte-for-byte
 internal records.
 
-## Adoption Boundary
+## Historical Adoption Boundary
 
-Switching engines is an offline startup operation:
+During the retired compatibility window, switching engines was an offline
+startup operation:
 
 1. stop the runtime;
 2. create a database backup;
@@ -206,7 +210,7 @@ Switching engines is an offline startup operation:
 4. perform one bounded, transactional, idempotent adoption;
 5. start serving only after adoption and invariant checks succeed.
 
-Adoption may reconstruct only business state needed by the selected engine,
+Adoption could reconstruct only business state needed by the selected engine,
 including:
 
 - open WorkItem scheduling generations;
@@ -215,8 +219,11 @@ including:
 - dequeued but non-terminal queue claims; and
 - recoverable task rejoins.
 
-Adoption must not install a rollout manifest, collect approval evidence, or
+Adoption could not install a rollout manifest, collect approval evidence, or
 grant authority by scenario class.
+
+The current binary does not perform engine adoption. Returning to legacy
+requires restoring the pre-migration backup and running v0.31.1.
 
 ## Scheduler Diagnose And Repair
 
@@ -310,9 +317,9 @@ Published migrations are immutable. The transition therefore:
 5. leaves historical tables intact for at least one compatibility release; and
 6. drops them only in a later, independently reversible schema change.
 
-The database stores scheduler facts and audit history. Configuration selects a
-temporary engine. Neither historical rollout rows nor repair records select
-authority.
+The database stores scheduler facts and audit history. There is no scheduler
+engine configuration. Neither historical rollout rows, legacy wire records,
+nor repair records select authority.
 
 The destructive cleanup migration requires a recovery fixed point: no open
 execution attempts, in-flight execution work items, or dequeued queue entries.
@@ -326,16 +333,9 @@ does not start a runtime or admit new work.
 
 There is no automatic per-scenario rollback.
 
-During the compatibility window, supported rollback is:
-
-1. stop new admission;
-2. settle or explicitly interrupt in-flight activation;
-3. stop the runtime;
-4. run diagnosis and any safe typed repair;
-5. restart with the other engine if reverse projection is supported.
-
-When reverse projection is not supported, restore the pre-cutover backup and
-run the previous binary.
+The supported legacy rollback is to stop the runtime, restore the pre-migration
+backup, and run v0.31.1. The current binary never switches engines or projects
+canonical state back into a legacy scheduler.
 
 Every supported path must be exercised in release acceptance. A rollback path
 that has not been tested is not a supported recovery promise.
@@ -353,8 +353,7 @@ Implementation is split into independently reversible changes:
 5. delete dead rollout, shadow, and semantic production surfaces (**complete**);
 6. reduce activation types only after rollout authority is gone; and
 7. delete legacy and the selector after one compatibility release
-   (**code/config removal in progress under #2509; schema cleanup follows in a
-   separate PR**).
+   (**complete; schema cleanup remains a separate migration concern**).
 
 The final legacy removal requires:
 
@@ -371,8 +370,7 @@ The final legacy removal requires:
 - Do not replace the canonical scheduler with the legacy implementation.
 - Do not weaken activation, settlement, wait, replay, or transaction
   invariants.
-- Do not support live engine switching.
-- Do not support per-agent or per-scenario engine selection.
+- Do not reintroduce live, per-agent, or per-scenario engine selection.
 - Do not preserve shadow comparison as a permanent observability system.
 - Do not make the repair tool a general database editor.
 - Do not combine destructive schema cleanup with the startup compatibility

--- a/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
+++ b/docs/rfcs/scheduler-work-item-unified-execution-protocol.md
@@ -31,12 +31,13 @@ accepted.
 
 ## Implementation Status
 
-As of 2026-08-05, canonical admission, turn binding, terminal settlement,
+As of 2026-08-18, canonical admission, turn binding, terminal settlement,
 operator interjection, exact wait reconciliation, and startup recovery read
-only the unified execution protocol and their owning business ledgers.
-Historical scheduler control tables remain available to the explicitly
-selected legacy engine and to explicit recovery diagnostics during the
-observation period; they do not grant or settle canonical execution.
+only the unified execution protocol and their owning business ledgers. The
+legacy engine and runtime engine selector have been removed. Historical
+scheduler control tables and wire shapes remain only as published-migration
+compatibility or explicit diagnostic input; they do not grant or settle
+execution.
 
 ## Motivation
 
@@ -404,14 +405,12 @@ facts are:
 - command results, audit, and delivery outbox.
 
 Historical activation authorities, slots, dispatch rows, scheduler WorkDemand,
-scheduler wait mirrors, missing-settlement rows, and rollout metadata become
-compatibility data or rebuildable evidence. During one compatibility release
-they may receive derived writes, but the canonical reader must not consult
-them for admission or settlement. Compatibility-write failure must not create
-partial primary state.
+scheduler wait mirrors, missing-settlement rows, and rollout metadata are
+compatibility data or rebuildable evidence. The canonical reader and writer do
+not consult or maintain them for admission or settlement.
 
-The process chooses `legacy` or `canonical` once at startup. There is no
-scenario, agent, conflict, or claim-time fallback between engines.
+The process always runs the canonical scheduler. There is no runtime selector
+or scenario, agent, conflict, or claim-time fallback between engines.
 
 The canonical cutover does not semantically migrate historical unresolved
 waits. A protocol-version migration cancels every pre-cutover unresolved wait
@@ -442,11 +441,9 @@ not revive, rebind, or trigger any historical wait.
 6. run required scheduler CI, crash/restart, soak, incident replay, upgrade,
    repair, and rollback drills;
 7. publish a canonical-default compatibility release retaining the
-   process-global legacy selector;
-8. remove legacy only after one explicit observation period and operator
-   approval.
-
-Legacy removal is not authorized by this RFC's implementation alone.
+   process-global legacy selector (**complete**);
+8. remove legacy after one explicit observation period and operator approval
+   (**complete**).
 
 ## Required Verification
 
@@ -482,4 +479,4 @@ slot/dispatch/WorkDemand/missing-settlement authority in the canonical reader.
 - replacement of the provider turn loop;
 - removal of append-only audit;
 - making plan, todo, prose, or focus grant execution;
-- deletion of legacy before the compatibility release and observation gate.
+- reintroduction of legacy or an engine selector after the completed cutover.

--- a/docs/testing/docker-acceptance.md
+++ b/docs/testing/docker-acceptance.md
@@ -140,10 +140,10 @@ python3 scripts/docker-e2e.py \
 
 The summary records the Git SHA, image ID and repository digest, requested
 model route, manifest hash, timings, provider attempts, token usage, tool
-counts, cleanup status, and previous image when supplied. A matrix run also
+counts, cleanup status, and previous image when supplied. A scheduler run also
 writes `scheduler-acceptance-report.json`, which binds the result to the Git
 SHA, immutable image digest, runtime schema revision, fixture corpus revision,
-manifest hash, both scheduler engines, and their per-case evidence identities.
+manifest hash, the canonical scheduler label, and per-case evidence identities.
 
 ### Checked-in cases
 
@@ -198,8 +198,8 @@ manifest hash, both scheduler engines, and their per-case evidence identities.
 
 #### Scheduler release acceptance cases
 
-The protected release run selects every case tagged `scheduler` and expands
-each into isolated `legacy` and `canonical` processes. The corpus includes:
+The protected release run selects every case tagged `scheduler` and runs each
+once in an isolated canonical process. The corpus includes:
 
 1. `scheduler-task-wait-resume` validates autonomous scheduling, promoted task
    yield/rejoin, external wait-resume, exact completion delivery binding, and
@@ -207,9 +207,8 @@ each into isolated `legacy` and `canonical` processes. The corpus includes:
 2. Provider-failure retry, multi-WorkItem scheduling, external/operator waits,
    interjection, compaction, worktree isolation, child supervision, and
    checkpoint replay retain their real process and persistence assertions.
-3. The canonical process additionally requires settled activation, demand,
-   and wait-generation state. The legacy process requires those canonical
-   execution tables to remain unused.
+3. Every scheduler case requires the canonical execution, WorkItem, queue,
+   task, and wait evidence appropriate to that scenario.
 
 These cases validate the complete boundary:
 
@@ -242,10 +241,10 @@ release ref are recorded in the run summary and attestation.
 The E2E job has read-only repository/package permissions and cannot publish a
 GitHub release, promote `latest`, or update Homebrew. Evidence is retained as a
 workflow artifact. Its attestation embeds the machine-readable scheduler
-acceptance report. The tag-triggered release workflow verifies that both
-engines passed against the same Git SHA, schema revision, fixture corpus, and
-candidate digest before publishing, then promotes that exact digest instead of
-rebuilding the container image.
+acceptance report. The tag-triggered release workflow verifies that the
+canonical scheduler suite passed against the same Git SHA, schema revision,
+fixture corpus, and candidate digest before publishing, then promotes that
+exact digest instead of rebuilding the container image.
 
 ## Phases
 

--- a/docs/website/spec/scheduler.md
+++ b/docs/website/spec/scheduler.md
@@ -12,20 +12,21 @@ It also documents the additive protocol transition layer that wraps scheduler
 decisions in atomic transactions with replay protection, explicit activation
 ownership, terminal settlement, and a public diagnostic event stream.
 
-> **Last verified:** 2026-07-31 against `src/runtime/scheduler.rs`,
+> **Last verified:** 2026-08-18 against `src/runtime/scheduler.rs`,
 > `src/runtime/scheduler_executor.rs`, `src/runtime/waiting.rs`,
 > `src/runtime/closure.rs`, `src/runtime/turn/execution.rs`,
-> `src/runtime_event.rs`, `src/types.rs`.
+> `src/runtime_db/transitions.rs`, `src/runtime_event.rs`, and `src/types.rs`.
 
 ## Source RFCs
 
 - [Runtime Scheduler Contract](https://github.com/holon-run/holon/blob/main/docs/rfcs/runtime-scheduler-contract.md)
+- [Scheduler–WorkItem Unified Execution Protocol](https://github.com/holon-run/holon/blob/main/docs/rfcs/scheduler-work-item-unified-execution-protocol.md)
 - [Scheduler Cutover Simplification](https://github.com/holon-run/holon/blob/main/docs/rfcs/scheduler-cutover-simplification.md)
 - [Scheduler Wait State And Recoverable Agent Continuation](https://github.com/holon-run/holon/blob/main/docs/rfcs/scheduler-wait-state.md)
 - [Waiting Plane And Reactivation](https://github.com/holon-run/holon/blob/main/docs/rfcs/waiting-plane-and-reactivation.md)
 - [Continuation Trigger](https://github.com/holon-run/holon/blob/main/docs/rfcs/continuation-trigger.md)
 - [Work Item Centered Agent Runtime](https://github.com/holon-run/holon/blob/main/docs/rfcs/work-item-centered-agent-runtime.md)
-- [Agent Activation, Settlement, and Dispatch](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-activation-settlement-and-dispatch.md) — normative target for admission, activation, settlement, and dispatch authority
+- [Agent Activation, Settlement, and Dispatch](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-activation-settlement-and-dispatch.md) — historical activation/settlement design; superseded where the unified protocol assigns current authority
 
 ## Core model
 
@@ -166,10 +167,9 @@ task, Turn, transcript, brief, delivery, activation, settlement, and execution
 facts share one authority and transaction path.
 
 The accepted transition contract retires runtime manifest/preflight gates,
-per-scenario authority, automatic hard-blocker rollback, and production shadow
-comparison. The retired selector is accepted only when its value is
-`canonical`, with a deprecation warning for one minor release. `legacy` and
-unknown values fail startup.
+per-scenario authority, automatic hard-blocker rollback, production shadow
+comparison, the legacy engine, and the runtime engine selector. Historical
+selector configuration is not a runtime input.
 
 ### Integration points
 
@@ -183,11 +183,10 @@ boundary records the canonical facts required by the next boundary:
 | Settlement (`runtime::commit_queue_settlement`) | `Settle` | matching activation, terminal Turn, WorkItem disposition |
 | Delivery disposition | `Settle` | settlement-bound brief or delivery evidence |
 | Operator interjection | `Admit` | running activation and safe-point identity |
-| Work-queue idle tick (`memory_refresh::emit_system_tick_from_work_queue`) | `Admit` | runnable demand and dispatch revision |
+| Work-queue idle tick (`memory_refresh::emit_system_tick_from_work_queue`) | `Admit` | runnable WorkItem identity, generation, and source revision |
 
-The semantic decision plane is not part of production admission. Its remaining
-module and fixtures are offline experimental surface and will be removed from
-the production dependency graph. Deterministic structural binding and the
+The semantic decision plane is not part of production admission. Its production
+module and fixtures have been removed. Deterministic structural binding and the
 canonical protocol retain all state-transition control.
 
 ### Public diagnostic event stream


### PR DESCRIPTION
## Summary
- align the scheduler cutover and unified protocol RFCs with the canonical-only runtime
- clarify that legacy wire/schema fields are migration or historical evidence, not runtime authority
- update runtime notes, Docker acceptance, and the website scheduler spec to remove the dual-engine/selector contract

## Verification
- `git diff --check`
- `python3 docs/website/.tools/check-links.py`
- `python3 docs/website/.tools/test-check-contract-refs.py`
- `python3 docs/website/.tools/check-contract-refs.py`
- `npm --prefix docs/website/.tools run build:index` (build succeeded; the generator also removes a pre-existing OpenAPI index entry, which was restored as an unrelated generated diff)

## Environment note
- Full `npm --prefix docs/website/.tools run build` reached `build:search` but could not load `indexbind` under local Node.js v18.20.8; the installed packages require Node.js 20+ and a compatible native addon.
