### PR TITLE
feat: observer-sync S1 identity foundations

### DIFF
--- a/docs/implementation-decisions/105-observer-sync-identity-foundations.md
+++ b/docs/implementation-decisions/105-observer-sync-identity-foundations.md
@@ -1,0 +1,43 @@
+# Observer-sync identity foundations (S1)
+
+Source: `docs/rfcs/observer-sync-agent-summary-and-read-markers.md` (S1
+identity slice). S1 makes the runtime's identity facts durable and gates the
+S0 capability evaluator on stored verification results instead of hard-coded
+defaults.
+
+Decisions:
+
+- Runtime identity stays in the existing `runtime_metadata` key-value table
+  (`runtime_id`, `event_log_epoch`,
+  `visibility_policy_generation`) and is minted lazily with
+  `INSERT OR IGNORE` at migration time. This matches the epoch lifecycle the
+  event envelope already depends on: reopen preserves, a replaced database
+  mints new values, and no epoch rotation API is added before a caller needs
+  one.
+- Agent identity reservations live in `agent_identity_reservations` and are
+  deliberately not epoch-scoped: the existing deletion contract already
+  promises that deleted agent ids remain reserved forever, so an epoch
+  rotation never releases a reservation. Deletion moves a reservation to
+  `retired`; the row is never removed. The guard runs inside
+  `upsert_agent_identity_tx`, the single transaction-level registry write, so
+  every creation, import, and replay path enforces it.
+- The v48 backfill treats `agent_identities` as authoritative for current
+  availability and only adds `retired` reservations from historical sources
+  (`agent_states`, deletion jobs, audit scopes, the legacy `agents` table).
+  It must stay idempotent under downgrade/re-upgrade cycles, so re-runs only
+  add missing rows and converge tombstones. Name-accepted upgrade paths may
+  lack historical tables entirely; each source is gated on table existence
+  and a missing source keeps the capability unverified rather than failing
+  the migration.
+- Verification results are durable rows in
+  `observer_sync_capability_verifications`, recomputed on every
+  migration/open. Invariant violations record `verified = 0` (capability
+  stays off) instead of failing the open; only structural database errors
+  fail. The handshake loads these rows through the S0 evaluator and degrades
+  to all-disabled on a load error, so a degraded database degrades
+  advertisement rather than startup or discovery.
+
+After S1 only `runtime_identity_stable` and `agent_identity_reserved` can
+become true; the snapshot/event/brief verification families stay absent
+(false) until their slices land, so no observer-sync capability is advertised
+yet.

--- a/docs/implementation-decisions/106-visibility-scope-id-derivation.md
+++ b/docs/implementation-decisions/106-visibility-scope-id-derivation.md
@@ -1,0 +1,20 @@
+# visibility_scope_id derivation inputs
+
+Source: `docs/rfcs/observer-sync-agent-summary-and-read-markers.md` (S1
+identity slice). `visibility_scope_id` is derived as a SHA-256 of
+`vscope1` domain separator, the runtime installation id, the server-resolved
+authority principal, the normalized visibility entitlement, and the
+`visibility_policy_generation` counter.
+
+Credential material is never an input. Rotating the control token with the
+same principal and entitlement therefore keeps the scope stable, while a
+principal, entitlement, policy-generation, or runtime-identity change rotates
+it. Local unauthenticated mode uses the fixed runtime-local `public` scope
+(`public`/`public`).
+
+S1 ships the pure derivation in `src/ids.rs` plus the durable policy
+generation in `runtime_metadata`; per-request authority resolution and the
+roster/projection snapshot fields that serve the scope arrive with the S4
+snapshot slice. The S1 foundation verification derives the public scope twice
+and records a fingerprint, proving determinism across reopens without
+exposing the value through any HTTP contract early.

--- a/src/http/agents.rs
+++ b/src/http/agents.rs
@@ -136,9 +136,11 @@ fn normalize_search_agent_ids(
 }
 
 /// Legacy control-plane capabilities plus the observer-sync capabilities
-/// evaluated from durable verification results. Until a verification source
-/// exists the evaluator keeps all observer-sync capabilities disabled.
-fn handshake_capabilities() -> Vec<&'static str> {
+/// evaluated from durable verification results. Observer-sync capabilities
+/// require their storage and consistency invariants to be verified for the
+/// current database; a verification load failure degrades to the all-disabled
+/// evaluator instead of failing the handshake.
+fn handshake_capabilities(state: &AppState) -> Vec<&'static str> {
     let mut capabilities = vec![
         "agents.list",
         "agents.state",
@@ -146,9 +148,20 @@ fn handshake_capabilities() -> Vec<&'static str> {
         "agents.control",
         "tui.remote",
     ];
-    capabilities.extend(advertised_observer_sync_capabilities(
-        &ObserverSyncCapabilityVerification::default(),
-    ));
+    let mut verification = ObserverSyncCapabilityVerification::default();
+    match state.host.runtime_db().observer_sync_foundations() {
+        Ok(foundations) => {
+            verification.runtime_identity_stable = foundations.runtime_identity_stable;
+            verification.agent_identity_reserved = foundations.agent_identity_reserved;
+        }
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "observer-sync foundation verification unavailable; keeping capabilities disabled"
+            );
+        }
+    }
+    capabilities.extend(advertised_observer_sync_capabilities(&verification));
     capabilities
 }
 
@@ -168,7 +181,7 @@ pub async fn handshake(
             "mode": if state.require_control_token { "bearer" } else { "local" },
             "required": state.require_control_token,
         },
