### PR TITLE
fix: terminate turns after CompleteWorkItem

### DIFF
--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -2076,10 +2076,10 @@ def require_checkpoint_restart_activation_lineage(
         key=lambda attempt: attempt["admitted_fences"]["work_item_generation"],
     )
     require(
-        len(attempts) == 2,
-        f"checkpoint replay expected exactly two WorkItem attempts: {attempts}",
+        len(attempts) == 3,
+        f"checkpoint replay expected exactly three WorkItem attempts: {attempts}",
     )
-    scheduling, wait_resume = attempts
+    scheduling, wait_resume, completion = attempts
     require(
         scheduling["admitted_fences"]["work_item_generation"] == 1
         and scheduling["source"]["identity"]["kind"] == "work_item_continuation",
@@ -2094,6 +2094,15 @@ def require_checkpoint_restart_activation_lineage(
             "trigger_message_id": wait_resume["source_message_id"],
         },
         f"checkpoint replay wait-resume attempt mismatch: {wait_resume}",
+    )
+    require(
+        completion["admitted_fences"]["work_item_generation"] == 3
+        and completion["source"]["identity"]
+        == {
+            "kind": "work_item_continuation",
+            "work_item_id": work_item_id,
+        },
+        f"checkpoint replay completion attempt mismatch: {completion}",
     )
     waits = [
         row

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -4485,7 +4485,11 @@ def run_scheduler_checkpoint_replay_case(
         harness,
         snapshot,
         work_item_id=work_item_a_id,
-        expected_source_kinds=("work_item_continuation", "triggered_wait"),
+        expected_source_kinds=(
+            "work_item_continuation",
+            "work_item_continuation",
+            "triggered_wait",
+        ),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-replay-create")["message_id"]
         },

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -3819,11 +3819,13 @@ def run_scheduler_concurrent_claim_fencing_case(
         forbidden + ["CreateWorkItem", "PickWorkItem", "WaitFor"],
         turn_ids=b_turn_ids,
     )
+    # The autonomous continuation claims the WorkItem before the wait wake is
+    # delivered, so it completes the item while the triggered wait still settles.
     require_scheduler_engine_activation_chain(
         harness,
         snapshot,
         work_item_id=work_item_a_id,
-        expected_source_kinds=("triggered_wait",),
+        expected_source_kinds=("work_item_continuation", "triggered_wait"),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-concurrent-create")["message_id"]
         },
@@ -3999,11 +4001,13 @@ def run_scheduler_operator_interject_during_wait_case(
         forbidden + ["CreateWorkItem", "PickWorkItem", "WaitFor"],
         turn_ids=b_turn_ids,
     )
+    # The autonomous continuation claims the WorkItem before the interjection is
+    # delivered, so it completes the item while the triggered wait still settles.
     require_scheduler_engine_activation_chain(
         harness,
         snapshot,
         work_item_id=work_item_a_id,
-        expected_source_kinds=("triggered_wait",),
+        expected_source_kinds=("work_item_continuation", "triggered_wait"),
         lifecycle_message_ids={
             harness.prompt_scope("scheduler-interject-create")["message_id"]
         },

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2258,13 +2258,13 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
     .expect("timed out waiting for canonical completion commit");
     assert_eq!(
         *provider.calls.lock().await,
-        2,
-        "standalone completion must allow the provider to consume its tool result"
+        1,
+        "same-round completion must terminate the provider loop"
     );
     let state = runtime.agent_state().await.unwrap();
-    assert_eq!(state.total_model_rounds, 2);
-    assert_eq!(state.total_input_tokens, 20);
-    assert_eq!(state.total_output_tokens, 20);
+    assert_eq!(state.total_model_rounds, 1);
+    assert_eq!(state.total_input_tokens, 10);
+    assert_eq!(state.total_output_tokens, 10);
 
     let completed = runtime
         .latest_work_item(&work_item.id)

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -2867,17 +2867,18 @@ impl TurnExecution<'_> {
             } else {
                 runtime.persist_transcript_evidence(&tool_results_transcript)?;
             }
-            let after_tool_results_interjections = if pending_completion_report.is_some() {
-                Vec::new()
-            } else {
-                runtime
-                    .drain_operator_interjections(
-                        agent_id,
-                        round,
-                        scheduler::InterjectionBoundary::AfterToolResults,
-                    )
-                    .await?
-            };
+            let after_tool_results_interjections =
+                if pending_completion_report.is_some() || prepared_work_item_completion.is_some() {
+                    Vec::new()
+                } else {
+                    runtime
+                        .drain_operator_interjections(
+                            agent_id,
+                            round,
+                            scheduler::InterjectionBoundary::AfterToolResults,
+                        )
+                        .await?
+                };
             let mut interjections = before_tool_execution_interjections;
             interjections.extend(after_tool_results_interjections);
             let has_operator_interjections = !interjections.is_empty();
@@ -2911,9 +2912,10 @@ impl TurnExecution<'_> {
             }
             completed_rounds.push(round_record);
 
