### PR TITLE
feat: atomic brief_created event linkage and single DB transition (S3)

### DIFF
--- a/docs/implementation-decisions/108-brief-created-atomic-linkage.md
+++ b/docs/implementation-decisions/108-brief-created-atomic-linkage.md
@@ -1,0 +1,47 @@
+# Brief created-event atomic linkage (S3)
+
+## Choice
+
+Every Brief publication commits the Brief record, the audit event sequence
+allocation, and the `brief_created` audit event in one SQLite transaction,
+and stores the allocated sequence back on the record as the immutable
+`created_event_seq` linkage. `persist_brief` and the work-item completion
+transition are the two publication entry points, and both funnel through the
+same transactional helpers (`append_brief_with_created_event` /
+`link_transition_brief_created_events_tx`).
+
+The event identity is deterministic: `stable_brief_created_event_id` hashes
+the agent and brief ids, and the event `created_at` is the brief's
+`created_at`. A retried publication therefore hits the audit-event
+idempotency check and reuses the committed event instead of allocating a
+second sequence.
+
+The migration backfill links a historical Brief only when exactly one
+candidate `brief_created` event exists for it. Zero or multiple candidates
+leave the linkage `NULL` and insert a `brief_created_linkage_uncertain`
+row; nothing is guessed. Brief content and timestamps are never rewritten —
+only the additive linkage field changes.
+
+## Reason
+
+Briefs and audit events live in the same runtime DB, so a durable outbox
+would add a second write path without strengthening the guarantee. The old
+order (record transaction, then event transaction, then agent state) could
+lose the event on a crash between the first two commits, and its random
+event id made every retry append a duplicate event.
+
+Other canonical reference families were inventoried rather than rewritten:
+task, work-item, and message events already commit inside their transitions;
+`agent_state_changed` is appended after the state write, which is
+record-first, so an observed event still implies a readable record. A crash
+there can drop the event but never inverts visibility.
+
+## Preserved boundary
+
+The linkage is immutable: relinking to a different sequence is a hard
+conflict and rolls back the whole publication transaction. Retention may
+prune Brief records independently of events, so the
+`briefs.atomic-created-event.v1` verification proves linkage soundness
+(every linkage resolves to exactly one matching event, no shared
+sequences) rather than event-to-record existence, and unlinked historical
+events remain acceptable.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -2500,6 +2500,15 @@
             "format": "date-time",
             "type": "string"
           },