-        "capabilities": handshake_capabilities(),
+        "capabilities": handshake_capabilities(&state),
         "runtime": {
             "default_agent": config.default_agent_id,
             "workspace_dir": config.workspace_dir,

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -106,6 +106,39 @@ pub(crate) fn event_log_epoch_id() -> String {
     runtime_id("epoch")
 }
 
+pub(crate) fn runtime_installation_id() -> String {
+    runtime_id("runtime")
+}
+
+/// Derives the opaque `visibility_scope_id` from stable server-side facts:
+/// the runtime installation identity, the server-resolved authority
+/// principal, the normalized visibility entitlement, and the visibility
+/// policy generation. Credential material is never an input: rotating a
+/// credential with unchanged entitlement keeps the scope stable, while a
+/// principal, entitlement, or policy change rotates it.
+pub(crate) fn visibility_scope_id(
+    runtime_id: &str,
+    authority_principal: &str,
+    authority_entitlement: &str,
+    policy_generation: u64,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"holon.visibility-scope.v1\x00");
+    hasher.update(runtime_id.as_bytes());
+    hasher.update(b"\x00");
+    hasher.update(authority_principal.as_bytes());
+    hasher.update(b"\x00");
+    hasher.update(authority_entitlement.as_bytes());
+    hasher.update(b"\x00");
+    hasher.update(policy_generation.to_string().as_bytes());
+    let digest = hasher.finalize();
+    format!("vscope1_{}", &hex(&digest[..16]))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
 pub fn work_item_delegation_id() -> String {
     runtime_id("delegation")
 }
@@ -202,6 +235,37 @@ mod tests {
         assert!(
             hex.chars().all(|ch| ch.is_ascii_hexdigit()),
             "hex portion should only contain hex digits"
+        );
+    }
+
+    #[test]
+    fn visibility_scope_id_is_stable_and_rotates_only_on_contract_inputs() {
+        let scope = visibility_scope_id("runtime_fixture", "control", "control", 0);
+        assert!(scope.starts_with("vscope1_"));
+        assert_eq!(scope.len(), "vscope1_".len() + 32);
+        // Deterministic: credential rotation with unchanged principal and
+        // entitlement has no input at all, so the scope cannot move.
+        assert_eq!(
+            scope,
+            visibility_scope_id("runtime_fixture", "control", "control", 0)
+        );
+        // Principal, entitlement, policy generation, and runtime identity
+        // changes each rotate the scope.
+        assert_ne!(
+            scope,
+            visibility_scope_id("runtime_fixture", "public", "control", 0)
+        );
+        assert_ne!(
+            scope,
+            visibility_scope_id("runtime_fixture", "control", "public", 0)
+        );
+        assert_ne!(
+            scope,
+            visibility_scope_id("runtime_fixture", "control", "control", 1)
+        );
+        assert_ne!(
+            scope,
+            visibility_scope_id("runtime_other", "control", "control", 0)
         );
     }
 }

--- a/src/runtime_db/evidence.rs
+++ b/src/runtime_db/evidence.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 
 use crate::runtime_db::index_outbox::RuntimeIndexChange;
 use crate::runtime_db::EVIDENCE_PREVIEW_LIMIT;