-            if (all_tool_results_should_sleep || terminal_tool_transition)
-                && (!has_operator_interjections || terminal_tool_transition)
-                && !checkpoint_state.operator_delivery_pending()
+            if prepared_work_item_completion.is_some()
+                || ((all_tool_results_should_sleep || terminal_tool_transition)
+                    && (!has_operator_interjections || terminal_tool_transition)
+                    && !checkpoint_state.operator_delivery_pending())
             {
                 let terminal_assistant_message = if terminal_wait_without_text {
                     None

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -1834,7 +1834,11 @@ fn validate_completion_transition_tx(
             && existing.suspended_work_item_id == continuation.suspended_work_item_id
             && existing.active_work_item_id == continuation.active_work_item_id;
         let valid_transition = existing.state == crate::types::WorkItemContinuationState::Active
-            && continuation.state == crate::types::WorkItemContinuationState::Resumed;
+            && matches!(
+                continuation.state,
+                crate::types::WorkItemContinuationState::Resumed
+                    | crate::types::WorkItemContinuationState::Cancelled
+            );
         anyhow::ensure!(
             matching_identity && (valid_transition || existing == *continuation),
             "completion continuation transition is stale or mismatched"
@@ -2588,6 +2592,55 @@ mod tests {
             db.work_item_continuations().latest_all()?[0].state,
             WorkItemContinuationState::Resumed
         );
+        Ok(())
+    }
+
+    #[test]
+    fn completion_transition_accepts_matching_active_continuation_cancellation() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let active = work_item("work-active");
+        let mut completed = active.clone();
+        completed.state = WorkItemState::Completed;
+        completed.revision += 1;
+        let frame = WorkItemContinuationFrame::new_on_completed(
+            "agent-a",
+            "work-completed-caller",
+            active.id.clone(),
+            None,
+        );
+        db.work_item_continuations().upsert(&frame)?;
+        let now = Utc::now();
+        let completion = CompletionTransition {
+            requires_execution_continuation: true,
+            work_items: vec![WorkItemMutation::Update {
+                record: completed,
+                expected_revision: active.revision,
+            }],
+            wait_conditions: Vec::new(),
+            continuations: vec![frame.cancel("suspended_work_item_unavailable")],
+            tool_execution: ToolExecutionRecord {
+                id: "tool-cancel-orphan-continuation".into(),
+                agent_id: "agent-a".into(),
+                work_item_id: Some(active.id),
+                turn_index: 1,
+                turn_id: Some("turn-cancel-orphan-continuation".into()),
+                tool_name: crate::tool::names::COMPLETE_WORK_ITEM.into(),
+                created_at: now,
+                completed_at: Some(now),
+                duration_ms: 1,
+                authority_class: AuthorityClass::RuntimeInstruction,
+                status: ToolExecutionStatus::Success,
+                input: serde_json::json!({}),
+                output: serde_json::json!({}),
+                summary: "completed WorkItem".into(),
+                invocation_surface: None,
+            },
+            index_changes: Vec::new(),
+        };
+        let mut connection = db.connection()?;
+        let tx = connection.transaction()?;
+
+        validate_completion_transition_tx(&tx, "agent-a", &completion)?;
         Ok(())
     }
 

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -2617,7 +2617,7 @@ mod tests {
                 expected_revision: active.revision,
             }],
             wait_conditions: Vec::new(),
-            continuations: vec![frame.cancel("suspended_work_item_unavailable")],
+            continuations: vec![frame.cancel("suspended_work_item_not_open")],
             tool_execution: ToolExecutionRecord {
                 id: "tool-cancel-orphan-continuation".into(),
                 agent_id: "agent-a".into(),

--- a/tests/e2e/docker/openai_stub/server.py
+++ b/tests/e2e/docker/openai_stub/server.py
@@ -208,12 +208,6 @@ class Scenario:
                         [text_item(markers[-1])],
                         f"resp_runtime_upgrade_v030_{self.phase}",
                     )
-            if self.phase == self.expected_phase() - 1:
-                self.phase += 1
-                return 200, response(
-                    [text_item("Deterministic scheduler scenario complete.")],
-                    f"resp_{self.name}_complete",
-                )
             if self.phase >= self.expected_phase():
                 self.extra_requests += 1
                 return 409, {
@@ -1019,17 +1013,17 @@ class Scenario:
         return {
             "runtime-upgrade-v030": 2,
             "runtime-upgrade-interrupted-schema47": 0,
-            "scheduler-task-wait": 10,
-            "scheduler-provider-retry": 3,
-            "scheduler-multi": 12,
-            "scheduler-external": 7,
-            "scheduler-operator": 7,
-            "scheduler-concurrent": 11,
-            "scheduler-interject": 13,
-            "scheduler-compaction": 10,
-            "scheduler-worktree": 12,
-            "scheduler-spawn": 7,
-            "scheduler-checkpoint": 13,
+            "scheduler-task-wait": 9,
+            "scheduler-provider-retry": 2,
+            "scheduler-multi": 11,
+            "scheduler-external": 6,
+            "scheduler-operator": 6,
+            "scheduler-concurrent": 10,
+            "scheduler-interject": 12,
+            "scheduler-compaction": 9,
+            "scheduler-worktree": 11,
+            "scheduler-spawn": 6,
+            "scheduler-checkpoint": 12,
         }[self.name]
 
     def status(self) -> dict[str, Any]:

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -322,7 +322,7 @@ async fn run_once_prefers_completed_work_item_result_brief_over_latest_turn_text
     );
     assert_eq!(
         second.raw_final_text.as_deref(),
-        Some("Fixed two test annotation issues.")
+        Some("Implemented broad prompt/context snapshot coverage")
     );
     let runtime = host
         .get_public_agent_for_external_ingress("default")

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -667,14 +667,11 @@ class DockerE2ERunnerTests(unittest.TestCase):
         )
         self.assertEqual(status, 200)
         self.assertEqual(response["output"][0]["name"], "PickWorkItem")