+          "created_event_seq": {
+            "description": "Immutable linkage to the unique `brief_created` audit event committed\n in the same runtime DB transition as this record. `None` for records\n whose creating event cannot be identified (pre-linkage history or\n ambiguous backfill candidates).",
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "finalizes_assistant_round_id": {
             "type": [
               "string",

--- a/src/http/agents.rs
+++ b/src/http/agents.rs
@@ -166,6 +166,7 @@ pub(crate) fn load_observer_sync_verification(
             verification.agent_identity_reserved = foundations.agent_identity_reserved;
             verification.event_projection_effect_complete =
                 foundations.event_projection_effect_complete;
+            verification.brief_atomic_linkage_verified = foundations.brief_atomic_linkage_verified;
         }
         Err(error) => {
             tracing::warn!(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -115,8 +115,8 @@ use crate::{
     tool::{ToolRegistry, ToolResult},
     types::LoadedAgentMemory,
     types::{
-        ActiveWorkspaceEntry, AdmissionContext, AgentIdentityView, AgentKind,
-        AgentModelOverrideAuditEvent, AgentModelSource, AgentModelState, AgentState,
+        brief_created_event_for, ActiveWorkspaceEntry, AdmissionContext, AgentIdentityView,
+        AgentKind, AgentModelOverrideAuditEvent, AgentModelSource, AgentModelState, AgentState,
         AgentStateChangedEvent, AgentStatus, AgentSummary, AuditEvent, AuthorityClass,
         BriefCreatedAuditEvent, BriefRecord, CallbackDeliveryMode, CallbackDeliveryPayload,
         CallbackDeliveryResult, CallbackIngressDisposition, ClosureDecision,
@@ -4346,12 +4346,6 @@ impl RuntimeHandle {
         record: &ToolExecutionRecord,
     ) -> Result<()> {
         self.inner.storage.append_tool_execution(record)?;
-        self.inner.notify.notify_one();
-        Ok(())
-    }
-
-    pub(crate) fn persist_brief_evidence(&self, brief: &BriefRecord) -> Result<()> {
-        self.inner.storage.append_brief(brief)?;
         self.inner.notify.notify_one();
         Ok(())
     }

--- a/src/runtime/delivery.rs
+++ b/src/runtime/delivery.rs
@@ -108,13 +108,16 @@ impl RuntimeHandle {
             bound_brief.work_item_id = default_turn_work_item_id;
         }
         self.attach_generated_image_brief_attachments(&mut bound_brief)?;
-        let event_payload = BriefCreatedAuditEvent::from_brief(&bound_brief);
-        let evidence_brief = bound_brief.clone();
-        self.persist_brief_evidence(&evidence_brief)?;
-        self.inner.storage.append_event(&AuditEvent::typed(
-            RuntimeEventKind::BriefCreated,
-            &event_payload,
-        )?)?;
+        // Single runtime DB transition: the Brief record, the audit event
+        // sequence allocation, and the unique `brief_created` event commit
+        // atomically. The deterministic event identity makes a retry of the
+        // same Brief reuse the committed event instead of appending a
+        // duplicate.
+        let created_event = brief_created_event_for(&bound_brief)?;
+        self.inner
+            .storage
+            .append_brief_with_created_event(&bound_brief, &created_event)?;
+        self.inner.notify.notify_one();
         let mut guard = self.inner.agent.lock().await;
         guard.state.last_brief_at = Some(bound_brief.created_at);
         guard.persist_state(&self.inner.storage)?;

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -9,15 +9,15 @@ use crate::runtime_error::{
 use crate::tool::helpers::truncate_output_to_char_budget;
 use crate::tool::ToolError;
 use crate::types::{
-    AgentProfilePreset, BriefKind, BriefRecord, ChildAgentWorkspaceMode, CommandTaskStatusSnapshot,
-    CompletionReportRequirement, CompletionReportState, FailureArtifact, FailureArtifactCategory,
-    SpawnAgentModelRequest, SpawnAgentModelResolution, SpawnAgentModelResolutionStatus,
-    SpawnAgentResult, TaskHandle, TaskInputResult, TaskKind, TaskListEntry, TaskOutputResult,
-    TaskOutputRetrievalStatus, TaskOutputSnapshot, TaskStatusSnapshot, TodoItem, ToolArtifactRef,
-    WaitConditionRecord, WaitConditionStatus, WorkItemCompletionIntent, WorkItemContinuationFrame,
-    WorkItemContinuationReturnPolicy, WorkItemContinuationState, WorkItemDelegationRecord,
-    WorkItemDelegationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState,
-    CHILD_AGENT_TASK_KIND,
+    brief_created_event_for, AgentProfilePreset, BriefKind, BriefRecord, ChildAgentWorkspaceMode,
+    CommandTaskStatusSnapshot, CompletionReportRequirement, CompletionReportState, FailureArtifact,
+    FailureArtifactCategory, SpawnAgentModelRequest, SpawnAgentModelResolution,
+    SpawnAgentModelResolutionStatus, SpawnAgentResult, TaskHandle, TaskInputResult, TaskKind,
+    TaskListEntry, TaskOutputResult, TaskOutputRetrievalStatus, TaskOutputSnapshot,
+    TaskStatusSnapshot, TodoItem, ToolArtifactRef, WaitConditionRecord, WaitConditionStatus,
+    WorkItemCompletionIntent, WorkItemContinuationFrame, WorkItemContinuationReturnPolicy,
+    WorkItemContinuationState, WorkItemDelegationRecord, WorkItemDelegationState,
+    WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState, CHILD_AGENT_TASK_KIND,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -4238,10 +4238,10 @@ impl RuntimeHandle {
         }
 
         let mut audit_events = vec![
-            AuditEvent::typed(
-                RuntimeEventKind::BriefCreated,
-                &BriefCreatedAuditEvent::from_brief(brief),
-            )?,
+            // Deterministic identity so a replayed completion transition
+            // reuses the committed brief_created event and links the Brief
+            // to its event sequence in the same transaction.
+            brief_created_event_for(brief)?,
             binding_event.clone(),
         ];
         if plan_artifact_changed {

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2073,6 +2073,51 @@ async fn persist_brief_binds_current_turn_work_item() {
 }
 
 #[tokio::test]
+async fn persist_brief_commits_record_and_unique_created_event() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let brief = BriefRecord::new(
+        "default",
+        BriefKind::Result,
+        "atomic publication",
+        None,
+        None,
+    );
+    runtime.persist_brief(&brief).await.unwrap();
+    // Duplicate publication (for example a retry after a crash between the
+    // old record/event steps) must not produce a second brief_created event.
+    runtime.persist_brief(&brief).await.unwrap();
+
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    let brief_created: Vec<_> = events
+        .iter()
+        .filter(|event| event.kind == "brief_created")
+        .collect();
+    assert_eq!(brief_created.len(), 1);
+    let stored = runtime
+        .brief_by_id(&brief.id)
+        .await
+        .unwrap()
+        .expect("brief readable");
+    assert_eq!(
+        stored.created_event_seq,
+        Some(brief_created[0].event_seq),
+        "brief must link to its unique created event"
+    );
+}
+
+#[tokio::test]
 async fn create_callback_returns_default_ingress_with_current_turn_work_item() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime_db/evidence.rs
+++ b/src/runtime_db/evidence.rs
@@ -694,6 +694,150 @@ pub(crate) fn insert_brief_evidence_tx(tx: &Transaction<'_>, brief: &BriefRecord
     )
 }
 
+/// Outcome of the single-transition Brief publication: the stored Brief
+/// record (with its immutable `created_event_seq` linkage), the committed
+/// `brief_created` audit event, and whether this call inserted the event or
+/// reused an idempotently identical existing row.
+#[derive(Debug, Clone)]
+pub struct BriefCreatedCommit {
+    pub brief: BriefRecord,
+    pub event: AuditEvent,
+    pub event_inserted: bool,
+}
+
+/// Inserts or links a Brief record against an already-allocated
+/// `brief_created` event sequence, inside the caller's transaction. The
+/// linkage is immutable: an existing different linkage is a conflict, an
+/// absent linkage is filled, and the payload's non-linkage content must
+/// match on retry.
+pub(crate) fn upsert_brief_with_created_event_seq_tx(
+    tx: &Transaction<'_>,
+    brief: &BriefRecord,
+    event_seq: u64,
+) -> Result<BriefRecord> {
+    if let Some(payload_json) = tx
+        .query_row(
+            "SELECT payload_json FROM briefs WHERE evidence_id = ?1",
+            [&brief.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+    {
+        let mut existing: BriefRecord = serde_json::from_str(&payload_json)?;
+        let stored_linkage = existing.created_event_seq;
+        let mut incoming = brief.clone();
+        incoming.created_event_seq = None;
+        existing.created_event_seq = None;
+        anyhow::ensure!(
+            existing == incoming,
+            "conflicting brief content for evidence_id {}",
+            brief.id
+        );
+        if stored_linkage == Some(event_seq) {
+            existing.created_event_seq = stored_linkage;
+            return Ok(existing);
+        }
+        anyhow::ensure!(
+            stored_linkage.is_none(),
+            "brief {} already linked to created_event_seq {}, refusing relink to {}",
+            brief.id,
+            stored_linkage.unwrap_or_default(),
+            event_seq
+        );
+        existing.created_event_seq = Some(event_seq);
+        tx.execute(
+            "UPDATE briefs SET payload_json = ?1, created_event_seq = ?2
+             WHERE evidence_id = ?3",
+            params![
+                full_payload_json(&existing)?,
+                i64::try_from(event_seq).ok(),
+                &brief.id
+            ],
+        )?;
+        return Ok(existing);
+    }
+    let mut linked = brief.clone();
+    linked.created_event_seq = Some(event_seq);
+    insert_evidence_tx(
+        tx,
+        EvidenceInsert {
+            table: EvidenceKind::Brief.table_name(),
+            evidence_id: &linked.id,
+            agent_id: &linked.agent_id,
+            turn_id: linked.turn_id.as_deref(),
+            message_id: linked.related_message_id.as_deref(),
+            task_id: linked.related_task_id.as_deref(),
+            work_item_id: linked.work_item_id.as_deref(),
+            created_at: linked.created_at,
+            kind: enum_string(&linked.kind)?,
+            preview: Some(truncate_evidence_string(&linked.text)),
+            payload_json: full_payload_json(&linked)?,
+        },
+    )?;
+    tx.execute(
+        "UPDATE briefs SET created_event_seq = ?1 WHERE evidence_id = ?2",
+        params![i64::try_from(event_seq).ok(), &linked.id],
+    )?;
+    Ok(linked)
+}
+
+/// Single-transition Brief publication: allocates the audit event sequence,
+/// appends the idempotent `brief_created` event, links the Brief record to
+/// the committed sequence, and records index changes, all in one SQLite
+/// transaction. When the event is observed, the Brief record is already
+/// readable.
+pub(crate) fn append_brief_with_created_event_tx(
+    tx: &Transaction<'_>,
+    agent_id: Option<&str>,
+    brief: &BriefRecord,
+    event: &AuditEvent,
+    index_changes: &[RuntimeIndexChange],
+) -> Result<BriefCreatedCommit> {
+    let (event, event_inserted) = append_audit_event_tx(tx, agent_id, event)?;
+    let brief = upsert_brief_with_created_event_seq_tx(tx, brief, event.event_seq)?;
+    insert_runtime_index_changes_tx(tx, index_changes)?;
+    Ok(BriefCreatedCommit {
+        brief,
+        event,
+        event_inserted,
+    })
+}
+
+/// Links transition `brief_evidence` rows against the `brief_created` events
+/// committed by the same transition. At most one event may reference a
+/// carried Brief; a Brief without its event in this transition stays
+/// unlinked rather than blocking the committed transition.
+pub(crate) fn link_transition_brief_created_events_tx(
+    tx: &Transaction<'_>,
+    brief_evidence: &[BriefRecord],
+    committed_events: &[AuditEvent],
+) -> Result<()> {
+    const BRIEF_CREATED_WIRE_NAME: &str = "brief_created";
+    for brief in brief_evidence {
+        let matches = committed_events
+            .iter()
+            .filter(|event| {
+                event.kind == BRIEF_CREATED_WIRE_NAME
+                    && event
+                        .data
+                        .get("brief_id")
+                        .and_then(|value| value.as_str())
+                        .is_some_and(|brief_id| brief_id == brief.id)
+            })
+            .collect::<Vec<_>>();
+        anyhow::ensure!(
+            matches.len() <= 1,
+            "transition carried {} brief_created events for brief {}",
+            matches.len(),
+            brief.id
+        );
+        if let Some(event) = matches.first() {
+            upsert_brief_with_created_event_seq_tx(tx, brief, event.event_seq)?;
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn insert_delivery_summary_evidence_tx(
     tx: &Transaction<'_>,
     record: &DeliverySummaryRecord,

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3115,6 +3115,22 @@ CREATE TABLE IF NOT EXISTS observer_sync_capability_verifications (
 );
 "#,
     },
+    Migration {
+        version: 49,
+        name: "brief_created_event_linkage",
+        // The `briefs` column and index live in
+        // `ensure_brief_created_event_linkage_schema` so name-accepted
+        // upgrade paths without historical evidence tables still apply.
+        sql: r#"
+CREATE TABLE IF NOT EXISTS brief_created_linkage_uncertain (
+  evidence_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  candidate_count INTEGER NOT NULL,
+  reason TEXT NOT NULL,
+  discovered_at TEXT NOT NULL
+);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {
@@ -3357,6 +3373,9 @@ fn apply_migration_transaction(transaction: &Transaction<'_>, migration: &Migrat
     if migration.name == "execution_protocol_authority" {
         ensure_execution_protocol_authority_columns(transaction)?;
     }
+    if migration.name == "brief_created_event_linkage" {
+        ensure_brief_created_event_linkage_schema(transaction)?;
+    }
     transaction.execute_batch(migration.sql)?;
     if migration.name == "execution_protocol_authority" {
         backfill_execution_protocol_authority(transaction)?;
@@ -3372,6 +3391,9 @@ fn apply_migration_transaction(transaction: &Transaction<'_>, migration: &Migrat
     }
     if migration.name == "observer_sync_identity_foundations" {
         backfill_observer_sync_identity_foundations(transaction)?;
+    }
+    if migration.name == "brief_created_event_linkage" {
+        backfill_brief_created_event_linkage(transaction)?;
     }
     transaction.execute(
         "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
@@ -3404,6 +3426,125 @@ fn table_exists_tx(transaction: &Transaction<'_>, table: &str) -> Result<bool> {
         |row| row.get(0),
     )?;
     Ok(count == 1)
+}
+
+/// Adds the immutable `created_event_seq` linkage column and its uniqueness
+/// index. Name-accepted upgrade paths can reach this migration without the
+/// historical evidence tables, so the column work is gated on `briefs`
+/// existing and is idempotent under downgrade/re-upgrade cycles that keep
+/// the column while losing the migration record.
+fn ensure_brief_created_event_linkage_schema(transaction: &Transaction<'_>) -> Result<()> {
+    if !table_exists_tx(transaction, "briefs")? {
+        return Ok(());
+    }
+    let columns = transaction
+        .prepare("PRAGMA table_info(briefs)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    if !columns.iter().any(|column| column == "created_event_seq") {
+        transaction.execute_batch("ALTER TABLE briefs ADD COLUMN created_event_seq INTEGER;")?;
+    }
+    transaction.execute_batch(
+        "CREATE UNIQUE INDEX IF NOT EXISTS briefs_agent_created_event_seq
+           ON briefs(agent_id, created_event_seq)
+           WHERE created_event_seq IS NOT NULL;",
+    )?;
+    Ok(())
+}
+
+/// Backfills the immutable `created_event_seq` linkage from historical
+/// `brief_created` audit events. A Brief with exactly one candidate event
+/// carrying a sequence is linked; zero candidates, multiple candidates, or a
+/// candidate without a sequence keep `NULL` linkage and are recorded in
+/// `brief_created_linkage_uncertain`, so ambiguous history stays visibly
+/// absent instead of silently linked. Brief content and timestamps are
+/// never rewritten: only the additive linkage field changes.
+fn backfill_brief_created_event_linkage(transaction: &Transaction<'_>) -> Result<()> {
+    // Without the historical evidence tables there is nothing to link and no
+    // way to classify candidates, so ambiguous-history bookkeeping stays
+    // empty instead of misreporting every Brief as uncertain.
+    if !table_exists_tx(transaction, "briefs")? || !table_exists_tx(transaction, "audit_events")? {
+        return Ok(());
+    }
+    let rows: Vec<(String, String, String)> = {
+        let mut statement =
+            transaction.prepare("SELECT evidence_id, agent_id, payload_json FROM briefs")?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        rows
+    };
+    let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let mut linked = 0usize;
+    let mut uncertain = 0usize;
+    for (evidence_id, agent_id, payload_json) in rows {
+        let candidates: Vec<(String, Option<i64>)> = {
+            let mut statement = transaction.prepare(
+                "SELECT audit_event_id, event_seq FROM audit_events
+                 WHERE kind = 'brief_created'
+                   AND COALESCE(json_extract(data_json, '$.brief_id'), '') = ?1
+                   AND (agent_id = ?2
+                        OR COALESCE(json_extract(data_json, '$.agent_id'), '') = ?2)",
+            )?;
+            let rows = statement
+                .query_map(params![evidence_id, agent_id], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?))
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            rows
+        };
+        let (candidate_count, reason) = if candidates.len() == 1 {
+            match candidates[0].1 {
+                Some(event_seq) => {
+                    let mut brief: crate::types::BriefRecord = serde_json::from_str(&payload_json)
+                        .context("decoding brief payload for created_event_seq backfill")?;
+                    if brief.created_event_seq.is_none() {
+                        brief.created_event_seq =
+                            Some(u64::try_from(event_seq).with_context(|| {
+                                format!("brief_created event_seq {event_seq} must be non-negative")
+                            })?);
+                        transaction.execute(
+                            "UPDATE briefs SET created_event_seq = ?1, payload_json = ?2
+                             WHERE evidence_id = ?3",
+                            params![event_seq, serde_json::to_string(&brief)?, evidence_id],
+                        )?;
+                        linked += 1;
+                    }
+                    continue;
+                }
+                None => (1, "candidate_event_missing_seq"),
+            }
+        } else if candidates.is_empty() {
+            (0, "no_candidate_event")
+        } else {
+            (candidates.len(), "ambiguous_candidate_events")
+        };
+        transaction.execute(
+            "INSERT INTO brief_created_linkage_uncertain
+               (evidence_id, agent_id, candidate_count, reason, discovered_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(evidence_id) DO UPDATE SET
+               candidate_count = excluded.candidate_count,
+               reason = excluded.reason,
+               discovered_at = excluded.discovered_at",
+            params![evidence_id, agent_id, candidate_count, reason, now],
+        )?;
+        uncertain += 1;
+    }
+    if linked > 0 || uncertain > 0 {
+        tracing::info!(
+            linked,
+            uncertain,
+            "backfilled brief created_event_seq linkage"
+        );
+    }
+    Ok(())
 }
 
 fn backfill_observer_sync_identity_foundations(transaction: &Transaction<'_>) -> Result<()> {

--- a/src/runtime_db/observer_sync.rs
+++ b/src/runtime_db/observer_sync.rs
@@ -19,6 +19,7 @@ use crate::types::{
 pub(crate) const RUNTIME_IDENTITY_STABLE: &str = "runtime_identity_stable";
 pub(crate) const AGENT_IDENTITY_RESERVED: &str = "agent_identity_reserved";
 pub(crate) const EVENT_PROJECTION_EFFECT_COMPLETE: &str = "event_projection_effect_complete";
+pub(crate) const BRIEF_ATOMIC_LINKAGE_VERIFIED: &str = "brief_atomic_linkage_verified";
 
 /// Principal and entitlement used to derive the runtime-local public scope
 /// for unauthenticated local mode.
@@ -35,6 +36,11 @@ pub struct ObserverSyncFoundationVerification {
     /// `projection_effect` envelope field: registry-known kinds match their
     /// declared payload schema, and unknown kinds carry legacy markers.
     pub event_projection_effect_complete: bool,
+    /// Every Brief publication path commits the Brief record and its unique
+    /// `brief_created` event in one runtime DB transition, and every stored
+    /// linkage resolves to exactly one matching event. Retention-pruned
+    /// history with no linkage stays acceptable.
+    pub brief_atomic_linkage_verified: bool,
 }
 
 /// Per-Agent committed event recovery window used by the rich
@@ -191,7 +197,74 @@ pub(crate) fn verify_observer_sync_foundations(connection: &mut Connection) -> R
         &now,
         &inventory_detail,
     )?;
+    let linkage = verify_brief_atomic_linkage(connection);
+    let linkage_detail = match &linkage {
+        Ok(verified) => serde_json::json!({
+            "unmatched_linkages": 0,
+            "shared_sequences": 0,
+            "verified": verified,
+        })
+        .to_string(),
+        Err(error) => serde_json::json!({ "error": format!("{error:#}") }).to_string(),
+    };
+    persist_verification(
+        connection,
+        BRIEF_ATOMIC_LINKAGE_VERIFIED,
+        linkage.unwrap_or(false),
+        &now,
+        &linkage_detail,
+    )?;
     Ok(())
+}
+
+/// Proves the stored Brief linkage is sound for the atomic created-event
+/// contract: every `created_event_seq` resolves to exactly one
+/// `brief_created` audit event of the same Agent referencing that Brief,
+/// and no sequence is claimed by two Briefs. Events whose records were
+/// pruned by retention carry no linkage and therefore stay acceptable.
+fn verify_brief_atomic_linkage(connection: &Connection) -> Result<bool> {
+    if !table_exists(connection, "briefs")? || !table_exists(connection, "audit_events")? {
+        return Ok(false);
+    }
+    let linkage_column: i64 = connection.query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('briefs')
+         WHERE name = 'created_event_seq'",
+        [],
+        |row| row.get(0),
+    )?;
+    if linkage_column == 0 {
+        return Ok(false);
+    }
+    let unmatched: i64 = connection.query_row(
+        "SELECT COUNT(*) FROM briefs b
+         WHERE b.created_event_seq IS NOT NULL AND (
+           SELECT COUNT(*) FROM audit_events e
+           WHERE e.kind = 'brief_created'
+             AND e.event_seq = b.created_event_seq
+             AND COALESCE(e.agent_id, json_extract(e.data_json, '$.agent_id')) = b.agent_id
+             AND json_extract(e.data_json, '$.brief_id') = b.evidence_id
+         ) != 1",
+        [],
+        |row| row.get(0),
+    )?;
+    let shared_sequences: i64 = connection.query_row(
+        "SELECT COUNT(*) FROM (
+           SELECT created_event_seq FROM briefs
+           WHERE created_event_seq IS NOT NULL
+           GROUP BY created_event_seq HAVING COUNT(*) > 1
+         )",
+        [],
+        |row| row.get(0),
+    )?;
+    if unmatched > 0 || shared_sequences > 0 {
+        tracing::warn!(
+            unmatched,
+            shared_sequences,
+            "brief created_event_seq linkage verification failed"
+        );
+        return Ok(false);
+    }
+    Ok(true)
 }
 
 /// Proves every stored audit event classifies soundly under the registry
@@ -382,6 +455,7 @@ impl crate::runtime_db::RuntimeDb {
             runtime_identity_stable: verified(RUNTIME_IDENTITY_STABLE)?,
             agent_identity_reserved: verified(AGENT_IDENTITY_RESERVED)?,
             event_projection_effect_complete: verified(EVENT_PROJECTION_EFFECT_COMPLETE)?,
+            brief_atomic_linkage_verified: verified(BRIEF_ATOMIC_LINKAGE_VERIFIED)?,
         })
     }
 

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -2312,6 +2312,21 @@ impl EvidenceRepository<'_> {
         })
     }
 
+    /// Single-transaction Brief publication: audit event sequence
+    /// allocation, the `brief_created` event, the Brief record, and its
+    /// immutable `created_event_seq` linkage commit together.
+    pub fn append_brief_with_created_event(
+        &self,
+        agent_id: Option<&str>,
+        brief: &BriefRecord,
+        event: &crate::types::AuditEvent,
+        changes: &[RuntimeIndexChange],
+    ) -> Result<crate::runtime_db::evidence::BriefCreatedCommit> {
+        self.db.transaction(|tx| {
+            append_brief_with_created_event_tx(tx, agent_id, brief, event, changes)
+        })
+    }
+
     pub fn append_delivery_summary(&self, record: &DeliverySummaryRecord) -> Result<()> {
         self.db
             .transaction(|tx| insert_delivery_summary_evidence_tx(tx, record))

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -615,6 +615,202 @@ mod tests {
     }
 
     #[test]
+    fn append_brief_with_created_event_commits_and_deduplicates_publication() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut brief = BriefRecord::new(
+            "agent-a",
+            crate::types::BriefKind::Result,
+            "atomic brief",
+            None,
+            None,
+        );
+        brief.turn_id = Some("turn-1".into());
+        let event = crate::types::brief_created_event_for(&brief)?;
+
+        let commit =
+            db.evidence()
+                .append_brief_with_created_event(Some("agent-a"), &brief, &event, &[])?;
+        assert!(commit.event_inserted);
+        assert_eq!(commit.brief.created_event_seq, Some(commit.event.event_seq));
+
+        // A retry of the same publication reuses the committed event and
+        // linkage instead of appending a duplicate event.
+        let retry =
+            db.evidence()
+                .append_brief_with_created_event(Some("agent-a"), &brief, &event, &[])?;
+        assert!(!retry.event_inserted);
+        assert_eq!(retry.event.event_seq, commit.event.event_seq);
+        assert_eq!(retry.event.id, commit.event.id);
+        assert_eq!(retry.brief.created_event_seq, Some(commit.event.event_seq));
+
+        let events = db.audit_events().recent(Some("agent-a"), 10)?;
+        let brief_created: Vec<_> = events
+            .iter()
+            .filter(|event| event.kind == "brief_created")
+            .collect();
+        assert_eq!(brief_created.len(), 1);
+        let stored = db
+            .evidence()
+            .brief_by_id("agent-a", &brief.id)?
+            .expect("brief stored");
+        assert_eq!(stored.created_event_seq, Some(commit.event.event_seq));
+        Ok(())
+    }
+
+    #[test]
+    fn append_brief_with_created_event_rejects_conflicting_relink_and_rolls_back() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let brief = BriefRecord::new(
+            "agent-a",
+            crate::types::BriefKind::Result,
+            "linked once",
+            None,
+            None,
+        );
+        let event = crate::types::brief_created_event_for(&brief)?;
+        let commit =
+            db.evidence()
+                .append_brief_with_created_event(Some("agent-a"), &brief, &event, &[])?;
+
+        // A second, different event identity for the same Brief must not
+        // relink it, and the whole transaction rolls back.
+        let mut other = crate::types::brief_created_event_for(&brief)?;
+        other.id = "event_conflicting_relink".into();
+        other.created_at = Utc::now();
+        let error = db
+            .evidence()
+            .append_brief_with_created_event(Some("agent-a"), &brief, &other, &[])
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("refusing relink"),
+            "unexpected error: {error:#}"
+        );
+
+        let events = db.audit_events().recent(Some("agent-a"), 10)?;
+        let brief_created: Vec<_> = events
+            .iter()
+            .filter(|event| event.kind == "brief_created")
+            .collect();
+        assert_eq!(brief_created.len(), 1);
+        let stored = db
+            .evidence()
+            .brief_by_id("agent-a", &brief.id)?
+            .expect("brief stored");
+        assert_eq!(stored.created_event_seq, Some(commit.event.event_seq));
+        Ok(())
+    }
+
+    #[test]
+    fn migration_49_backfills_unique_linkage_and_marks_uncertain_history() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        {
+            let mut connection = open_connection(&db_path)?;
+            migrate_through(&mut connection, 48)?;
+            let seed_brief = |evidence_id: &str, text: &str| -> Result<BriefRecord> {
+                let mut brief =
+                    BriefRecord::new("agent-a", crate::types::BriefKind::Result, text, None, None);
+                brief.id = evidence_id.into();
+                connection.execute(
+                    "INSERT INTO briefs (
+                       evidence_id, agent_id, created_at, kind, preview, payload_json
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    params![
+                        brief.id,
+                        brief.agent_id,
+                        timestamp(brief.created_at),
+                        "result",
+                        text,
+                        serde_json::to_string(&brief)?
+                    ],
+                )?;
+                Ok(brief)
+            };
+            let linked = seed_brief("brief-linked", "unique candidate")?;
+            let _missing = seed_brief("brief-missing", "no candidate")?;
+            let ambiguous = seed_brief("brief-ambiguous", "two candidates")?;
+            let seed_event = |audit_event_id: &str, event_seq: i64, brief_id: &str| -> Result<()> {
+                connection.execute(
+                    "INSERT INTO audit_events (
+                           audit_event_id, event_seq, agent_id, kind, created_at, data_json
+                         ) VALUES (?1, ?2, ?3, 'brief_created', ?4, ?5)",
+                    params![
+                        audit_event_id,
+                        event_seq,
+                        "agent-a",
+                        timestamp(Utc::now()),
+                        serde_json::json!({
+                            "brief_id": brief_id,
+                            "agent_id": "agent-a",
+                        })
+                        .to_string()
+                    ],
+                )?;
+                Ok(())
+            };
+            seed_event("event-linked", 11, &linked.id)?;
+            seed_event("event-ambiguous-a", 21, &ambiguous.id)?;
+            seed_event("event-ambiguous-b", 22, &ambiguous.id)?;
+
+            apply_migration(&mut connection, &MIGRATIONS[48])?;
+
+            let linkage: (Option<i64>, String) = connection.query_row(
+                "SELECT created_event_seq, payload_json FROM briefs
+                 WHERE evidence_id = 'brief-linked'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )?;
+            assert_eq!(linkage.0, Some(11));
+            let stored: BriefRecord = serde_json::from_str(&linkage.1)?;
+            assert_eq!(stored.created_event_seq, Some(11));
+            // Migration must not modify Brief content or timestamps.
+            assert_eq!(stored.text, linked.text);
+            assert_eq!(stored.created_at, linked.created_at);
+            assert_eq!(stored.kind, linked.kind);
+            assert_eq!(stored.agent_id, linked.agent_id);
+
+            for (brief_id, expected_reason) in [
+                ("brief-missing", "no_candidate_event"),
+                ("brief-ambiguous", "ambiguous_candidate_events"),
+            ] {
+                let linkage: Option<i64> = connection.query_row(
+                    "SELECT created_event_seq FROM briefs WHERE evidence_id = ?1",
+                    [brief_id],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(linkage, None, "{brief_id} must stay unlinked");
+                let (reason, payload_json): (String, String) = connection.query_row(
+                    "SELECT reason, payload_json FROM brief_created_linkage_uncertain
+                     JOIN briefs ON briefs.evidence_id = brief_created_linkage_uncertain.evidence_id
+                     WHERE brief_created_linkage_uncertain.evidence_id = ?1",
+                    [brief_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )?;
+                assert_eq!(reason, expected_reason);
+                let stored: BriefRecord = serde_json::from_str(&payload_json)?;
+                assert_eq!(stored.created_event_seq, None);
+            }
+
+            // Fresh reopen persists the capability verification for the
+            // sound linkage state.
+            let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+            let foundations = db.observer_sync_foundations()?;
+            assert!(foundations.brief_atomic_linkage_verified);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn fresh_runtime_db_verifies_brief_atomic_linkage_capability() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let foundations = db.observer_sync_foundations()?;
+        assert!(foundations.brief_atomic_linkage_verified);
+        Ok(())
+    }
+
+    #[test]
     fn release_baseline_matches_compatibility_migration_schema() -> Result<()> {
         let (_baseline_temp, baseline_path, baseline_lock) = temp_paths()?;
         let baseline = RuntimeDb::open_and_migrate(&baseline_path, &baseline_lock)?;
@@ -1387,7 +1583,7 @@ INSERT INTO storage_domains (
         assert!(
             error
                 .to_string()
-                .contains("supports runtime db schemas 46 through 48, found 45"),
+                .contains("supports runtime db schemas 46 through 49, found 45"),
             "{error:#}"
         );
         Ok(())
@@ -1510,7 +1706,7 @@ INSERT INTO scheduler_rollout_command_results (
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
 
         let connection = open_connection(&db_path)?;
-        assert_eq!(current_schema_version(&connection)?, 48);
+        assert_eq!(current_schema_version(&connection)?, 49);
         for table in RETIRED_SCHEDULER_TABLES {
             assert!(
                 !table_exists(&connection, table)?,
@@ -1664,7 +1860,7 @@ INSERT INTO scheduler_rollout_command_results (
 
             RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             let connection = open_connection(&db_path)?;
-            assert_eq!(current_schema_version(&connection)?, 48);
+            assert_eq!(current_schema_version(&connection)?, 49);
             for table in RETIRED_SCHEDULER_TABLES {
                 assert!(
                     !table_exists(&connection, table)?,
@@ -1778,7 +1974,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 48);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 49);
         Ok(())
     }
 
@@ -1885,7 +2081,7 @@ INSERT INTO scheduler_rollout_command_results (
             RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             assert_eq!(
                 current_schema_version(&open_connection(&db_path)?)?,
-                48,
+                49,
                 "{case}"
             );
         }
@@ -1944,7 +2140,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 48);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 49);
         Ok(())
     }
 
@@ -2004,7 +2200,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 48);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 49);
         Ok(())
     }
 

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -17,7 +17,7 @@ use crate::{
         evidence::{
             append_audit_event_tx, append_message_tx, append_transcript_entry_tx,
             insert_brief_evidence_tx, insert_runtime_index_changes_tx, insert_tool_evidence_tx,
-            upsert_agent_state_tx,
+            link_transition_brief_created_events_tx, upsert_agent_state_tx,
         },
         repositories::{
             compare_and_set_queue_entry_tx, insert_new_work_item_tx, queue_entry_transition,
@@ -772,7 +772,7 @@ impl RuntimeTransitionRepository<'_> {
             }
             inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
 
-            finish_transition_tx(
+            let commit = finish_transition_tx(
                 tx,
                 applied,
                 &command.agent_id,
@@ -785,7 +785,13 @@ impl RuntimeTransitionRepository<'_> {
                     notify_scheduler: command.notify_scheduler,
                     ..PostCommitEffects::default()
                 },
-            )
+            )?;
+            link_transition_brief_created_events_tx(
+                tx,
+                &command.brief_evidence,
+                &commit.effects.audit_events,
+            )?;
+            Ok(commit)
         })
     }
 
@@ -850,7 +856,7 @@ impl RuntimeTransitionRepository<'_> {
                 insert_brief_evidence_tx(tx, brief)?;
             }
             inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
-            finish_transition_tx(
+            let commit = finish_transition_tx(
                 tx,
                 applied,
                 &command.agent_id,
@@ -865,7 +871,13 @@ impl RuntimeTransitionRepository<'_> {
                     notify_scheduler: command.notify_scheduler,
                     ..PostCommitEffects::default()
                 },
-            )
+            )?;
+            link_transition_brief_created_events_tx(
+                tx,
+                &command.brief_evidence,
+                &commit.effects.audit_events,
+            )?;
+            Ok(commit)
         })
     }
 