+use crate::types::AgentRegistryStatus;
 use crate::types::{
     AgentDeletionJob, AgentIdentityRecord, AgentState, AuditEvent, BriefRecord,
     DeliverySummaryRecord, ExecutionRootEntry, MessageEnvelope, ToolExecutionRecord,
@@ -368,10 +369,62 @@ pub(crate) fn upsert_execution_root_entry_tx(
     Ok(())
 }
 
+/// Enforces the durable Agent identity reservation invariant inside every
+/// registry write: an id retired in this runtime event-log epoch can never
+/// regain availability. Deletion only moves the reservation to `retired`;
+/// the reservation row itself is never removed.
+pub(crate) fn reserve_agent_identity_tx(
+    tx: &Transaction<'_>,
+    record: &AgentIdentityRecord,
+) -> Result<()> {
+    let retired: Option<bool> = tx
+        .query_row(
+            "SELECT reservation_state = 'retired'
+             FROM agent_identity_reservations
+             WHERE agent_id = ?1",
+            [&record.agent_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    if retired == Some(true) {
+        if record.status != AgentRegistryStatus::Deleted {
+            return Err(anyhow!(
+                "agent id {} was retired in this runtime event-log epoch; \
+                 retired agent ids are never reused",
+                record.agent_id
+            ));
+        }
+        // Re-asserting the tombstone keeps the reservation retired; the
+        // registry write below remains an idempotent stale-safe no-op.
+        return Ok(());
+    }
+    if record.status == AgentRegistryStatus::Deleted {
+        tx.execute(
+            "INSERT INTO agent_identity_reservations (agent_id, reservation_state, reserved_at, retired_at, source)
+             VALUES (?1, 'retired', ?2, ?2, 'agent_registry')
+             ON CONFLICT(agent_id) DO UPDATE SET
+               reservation_state = 'retired',
+               retired_at = excluded.retired_at",
+            params![record.agent_id, now],
+        )?;
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT OR IGNORE INTO agent_identity_reservations (agent_id, reservation_state, reserved_at, retired_at, source)
+         VALUES (?1, 'active', ?2, NULL, 'agent_registry')",
+        params![record.agent_id, now],
+    )?;
+    Ok(())
+}
+
 pub(crate) fn upsert_agent_identity_tx(
     tx: &Transaction<'_>,
     record: &AgentIdentityRecord,
 ) -> Result<()> {
+    // The reservation guard runs before the registry write so a retired id
+    // can never regain availability, not even through a stale replay.
+    reserve_agent_identity_tx(tx, record)?;
     let payload_json = serde_json::to_string(record)?;
     let kind = enum_string(&record.kind)?;
     let visibility = enum_string(&record.visibility)?;

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3095,6 +3095,26 @@ CREATE INDEX IF NOT EXISTS idx_queue_head_no_progress_agent_status
         name: "drop_retired_scheduler_schema",
         sql: "",
     },
+    Migration {
+        version: 48,
+        name: "observer_sync_identity_foundations",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS agent_identity_reservations (
+  agent_id TEXT PRIMARY KEY,
+  reservation_state TEXT NOT NULL CHECK (reservation_state IN ('active', 'retired')),
+  reserved_at TEXT NOT NULL,
+  retired_at TEXT,
+  source TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS observer_sync_capability_verifications (
+  capability TEXT PRIMARY KEY,
+  verified INTEGER NOT NULL,
+  verified_at TEXT NOT NULL,
+  detail TEXT NOT NULL
+);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {
@@ -3350,6 +3370,9 @@ fn apply_migration_transaction(transaction: &Transaction<'_>, migration: &Migrat
     if migration.name == "runtime_retention_created_at_indexes" {
         migrate_runtime_retention_created_at_indexes(transaction)?;
     }
+    if migration.name == "observer_sync_identity_foundations" {
+        backfill_observer_sync_identity_foundations(transaction)?;
+    }
     transaction.execute(
         "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
         (
@@ -3358,6 +3381,187 @@ fn apply_migration_transaction(transaction: &Transaction<'_>, migration: &Migrat
             Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         ),
     )?;
+    Ok(())
+}
+
+/// Backfills the durable Agent identity reservation registry and seeds the
+/// observer-sync capability verification table.
+///
+/// The registry (`agent_identities`) is authoritative for current
+/// availability: an Active row keeps the id reserved and available, any other
+/// status is a tombstone. Historical sources (`agent_states`, deletion jobs,
+/// audit scopes, the legacy `agents` table) only add reservations the
+/// registry lacks, always as retired tombstones, so a historical id can never
+/// be silently reused after migration.
+///
+/// Reservations are deliberately not epoch-scoped: the existing deletion
+/// contract already promises ids stay reserved forever, so an epoch rotation
+/// never releases them.
+fn table_exists_tx(transaction: &Transaction<'_>, table: &str) -> Result<bool> {
+    let count: i64 = transaction.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        [table],
+        |row| row.get(0),
+    )?;
+    Ok(count == 1)
+}
+
+fn backfill_observer_sync_identity_foundations(transaction: &Transaction<'_>) -> Result<()> {
+    // Name-accepted upgrade paths can reach this migration without every
+    // historical source table present; each source is gated so backfill
+    // never fails an otherwise acceptable database.
+    if table_exists_tx(transaction, "agent_identities")? {
+        // The registry mapping must stay idempotent under downgrade and
+        // re-upgrade cycles, so re-runs only add missing rows and converge
+        // tombstones instead of rewriting reservation history.
+        transaction.execute(
+            r#"
+INSERT OR IGNORE INTO agent_identity_reservations (agent_id, reservation_state, reserved_at, retired_at, source)
+SELECT agent_id,
+       CASE WHEN status = 'deleted' THEN 'retired' ELSE 'active' END,
+       created_at,
+       CASE WHEN status = 'deleted' THEN COALESCE(archived_at, updated_at) ELSE NULL END,
+       'agent_registry'
+FROM agent_identities
+"#,
+            [],
+        )?;
+        transaction.execute(
+            r#"
+UPDATE agent_identity_reservations
+SET reservation_state = 'retired',
+    retired_at = COALESCE(
+        retired_at,
+        (SELECT COALESCE(i.archived_at, i.updated_at)
+         FROM agent_identities i
+         WHERE i.agent_id = agent_identity_reservations.agent_id)
+    )
+WHERE reservation_state != 'retired'
+  AND agent_id IN (SELECT agent_id FROM agent_identities WHERE status = 'deleted')
+"#,
+            [],
+        )?;
+    }
+    if table_exists_tx(transaction, "agent_states")? {
+        transaction.execute(
+            r#"
+INSERT OR IGNORE INTO agent_identity_reservations (agent_id, reservation_state, reserved_at, retired_at, source)
+SELECT agent_id, 'retired', updated_at, NULL, 'backfill:agent-state'
+FROM agent_states
+"#,
+            [],
+        )?;
+    }
+    if table_exists_tx(transaction, "agent_deletion_jobs")? {
+        transaction.execute(
+            r#"
+INSERT OR IGNORE INTO agent_identity_reservations (agent_id, reservation_state, reserved_at, retired_at, source)
+SELECT agent_id, 'retired', created_at, completed_at, 'backfill:deletion-evidence'
+FROM agent_deletion_jobs
+"#,
+            [],
+        )?;
+    }
+    if table_exists_tx(transaction, "audit_events")? {
+        transaction.execute(
+            r#"
+INSERT OR IGNORE INTO agent_identity_reservations (agent_id, reservation_state, reserved_at, retired_at, source)
+SELECT agent_id, 'retired', MIN(created_at), NULL, 'backfill:audit'
+FROM audit_events
+WHERE agent_id IS NOT NULL
+GROUP BY agent_id
+"#,
+            [],
+        )?;
+    }
+    if table_exists_tx(transaction, "agents")? {
+        transaction.execute(
+            r#"
+INSERT OR IGNORE INTO agent_identity_reservations (agent_id, reservation_state, reserved_at, retired_at, source)
+SELECT agent_id, 'retired', created_at, NULL, 'backfill:legacy-agents'
+FROM agents
+"#,
+            [],
+        )?;
+    }
+
+    let mut anomalies = serde_json::Map::new();
+
+    // An agent_states payload that names a different agent than its row key
+    // means the historical identity of at least one of the two rows is
+    // untrustworthy.
+    let mut identity_mismatches = Vec::new();
+    if table_exists_tx(transaction, "agent_states")? {
+        let mut statement = transaction
+            .prepare("SELECT agent_id, payload_json FROM agent_states ORDER BY agent_id ASC")?;
+        let rows = statement.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        for row in rows {
+            let (row_agent_id, payload_json) = row?;
+            let payload_agent_id = serde_json::from_str::<serde_json::Value>(&payload_json)
+                .ok()
+                .and_then(|payload| {
+                    payload
+                        .get("agent_id")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string)
+                });
+            if payload_agent_id.as_deref() != Some(row_agent_id.as_str())
+                && identity_mismatches.len() < 20
+            {
+                identity_mismatches.push(row_agent_id);
+            }
+        }
+    }
+    if !identity_mismatches.is_empty() {
+        anomalies.insert(
+            "agent_state_identity_mismatch".to_string(),
+            serde_json::json!(identity_mismatches),
+        );
+    }
+
+    // A completed deletion job whose registry row is still available means
+    // the id was reused after retirement before this invariant existed.
+    let completed_deletions_with_available_registry: Vec<String> =
+        if table_exists_tx(transaction, "agent_deletion_jobs")?
+            && table_exists_tx(transaction, "agent_identities")?
+        {
+            let mut statement = transaction.prepare(
+                r#"
+SELECT d.agent_id
+FROM agent_deletion_jobs d
+JOIN agent_identities i ON i.agent_id = d.agent_id
+WHERE d.status = 'completed' AND i.status != 'deleted'
+ORDER BY d.agent_id ASC
+LIMIT 20
+"#,
+            )?;
+            let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+            rows.collect::<std::result::Result<_, _>>()?
+        } else {
+            Vec::new()
+        };
+    if !completed_deletions_with_available_registry.is_empty() {
+        anomalies.insert(
+            "completed_deletion_with_available_registry".to_string(),
+            serde_json::json!(completed_deletions_with_available_registry),
+        );
+    }
+
+    let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let detail = serde_json::json!({
+        "stage": "migration-backfill",
+        "anomalies": anomalies,
+    })
+    .to_string();
+    for capability in ["runtime_identity_stable", "agent_identity_reserved"] {
+        transaction.execute(
+            "INSERT OR REPLACE INTO observer_sync_capability_verifications (capability, verified, verified_at, detail)
+             VALUES (?1, 0, ?2, ?3)",
+            params![capability, now, detail],
+        )?;
+    }
     Ok(())
 }
 

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -22,6 +22,8 @@ pub(crate) mod transitions;
 pub mod types;
 pub mod write_queue;
 
+pub mod observer_sync;
+
 mod index_outbox;
 
 // Re-export public types that are referenced as `crate::runtime_db::Type`.
@@ -804,9 +806,10 @@ impl RuntimeDb {
                 apply_migration(&mut connection, migration)?;
             }
         }
-        ensure_event_log_epoch(&connection)?;
+        ensure_runtime_identity_metadata(&connection)?;
         backfill_wait_condition_payload_columns(&connection)?;
         backfill_work_item_recheck_columns(&connection)?;
+        observer_sync::verify_observer_sync_foundations(&mut connection)?;
         Ok(())
     }
 
@@ -820,14 +823,54 @@ impl RuntimeDb {
             )
             .context("runtime event-log epoch is missing")
     }
+
+    /// Stable public identity of this runtime installation. Survives
+    /// restarts and ordinary reopens; a replaced or rebuilt database mints a
+    /// new one. Not a secret.
+    pub fn runtime_id(&self) -> Result<String> {
+        let connection = self.connection()?;
+        connection
+            .query_row(
+                "SELECT value FROM runtime_metadata WHERE key = 'runtime_id'",
+                [],
+                |row| row.get(0),
+            )
+            .context("runtime installation id is missing")
+    }
+
+    /// Monotone visibility policy generation. Bumping it rotates every
+    /// derived `visibility_scope_id` without touching the event-log epoch.
+    pub fn visibility_policy_generation(&self) -> Result<u64> {
+        let connection = self.connection()?;
+        let value: String = connection
+            .query_row(
+                "SELECT value FROM runtime_metadata WHERE key = 'visibility_policy_generation'",
+                [],
+                |row| row.get(0),
+            )
+            .context("visibility policy generation is missing")?;
+        value
+            .parse()
+            .with_context(|| format!("invalid visibility policy generation {value}"))
+    }
 }
 
-fn ensure_event_log_epoch(connection: &Connection) -> Result<()> {
+fn ensure_runtime_identity_metadata(connection: &Connection) -> Result<()> {
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
     connection.execute(
         "INSERT OR IGNORE INTO runtime_metadata (key, value, created_at, updated_at)
          VALUES ('event_log_epoch', ?1, ?2, ?2)",
         rusqlite::params![crate::ids::event_log_epoch_id(), now],
+    )?;
+    connection.execute(
+        "INSERT OR IGNORE INTO runtime_metadata (key, value, created_at, updated_at)
+         VALUES ('runtime_id', ?1, ?2, ?2)",
+        rusqlite::params![crate::ids::runtime_installation_id(), now],
+    )?;
+    connection.execute(
+        "INSERT OR IGNORE INTO runtime_metadata (key, value, created_at, updated_at)
+         VALUES ('visibility_policy_generation', '0', ?1, ?1)",
+        rusqlite::params![now],
     )?;
     Ok(())
 }

--- a/src/runtime_db/observer_sync.rs
+++ b/src/runtime_db/observer_sync.rs
@@ -1,0 +1,291 @@
+//! Durable observer-sync capability verification.
+//!
+//! S1 of the observer-sync plan introduces the verification source the S0
+//! capability evaluator requires: a capability may be advertised only while
+//! its storage and consistency invariants hold for the current database.
+//! Verification re-runs on every migration/open, and a failed check records
+//! `verified = 0` durably instead of failing the open, so a degraded database
+//! degrades advertisement rather than startup.
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OptionalExtension};
+
+use crate::runtime_db::evidence::upsert_agent_identity_tx;
+use crate::types::{
+    AgentIdentityRecord, AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
+    AgentVisibility,
+};
+
+pub(crate) const RUNTIME_IDENTITY_STABLE: &str = "runtime_identity_stable";
+pub(crate) const AGENT_IDENTITY_RESERVED: &str = "agent_identity_reserved";
+
+/// Principal and entitlement used to derive the runtime-local public scope
+/// for unauthenticated local mode.
+pub(crate) const PUBLIC_SCOPE_PRINCIPAL: &str = "public";
+pub(crate) const PUBLIC_SCOPE_ENTITLEMENT: &str = "public";
+
+/// Verification rows for the two S1 foundations. The S2-S5 verification
+/// families stay absent (and therefore false) until their slices land.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ObserverSyncFoundationVerification {
+    pub runtime_identity_stable: bool,
+    pub agent_identity_reserved: bool,
+}
+
+/// Recomputes the S1 foundation verifications and persists the results.
+///
+/// Must run after `ensure_runtime_identity_metadata` so the runtime id and
+/// epoch exist. Structural database errors propagate; invariant violations
+/// are recorded as `verified = 0`.
+pub(crate) fn verify_observer_sync_foundations(connection: &mut Connection) -> Result<()> {
+    if !verification_tables_exist(connection)? {
+        return Ok(());
+    }
+
+    let runtime_id = read_metadata(connection, "runtime_id")?;
+    let event_log_epoch = read_metadata(connection, "event_log_epoch")?;
+    let policy_generation: u64 = read_metadata(connection, "visibility_policy_generation")?
+        .parse()
+        .context("invalid visibility policy generation")?;
+
+    // The derived public (unauthenticated) scope must be deterministic for
+    // this installation identity; the roster snapshot serves it verbatim.
+    let public_scope = crate::ids::visibility_scope_id(
+        &runtime_id,
+        PUBLIC_SCOPE_PRINCIPAL,
+        PUBLIC_SCOPE_ENTITLEMENT,
+        policy_generation,
+    );
+    let runtime_identity_stable = !runtime_id.is_empty()
+        && !event_log_epoch.is_empty()
+        && public_scope
+            == crate::ids::visibility_scope_id(
+                &runtime_id,
+                PUBLIC_SCOPE_PRINCIPAL,
+                PUBLIC_SCOPE_ENTITLEMENT,
+                policy_generation,
+            );
+
+    // Name-accepted upgrade paths can leave historical source tables absent;
+    // the reservation invariant cannot be verified against a missing source,
+    // so the capability stays off instead of failing the open.
+    let required_sources = ["agent_identities", "agent_states", "agent_deletion_jobs"];
+    let missing_sources: Vec<&str> = required_sources
+        .iter()
+        .copied()
+        .filter(|table| !table_exists(connection, table).unwrap_or(false))
+        .collect();
+
+    let (missing_reservations, active_reservations_without_registry, tombstone_state_drift) =
+        if missing_sources.is_empty() {
+            (
+                count_rows(
+                    connection,
+                    "SELECT COUNT(*) FROM agent_identities i
+                     LEFT JOIN agent_identity_reservations r ON r.agent_id = i.agent_id
+                     WHERE r.agent_id IS NULL",
+                )?,
+                count_rows(
+                    connection,
+                    "SELECT COUNT(*) FROM agent_identity_reservations r
+                     LEFT JOIN agent_identities i ON i.agent_id = r.agent_id
+                     WHERE r.reservation_state = 'active' AND i.agent_id IS NULL",
+                )?,
+                count_rows(
+                    connection,
+                    "SELECT COUNT(*) FROM agent_identities i
+                     JOIN agent_identity_reservations r ON r.agent_id = i.agent_id
+                     WHERE (i.status = 'deleted') != (r.reservation_state = 'retired')",
+                )?,
+            )
+        } else {
+            (0, 0, 0)
+        };
+    let agent_state_identity_mismatch = if missing_sources.is_empty() {
+        count_agent_state_identity_mismatches(connection)?
+    } else {
+        0
+    };
+    let completed_deletion_with_available_registry = if missing_sources.is_empty() {
+        count_rows(
+            connection,
+            "SELECT COUNT(*) FROM agent_deletion_jobs d
+             JOIN agent_identities i ON i.agent_id = d.agent_id
+             WHERE d.status = 'completed' AND i.status != 'deleted'",
+        )?
+    } else {
+        0
+    };
+    let enforcement_probe_passed = probe_reservation_enforcement(connection)?;
+
+    let agent_identity_reserved = missing_sources.is_empty()
+        && missing_reservations == 0
+        && active_reservations_without_registry == 0
+        && tombstone_state_drift == 0
+        && agent_state_identity_mismatch == 0
+        && completed_deletion_with_available_registry == 0
+        && enforcement_probe_passed;
+
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let identity_detail = serde_json::json!({
+        "runtime_id": runtime_id,
+        "event_log_epoch": event_log_epoch,
+        "visibility_policy_generation": policy_generation,
+        "public_scope_id_fingerprint": &public_scope[..public_scope.len().min(16)],
+    })
+    .to_string();
+    let reserved_detail = serde_json::json!({
+        "missing_source_tables": missing_sources,
+        "missing_reservations": missing_reservations,
+        "active_reservations_without_registry": active_reservations_without_registry,
+        "tombstone_state_drift": tombstone_state_drift,
+        "agent_state_identity_mismatch": agent_state_identity_mismatch,
+        "completed_deletion_with_available_registry": completed_deletion_with_available_registry,
+        "enforcement_probe": if enforcement_probe_passed { "passed" } else { "failed" },
+    })
+    .to_string();
+    persist_verification(
+        connection,
+        RUNTIME_IDENTITY_STABLE,
+        runtime_identity_stable,
+        &now,
+        &identity_detail,
+    )?;
+    persist_verification(
+        connection,
+        AGENT_IDENTITY_RESERVED,
+        agent_identity_reserved,
+        &now,
+        &reserved_detail,
+    )?;
+    Ok(())
+}
+
+/// Proves the creation guard is wired into the registry write path: an
+/// Active identity write for a retired reservation must be rejected, while
+/// re-asserting the tombstone stays legal. Runs inside a transaction that is
+/// always rolled back.
+fn probe_reservation_enforcement(connection: &mut Connection) -> Result<bool> {
+    let transaction = connection.transaction()?;
+    let probe_id = "__observer_sync_reservation_probe__";
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    transaction.execute(
+        "INSERT INTO agent_identity_reservations (agent_id, reservation_state, reserved_at, retired_at, source)
+         VALUES (?1, 'retired', ?2, NULL, 'verification_probe')",
+        rusqlite::params![probe_id, now],
+    )?;
+    let mut probe = AgentIdentityRecord::new(
+        probe_id,
+        AgentKind::Named,
+        AgentVisibility::Public,
+        AgentOwnership::SelfOwned,
+        AgentProfilePreset::PublicNamed,
+        None,
+        None,
+    );
+    let rejected_availability_write = upsert_agent_identity_tx(&transaction, &probe).is_err();
+    probe.status = AgentRegistryStatus::Deleted;
+    let accepted_tombstone_write = upsert_agent_identity_tx(&transaction, &probe).is_ok();
+    transaction.rollback()?;
+    Ok(rejected_availability_write && accepted_tombstone_write)
+}
+
+fn count_agent_state_identity_mismatches(connection: &Connection) -> Result<u64> {
+    let mut statement = connection.prepare("SELECT agent_id, payload_json FROM agent_states")?;
+    let rows = statement.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    let mut mismatches = 0u64;
+    for row in rows {
+        let (row_agent_id, payload_json) = row?;
+        let payload_agent_id = serde_json::from_str::<serde_json::Value>(&payload_json)
+            .ok()
+            .and_then(|payload| {
+                payload
+                    .get("agent_id")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string)
+            });
+        if payload_agent_id.as_deref() != Some(row_agent_id.as_str()) {
+            mismatches += 1;
+        }
+    }
+    Ok(mismatches)
+}
+
+fn table_exists(connection: &Connection, table: &str) -> Result<bool> {
+    let count: i64 = connection.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        [table],
+        |row| row.get(0),
+    )?;
+    Ok(count == 1)
+}
+
+fn verification_tables_exist(connection: &Connection) -> Result<bool> {
+    let count: i64 = connection.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'
+         AND name IN ('agent_identity_reservations', 'observer_sync_capability_verifications')",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(count == 2)
+}
+
+fn read_metadata(connection: &Connection, key: &str) -> Result<String> {
+    connection
+        .query_row(
+            "SELECT value FROM runtime_metadata WHERE key = ?1",
+            [key],
+            |row| row.get(0),
+        )
+        .optional()?
+        .ok_or_else(|| anyhow::anyhow!("runtime metadata key {key} is missing"))
+}
+
+fn count_rows(connection: &Connection, sql: &str) -> Result<u64> {
+    let count: i64 = connection.query_row(sql, [], |row| row.get(0))?;
+    Ok(count.max(0) as u64)
+}
+
+fn persist_verification(
+    connection: &Connection,
+    capability: &str,
+    verified: bool,
+    verified_at: &str,
+    detail: &str,
+) -> Result<()> {
+    connection.execute(
+        "INSERT INTO observer_sync_capability_verifications (capability, verified, verified_at, detail)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(capability) DO UPDATE SET
+           verified = excluded.verified,
+           verified_at = excluded.verified_at,
+           detail = excluded.detail",
+        rusqlite::params![capability, verified, verified_at, detail],
+    )?;
+    Ok(())
+}
+
+impl crate::runtime_db::RuntimeDb {
+    /// Loads the durable S1 foundation verification results. Missing rows
+    /// read as false; load errors should degrade, not fail, the caller.
+    pub fn observer_sync_foundations(&self) -> Result<ObserverSyncFoundationVerification> {
+        let connection = self.connection()?;
+        let verified = |capability: &str| -> Result<bool> {
+            Ok(connection
+                .query_row(
+                    "SELECT verified FROM observer_sync_capability_verifications
+                     WHERE capability = ?1",
+                    [capability],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()?
+                .is_some_and(|value| value != 0))
+        };
+        Ok(ObserverSyncFoundationVerification {
+            runtime_identity_stable: verified(RUNTIME_IDENTITY_STABLE)?,
+            agent_identity_reserved: verified(AGENT_IDENTITY_RESERVED)?,
+        })
+    }
+}

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -100,6 +100,7 @@ mod tests {
             AgentVisibility, BriefKind,
         },
     };