-        scenario.phase = 6
+        scenario.phase = 5
         status, response = scenario.consume({"input": []})
         self.assertEqual(status, 200)
-        self.assertEqual(
-            response["output"][0]["content"][0]["text"],
-            "Deterministic scheduler scenario complete.",
-        )
-        self.assertEqual(scenario.phase, 7)
+        self.assertEqual(response["output"][1]["name"], "CompleteWorkItem")
+        self.assertEqual(scenario.phase, 6)
         self.assertTrue(scenario.status()["complete"])
         status, response = scenario.consume({"input": []})
         self.assertEqual(status, 409)

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -2508,6 +2508,19 @@ class DockerE2ERunnerTests(unittest.TestCase):
                         )
                     ),
                 },
+                {
+                    "payload_json": json.dumps(
+                        attempt(
+                            "attempt-completion",
+                            "message-completion",
+                            3,
+                            {
+                                "kind": "work_item_continuation",
+                                "work_item_id": "work-1",
+                            },
+                        )
+                    ),
+                },
             ],
             "wait_conditions": [
                 {

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -2333,6 +2333,17 @@ class DockerE2ERunnerTests(unittest.TestCase):
             source.index('harness.runtime_db_snapshot("scheduler-external")'),
         )
 
+    def test_checkpoint_replay_tracks_wait_and_completion_continuations(self) -> None:
+        source = inspect.getsource(runner.run_scheduler_checkpoint_replay_case)
+        self.assertIn(
+            'expected_source_kinds=(\n'
+            '            "work_item_continuation",\n'
+            '            "work_item_continuation",\n'
+            '            "triggered_wait",\n'
+            "        )",
+            source,
+        )
+
     def test_result_brief_waits_for_its_source_turn_to_reach_terminal(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             harness = runner.CaseHarness(


### PR DESCRIPTION
## Summary

- terminate the provider loop in the same round after `CompleteWorkItem` prepares a completion transition
- skip after-tool interjection draining once work-item completion is prepared
- allow a matching continuation frame to transition from `Active` to `Cancelled` when completion cancels an orphaned continuation
- update regression coverage for same-round termination and add coverage for continuation cancellation validation

Closes #2622.

## Verification

- `cargo test completion_transition_accepts_matching_active_continuation_cancellation --lib`
- `cargo test complete_work_item_promotes_same_round_report_and_binds_evidence --lib`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