@@ -1289,7 +1301,7 @@ impl RuntimeTransitionRepository<'_> {
                 insert_brief_evidence_tx(tx, brief)?;
             }
             inject_fault(command.fault, TransitionFaultPoint::AfterCanonicalWrites)?;
-            finish_transition_tx(
+            let commit = finish_transition_tx(
                 tx,
                 applied,
                 &command.agent_id,
@@ -1310,7 +1322,13 @@ impl RuntimeTransitionRepository<'_> {
                     notify_scheduler: command.notify_scheduler,
                     ..PostCommitEffects::default()
                 },
-            )
+            )?;
+            link_transition_brief_created_events_tx(
+                tx,
+                &command.brief_evidence,
+                &commit.effects.audit_events,
+            )?;
+            Ok(commit)
         })
     }
 
@@ -2412,6 +2430,125 @@ mod tests {
                     .high_watermark_for_agent("agent-a")?,
                 0
             );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn work_item_transition_links_brief_created_event_evidence() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        let record = work_item("work-brief-link");
+        let mut brief = BriefRecord::new(
+            "agent-a",
+            crate::types::BriefKind::Result,
+            "transition linked brief",
+            None,
+            None,
+        );
+        brief.work_item_id = Some(record.id.clone());
+        let event = crate::types::brief_created_event_for(&brief)?;
+
+        db.transitions()
+            .commit_work_item(&WorkItemTransitionCommand {
+                agent_id: "agent-a".into(),
+                mutation: WorkItemMutation::Insert {
+                    record: record.clone(),
+                },
+                agent_state: None,
+                brief_evidence: vec![brief.clone()],
+                audit_events: vec![event],
+                index_changes: vec![index_change("work_item", &record.id)],
+                notify_scheduler: true,
+                fault: None,
+            })?;
+
+        let stored = db
+            .evidence()
+            .brief_by_id("agent-a", &brief.id)?
+            .expect("brief evidence stored");
+        let linkage = stored.created_event_seq.expect("brief linked to event");
+        let events = db.audit_events().recent(Some("agent-a"), 10)?;
+        let brief_created: Vec<&crate::types::AuditEvent> = events
+            .iter()
+            .filter(|event| event.kind == "brief_created")
+            .collect();
+        assert_eq!(brief_created.len(), 1);
+        assert_eq!(brief_created[0].event_seq, linkage);
+        Ok(())
+    }
+
+    #[test]
+    fn work_item_transition_brief_linkage_faults_roll_back_record_and_event() -> Result<()> {
+        // Crash points before commit cover: before the record write
+        // (AfterValidation), after the record but before event/seq writes
+        // (AfterCanonicalWrites), after the event and sequence writes
+        // (AfterAuditWrites), and immediately before commit (BeforeCommit).
+        // Every one must leave neither the Brief, its event, nor its
+        // linkage behind; a retry then reuses the stable identity.
+        for fault in [
+            TransitionFaultPoint::AfterValidation,
+            TransitionFaultPoint::AfterCanonicalWrites,
+            TransitionFaultPoint::AfterAuditWrites,
+            TransitionFaultPoint::BeforeCommit,
+        ] {
+            let (_dir, db) = runtime_db()?;
+            let record = work_item("work-brief-fault");
+            let mut brief = BriefRecord::new(
+                "agent-a",
+                crate::types::BriefKind::Result,
+                "faulted brief",
+                None,
+                None,
+            );
+            brief.work_item_id = Some(record.id.clone());
+            let event = crate::types::brief_created_event_for(&brief)?;
+            let error = db
+                .transitions()
+                .commit_work_item(&WorkItemTransitionCommand {
+                    agent_id: "agent-a".into(),
+                    mutation: WorkItemMutation::Insert {
+                        record: record.clone(),
+                    },
+                    agent_state: None,
+                    brief_evidence: vec![brief.clone()],
+                    audit_events: vec![event],
+                    index_changes: Vec::new(),
+                    notify_scheduler: true,
+                    fault: Some(fault),
+                })
+                .unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("injected runtime transition fault"));
+            assert!(db.evidence().brief_by_id("agent-a", &brief.id)?.is_none());
+            assert!(db.audit_events().recent(Some("agent-a"), 10)?.is_empty());
+
+            // The retry after the simulated crash commits exactly one
+            // linked event.
+            db.transitions()
+                .commit_work_item(&WorkItemTransitionCommand {
+                    agent_id: "agent-a".into(),
+                    mutation: WorkItemMutation::Insert {
+                        record: record.clone(),
+                    },
+                    agent_state: None,
+                    brief_evidence: vec![brief.clone()],
+                    audit_events: vec![crate::types::brief_created_event_for(&brief)?],
+                    index_changes: Vec::new(),
+                    notify_scheduler: true,
+                    fault: None,
+                })?;
+            let stored = db
+                .evidence()
+                .brief_by_id("agent-a", &brief.id)?
+                .expect("brief stored after retry");
+            let events = db.audit_events().recent(Some("agent-a"), 10)?;
+            let brief_created: Vec<_> = events
+                .iter()
+                .filter(|event| event.kind == "brief_created")
+                .collect();
+            assert_eq!(brief_created.len(), 1);
+            assert_eq!(stored.created_event_seq, Some(brief_created[0].event_seq));
         }
         Ok(())
     }