+    use rusqlite::OptionalExtension;
     use std::process::Command;
     use tempfile::tempdir;
 
@@ -532,6 +533,8 @@ mod tests {
             "workspace_entries",
             "workspace_occupancies",
             "agent_identities",
+            "agent_identity_reservations",
+            "observer_sync_capability_verifications",
             "context_episode_anchors",
             "scheduler_activations",
             "scheduler_activation_settlements",
@@ -1384,7 +1387,7 @@ INSERT INTO storage_domains (
         assert!(
             error
                 .to_string()
-                .contains("supports runtime db schemas 46 through 47, found 45"),
+                .contains("supports runtime db schemas 46 through 48, found 45"),
             "{error:#}"
         );
         Ok(())
@@ -1507,7 +1510,7 @@ INSERT INTO scheduler_rollout_command_results (
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
 
         let connection = open_connection(&db_path)?;
-        assert_eq!(current_schema_version(&connection)?, 47);
+        assert_eq!(current_schema_version(&connection)?, 48);
         for table in RETIRED_SCHEDULER_TABLES {
             assert!(
                 !table_exists(&connection, table)?,
@@ -1661,7 +1664,7 @@ INSERT INTO scheduler_rollout_command_results (
 
             RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             let connection = open_connection(&db_path)?;
-            assert_eq!(current_schema_version(&connection)?, 47);
+            assert_eq!(current_schema_version(&connection)?, 48);
             for table in RETIRED_SCHEDULER_TABLES {
                 assert!(
                     !table_exists(&connection, table)?,
@@ -1775,7 +1778,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 47);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 48);
         Ok(())
     }
 
@@ -1882,7 +1885,7 @@ INSERT INTO scheduler_rollout_command_results (
             RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             assert_eq!(
                 current_schema_version(&open_connection(&db_path)?)?,
-                47,
+                48,
                 "{case}"
             );
         }
@@ -1941,7 +1944,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 47);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 48);
         Ok(())
     }
 
@@ -2001,7 +2004,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 47);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 48);
         Ok(())
     }
 