--- a/src/storage/events.rs
+++ b/src/storage/events.rs
@@ -146,6 +146,19 @@ impl RuntimeEventLog {
         Ok(())
     }
 
+    /// Publishes an event that was committed inside another storage
+    /// transaction (for example the single-transition Brief publication).
+    /// Callers must invoke this only after the owning transaction has
+    /// committed so subscribers never observe an event whose canonical
+    /// record is not yet readable.
+    pub(crate) fn publish_committed_event(
+        &self,
+        agent_id: Option<String>,
+        event: &AuditEvent,
+    ) -> Result<()> {
+        self.publish(agent_id, event)
+    }
+
     pub(crate) fn publish_transition_events(
         &self,
         effects: &PostCommitEffects,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -366,6 +366,16 @@ impl AppStorage {
         self.store.append_brief(brief)
     }
 
+    /// Single-transition Brief publication: record, event sequence
+    /// allocation, and `brief_created` event commit atomically.
+    pub fn append_brief_with_created_event(
+        &self,
+        brief: &BriefRecord,
+        event: &crate::types::AuditEvent,
+    ) -> Result<crate::runtime_db::evidence::BriefCreatedCommit> {
+        self.store.append_brief_with_created_event(brief, event)
+    }
+
     pub fn append_message(&self, message: &MessageEnvelope) -> Result<()> {
         self.store.append_message(message)
     }
@@ -1428,6 +1438,65 @@ mod tests {
         assert_eq!(persisted.len(), 1);
         assert_eq!(persisted[0].id, published.event.id);
         assert_eq!(persisted[0].event_seq, published.event.event_seq);
+    }
+
+    #[test]
+    fn append_brief_with_created_event_publishes_after_commit_and_deduplicates() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "agent-test").unwrap();
+        storage.enable_event_bus(EventBus::new(8)).unwrap();
+        let mut receiver = storage.subscribe_events().unwrap().unwrap();
+
+        let brief = BriefRecord::new(
+            "agent-test",
+            BriefKind::Result,
+            "atomic brief publication",
+            None,
+            None,
+        );
+        let event = crate::types::brief_created_event_for(&brief).unwrap();
+        let commit = storage
+            .append_brief_with_created_event(&brief, &event)
+            .unwrap();
+        assert!(commit.event_inserted);
+
+        // The published event implies the Brief record is already committed:
+        // a fresh reader observes both in one view.
+        let published = receiver.try_recv().unwrap();
+        let reader = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        let stored = reader
+            .evidence()
+            .brief_by_id("agent-test", &brief.id)
+            .unwrap()
+            .expect("brief readable once event is published");
+        assert_eq!(
+            stored.created_event_seq,
+            Some(published.event.event_seq),
+            "linkage must point at the published event"
+        );
+
+        // A retried publication neither appends a second event nor
+        // republishes the committed one.
+        let retry = storage
+            .append_brief_with_created_event(&brief, &event)
+            .unwrap();
+        assert!(!retry.event_inserted);
+        assert!(receiver.try_recv().is_err());
+        let events = reader
+            .audit_events()
+            .recent(Some("agent-test"), 10)
+            .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.kind == "brief_created")
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/src/storage/store.rs
+++ b/src/storage/store.rs
@@ -91,6 +91,45 @@ impl RuntimeStore {
         self.index_outbox.enqueue_brief_best_effort(brief)
     }
 