@@ -5661,6 +5664,263 @@ CREATE TABLE working_memory_deltas (
 
         let result = repo.get("nonexistent")?;
         assert!(result.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn observer_sync_fresh_database_mints_and_preserves_runtime_identity() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        {
+            let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+            let runtime_id = db.runtime_id()?;
+            let epoch = db.event_log_epoch()?;
+            assert!(runtime_id.starts_with("runtime_"));
+            assert!(epoch.starts_with("epoch_"));
+            assert_ne!(runtime_id, epoch);
+            assert_eq!(db.visibility_policy_generation()?, 0);
+            let foundations = db.observer_sync_foundations()?;
+            assert!(foundations.runtime_identity_stable);
+            assert!(foundations.agent_identity_reserved);
+        }
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert!(reopened.runtime_id()?.starts_with("runtime_"));
+        assert!(reopened.event_log_epoch()?.starts_with("epoch_"));
+        let foundations = reopened.observer_sync_foundations()?;
+        assert!(foundations.runtime_identity_stable);
+        assert!(foundations.agent_identity_reserved);
+        Ok(())
+    }
+
+    #[test]
+    fn observer_sync_fresh_databases_mint_distinct_identity() -> Result<()> {
+        let (_first_dir, first_path, first_lock) = temp_paths()?;
+        let (_second_dir, second_path, second_lock) = temp_paths()?;
+        let first = RuntimeDb::open_and_migrate(&first_path, &first_lock)?;
+        let second = RuntimeDb::open_and_migrate(&second_path, &second_lock)?;
+        assert_ne!(first.runtime_id()?, second.runtime_id()?);
+        assert_ne!(first.event_log_epoch()?, second.event_log_epoch()?);
+        Ok(())
+    }
+
+    #[test]
+    fn observer_sync_retired_agent_ids_are_never_reusable() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut identity = agent_identity("agent-doomed", 0);
+        db.agent_identities().upsert(&identity)?;
+
+        identity.status = AgentRegistryStatus::Deleted;
+        identity.deleted_at = Some(Utc::now());
+        identity.updated_at = Utc::now();
+        db.agent_identities().upsert(&identity)?;
+
+        let reservation: Option<(String, String)> = db
+            .connection()?
+            .query_row(
+                "SELECT reservation_state, source FROM agent_identity_reservations
+                 WHERE agent_id = 'agent-doomed'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        assert_eq!(
+            reservation,
+            Some(("retired".to_string(), "agent_registry".to_string()))
+        );
+
+        let mut revived = agent_identity("agent-doomed", 10);
+        let error = db
+            .agent_identities()
+            .upsert(&revived)
+            .expect_err("retired agent id must not be reusable");
+        assert!(error.to_string().contains("never reused"));
+        revived.status = AgentRegistryStatus::Deleting;
+        assert!(db.agent_identities().upsert(&revived).is_err());
+
+        // Re-asserting the tombstone stays idempotent.
+        let mut tombstone = agent_identity("agent-doomed", 20);
+        tombstone.status = AgentRegistryStatus::Deleted;
+        tombstone.deleted_at = Some(Utc::now());
+        db.agent_identities().upsert(&tombstone)?;
+        Ok(())
+    }
+
+    fn reservation_state(
+        db: &RuntimeDb,
+        agent_id: &str,
+    ) -> Result<Option<(String, String, Option<String>)>> {
+        db.connection()?
+            .query_row(
+                "SELECT reservation_state, source, retired_at
+                 FROM agent_identity_reservations WHERE agent_id = ?1",
+                [agent_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    #[test]
+    fn observer_sync_migration_backfills_reservations_from_history() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        {
+            let mut connection = open_connection(&db_path)?;
+            migrate_through(&mut connection, 47)?;
+            let now = "2026-01-01T00:00:00.000Z";
+            connection.execute(
+                "INSERT INTO agent_identities (
+                    agent_id, kind, visibility, ownership, profile_preset, status,
+                    parent_agent_id, lineage_parent_agent_id, delegated_from_task_id,
+                    created_at, updated_at, archived_at, payload_json
+                 ) VALUES
+                    ('agent-keep', 'named', 'public', 'self_owned', 'public_named', 'active',
+                     NULL, NULL, NULL, ?1, ?1, NULL, '{}'),
+                    ('agent-gone', 'named', 'public', 'self_owned', 'public_named', 'deleted',
+                     NULL, NULL, NULL, ?1, ?1, ?1, '{}'),
+                    ('agent-del-only', 'named', 'public', 'self_owned', 'public_named', 'deleted',
+                     NULL, NULL, NULL, ?1, ?1, NULL, '{}')",
+                [now],
+            )?;
+            connection.execute(
+                "INSERT INTO agent_states (agent_id, status, updated_at, payload_json) VALUES
+                    ('agent-state-only', 'idle', ?1, '{\"agent_id\":\"agent-state-only\"}')",
+                [now],
+            )?;
+            connection.execute(
+                "INSERT INTO audit_events (audit_event_id, agent_id, kind, created_at, data_json)
+                 VALUES ('event-audit', 'agent-audit-only', 'fixture', ?1, '{}')",
+                [now],
+            )?;
+            connection.execute(
+                "INSERT INTO agent_deletion_jobs (
+                    deletion_id, agent_id, status, phase, created_at, updated_at,
+                    completed_at, payload_json
+                 ) VALUES ('del-job', 'agent-del-only', 'completed', 'finalize', ?1, ?1, ?1, '{}')",
+                [now],
+            )?;
+            connection.execute(
+                "INSERT INTO agents (
+                    agent_id, status, visibility, ownership, profile_preset,
+                    created_at, updated_at, payload_json
+                 ) VALUES ('agent-legacy-only', 'active', 'public', NULL, NULL, ?1, ?1, '{}')",
+                [now],
+            )?;
+        }
+
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert_eq!(
+            reservation_state(&db, "agent-keep")?,
+            Some(("active".to_string(), "agent_registry".to_string(), None))
+        );
+        assert_eq!(
+            reservation_state(&db, "agent-gone")?,
+            Some((
+                "retired".to_string(),
+                "agent_registry".to_string(),
+                Some("2026-01-01T00:00:00.000Z".to_string())
+            ))
+        );
+        assert_eq!(
+            reservation_state(&db, "agent-state-only")?,
+            Some((
+                "retired".to_string(),
+                "backfill:agent-state".to_string(),
+                None
+            ))
+        );
+        assert_eq!(
+            reservation_state(&db, "agent-audit-only")?,
+            Some(("retired".to_string(), "backfill:audit".to_string(), None))
+        );
+        assert_eq!(
+            reservation_state(&db, "agent-del-only")?,
+            Some((
+                "retired".to_string(),
+                "agent_registry".to_string(),
+                Some("2026-01-01T00:00:00.000Z".to_string())
+            ))
+        );
+        assert_eq!(
+            reservation_state(&db, "agent-legacy-only")?,
+            Some((
+                "retired".to_string(),
+                "backfill:legacy-agents".to_string(),
+                None
+            ))
+        );
+        let foundations = db.observer_sync_foundations()?;
+        assert!(foundations.runtime_identity_stable);
+        assert!(foundations.agent_identity_reserved);
+        Ok(())
+    }
+
+    #[test]
+    fn observer_sync_backfill_ambiguity_blocks_agent_identity_capability() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        {
+            let mut connection = open_connection(&db_path)?;
+            migrate_through(&mut connection, 47)?;
+            let now = "2026-01-01T00:00:00.000Z";
+            connection.execute(
+                "INSERT INTO agent_states (agent_id, status, updated_at, payload_json) VALUES
+                    ('agent-broken', 'idle', ?1, '{\"agent_id\":\"agent-other\"}')",
+                [now],
+            )?;
+            connection.execute(
+                "INSERT INTO agent_identities (
+                    agent_id, kind, visibility, ownership, profile_preset, status,
+                    parent_agent_id, lineage_parent_agent_id, delegated_from_task_id,
+                    created_at, updated_at, archived_at, payload_json
+                 ) VALUES ('agent-reused', 'named', 'public', 'self_owned', 'public_named',
+                     'active', NULL, NULL, NULL, ?1, ?1, NULL, '{}')",
+                [now],
+            )?;
+            connection.execute(
+                "INSERT INTO agent_deletion_jobs (
+                    deletion_id, agent_id, status, phase, created_at, updated_at,
+                    completed_at, payload_json
+                 ) VALUES ('del-reused', 'agent-reused', 'completed', 'finalize', ?1, ?1, ?1, '{}')",
+                [now],
+            )?;
+        }
+
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let foundations = db.observer_sync_foundations()?;
+        assert!(foundations.runtime_identity_stable);
+        assert!(!foundations.agent_identity_reserved);
+        let detail: String = db.connection()?.query_row(
+            "SELECT detail FROM observer_sync_capability_verifications
+             WHERE capability = 'agent_identity_reserved'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert!(detail.contains("agent_state_identity_mismatch"));
+        assert!(detail.contains("completed_deletion_with_available_registry"));
+        Ok(())
+    }
+
+    #[test]
+    fn observer_sync_reservation_drift_blocks_capability() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        {
+            let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+            db.agent_identities()
+                .upsert(&agent_identity("agent-drift", 0))?;
+            let foundations = db.observer_sync_foundations()?;
+            assert!(foundations.agent_identity_reserved);
+            db.connection()?
+                .execute("DELETE FROM agent_identity_reservations", [])?;
+        }
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let foundations = reopened.observer_sync_foundations()?;
+        assert!(foundations.runtime_identity_stable);
+        assert!(!foundations.agent_identity_reserved);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