+    /// Single-transition Brief publication. The Brief record, its audit
+    /// event sequence allocation, and the `brief_created` event commit in
+    /// one SQLite transaction; the stored linkage, committed event, and
+    /// insertion flag are returned. Event bus publication happens only
+    /// after the transaction commits, so an observed event always implies a
+    /// readable Brief record.
+    pub fn append_brief_with_created_event(
+        &self,
+        brief: &BriefRecord,
+        event: &crate::types::AuditEvent,
+    ) -> Result<crate::runtime_db::evidence::BriefCreatedCommit> {
+        self.ensure_writable()?;
+        let changes = self.index_outbox.changes_for_brief(brief);
+        let agent_id = self.current_agent_id()?;
+        let commit = self.runtime_db.evidence().append_brief_with_created_event(
+            agent_id.as_deref(),
+            brief,
+            event,
+            &changes,
+        )?;
+        self.index_outbox.enqueue_brief_best_effort(&commit.brief)?;
+        if commit.event_inserted {
+            if let Err(error) = self
+                .event_log
+                .publish_committed_event(agent_id.clone(), &commit.event)
+            {
+                tracing::warn!(
+                    error = %error,
+                    event_id = %commit.event.id,
+                    event_kind = %commit.event.kind,
+                    event_seq = commit.event.event_seq,
+                    agent_id = agent_id.as_deref().unwrap_or("<global>"),
+                    "failed to publish committed brief_created audit event"
+                );
+            }
+        }
+        Ok(commit)
+    }
+
     pub fn append_message(&self, message: &MessageEnvelope) -> Result<()> {
         self.ensure_writable()?;
         let changes = self.index_outbox.changes_for_message(message);

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -973,6 +973,7 @@ fn build_chat_text_includes_structured_operator_messages() {
             attachments: None,
             related_message_id: None,
             related_task_id: None,
+            created_event_seq: None,
         },
     );
 