S1 slice of `docs/rfcs/observer-sync-agent-summary-and-read-markers.md` (implementation plan step 2): durable runtime identity, Agent identity reservation/tombstone, durable capability verification, and `visibility_scope_id` derivation. No observer-sync capability is advertised yet — the evaluator stays gated until the S2-S5 verification families land.

### Runtime identity

- `runtime_id` and `visibility_policy_generation` join the existing `event_log_epoch` in `runtime_metadata`, minted lazily with `INSERT OR IGNORE` (reopen-stable, fresh database mints fresh values).
- Accessors: `RuntimeDb::runtime_id()`, `visibility_policy_generation()`.

### Agent identity reservation (migration 48)

- New `agent_identity_reservations` table: permanent reservations, not epoch-scoped, matching the existing "deleted ids stay reserved" contract. Deletion only moves a reservation to `retired`; rows are never removed.
- Backfill is idempotent and source-gated: the registry is authoritative; `agent_states`, deletion jobs, audit scopes, and the legacy `agents` table only add `retired` reservations. Name-accepted upgrade paths without historical tables are tolerated (source skipped, capability stays unverified instead of failing migration).
- Enforcement runs inside `upsert_agent_identity_tx`, the single registry write choke point: an Active/Deleting write over a retired reservation is rejected (`retired agent ids are never reused`), covering creation, import, and replay.