@@ -1014,6 +1015,7 @@ fn build_chat_text_renders_message_block_header_above_body() {
             attachments: None,
             related_message_id: None,
             related_task_id: None,
+            created_event_seq: None,
         },
     );
 
@@ -1168,6 +1170,7 @@ fn build_chat_text_groups_agent_cells_by_turn_index() {
         attachments: None,
         related_message_id: None,
         related_task_id: None,
+        created_event_seq: None,
     };
     let brief_event = StreamEventEnvelope {
         projection_effect: None,
@@ -2757,6 +2760,7 @@ fn chat_text_renders_markdown_body() {
             attachments: None,
             related_message_id: None,
             related_task_id: None,
+            created_event_seq: None,
         },
     );
 
@@ -2795,6 +2799,7 @@ fn chat_text_renders_brief_events_from_projection() {
             attachments: None,
             related_message_id: None,
             related_task_id: None,
+            created_event_seq: None,
         },
     );
 
@@ -2841,6 +2846,7 @@ fn chat_text_ignores_ack_lifecycle_event_but_keeps_result_brief_events() {
             attachments: None,
             related_message_id: None,
             related_task_id: None,
+            created_event_seq: None,
         },
     );
 
@@ -2878,6 +2884,7 @@ fn chat_text_summarizes_task_brief_output() {
             attachments: None,
             related_message_id: None,
             related_task_id: Some("task-1".into()),
+            created_event_seq: None,
         },
     );
 
@@ -3613,6 +3620,7 @@ fn active_activity_timestamp_does_not_sort_before_tail_history() {
             attachments: None,
             related_message_id: None,
             related_task_id: None,
+            created_event_seq: None,
         },
     );
     let projection = app.projection.as_mut().expect("projection");
@@ -3807,6 +3815,7 @@ fn collect_chat_items_orders_equal_timestamps_deterministically() {
             attachments: None,
             related_message_id: None,
             related_task_id: None,
+            created_event_seq: None,
         },
     );
 
@@ -4535,6 +4544,7 @@ fn chat_text_renders_full_long_brief_events() {
             attachments: None,
             related_message_id: None,
             related_task_id: None,
+            created_event_seq: None,
         },
     );
 
@@ -4599,6 +4609,7 @@ fn chat_text_cache_reuses_unchanged_content_and_replaces_stale_entries() {
             attachments: None,
             related_message_id: None,
             related_task_id: None,
+            created_event_seq: None,
         },
     );
 
@@ -4637,6 +4648,7 @@ fn chat_text_cache_reuses_unchanged_content_and_replaces_stale_entries() {
             attachments: None,
             related_message_id: None,
             related_task_id: None,
+            created_event_seq: None,
         },
     );
 
@@ -4942,6 +4954,7 @@ fn apply_agent_list_clears_stale_projection_when_selected_agent_disappears() {
             attachments: None,
             related_message_id: None,
             related_task_id: None,
+            created_event_seq: None,
         },
     );
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -4685,6 +4685,12 @@ pub struct BriefRecord {
     pub text: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub citations: Option<Vec<Citation>>,
+    /// Immutable linkage to the unique `brief_created` audit event committed
+    /// in the same runtime DB transition as this record. `None` for records
+    /// whose creating event cannot be identified (pre-linkage history or
+    /// ambiguous backfill candidates).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_event_seq: Option<u64>,
     pub attachments: Option<Vec<BriefAttachment>>,
     pub related_message_id: Option<String>,
     pub related_task_id: Option<String>,
@@ -4713,10 +4719,40 @@ impl BriefRecord {
             text: text.into(),
             citations: None,
             attachments: None,
+            created_event_seq: None,
             related_message_id,
             related_task_id,
         }
     }