### Capability verification + evaluator wiring

- New `observer_sync_capability_verifications` table; `verify_observer_sync_foundations` recomputes on every migrate/open and persists results. Invariant violations record `verified = 0` (degraded advertisement) instead of failing startup.
- Checks include reservation coverage, tombstone drift, `agent_states` payload identity mismatch, completed-deletion-with-available-registry (historical id-reuse evidence), and a rolled-back enforcement probe proving the creation guard is wired.
- `handshake` now loads the durable rows through the S0 evaluator and degrades to all-disabled on load errors.

### visibility_scope_id

- Pure SHA-256 derivation in `src/ids.rs` over runtime id + authority principal + entitlement + policy generation. Credential material is never an input: token rotation keeps the scope, principal/entitlement/policy changes rotate it. Local unauthenticated mode uses the fixed `public` scope. Per-request authority resolution ships with the S4 snapshot slice.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib` (2723 passed)
- `cargo test --test http_control --test openapi_snapshot --test http_route_snapshot --test http_client`
- New tests: fresh-DB identity mint/preserve, distinct epochs per database, retired-id non-reuse (Active + Deleting rejected, tombstone idempotent), backfill sources and states, backfill ambiguity blocks `agent_identity_reserved`, reservation drift blocks capability, scope derivation stability/rotation.

## Docs

- `docs/implementation-decisions/105-observer-sync-identity-foundations.md`
- `docs/implementation-decisions/106-visibility-scope-id-derivation.md`