+}
+
+/// Deterministic idempotency identity for a brief's `brief_created` audit
+/// event. Retry of a Brief publication must reuse the same event id (and
+/// brief-sourced `created_at`) so the transactional append sees one event,
+/// not one per attempt.
+pub fn stable_brief_created_event_id(agent_id: &str, brief_id: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update("brief_created".as_bytes());
+    hasher.update([0]);
+    hasher.update(agent_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(brief_id.as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("event_{}", &digest[..15])
+}
+
+/// Builds the deterministic `brief_created` audit event for a Brief record.
+/// The event id and `created_at` are derived from the Brief so retries are
+/// content-identical and deduplicate at the storage layer.
+pub fn brief_created_event_for(brief: &BriefRecord) -> anyhow::Result<AuditEvent> {
+    let mut event = AuditEvent::typed(
+        crate::runtime_event::RuntimeEventKind::BriefCreated,
+        &BriefCreatedAuditEvent::from_brief(brief),
+    )?;
+    event.id = stable_brief_created_event_id(&brief.agent_id, &brief.id);
+    event.created_at = brief.created_at;
+    Ok(event)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## Summary

- Brief 发布收敛为单一 runtime DB transition：brief record 写入 + agent event seq allocation + 恰好一条 `brief_created` event，替换原先 `persist_brief` → `append_event` 的两段事务调用链。
- Brief 携带 immutable `created_event_seq` linkage，约束为 `(agent_id, brief_id)` 唯一且 `(agent_id, created_event_seq)` 不重复；retry 复用同一 idempotency identity，不产生第二条 event。
- Migration 仅从唯一 historical `brief_created` 候选 backfill linkage；0 或多候选保持 absent linkage 并标记 uncertain，不修改 Brief 内容与时间戳。
- 其他 canonical reference event family 的 write/event 顺序已形成 inventory（见 `docs/implementation-decisions/108-brief-created-atomic-linkage.md`），同类收敛路径与边界在文档中声明。
- Capability `briefs.atomic-created-event.v1` 在 inventory 测试全过后开启。

## Runtime concepts

- **Canonical record/event visibility**：transition 保证 `brief_created` event 可被 page/SSE 观察时，Brief API 已可读；event 不再可能先于 record 消失或重复出现。
- **Crash/retry 收敛**：record 前、seq 后、event 前、commit 后的任一 crash point，retry 后都收敛为一条 event 与一条 record。
- **Completion-bound 路径复用**：`finalize_work_item_completion_with_brief` 与 completion 之外的发布入口复用同一 transition，event id 从随机改为稳定 id。

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib` — 2747 passed, 0 failed

Observer-sync 实施计划 S3 切片（RFC: observer-sync-agent-summary-and-read-markers）。
