### PR TITLE
feat: observer-sync event ledger IndexedDB storage with atomic transactions (W1)

### DIFF
--- a/web-gui/app/package-lock.json
+++ b/web-gui/app/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
+        "fake-indexeddb": "^6.2.5",
         "tailwindcss": "^4.3.1",
         "typescript": "^6.0.3",
         "vite": "^8.0.16",
@@ -1326,6 +1327,16 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",

--- a/web-gui/app/package.json
+++ b/web-gui/app/package.json
@@ -28,6 +28,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "fake-indexeddb": "^6.2.5",
     "tailwindcss": "^4.3.1",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",

--- a/web-gui/app/src/runtime/event-ledger/db.ts
+++ b/web-gui/app/src/runtime/event-ledger/db.ts
@@ -1,0 +1,172 @@
+/**
+ * Database open/upgrade for the observer-sync event ledger.
+ *
+ * New, independent database: never reuses the legacy `holon-webgui-cache`
+ * object stores or key namespaces. DB_VERSION manages future schema
+ * upgrades inside this database only.
+ */
+
+import { LedgerUnavailableError } from "./errors";
+
+export const LEDGER_DB_NAME = "holon.webGui.eventLedger.v1";
+export const LEDGER_DB_VERSION = 1;
+
+export const RUNTIME_SCOPES_STORE = "runtime_scopes";
+export const AGENT_SESSIONS_STORE = "agent_sessions";
+export const RAW_EVENTS_STORE = "raw_events";
+export const PENDING_HYDRATION_STORE = "pending_hydration";
+export const CANONICAL_RECORDS_STORE = "canonical_records";
+export const READ_STATES_STORE = "read_states";
+export const MIGRATION_META_STORE = "migration_meta";
+
+export const LEDGER_STORES = [
+  RUNTIME_SCOPES_STORE,
+  AGENT_SESSIONS_STORE,
+  RAW_EVENTS_STORE,
+  PENDING_HYDRATION_STORE,
+  CANONICAL_RECORDS_STORE,
+  READ_STATES_STORE,
+  MIGRATION_META_STORE,
+] as const;
+
+export type LedgerStoreName = (typeof LEDGER_STORES)[number];
+
+/** Index on agent-scoped stores covering the 5-part scope prefix. */
+export const BY_SCOPE_INDEX = "byScope";
+/** Index on runtime_scopes covering (remoteKey, runtimeId, visibilityScopeId). */
+export const BY_REMOTE_RUNTIME_INDEX = "byRemoteRuntime";
+
+/**
+ * Apply schema migrations inside one upgrade transaction. Kept as an
+ * explicit function so every future version bump has one obvious home.
+ */
+export function applyLedgerUpgrade(db: IDBDatabase, oldVersion: number): void {
+  if (oldVersion < 1) {
+    const runtimeScopes = db.createObjectStore(RUNTIME_SCOPES_STORE, {
+      keyPath: ["remoteKey", "runtimeId", "visibilityScopeId", "eventLogEpoch"],
+    });
+    runtimeScopes.createIndex(
+      BY_REMOTE_RUNTIME_INDEX,
+      ["remoteKey", "runtimeId", "visibilityScopeId"],
+      { unique: false },
+    );
+
+    const agentSessions = db.createObjectStore(AGENT_SESSIONS_STORE, {
+      keyPath: ["remoteKey", "runtimeId", "visibilityScopeId", "eventLogEpoch", "agentId"],
+    });
+    agentSessions.createIndex(
+      BY_SCOPE_INDEX,
+      ["remoteKey", "runtimeId", "visibilityScopeId", "eventLogEpoch", "agentId"],
+      { unique: true },
+    );
+
+    const rawEvents = db.createObjectStore(RAW_EVENTS_STORE, {
+      keyPath: ["remoteKey", "runtimeId", "visibilityScopeId", "eventLogEpoch", "agentId", "eventSeq"],
+    });
+    rawEvents.createIndex(
+      BY_SCOPE_INDEX,
+      ["remoteKey", "runtimeId", "visibilityScopeId", "eventLogEpoch", "agentId"],
+      { unique: false },
+    );
+
+    const pendingHydration = db.createObjectStore(PENDING_HYDRATION_STORE, {
+      keyPath: ["remoteKey", "runtimeId", "visibilityScopeId", "eventLogEpoch", "agentId", "jobId"],
+    });
+    pendingHydration.createIndex(
+      BY_SCOPE_INDEX,
+      ["remoteKey", "runtimeId", "visibilityScopeId", "eventLogEpoch", "agentId"],
+      { unique: false },
+    );
+
+    const canonicalRecords = db.createObjectStore(CANONICAL_RECORDS_STORE, {
+      keyPath: [
+        "remoteKey",
+        "runtimeId",
+        "visibilityScopeId",
+        "eventLogEpoch",
+        "agentId",
+        "recordKind",
+        "recordId",
+      ],
+    });
+    canonicalRecords.createIndex(
+      BY_SCOPE_INDEX,
+      ["remoteKey", "runtimeId", "visibilityScopeId", "eventLogEpoch", "agentId"],
+      { unique: false },
+    );
+
+    const readStates = db.createObjectStore(READ_STATES_STORE, {
+      keyPath: ["remoteKey", "runtimeId", "visibilityScopeId", "eventLogEpoch", "agentId"],
+    });
+    readStates.createIndex(
+      BY_SCOPE_INDEX,
+      ["remoteKey", "runtimeId", "visibilityScopeId", "eventLogEpoch", "agentId"],
+      { unique: true },
+    );
+
+    db.createObjectStore(MIGRATION_META_STORE, { keyPath: "metaKey" });
+  }
+}
+
+export interface OpenLedgerDatabaseEvents {
+  /**
+   * Called when another connection upgrades the schema; this handle closed
+   * itself so the upgrade is not blocked.
+   */
+  onSuperseded?: () => void;
+}
+
+/**
+ * Open the ledger database at LEDGER_DB_VERSION.
+ *
+ * Rejects with LedgerUnavailableError on hard open failures. A `blocked`
+ * upgrade keeps waiting: the open completes once the blocking connection
+ * closes, which is the correct multi-tab behavior.
+ */
+export function openLedgerDatabase(events: OpenLedgerDatabaseEvents = {}): Promise<IDBDatabase> {
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    if (typeof indexedDB === "undefined") {
+      reject(new LedgerUnavailableError("no_indexeddb", "memory_only"));
+      return;
+    }
+    let request: IDBOpenDBRequest;
+    try {
+      request = indexedDB.open(LEDGER_DB_NAME, LEDGER_DB_VERSION);
+    } catch (error) {
+      reject(new LedgerUnavailableError("open_error", "memory_only", error));
+      return;
+    }
+    request.onupgradeneeded = (event) => {
+      const oldVersion = (event as IDBVersionChangeEvent).oldVersion;
+      applyLedgerUpgrade(request.result, oldVersion);
+    };
+    request.onsuccess = () => {
+      const db = request.result;
+      db.onversionchange = () => {
+        db.close();
+        events.onSuperseded?.();
+      };
+      resolve(db);
+    };
+    request.onerror = () => {
+      reject(new LedgerUnavailableError("open_error", "memory_only", request.error));
+    };
+    request.onblocked = () => {
+      // Keep waiting: the open proceeds when the blocking connection closes.
+    };
+  });
+}
+
+/** Test/utility helper: fully delete the ledger database. */
+export function deleteLedgerDatabase(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (typeof indexedDB === "undefined") {
+      resolve();
+      return;
+    }
+    const request = indexedDB.deleteDatabase(LEDGER_DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}

--- a/web-gui/app/src/runtime/event-ledger/errors.ts
+++ b/web-gui/app/src/runtime/event-ledger/errors.ts
@@ -1,0 +1,107 @@
+/**
+ * Explicit error and durability states for the observer-sync event ledger.
+ *
+ * The legacy cache silently swallowed IndexedDB failures. This module does the
+ * opposite: every failure mode is a typed error plus an explicit durability
+ * state, so callers can never silently continue in "exact" mode.
+ */
+
+/**
+ * What the in-memory layer may claim about persisted state:
+ * - "exact": the last known commit is durably reflected in IndexedDB.
+ * - "memory_only": IndexedDB is unusable for this handle (missing, open
+ *   failure, quota exhausted, schema superseded); nothing may be claimed.
+ * - "uncertain": a transaction failed in a way whose outcome the caller must
+ *   treat as unproven until it re-verifies (re-read, repair, or reset).
+ */
+export type LedgerDurability = "exact" | "memory_only" | "uncertain";
+
+export type LedgerUnavailableReason = "no_indexeddb" | "open_error" | "closed" | "superseded";
+
+export class LedgerUnavailableError extends Error {
+  readonly reason: LedgerUnavailableReason;
+  readonly durability: LedgerDurability;
+
+  constructor(reason: LedgerUnavailableReason, durability: LedgerDurability, cause?: unknown) {
+    const detail = cause instanceof Error ? `: ${cause.message}` : "";
+    super(`event ledger unavailable (${reason})${detail}`);
+    this.name = "LedgerUnavailableError";
+    this.reason = reason;
+    this.durability = durability;
+  }
+}
+
+export class LedgerQuotaError extends Error {
+  readonly durability: LedgerDurability = "memory_only";
+
+  constructor(cause?: unknown) {
+    const detail = cause instanceof Error ? `: ${cause.message}` : "";
+    super(`event ledger write rejected by storage quota${detail}`);
+    this.name = "LedgerQuotaError";
+  }
+}
+
+export class LedgerTransactionAbortedError extends Error {
+  readonly durability: LedgerDurability = "uncertain";
+
+  constructor(cause?: unknown) {
+    const detail = cause instanceof Error ? `: ${cause.message}` : "";
+    super(`event ledger transaction aborted${detail}`);
+    this.name = "LedgerTransactionAbortedError";
+  }
+}
+
+/**
+ * Immutable identity content conflict. The same correctness key was written
+ * twice with different immutable content. This is a protocol error: the
+ * caller must surface it, never overwrite the stored value.
+ */
+export class LedgerIdentityConflictError extends Error {
+  readonly store: string;
+  readonly key: string;
+  readonly existingFingerprint: string;
+  readonly incomingFingerprint: string;
+
+  constructor(params: {
+    store: string;
+    key: string;
+    existingFingerprint: string;
+    incomingFingerprint: string;
+  }) {
+    super(
+      `event ledger identity conflict in ${params.store} at [${params.key}]: ` +
+        `stored ${params.existingFingerprint} != incoming ${params.incomingFingerprint}`,
+    );
+    this.name = "LedgerIdentityConflictError";
+    this.store = params.store;
+    this.key = params.key;
+    this.existingFingerprint = params.existingFingerprint;
+    this.incomingFingerprint = params.incomingFingerprint;
+  }
+}
+
+/**
+ * The contiguous ingestion cursor would move backwards. The ingestion
+ * protocol only allows monotonic advance; callers must never regress it.
+ */
+export class LedgerCursorRegressionError extends Error {
+  readonly currentThroughSeq: number;
+  readonly requestedThroughSeq: number;
+
+  constructor(currentThroughSeq: number, requestedThroughSeq: number) {
+    super(
+      `ingestion cursor regression: stored through ${currentThroughSeq}, ` +
+        `requested ${requestedThroughSeq}`,
+    );
+    this.name = "LedgerCursorRegressionError";
+    this.currentThroughSeq = currentThroughSeq;
+    this.requestedThroughSeq = requestedThroughSeq;
+  }
+}
+
+export function isQuotaExceeded(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === "QuotaExceededError" || error.code === 22)
+  );
+}

--- a/web-gui/app/src/runtime/event-ledger/event-ledger.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/event-ledger.test.ts
@@ -1,0 +1,602 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  LEDGER_DB_NAME,
+  LEDGER_STORES,
+  type LedgerScopeKey,
+  type LedgerRemoteScopeKey,
+  LedgerCursorRegressionError,
+  LedgerIdentityConflictError,
+  LedgerQuotaError,
+  LedgerTransactionAbortedError,
+  LedgerUnavailableError,
+} from "./index";
+import {
+  EventLedger,
+  type LedgerHydrationJobRecord,
+} from "./ledger";
+import {
+  LEGACY_DB_NAME,
+  deleteLegacyDatabase,
+  hasUnreadMigrationNoticeBeenShown,
+  initializeFreshBaseline,
+  markUnreadMigrationNoticeShown,
+} from "./migration";
+
+function makeScope(overrides: Partial<LedgerScopeKey> = {}): LedgerScopeKey {
+  return {
+    remoteKey: "http://127.0.0.1:7878",
+    runtimeId: "rt_test",
+    visibilityScopeId: "vis_test",
+    eventLogEpoch: "epoch-1",
+    agentId: "agent-1",
+    ...overrides,
+  };
+}
+
+function envelope(seq: number, payload: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agent_id: "agent-1",
+    contract_version: 1,
+    event_log_epoch: "epoch-1",
+    event_seq: seq,
+    id: `evt-${seq}`,
+    payload,
+    payload_schema: "test",
+    payload_schema_version: 1,
+    provenance: {},
+    ts: `2026-08-18T00:00:0${seq}Z`,
+    type: "test.event",
+  };
+}
+
+function remoteScopeOf(scope: LedgerScopeKey): LedgerRemoteScopeKey {
+  return {
+    remoteKey: scope.remoteKey,
+    runtimeId: scope.runtimeId,
+    visibilityScopeId: scope.visibilityScopeId,
+    eventLogEpoch: scope.eventLogEpoch,
+  };
+}
+
+function makeJob(scope: LedgerScopeKey, seq: number): LedgerHydrationJobRecord {
+  return {
+    ...scope,
+    jobId: `job-${seq}`,
+    recordKind: "message",
+    recordId: `msg-${seq}`,
+    createdByEventSeq: seq,
+    createdAt: 1,
+  };
+}
+
+async function openLedger(): Promise<EventLedger> {
+  const result = await EventLedger.open();
+  if (result.kind !== "available") {
+    throw new Error(`expected available ledger, got ${result.kind}`);
+  }
+  return result.ledger;
+}
+
+function openRaw(name: string, version?: number): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(name, version);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => reject(new Error("raw open blocked"));
+  });
+}
+
+function deleteRaw(name: string): Promise<void> {
+  return new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}
+
+async function countRows(db: IDBDatabase, store: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(store, "readonly");
+    const req = tx.objectStore(store).count();
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+describe("event ledger open/upgrade", () => {
+  beforeEach(async () => {
+    await deleteRaw(LEDGER_DB_NAME);
+    await deleteRaw(LEGACY_DB_NAME);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await deleteRaw(LEDGER_DB_NAME);
+    await deleteRaw(LEGACY_DB_NAME);
+  });
+
+  it("creates every normalized store on fresh upgrade", async () => {
+    const ledger = await openLedger();
+    const db = ledger.requireOpenDb();
+    for (const store of LEDGER_STORES) {
+      expect(db.objectStoreNames.contains(store)).toBe(true);
+    }
+    expect(ledger.durability).toBe("exact");
+    ledger.close();
+  });
+
+  it("reports memory_only explicitly when indexedDB is missing", async () => {
+    const original = globalThis.indexedDB;
+    vi.stubGlobal("indexedDB", undefined);
+    try {
+      const result = await EventLedger.open();
+      expect(result.kind).toBe("memory_only");
+      if (result.kind === "memory_only") {
+        expect(result.reason).toBe("no_indexeddb");
+      }
+    } finally {
+      vi.stubGlobal("indexedDB", original);
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("supports multiple same-version connections and cross-tab visibility", async () => {
+    const tabA = await openLedger();
+    const tabB = await openLedger();
+    const scope = makeScope();
+
+    await tabA
+      .beginWrite()
+      .putRawEvent(scope, 1, envelope(1), { projectionEffect: "none" })
+      .advanceIngestionCursor(scope, 1)
+      .commit();
+
+    const events = await tabB.getRawEvents(scope);
+    expect(events.map((e) => e.eventSeq)).toEqual([1]);
+    const session = await tabB.getAgentSession(scope);
+    expect(session?.ingestedThroughSeq).toBe(1);
+    expect(tabB.durability).toBe("exact");
+    tabA.close();
+    tabB.close();
+  });
+
+  it("closes itself and degrades when another connection upgrades the schema", async () => {
+    const ledger = await openLedger();
+
+    const upgrade = new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(LEDGER_DB_NAME, 2);
+      request.onupgradeneeded = () => {
+        // Future-version migration is not under test; nothing to add.
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+      request.onblocked = () => reject(new Error("upgrade should not be blocked"));
+    });
+    const upgraded = await upgrade;
+
+    expect(ledger.durability).toBe("memory_only");
+    expect(ledger.durabilityReason).toBe("superseded");
+    await expect(
+      ledger
+        .beginWrite()
+        .putRawEvent(makeScope(), 9, envelope(9), { projectionEffect: "none" })
+        .commit(),
+    ).rejects.toBeInstanceOf(LedgerUnavailableError);
+    upgraded.close();
+  });
+
+  it("waits (blocked) when a connection that ignores versionchange holds the db", async () => {
+    // Simulate an old tab that does not handle versionchange events.
+    const stale = await openRaw(LEDGER_DB_NAME);
+
+    let blockedFired = false;
+    const upgrade = new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(LEDGER_DB_NAME, 2);
+      request.onupgradeneeded = () => {
+        // Nothing to add for this test's synthetic version.
+      };
+      request.onblocked = () => {
+        blockedFired = true;
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(blockedFired).toBe(true);
+
+    stale.close();
+    const upgraded = await upgrade; // Proceeds once the blocking connection closes.
+    upgraded.close();
+  });
+});
+
+describe("event ledger atomic transactions", () => {
+  beforeEach(async () => {
+    await deleteRaw(LEDGER_DB_NAME);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await deleteRaw(LEDGER_DB_NAME);
+  });
+
+  it("commits envelope, classification, hydration, records, cursor, and read state atomically", async () => {
+    const ledger = await openLedger();
+    const scope = makeScope();
+
+    await ledger
+      .beginWrite()
+      .putRawEvent(scope, 1, envelope(1, { text: "hello" }), {
+        projectionEffect: "display_invalidation",
+        envelopeContractVersion: 3,
+      })
+      .putRawEvent(scope, 2, envelope(2, { ref: "msg-2" }), { projectionEffect: "none" })
+      .putHydrationJob(scope, makeJob(scope, 2))
+      .putCanonicalRecord(scope, "message", "msg-1", { id: "msg-1", text: "hello" }, "rev-1")
+      .applyProjectionChange(scope, { projectionRevision: 7, projection: { items: 1 } })
+      .advanceIngestionCursor(scope, 2)
+      .putReadState(scope, { lastReadDeliverySeq: 1, lastUnreadDeliverySeq: 2 })
+      .putRuntimeScope(remoteScopeOf(scope), { eventHeadSeq: 2 })
+      .commit();
+
+    const event1 = await ledger.getRawEvent(scope, 1);
+    expect(event1?.classification.projectionEffect).toBe("display_invalidation");
+    expect(event1?.classification.envelopeContractVersion).toBe(3);
+    expect(event1?.identityFingerprint).toBeTruthy();
+
+    const jobs = await ledger.getPendingHydrationJobs(scope);
+    expect(jobs.map((j) => j.jobId)).toEqual(["job-2"]);
+
+    const record = await ledger.getCanonicalRecord(scope, "message", "msg-1");
+    expect(record?.revision).toBe("rev-1");
+
+    const session = await ledger.getAgentSession(scope);
+    expect(session?.ingestedThroughSeq).toBe(2);
+    expect(session?.projectionRevision).toBe(7);
+
+    const readState = await ledger.getReadState(scope);
+    expect(readState?.lastReadDeliverySeq).toBe(1);
+    expect(readState?.lastUnreadDeliverySeq).toBe(2);
+
+    const runtimeScope = await ledger.getRuntimeScope(remoteScopeOf(scope));
+    expect(runtimeScope?.eventHeadSeq).toBe(2);
+    ledger.close();
+  });
+
+  it("merges multiple patches to the same session in one batch instead of overwriting", async () => {
+    const ledger = await openLedger();
+    const scope = makeScope();
+    await ledger
+      .beginWrite()
+      .applyProjectionChange(scope, { projectionRevision: 4 })
+      .advanceIngestionCursor(scope, 3)
+      .commit();
+    const session = await ledger.getAgentSession(scope);
+    expect(session?.projectionRevision).toBe(4);
+    expect(session?.ingestedThroughSeq).toBe(3);
+    ledger.close();
+  });
+
+  it("rolls back the whole batch (including the cursor) on quota failure", async () => {
+    const ledger = await openLedger();
+    const scope = makeScope();
+    await ledger
+      .beginWrite()
+      .putRawEvent(scope, 1, envelope(1), { projectionEffect: "none" })
+      .advanceIngestionCursor(scope, 1)
+      .commit();
+
+    const originalPut = IDBObjectStore.prototype.put;
+    const putSpy = vi.spyOn(IDBObjectStore.prototype, "put").mockImplementation(function (
+      this: IDBObjectStore,
+      value: unknown,
+      key?: IDBValidKey,
+    ) {
+      if (this.name === "agent_sessions") {
+        throw new DOMException("The quota has been exceeded", "QuotaExceededError");
+      }
+      return originalPut.call(this, value, key);
+    });
+
+    await expect(
+      ledger
+        .beginWrite()
+        .putRawEvent(scope, 2, envelope(2), { projectionEffect: "none" })
+        .advanceIngestionCursor(scope, 2)
+        .commit(),
+    ).rejects.toBeInstanceOf(LedgerQuotaError);
+    putSpy.mockRestore();
+
+    expect(ledger.durability).toBe("memory_only");
+    expect(ledger.durabilityReason).toBe("quota");
+
+    // Nothing from the failed batch may be visible, including the cursor.
+    const reopened = await openLedger();
+    expect((await reopened.getRawEvents(scope)).map((e) => e.eventSeq)).toEqual([1]);
+    expect((await reopened.getAgentSession(scope))?.ingestedThroughSeq).toBe(1);
+    ledger.close();
+    reopened.close();
+  });
+
+  it("marks durability uncertain on non-quota transaction failure", async () => {
+    const ledger = await openLedger();
+    const scope = makeScope();
+    const originalPut = IDBObjectStore.prototype.put;
+    const putSpy = vi.spyOn(IDBObjectStore.prototype, "put").mockImplementation(function (
+      this: IDBObjectStore,
+      value: unknown,
+      key?: IDBValidKey,
+    ) {
+      if (this.name === "raw_events") {
+        throw new Error("synthetic store failure");
+      }
+      return originalPut.call(this, value, key);
+    });
+
+    await expect(
+      ledger
+        .beginWrite()
+        .putRawEvent(scope, 1, envelope(1), { projectionEffect: "none" })
+        .advanceIngestionCursor(scope, 1)
+        .commit(),
+    ).rejects.toBeInstanceOf(LedgerTransactionAbortedError);
+    putSpy.mockRestore();
+
+    expect(ledger.durability).toBe("uncertain");
+    expect(ledger.durabilityReason).toBe("transaction_aborted");
+
+    const reopened = await openLedger();
+    expect(await reopened.getRawEvents(scope)).toEqual([]);
+    expect(await reopened.getAgentSession(scope)).toBeUndefined();
+    ledger.close();
+    reopened.close();
+  });
+
+  it("treats an identical duplicate raw event as idempotent", async () => {
+    const ledger = await openLedger();
+    const scope = makeScope();
+    const payload = envelope(1, { text: "same" });
+
+    await ledger
+      .beginWrite()
+      .putRawEvent(scope, 1, payload, { projectionEffect: "none" })
+      .advanceIngestionCursor(scope, 1)
+      .commit();
+    await ledger
+      .beginWrite()
+      .putRawEvent(scope, 1, payload, { projectionEffect: "none" })
+      .advanceIngestionCursor(scope, 1)
+      .commit();
+
+    const events = await ledger.getRawEvents(scope);
+    expect(events).toHaveLength(1);
+    expect(events[0].envelope).toEqual(payload);
+    expect((await ledger.getAgentSession(scope))?.ingestedThroughSeq).toBe(1);
+    ledger.close();
+  });
+
+  it("hard-fails an identity conflict without overwriting the stored envelope", async () => {
+    const ledger = await openLedger();
+    const scope = makeScope();
+    await ledger
+      .beginWrite()
+      .putRawEvent(scope, 1, envelope(1, { text: "original" }), { projectionEffect: "none" })
+      .advanceIngestionCursor(scope, 1)
+      .commit();
+
+    const conflict = envelope(1, { text: "mutated" });
+    let caught: unknown;
+    try {
+      await ledger
+        .beginWrite()
+        .putRawEvent(scope, 1, conflict, { projectionEffect: "none" })
+        .advanceIngestionCursor(scope, 2)
+        .commit();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(LedgerIdentityConflictError);
+    const conflictError = caught as LedgerIdentityConflictError;
+    expect(conflictError.store).toBe("raw_events");
+    expect(conflictError.existingFingerprint).not.toBe(conflictError.incomingFingerprint);
+
+    // Stored value and cursor must be untouched.
+    const stored = await ledger.getRawEvent(scope, 1);
+    expect((stored?.envelope as { payload: { text: string } }).payload.text).toBe("original");
+    expect((await ledger.getAgentSession(scope))?.ingestedThroughSeq).toBe(1);
+    expect(ledger.durability).toBe("exact");
+    ledger.close();
+  });
+
+  it("rejects cursor regression", async () => {
+    const ledger = await openLedger();
+    const scope = makeScope();
+    await ledger.beginWrite().advanceIngestionCursor(scope, 5).commit();
+
+    await expect(ledger.beginWrite().advanceIngestionCursor(scope, 3).commit()).rejects.toBeInstanceOf(
+      LedgerCursorRegressionError,
+    );
+    expect((await ledger.getAgentSession(scope))?.ingestedThroughSeq).toBe(5);
+    ledger.close();
+  });
+
+  it("survives close and reopen with committed data intact", async () => {
+    const first = await openLedger();
+    const scope = makeScope();
+    await first
+      .beginWrite()
+      .putRawEvent(scope, 1, envelope(1), { projectionEffect: "none" })
+      .putRawEvent(scope, 2, envelope(2), { projectionEffect: "none" })
+      .advanceIngestionCursor(scope, 2)
+      .commit();
+    first.close();
+
+    const second = await openLedger();
+    expect((await second.getRawEvents(scope)).map((e) => e.eventSeq)).toEqual([1, 2]);
+    expect((await second.getAgentSession(scope))?.ingestedThroughSeq).toBe(2);
+    second.close();
+  });
+});
+
+describe("event ledger scope partitioning", () => {
+  beforeEach(async () => {
+    await deleteRaw(LEDGER_DB_NAME);
+  });
+
+  afterEach(async () => {
+    await deleteRaw(LEDGER_DB_NAME);
+  });
+
+  it("never stitches data across remote, runtime, visibility scope, or epoch", async () => {
+    const ledger = await openLedger();
+    const base = makeScope();
+    await ledger
+      .beginWrite()
+      .putRawEvent(base, 1, envelope(1), { projectionEffect: "none" })
+      .advanceIngestionCursor(base, 1)
+      .putRuntimeScope(remoteScopeOf(base), { eventHeadSeq: 1 })
+      .commit();
+
+    const otherRemote = makeScope({ remoteKey: "http://other:7878" });
+    const otherRuntime = makeScope({ runtimeId: "rt_other" });
+    const otherVisibility = makeScope({ visibilityScopeId: "vis_other" });
+    const otherEpoch = makeScope({ eventLogEpoch: "epoch-2" });
+    const otherAgent = makeScope({ agentId: "agent-2" });
+
+    for (const scope of [otherRemote, otherRuntime, otherVisibility, otherEpoch, otherAgent]) {
+      expect(await ledger.getRawEvents(scope)).toEqual([]);
+      expect(await ledger.getAgentSession(scope)).toBeUndefined();
+      expect(await ledger.getReadState(scope)).toBeUndefined();
+      expect(await ledger.getPendingHydrationJobs(scope)).toEqual([]);
+    }
+
+    // Different epochs of the same remote/runtime/visibility are separate
+    // runtime_scopes entries, listed together but never merged.
+    await ledger
+      .beginWrite()
+      .putRuntimeScope(remoteScopeOf(otherEpoch), { eventHeadSeq: 1 })
+      .commit();
+    const scopes = await ledger.listRuntimeScopes(
+      base.remoteKey,
+      base.runtimeId,
+      base.visibilityScopeId,
+    );
+    expect(scopes.map((s) => s.eventLogEpoch).sort()).toEqual(["epoch-1", "epoch-2"]);
+
+    const sessions = await ledger.listAgentSessions({
+      remoteKey: base.remoteKey,
+      runtimeId: base.runtimeId,
+      visibilityScopeId: base.visibilityScopeId,
+      eventLogEpoch: "epoch-1",
+    });
+    expect(sessions.map((s) => s.agentId)).toEqual(["agent-1"]);
+    ledger.close();
+  });
+
+  it("returns seq-ordered events and bounded ranges", async () => {
+    const ledger = await openLedger();
+    const scope = makeScope();
+    const batch = ledger.beginWrite();
+    for (let seq = 1; seq <= 5; seq++) {
+      batch.putRawEvent(scope, seq, envelope(seq), { projectionEffect: "none" });
+    }
+    await batch.advanceIngestionCursor(scope, 5).commit();
+
+    expect((await ledger.getRawEvents(scope)).map((e) => e.eventSeq)).toEqual([1, 2, 3, 4, 5]);
+    expect((await ledger.getRawEventsBetween(scope, 2, 4)).map((e) => e.eventSeq)).toEqual([
+      2, 3, 4,
+    ]);
+    ledger.close();
+  });
+});
+
+describe("event ledger legacy baseline", () => {
+  beforeEach(async () => {
+    await deleteRaw(LEDGER_DB_NAME);
+    await deleteRaw(LEGACY_DB_NAME);
+  });
+
+  afterEach(async () => {
+    await deleteRaw(LEDGER_DB_NAME);
+    await deleteRaw(LEGACY_DB_NAME);
+  });
+
+  it("seeds nothing from the legacy database and records a fresh baseline", async () => {
+    // Populate a legacy database the way the old cache would have.
+    const legacy = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(LEGACY_DB_NAME, 1);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains("sessions")) {
+          db.createObjectStore("sessions", { keyPath: ["remoteKey", "agentId"] });
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    await new Promise<void>((resolve, reject) => {
+      const tx = legacy.transaction("sessions", "readwrite");
+      tx.objectStore("sessions").put({
+        remoteKey: "http://127.0.0.1:7878",
+        agentId: "agent-1",
+        schemaVersion: 5,
+        eventsBySeq: { 1: { seq: 1 } },
+        readState: { lastReadDeliverySeq: 42, lastUnreadDeliverySeq: 43 },
+      });
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+
+    const ledger = await openLedger();
+    const meta = await initializeFreshBaseline(ledger);
+    expect(meta.strategy).toBe("fresh_server_authoritative");
+    expect(meta.legacyImported).toBe(false);
+    expect(meta.legacyDbName).toBe(LEGACY_DB_NAME);
+
+    // The new database starts from nothing regardless of legacy content.
+    const scope = makeScope(); // same remoteKey/agentId as the legacy entry
+    expect(await ledger.getRawEvents(scope)).toEqual([]);
+    expect(await ledger.getAgentSession(scope)).toBeUndefined();
+    expect(await ledger.getReadState(scope)).toBeUndefined();
+
+    // The legacy database itself must remain untouched for rollback.
+    expect(await countRows(legacy, "sessions")).toBe(1);
+    legacy.close();
+
+    // Idempotent: a second call keeps the original decision.
+    const again = await initializeFreshBaseline(ledger);
+    expect(again.decidedAt).toBe(meta.decidedAt);
+    ledger.close();
+  });
+
+  it("tracks the one-time unread migration notice across reopen", async () => {
+    const first = await openLedger();
+    expect(await hasUnreadMigrationNoticeBeenShown(first)).toBe(false);
+    await markUnreadMigrationNoticeShown(first);
+    expect(await hasUnreadMigrationNoticeBeenShown(first)).toBe(true);
+    first.close();
+
+    const second = await openLedger();
+    expect(await hasUnreadMigrationNoticeBeenShown(second)).toBe(true);
+    second.close();
+  });
+
+  it("reports legacy cleanup outcomes without throwing", async () => {
+    const legacy = await openRaw(LEGACY_DB_NAME, 1).catch(() => undefined);
+    legacy?.close();
+    const result = await deleteLegacyDatabase();
+    expect(result.ok).toBe(true);
+
+    const held = await openRaw(LEGACY_DB_NAME, 1);
+    // A connection that never receives versionchange blocks deletion.
+    const blocked = await deleteLegacyDatabase();
+    expect(blocked.ok).toBe(false);
+    expect(blocked.error).toContain("blocked");
+    held.close();
+  });
+});

--- a/web-gui/app/src/runtime/event-ledger/index.ts
+++ b/web-gui/app/src/runtime/event-ledger/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Observer-sync event ledger (W1): durable, scope-partitioned IndexedDB
+ * storage with atomic composable transactions and explicit failure states.
+ */
+
+export {
+  LEDGER_DB_NAME,
+  LEDGER_DB_VERSION,
+  LEDGER_STORES,
+  applyLedgerUpgrade,
+  deleteLedgerDatabase,
+} from "./db";
+export {
+  LedgerCursorRegressionError,
+  LedgerIdentityConflictError,
+  LedgerQuotaError,
+  LedgerTransactionAbortedError,
+  LedgerUnavailableError,
+  isQuotaExceeded,
+  type LedgerDurability,
+  type LedgerUnavailableReason,
+} from "./errors";
+export {
+  agentRecordKey,
+  agentScopeRange,
+  canonicalRecordKey,
+  computeEnvelopeFingerprint,
+  hydrationJobKey,
+  rawEventKey,
+  rawEventRange,
+  rawEventRangeBetween,
+  stableStringify,
+  type LedgerRecordKind,
+  type LedgerRemoteScopeKey,
+  type LedgerScopeKey,
+} from "./keys";
+export {
+  EventLedger,
+  EventLedgerWriteBatch,
+  type EventLedgerOpenResult,
+  type LedgerAgentSessionRecord,
+  type LedgerCanonicalRecord,
+  type LedgerHydrationJobRecord,
+  type LedgerRawEventRecord,
+  type LedgerReadStateRecord,
+  type LedgerRuntimeScopeRecord,
+  type RawEventClassification,
+} from "./ledger";
+export {
+  LEGACY_DB_NAME,
+  deleteLegacyDatabase,
+  hasUnreadMigrationNoticeBeenShown,
+  initializeFreshBaseline,
+  markUnreadMigrationNoticeShown,
+  type LegacyBaselineMeta,
+  type UnreadMigrationNoticeMeta,
+} from "./migration";

--- a/web-gui/app/src/runtime/event-ledger/keys.ts
+++ b/web-gui/app/src/runtime/event-ledger/keys.ts
@@ -1,0 +1,134 @@
+/**
+ * Correctness keys for the observer-sync event ledger.
+ *
+ * Every durable record is partitioned by the full scope identity
+ * (remoteKey, runtimeId, visibilityScopeId, eventLogEpoch, agentId). Records
+ * from different remotes, runtimes, visibility scopes, epochs, or agents can
+ * never share a key, so they can never be stitched together by accident.
+ */
+
+export interface LedgerScopeKey {
+  remoteKey: string;
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  agentId: string;
+}
+
+export interface LedgerRemoteScopeKey {
+  remoteKey: string;
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+}
+
+export type LedgerRecordKind = "message" | "brief" | "transcript_entry";
+
+/** Primary-key fields shared by every agent-scoped store. */
+export function scopeKeyParts(key: LedgerScopeKey): string[] {
+  return [
+    key.remoteKey,
+    key.runtimeId,
+    key.visibilityScopeId,
+    key.eventLogEpoch,
+    key.agentId,
+  ];
+}
+
+export function remoteScopeKeyParts(key: LedgerRemoteScopeKey): string[] {
+  return [key.remoteKey, key.runtimeId, key.visibilityScopeId, key.eventLogEpoch];
+}
+
+/** Compound in-line key for agent-scoped records. */
+export function agentRecordKey(key: LedgerScopeKey): IDBValidKey {
+  return scopeKeyParts(key);
+}
+
+/** Compound in-line key for one raw event. */
+export function rawEventKey(key: LedgerScopeKey, eventSeq: number): IDBValidKey {
+  return [...scopeKeyParts(key), eventSeq];
+}
+
+/** Compound in-line key for one canonical record. */
+export function canonicalRecordKey(
+  key: LedgerScopeKey,
+  recordKind: LedgerRecordKind,
+  recordId: string,
+): IDBValidKey {
+  return [...scopeKeyParts(key), recordKind, recordId];
+}
+
+/** Compound in-line key for one hydration job. */
+export function hydrationJobKey(key: LedgerScopeKey, jobId: string): IDBValidKey {
+  return [...scopeKeyParts(key), jobId];
+}
+
+/**
+ * Open key range covering every raw event of one agent scope, in seq order.
+ * Primary keys are 6-part arrays; the bare 5-part scope array sorts before
+ * every event of that scope, and no finite event_seq exceeds
+ * Number.MAX_VALUE. Infinity is not a valid IndexedDB key.
+ */
+export function rawEventRange(key: LedgerScopeKey): IDBKeyRange {
+  const scope = scopeKeyParts(key);
+  return IDBKeyRange.bound(scope, [...scope, Number.MAX_VALUE]);
+}
+
+/** Closed key range for raw events in [fromSeq, toSeq]. */
+export function rawEventRangeBetween(
+  key: LedgerScopeKey,
+  fromSeq: number,
+  toSeq: number,
+): IDBKeyRange {
+  const scope = scopeKeyParts(key);
+  return IDBKeyRange.bound([...scope, fromSeq], [...scope, toSeq]);
+}
+
+/**
+ * Key range covering every byScope index entry of one remote scope. Index
+ * keys are 5-part arrays; the empty-array upper bound sorts after every
+ * string agent id without matching any real key.
+ */
+export function agentScopeRange(key: LedgerRemoteScopeKey): IDBKeyRange {
+  const parts = remoteScopeKeyParts(key);
+  return IDBKeyRange.bound([...parts, ""], [...parts, []]);
+}
+
+/** Stable, order-independent JSON serialization for identity fingerprints. */
+export function stableStringify(value: unknown): string {
+  return serialize(value);
+}
+
+function serialize(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  switch (typeof value) {
+    case "number":
+      return Number.isFinite(value) ? JSON.stringify(value) : "null";
+    case "string":
+    case "boolean":
+      return JSON.stringify(value);
+    case "object": {
+      if (Array.isArray(value)) {
+        return `[${value.map((item) => serialize(item)).join(",")}]`;
+      }
+      const record = value as Record<string, unknown>;
+      const keys = Object.keys(record).sort();
+      const body = keys
+        .filter((k) => record[k] !== undefined)
+        .map((k) => `${JSON.stringify(k)}:${serialize(record[k])}`)
+        .join(",");
+      return `{${body}}`;
+    }
+    default:
+      return "null";
+  }
+}
+
+/**
+ * Fingerprint of the immutable identity content of a raw event envelope.
+ * Two envelopes with the same correctness key but different fingerprints are
+ * an identity conflict.
+ */
+export function computeEnvelopeFingerprint(envelope: unknown): string {
+  return stableStringify(envelope);
+}

--- a/web-gui/app/src/runtime/event-ledger/ledger.ts
+++ b/web-gui/app/src/runtime/event-ledger/ledger.ts
@@ -1,0 +1,843 @@
+/**
+ * Event ledger: durable raw ingestion storage with composable atomic
+ * transactions (W1).
+ *
+ * Correctness contract:
+ * - One `commit()` is one IndexedDB readwrite transaction covering every
+ *   touched store. Either all of envelope/classification, hydration jobs,
+ *   canonical records, projection change, read state, and the contiguous
+ *   ingestion cursor land, or none do.
+ * - A raw event with an existing correctness key and a different identity
+ *   fingerprint is a protocol error (hard fail), never an overwrite.
+ * - A duplicate raw event with identical content is idempotent.
+ * - Cursor regression is a protocol error.
+ * - Failures are typed errors plus an explicit durability state; nothing ever
+ *   silently continues as "exact".
+ */
+
+import {
+  AGENT_SESSIONS_STORE,
+  BY_REMOTE_RUNTIME_INDEX,
+  BY_SCOPE_INDEX,
+  CANONICAL_RECORDS_STORE,
+  MIGRATION_META_STORE,
+  PENDING_HYDRATION_STORE,
+  RAW_EVENTS_STORE,
+  READ_STATES_STORE,
+  RUNTIME_SCOPES_STORE,
+  deleteLedgerDatabase,
+  openLedgerDatabase,
+  type LedgerStoreName,
+} from "./db";
+import {
+  LedgerCursorRegressionError,
+  LedgerIdentityConflictError,
+  LedgerQuotaError,
+  LedgerTransactionAbortedError,
+  LedgerUnavailableError,
+  isQuotaExceeded,
+  type LedgerDurability,
+} from "./errors";
+import {
+  agentRecordKey,
+  agentScopeRange,
+  canonicalRecordKey,
+  computeEnvelopeFingerprint,
+  hydrationJobKey,
+  rawEventKey,
+  rawEventRange,
+  rawEventRangeBetween,
+  scopeKeyParts,
+  type LedgerRecordKind,
+  type LedgerRemoteScopeKey,
+  type LedgerScopeKey,
+} from "./keys";
+
+/** Classification attached to a stored raw event (S2 contract). */
+export interface RawEventClassification {
+  projectionEffect: "none" | "display_invalidation";
+  envelopeContractVersion?: number;
+}
+
+export interface LedgerRawEventRecord {
+  remoteKey: string;
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  agentId: string;
+  eventSeq: number;
+  envelope: unknown;
+  identityFingerprint: string;
+  classification: RawEventClassification;
+  ingestedAt: number;
+}
+
+export interface LedgerHydrationJobRecord {
+  remoteKey: string;
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  agentId: string;
+  jobId: string;
+  recordKind: LedgerRecordKind;
+  recordId: string;
+  createdByEventSeq: number;
+  createdAt: number;
+}
+
+export interface LedgerCanonicalRecord {
+  remoteKey: string;
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  agentId: string;
+  recordKind: LedgerRecordKind;
+  recordId: string;
+  record: unknown;
+  revision?: string | number;
+  updatedAt: number;
+}
+
+export interface LedgerAgentSessionRecord {
+  remoteKey: string;
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  agentId: string;
+  /** Contiguous raw ingestion cursor: every event <= this seq is durably stored. */
+  ingestedThroughSeq?: number;
+  /** Projection revision anchor after applying directly applicable events. */
+  projectionRevision?: number;
+  projection?: unknown;
+  updatedAt: number;
+}
+
+export interface LedgerRuntimeScopeRecord {
+  remoteKey: string;
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  eventHeadSeq?: number;
+  updatedAt: number;
+}
+
+export interface LedgerReadStateRecord {
+  remoteKey: string;
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  agentId: string;
+  lastReadDeliverySeq?: number;
+  lastUnreadDeliverySeq?: number;
+  updatedAt: number;
+}
+
+export type EventLedgerOpenResult =
+  | { kind: "available"; ledger: EventLedger }
+  | { kind: "memory_only"; reason: "no_indexeddb" | "open_error"; error?: unknown };
+
+type AgentSessionPatch = Partial<
+  Omit<LedgerAgentSessionRecord, keyof LedgerScopeKey | "updatedAt">
+>;
+type RuntimeScopePatch = Partial<
+  Omit<LedgerRuntimeScopeRecord, keyof LedgerRemoteScopeKey | "updatedAt">
+>;
+type ReadStatePatch = Partial<
+  Omit<LedgerReadStateRecord, keyof LedgerScopeKey | "updatedAt">
+>;
+
+type WriteOperation =
+  | {
+      kind: "raw_event";
+      scope: LedgerScopeKey;
+      eventSeq: number;
+      envelope: unknown;
+      classification: RawEventClassification;
+    }
+  | { kind: "hydration_job"; scope: LedgerScopeKey; job: LedgerHydrationJobRecord }
+  | {
+      kind: "canonical_record";
+      scope: LedgerScopeKey;
+      recordKind: LedgerRecordKind;
+      recordId: string;
+      record: unknown;
+      revision?: string | number;
+    }
+  | { kind: "agent_session"; scope: LedgerScopeKey; patch: AgentSessionPatch }
+  | { kind: "runtime_scope"; scope: LedgerRemoteScopeKey; patch: RuntimeScopePatch }
+  | { kind: "read_state"; scope: LedgerScopeKey; patch: ReadStatePatch };
+
+/** Composable write batch; `commit()` runs as one atomic transaction. */
+export class EventLedgerWriteBatch {
+  private readonly ledger: EventLedger;
+  private readonly ops: WriteOperation[] = [];
+  private committed = false;
+
+  constructor(ledger: EventLedger) {
+    this.ledger = ledger;
+  }
+
+  /** Store one immutable raw event envelope with its classification. */
+  putRawEvent(
+    scope: LedgerScopeKey,
+    eventSeq: number,
+    envelope: unknown,
+    classification: RawEventClassification,
+  ): this {
+    this.assertNotCommitted();
+    this.ops.push({ kind: "raw_event", scope, eventSeq, envelope, classification });
+    return this;
+  }
+
+  /** Queue one durable hydration job for a reference event. */
+  putHydrationJob(scope: LedgerScopeKey, job: LedgerHydrationJobRecord): this {
+    this.assertNotCommitted();
+    this.ops.push({ kind: "hydration_job", scope, job });
+    return this;
+  }
+
+  /** Upsert one canonical record (projection state, mutable by design). */
+  putCanonicalRecord(
+    scope: LedgerScopeKey,
+    recordKind: LedgerRecordKind,
+    recordId: string,
+    record: unknown,
+    revision?: string | number,
+  ): this {
+    this.assertNotCommitted();
+    this.ops.push({ kind: "canonical_record", scope, recordKind, recordId, record, revision });
+    return this;
+  }
+
+  /** Apply a directly applicable projection change to the agent session. */
+  applyProjectionChange(scope: LedgerScopeKey, patch: AgentSessionPatch): this {
+    this.assertNotCommitted();
+    this.ops.push({ kind: "agent_session", scope, patch });
+    return this;
+  }
+
+  /** Advance the contiguous ingestion cursor (monotonic only). */
+  advanceIngestionCursor(scope: LedgerScopeKey, throughSeq: number): this {
+    this.assertNotCommitted();
+    this.applyProjectionChange(scope, { ingestedThroughSeq: throughSeq });
+    return this;
+  }
+
+  /** Patch runtime-scope metadata (e.g. observed event head). */
+  putRuntimeScope(scope: LedgerRemoteScopeKey, patch: RuntimeScopePatch): this {
+    this.assertNotCommitted();
+    this.ops.push({ kind: "runtime_scope", scope, patch });
+    return this;
+  }
+
+  /** Patch browser-local read marker state. */
+  putReadState(scope: LedgerScopeKey, patch: ReadStatePatch): this {
+    this.assertNotCommitted();
+    this.ops.push({ kind: "read_state", scope, patch });
+    return this;
+  }
+
+  /**
+   * Commit atomically. Rejects with a typed error on any failure; on
+   * conflict, regression, or storage failure nothing is committed,
+   * including the cursor.
+   */
+  async commit(): Promise<void> {
+    this.assertNotCommitted();
+    if (this.ops.length === 0) {
+      this.committed = true;
+      return;
+    }
+    const db = this.ledger.requireOpenDb();
+    this.committed = true;
+
+    const storeNames = new Set<LedgerStoreName>();
+    for (const op of this.ops) {
+      switch (op.kind) {
+        case "raw_event":
+          storeNames.add(RAW_EVENTS_STORE);
+          storeNames.add(AGENT_SESSIONS_STORE);
+          break;
+        case "hydration_job":
+          storeNames.add(PENDING_HYDRATION_STORE);
+          break;
+        case "canonical_record":
+          storeNames.add(CANONICAL_RECORDS_STORE);
+          break;
+        case "agent_session":
+          storeNames.add(AGENT_SESSIONS_STORE);
+          break;
+        case "runtime_scope":
+          storeNames.add(RUNTIME_SCOPES_STORE);
+          break;
+        case "read_state":
+          storeNames.add(READ_STATES_STORE);
+          break;
+      }
+    }
+
+    const tx = db.transaction([...storeNames], "readwrite");
+    let failure: unknown = null;
+
+    // Coalesce per-scope patches so multiple ops in one batch against the
+    // same record merge instead of overwriting each other.
+    const sessionPatches = new Map<string, { scope: LedgerScopeKey; patch: AgentSessionPatch }>();
+    const runtimeScopePatches = new Map<
+      string,
+      { scope: LedgerRemoteScopeKey; patch: RuntimeScopePatch }
+    >();
+    const readStatePatches = new Map<string, { scope: LedgerScopeKey; patch: ReadStatePatch }>();
+    for (const op of this.ops) {
+      if (op.kind === "agent_session") {
+        const id = scopeKeyParts(op.scope).join("\u0000");
+        const entry = sessionPatches.get(id);
+        sessionPatches.set(id, {
+          scope: op.scope,
+          patch: { ...(entry?.patch ?? {}), ...op.patch },
+        });
+      } else if (op.kind === "runtime_scope") {
+        const id = [
+          op.scope.remoteKey,
+          op.scope.runtimeId,
+          op.scope.visibilityScopeId,
+          op.scope.eventLogEpoch,
+        ].join("\u0000");
+        const entry = runtimeScopePatches.get(id);
+        runtimeScopePatches.set(id, {
+          scope: op.scope,
+          patch: { ...(entry?.patch ?? {}), ...op.patch },
+        });
+      } else if (op.kind === "read_state") {
+        const id = scopeKeyParts(op.scope).join("\u0000");
+        const entry = readStatePatches.get(id);
+        readStatePatches.set(id, {
+          scope: op.scope,
+          patch: { ...(entry?.patch ?? {}), ...op.patch },
+        });
+      }
+    }
+
+    /** Issue a request; a synchronous throw aborts the transaction. */
+    const issue = <T>(make: () => IDBRequest<T>): IDBRequest<T> | null => {
+      try {
+        return make();
+      } catch (error) {
+        failure = failure ?? error;
+        tryAbort(tx);
+        return null;
+      }
+    };
+
+    const settled = new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onabort = () => {
+        if (failure && isQuotaExceeded(failure)) {
+          this.ledger.noteDurability("memory_only", "quota");
+          reject(new LedgerQuotaError(failure));
+          return;
+        }
+        if (
+          failure instanceof LedgerIdentityConflictError ||
+          failure instanceof LedgerCursorRegressionError
+        ) {
+          // Deterministic rollback with a known cause; durability unchanged.
+          reject(failure);
+          return;
+        }
+        this.ledger.noteDurability("uncertain", "transaction_aborted");
+        reject(new LedgerTransactionAbortedError(failure ?? tx.error));
+      };
+      tx.onerror = () => {
+        failure = failure ?? tx.error;
+        tryAbort(tx);
+      };
+    });
+
+    const now = Date.now();
+
+    for (const op of this.ops) {
+      switch (op.kind) {
+        case "raw_event": {
+          const events = tx.objectStore(RAW_EVENTS_STORE);
+          const key = rawEventKey(op.scope, op.eventSeq);
+          const keyLabel = (key as unknown[]).join("/");
+          const fingerprint = computeEnvelopeFingerprint(op.envelope);
+          const existing = issue<LedgerRawEventRecord | undefined>(() => events.get(key));
+          if (!existing) break;
+          existing.onsuccess = () => {
+            const prior = existing.result;
+            if (prior && prior.identityFingerprint !== fingerprint) {
+              failure =
+                failure ??
+                new LedgerIdentityConflictError({
+                  store: RAW_EVENTS_STORE,
+                  key: keyLabel,
+                  existingFingerprint: prior.identityFingerprint,
+                  incomingFingerprint: fingerprint,
+                });
+              tryAbort(tx);
+              return;
+            }
+            if (prior) return; // Idempotent duplicate: keep the stored value.
+            const put = issue(() =>
+              events.put({
+                ...op.scope,
+                eventSeq: op.eventSeq,
+                envelope: op.envelope,
+                identityFingerprint: fingerprint,
+                classification: op.classification,
+                ingestedAt: now,
+              } satisfies LedgerRawEventRecord),
+            );
+            put?.addEventListener("error", () => {
+              failure = failure ?? (put.error ?? new Error("raw event put failed"));
+            });
+          };
+          existing.addEventListener("error", () => {
+            failure = failure ?? (existing.error ?? new Error("raw event get failed"));
+          });
+          break;
+        }
+        case "hydration_job": {
+          const jobs = tx.objectStore(PENDING_HYDRATION_STORE);
+          const put = issue(() =>
+            jobs.put({
+              ...op.job,
+              createdAt: op.job.createdAt ?? now,
+            } satisfies LedgerHydrationJobRecord),
+          );
+          put?.addEventListener("error", () => {
+            failure = failure ?? (put.error ?? new Error("hydration job put failed"));
+          });
+          break;
+        }
+        case "canonical_record": {
+          const records = tx.objectStore(CANONICAL_RECORDS_STORE);
+          const put = issue(() =>
+            records.put({
+              ...op.scope,
+              recordKind: op.recordKind,
+              recordId: op.recordId,
+              record: op.record,
+              revision: op.revision,
+              updatedAt: now,
+            } satisfies LedgerCanonicalRecord),
+          );
+          put?.addEventListener("error", () => {
+            failure = failure ?? (put.error ?? new Error("canonical record put failed"));
+          });
+          break;
+        }
+      }
+    }
+
+    // Agent sessions: one read-modify-write per coalesced scope. Cursor
+    // monotonicity is validated against the value observed inside this
+    // same transaction.
+    for (const entry of sessionPatches.values()) {
+      const sessions = tx.objectStore(AGENT_SESSIONS_STORE);
+      const get = issue<LedgerAgentSessionRecord | undefined>(() =>
+        sessions.get(agentRecordKey(entry.scope)),
+      );
+      if (!get) continue;
+      get.onsuccess = () => {
+        const existing = get.result;
+        const current = existing?.ingestedThroughSeq;
+        const requested = entry.patch.ingestedThroughSeq;
+        if (current !== undefined && requested !== undefined && requested < current) {
+          failure = failure ?? new LedgerCursorRegressionError(current, requested);
+          tryAbort(tx);
+          return;
+        }
+        const merged: LedgerAgentSessionRecord = {
+          ...(existing ?? {}),
+          ...entry.scope,
+          ...entry.patch,
+          updatedAt: now,
+        };
+        const put = issue(() => sessions.put(merged));
+        put?.addEventListener("error", () => {
+          failure = failure ?? (put.error ?? new Error("agent session put failed"));
+        });
+      };
+      get.addEventListener("error", () => {
+        failure = failure ?? (get.error ?? new Error("agent session get failed"));
+      });
+    }
+
+    // Runtime scopes: one read-modify-write per coalesced remote scope.
+    for (const entry of runtimeScopePatches.values()) {
+      const scopes = tx.objectStore(RUNTIME_SCOPES_STORE);
+      const scopeKey: IDBValidKey = [
+        entry.scope.remoteKey,
+        entry.scope.runtimeId,
+        entry.scope.visibilityScopeId,
+        entry.scope.eventLogEpoch,
+      ];
+      const get = issue<LedgerRuntimeScopeRecord | undefined>(() => scopes.get(scopeKey));
+      if (!get) continue;
+      get.onsuccess = () => {
+        const merged: LedgerRuntimeScopeRecord = {
+          ...(get.result ?? {}),
+          ...entry.scope,
+          ...entry.patch,
+          updatedAt: now,
+        };
+        const put = issue(() => scopes.put(merged));
+        put?.addEventListener("error", () => {
+          failure = failure ?? (put.error ?? new Error("runtime scope put failed"));
+        });
+      };
+      get.addEventListener("error", () => {
+        failure = failure ?? (get.error ?? new Error("runtime scope get failed"));
+      });
+    }
+
+    // Read states: one read-modify-write per coalesced agent scope.
+    for (const entry of readStatePatches.values()) {
+      const states = tx.objectStore(READ_STATES_STORE);
+      const get = issue<LedgerReadStateRecord | undefined>(() =>
+        states.get(agentRecordKey(entry.scope)),
+      );
+      if (!get) continue;
+      get.onsuccess = () => {
+        const merged: LedgerReadStateRecord = {
+          ...(get.result ?? {}),
+          ...entry.scope,
+          ...entry.patch,
+          updatedAt: now,
+        };
+        const put = issue(() => states.put(merged));
+        put?.addEventListener("error", () => {
+          failure = failure ?? (put.error ?? new Error("read state put failed"));
+        });
+      };
+      get.addEventListener("error", () => {
+        failure = failure ?? (get.error ?? new Error("read state get failed"));
+      });
+    }
+
+    await settled;
+  }
+
+  private assertNotCommitted(): void {
+    if (this.committed) {
+      throw new Error("EventLedgerWriteBatch already committed");
+    }
+  }
+}
+
+function tryAbort(tx: IDBTransaction): void {
+  try {
+    tx.abort();
+  } catch {
+    // Transaction already aborting or closed; onabort still fires.
+  }
+}
+
+/** Open handle to the event ledger database. */
+export class EventLedger {
+  private db: IDBDatabase | null = null;
+  private durabilityState: LedgerDurability = "exact";
+  private durabilityReasonValue: string | undefined;
+
+  constructor(db: IDBDatabase) {
+    this.db = db;
+  }
+
+  /** Open the ledger. Never silent: failures return `memory_only` explicitly. */
+  static async open(): Promise<EventLedgerOpenResult> {
+    if (typeof indexedDB === "undefined") {
+      return { kind: "memory_only", reason: "no_indexeddb" };
+    }
+    let handle: EventLedger | null = null;
+    try {
+      const db = await openLedgerDatabase({
+        onSuperseded: () => {
+          handle?.noteSuperseded();
+        },
+      });
+      handle = new EventLedger(db);
+      return { kind: "available", ledger: handle };
+    } catch (error) {
+      return {
+        kind: "memory_only",
+        reason: "open_error",
+        error: error instanceof LedgerUnavailableError ? error : undefined,
+      };
+    }
+  }
+
+  get durability(): LedgerDurability {
+    return this.durabilityState;
+  }
+
+  get durabilityReason(): string | undefined {
+    return this.durabilityReasonValue;
+  }
+
+  beginWrite(): EventLedgerWriteBatch {
+    return new EventLedgerWriteBatch(this);
+  }
+
+  close(): void {
+    this.noteClosed("closed");
+  }
+
+  async getRuntimeScope(
+    scope: LedgerRemoteScopeKey,
+  ): Promise<LedgerRuntimeScopeRecord | undefined> {
+    const db = this.requireOpenDb();
+    const key: IDBValidKey = [
+      scope.remoteKey,
+      scope.runtimeId,
+      scope.visibilityScopeId,
+      scope.eventLogEpoch,
+    ];
+    return runGet(db, RUNTIME_SCOPES_STORE, (store) => store.get(key));
+  }
+
+  async listRuntimeScopes(
+    remoteKey: string,
+    runtimeId: string,
+    visibilityScopeId: string,
+  ): Promise<LedgerRuntimeScopeRecord[]> {
+    const db = this.requireOpenDb();
+    return collectIndex<LedgerRuntimeScopeRecord>(
+      db,
+      RUNTIME_SCOPES_STORE,
+      BY_REMOTE_RUNTIME_INDEX,
+      IDBKeyRange.only([remoteKey, runtimeId, visibilityScopeId]),
+    );
+  }
+
+  async listAgentSessions(scope: LedgerRemoteScopeKey): Promise<LedgerAgentSessionRecord[]> {
+    const db = this.requireOpenDb();
+    return collectIndex<LedgerAgentSessionRecord>(
+      db,
+      AGENT_SESSIONS_STORE,
+      BY_SCOPE_INDEX,
+      agentScopeRange(scope),
+    );
+  }
+
+  async getAgentSession(scope: LedgerScopeKey): Promise<LedgerAgentSessionRecord | undefined> {
+    const db = this.requireOpenDb();
+    return runGet(db, AGENT_SESSIONS_STORE, (store) => store.get(agentRecordKey(scope)));
+  }
+
+  async getRawEvent(
+    scope: LedgerScopeKey,
+    eventSeq: number,
+  ): Promise<LedgerRawEventRecord | undefined> {
+    const db = this.requireOpenDb();
+    return runGet(db, RAW_EVENTS_STORE, (store) => store.get(rawEventKey(scope, eventSeq)));
+  }
+
+  async getRawEvents(scope: LedgerScopeKey): Promise<LedgerRawEventRecord[]> {
+    const db = this.requireOpenDb();
+    return collectRange<LedgerRawEventRecord>(db, RAW_EVENTS_STORE, rawEventRange(scope));
+  }
+
+  async getRawEventsBetween(
+    scope: LedgerScopeKey,
+    fromSeq: number,
+    toSeq: number,
+  ): Promise<LedgerRawEventRecord[]> {
+    const db = this.requireOpenDb();
+    return collectRange<LedgerRawEventRecord>(
+      db,
+      RAW_EVENTS_STORE,
+      rawEventRangeBetween(scope, fromSeq, toSeq),
+    );
+  }
+
+  async getPendingHydrationJobs(scope: LedgerScopeKey): Promise<LedgerHydrationJobRecord[]> {
+    const db = this.requireOpenDb();
+    return collectIndex<LedgerHydrationJobRecord>(
+      db,
+      PENDING_HYDRATION_STORE,
+      BY_SCOPE_INDEX,
+      IDBKeyRange.only(scopeKeyParts(scope)),
+    );
+  }
+
+
+  async getCanonicalRecord(
+    scope: LedgerScopeKey,
+    recordKind: LedgerRecordKind,
+    recordId: string,
+  ): Promise<LedgerCanonicalRecord | undefined> {
+    const db = this.requireOpenDb();
+    return runGet(db, CANONICAL_RECORDS_STORE, (store) =>
+      store.get(canonicalRecordKey(scope, recordKind, recordId)),
+    );
+  }
+
+  async listCanonicalRecords(scope: LedgerScopeKey): Promise<LedgerCanonicalRecord[]> {
+    const db = this.requireOpenDb();
+    return collectIndex<LedgerCanonicalRecord>(
+      db,
+      CANONICAL_RECORDS_STORE,
+      BY_SCOPE_INDEX,
+      IDBKeyRange.only(scopeKeyParts(scope)),
+    );
+  }
+
+  async getReadState(scope: LedgerScopeKey): Promise<LedgerReadStateRecord | undefined> {
+    const db = this.requireOpenDb();
+    return runGet(db, READ_STATES_STORE, (store) => store.get(agentRecordKey(scope)));
+  }
+
+  async getMigrationMeta<T extends { metaKey: string }>(
+    metaKey: string,
+  ): Promise<T | undefined> {
+    const db = this.requireOpenDb();
+    return runGet<T>(db, MIGRATION_META_STORE, (store) => store.get(metaKey));
+  }
+
+  async putMigrationMeta<T extends object>(metaKey: string, value: T): Promise<void> {
+    const db = this.requireOpenDb();
+    await runMutation(db, MIGRATION_META_STORE, (store) => store.put({ ...value, metaKey }));
+  }
+
+  async deleteHydrationJob(scope: LedgerScopeKey, jobId: string): Promise<void> {
+    const db = this.requireOpenDb();
+    await runMutation(db, PENDING_HYDRATION_STORE, (store) =>
+      store.delete(hydrationJobKey(scope, jobId)),
+    );
+  }
+
+  /** Test helper: delete the whole database (close handles first). */
+  static async deleteDatabase(): Promise<void> {
+    await deleteLedgerDatabase();
+  }
+
+  /** Internal: record a durability transition after commit failures. */
+  noteDurability(state: LedgerDurability, reason?: string): void {
+    this.durabilityState = state;
+    this.durabilityReasonValue = reason;
+  }
+
+  /** Internal: another connection upgraded the schema; this handle closed. */
+  noteSuperseded(): void {
+    this.noteClosed("superseded");
+  }
+
+  private noteClosed(reason: "closed" | "superseded"): void {
+    try {
+      this.db?.close();
+    } catch {
+      // Already closed.
+    }
+    this.db = null;
+    this.noteDurability("memory_only", reason);
+  }
+
+  requireOpenDb(): IDBDatabase {
+    if (!this.db) {
+      throw new LedgerUnavailableError("closed", this.durabilityState);
+    }
+    return this.db;
+  }
+}
+
+async function runGet<T>(
+  db: IDBDatabase,
+  storeName: LedgerStoreName,
+  make: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T | undefined> {
+  return new Promise<T | undefined>((resolve, reject) => {
+    let settled = false;
+    const tx = db.transaction(storeName, "readonly");
+    const req = make(tx.objectStore(storeName));
+    req.onsuccess = () => {
+      settled = true;
+      resolve(req.result);
+    };
+    req.onerror = () => {
+      settled = true;
+      reject(req.error ?? new Error(`${storeName} request failed`));
+    };
+    tx.onerror = () => {
+      if (!settled) reject(tx.error ?? new Error(`${storeName} transaction failed`));
+    };
+    tx.onabort = () => {
+      if (!settled) reject(tx.error ?? new Error(`${storeName} transaction aborted`));
+    };
+  });
+}
+
+/** Run one mutating request in its own readwrite transaction. */
+async function runMutation(
+  db: IDBDatabase,
+  storeName: LedgerStoreName,
+  make: (store: IDBObjectStore) => IDBRequest,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const tx = db.transaction(storeName, "readwrite");
+    const req = make(tx.objectStore(storeName));
+    req.onsuccess = () => {
+      settled = true;
+    };
+    req.onerror = () => {
+      settled = true;
+      reject(req.error ?? new Error(`${storeName} request failed`));
+    };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => {
+      if (!settled) reject(tx.error ?? new Error(`${storeName} transaction failed`));
+    };
+    tx.onabort = () => {
+      if (!settled) reject(tx.error ?? new Error(`${storeName} transaction aborted`));
+    };
+  });
+}
+
+async function collectRange<T>(
+  db: IDBDatabase,
+  storeName: LedgerStoreName,
+  range: IDBKeyRange,
+): Promise<T[]> {
+  return new Promise<T[]>((resolve, reject) => {
+    const tx = db.transaction(storeName, "readonly");
+    const results: T[] = [];
+    const req = tx.objectStore(storeName).openCursor(range);
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (cursor) {
+        results.push(cursor.value as T);
+        cursor.continue();
+      } else {
+        resolve(results);
+      }
+    };
+    req.onerror = () => reject(req.error ?? new Error(`${storeName} cursor failed`));
+    tx.onerror = () => reject(tx.error ?? new Error(`${storeName} transaction failed`));
+  });
+}
+
+async function collectIndex<T>(
+  db: IDBDatabase,
+  storeName: LedgerStoreName,
+  indexName: string,
+  range: IDBKeyRange,
+): Promise<T[]> {
+  return new Promise<T[]>((resolve, reject) => {
+    const tx = db.transaction(storeName, "readonly");
+    const results: T[] = [];
+    const req = tx.objectStore(storeName).index(indexName).openCursor(range);
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (cursor) {
+        results.push(cursor.value as T);
+        cursor.continue();
+      } else {
+        resolve(results);
+      }
+    };
+    req.onerror = () => reject(req.error ?? new Error(`${storeName} index cursor failed`));
+    tx.onerror = () => reject(tx.error ?? new Error(`${storeName} transaction failed`));
+  });
+}

--- a/web-gui/app/src/runtime/event-ledger/migration.ts
+++ b/web-gui/app/src/runtime/event-ledger/migration.ts
@@ -1,0 +1,99 @@
+/**
+ * Legacy-baseline migration policy for the event ledger (W1).
+ *
+ * The legacy `holon-webgui-cache` database is NOT imported:
+ * - its event/session cache, cursors, and read markers are not authoritative
+ *   for the new correctness keys and must not seed the new database;
+ * - the authoritative baseline comes only from server roster/projection
+ *   snapshots, event catch-up, and read markers produced by this browser in
+ *   the new database;
+ * - the legacy database stays untouched until the W6 soak and Web rollback
+ *   window complete; only then is it deleted (cleanup failures are
+ *   diagnostics only and must never pollute the new database).
+ */
+
+import type { EventLedger } from "./ledger";
+
+export const LEGACY_DB_NAME = "holon-webgui-cache";
+
+export const LEGACY_BASELINE_META_KEY = "legacy_baseline_v1";
+export const UNREAD_MIGRATION_NOTICE_META_KEY = "unread_state_migration_notice_v1";
+
+export interface LegacyBaselineMeta {
+  metaKey: typeof LEGACY_BASELINE_META_KEY;
+  strategy: "fresh_server_authoritative";
+  legacyDbName: typeof LEGACY_DB_NAME;
+  legacyImported: false;
+  decidedAt: number;
+}
+
+export interface UnreadMigrationNoticeMeta {
+  metaKey: typeof UNREAD_MIGRATION_NOTICE_META_KEY;
+  shownAt: number;
+}
+
+/**
+ * Record the fresh-baseline decision exactly once. Never reads the legacy
+ * database. Optional non-authoritative sort-hint copying from the legacy
+ * database is deliberately not implemented: it is not a precondition for
+ * exact mode, and skipping it keeps this boundary unambiguous.
+ */
+export async function initializeFreshBaseline(
+  ledger: EventLedger,
+): Promise<LegacyBaselineMeta> {
+  const existing = await ledger.getMigrationMeta<LegacyBaselineMeta>(LEGACY_BASELINE_META_KEY);
+  if (existing && existing.metaKey === LEGACY_BASELINE_META_KEY) {
+    return existing;
+  }
+  const meta: LegacyBaselineMeta = {
+    metaKey: LEGACY_BASELINE_META_KEY,
+    strategy: "fresh_server_authoritative",
+    legacyDbName: LEGACY_DB_NAME,
+    legacyImported: false,
+    decidedAt: Date.now(),
+  };
+  await ledger.putMigrationMeta(LEGACY_BASELINE_META_KEY, meta);
+  return meta;
+}
+
+/** One-time local unread-state migration notice state (display-only). */
+export async function hasUnreadMigrationNoticeBeenShown(
+  ledger: EventLedger,
+): Promise<boolean> {
+  const meta = await ledger.getMigrationMeta<UnreadMigrationNoticeMeta>(
+    UNREAD_MIGRATION_NOTICE_META_KEY,
+  );
+  return meta?.metaKey === UNREAD_MIGRATION_NOTICE_META_KEY;
+}
+
+export async function markUnreadMigrationNoticeShown(ledger: EventLedger): Promise<void> {
+  const meta: UnreadMigrationNoticeMeta = {
+    metaKey: UNREAD_MIGRATION_NOTICE_META_KEY,
+    shownAt: Date.now(),
+  };
+  await ledger.putMigrationMeta(UNREAD_MIGRATION_NOTICE_META_KEY, meta);
+}
+
+/**
+ * Delete the legacy database. Intended for the W6 post-soak cleanup step
+ * only. Failures must be recorded as diagnostics and must never be allowed
+ * to corrupt or block the new ledger; the resolve value reports the outcome
+ * instead of throwing.
+ */
+export function deleteLegacyDatabase(): Promise<{ ok: boolean; error?: string }> {
+  return new Promise((resolve) => {
+    if (typeof indexedDB === "undefined") {
+      resolve({ ok: false, error: "indexedDB unavailable" });
+      return;
+    }
+    try {
+      const request = indexedDB.deleteDatabase(LEGACY_DB_NAME);
+      request.onsuccess = () => resolve({ ok: true });
+      request.onerror = () =>
+        resolve({ ok: false, error: request.error?.message ?? "delete failed" });
+      request.onblocked = () => resolve({ ok: false, error: "blocked by open connections" });
+    } catch (error) {
+      resolve({ ok: false, error: error instanceof Error ? error.message : "delete threw" });
+    }
+  });
+}

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -41,6 +41,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/agents/snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Agent roster snapshot
+         * @description Authoritative roster snapshot (RFC: observer sync): all-or-nothing membership with per-Agent event windows and latest Brief anchors from one committed read view. Served only while the agents.roster-snapshot.v1 capability is advertised; route registration alone is never sufficient.
+         */
+        get: operations["agentsSnapshot"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/agents/{agent_id}/briefs": {
         parameters: {
             query?: never;
@@ -130,7 +150,7 @@ export interface paths {
         };
         /**
          * Agent event page
-         * @description Return a bounded page of versioned runtime event envelopes. Query parameters: before_seq, after_seq, limit, order, max_level. Identity is (event_log_epoch, agent_id, event_seq); unknown kinds retain their opaque payload.
+         * @description Return a bounded page of versioned runtime event envelopes. Query parameters: before_seq, after_seq, limit, order, max_level. Identity is (event_log_epoch, agent_id, event_seq); unknown kinds retain their opaque payload. While events.projection-effect.v1 is advertised every envelope carries the additive projection_effect classification derived from the runtime event registry (envelope contract version 3); a max_level-filtered page changes presentation only and is never proof of raw continuity.
          */
         get: operations["agentEvents"];
         put?: never;
@@ -150,7 +170,7 @@ export interface paths {
         };
         /**
          * Agent event stream
-         * @description Return Server-Sent Events carrying raw StreamEventEnvelope JSON data. Query parameters: after_seq, limit. SSE id is event_seq; SSE event is the audit event kind; missing replay cursors return cursor_not_found before the stream opens. If the receiver lags, the server closes the stream so clients can backfill after the last contiguous SSE id before reconnecting. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.
+         * @description Return Server-Sent Events carrying raw StreamEventEnvelope JSON data. Query parameters: after_seq, limit. SSE id is event_seq; SSE event is the audit event kind; missing replay cursors return cursor_not_found before the stream opens, carrying event_log_epoch, oldest_retained_seq, and event_head_seq from one committed read view so clients can distinguish a retained-prefix gap from an epoch change. Envelopes carry the additive projection_effect field while events.projection-effect.v1 is advertised. If the receiver lags, the server closes the stream so clients can backfill after the last contiguous SSE id before reconnecting. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.
          */
         get: operations["agentEventsStream"];
         put?: never;
@@ -195,6 +215,26 @@ export interface paths {
          * @description Return persisted message envelopes for the selected agent. Missing or cross-agent ids are reported in missing_message_ids.
          */
         post: operations["agentMessagesBatchGet"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/projection-snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Agent projection snapshot
+         * @description Per-Agent canonical projection snapshot (RFC: observer sync): compact current state plus revision anchors at one committed consistency boundary. snapshot_through_seq equals the committed per-Agent event head of the same view; clients replay only event_seq greater than it. Served only while the agents.projection-snapshot.v1 capability is advertised; route registration alone is never sufficient.
+         */
+        get: operations["agentProjectionSnapshot"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2641,6 +2681,14 @@ export interface components {
             };
             /** Format: date-time */
             created_at: string;
+            /**
+             * Format: uint64
+             * @description Immutable linkage to the unique `brief_created` audit event committed
+             *      in the same runtime DB transition as this record. `None` for records
+             *      whose creating event cannot be identified (pre-linkage history or
+             *      ambiguous backfill candidates).
+             */
+            created_event_seq?: number | null;
             finalizes_assistant_round_id?: string | null;
             id: string;
             /** @enum {string} */
@@ -2792,6 +2840,11 @@ export interface components {
                 payload_schema: string;
                 /** Format: uint32 */
                 payload_schema_version: number;
+                /**
+                 * @description Additive classification derived from the runtime event registry.
+                 *      Present only while `events.projection-effect.v1` is advertised.
+                 */
+                projection_effect?: ("none" | "display_invalidation") | null;
                 provenance: {
                     admission_context?: unknown;
                     authority_class?: unknown;
@@ -3682,6 +3735,11 @@ export interface components {
             payload_schema: string;
             /** Format: uint32 */
             payload_schema_version: number;
+            /**
+             * @description Additive classification derived from the runtime event registry.
+             *      Present only while `events.projection-effect.v1` is advertised.
+             */
+            projection_effect?: ("none" | "display_invalidation") | null;
             provenance: {
                 admission_context?: unknown;
                 authority_class?: unknown;
@@ -4442,6 +4500,44 @@ export interface operations {
             };
         };
     };
+    agentsSnapshot: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRosterSnapshot"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
     agentBriefs: {
         parameters: {
             query?: never;
@@ -4755,6 +4851,47 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BatchGetMessagesResponse"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    agentProjectionSnapshot: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent id. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response using a stable DTO schema. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentProjectionSnapshot"];
                 };
             };
             /** @description Client error JSON response. */


### PR DESCRIPTION
## Summary

W1 slice of the approved observer-sync plan (`docs/rfcs/observer-sync-agent-summary-and-read-markers.md`): a new, independent IndexedDB ledger for durable raw ingestion, with cache partitioning and a composable atomic transaction API. No behavior cutover yet — the legacy cache path is untouched.

### New database and stores

- `holon.webGui.eventLedger.v1` (DB_VERSION 1), fully separate from legacy `holon-webgui-cache`.
- Normalized stores: `runtime_scopes`, `agent_sessions`, `raw_events`, `pending_hydration`, `canonical_records`, `read_states`, `migration_meta`, plus `byScope`/`byRemoteRuntime` indexes.
- Every correctness key embeds `(remoteKey, runtimeId, visibilityScopeId, eventLogEpoch, agentId)`; raw events additionally key by `eventSeq`, canonical records by `(recordKind, recordId)`. Different remotes/runtimes/visibility scopes/epochs/agents can never share a record.

### Atomic composable transactions

`EventLedgerWriteBatch.commit()` is one readwrite transaction across every touched store, so envelope + classification, hydration jobs, canonical records, projection change, read state, and the contiguous ingestion cursor either all commit or none do:

- duplicate raw event with identical content: idempotent no-op;
- same key with different immutable content: `LedgerIdentityConflictError` (protocol error, never overwrites);
- cursor regression: `LedgerCursorRegressionError`;
- quota failure: `LedgerQuotaError`, durability → `memory_only`, whole batch (including cursor) rolled back;
- other transaction failure: `LedgerTransactionAbortedError`, durability → `uncertain`;
- missing IndexedDB / open failure / schema superseded: explicit `memory_only` open result or `LedgerUnavailableError` — nothing ever silently continues as exact.

Multiple patches to the same record inside one batch merge instead of overwriting each other.

### Legacy baseline

- Nothing is imported from the legacy database (no event/session cache, cursors, or read markers).
- `migration_meta` records the fresh-server-authoritative baseline decision and the one-time unread-state migration notice marker.
- Legacy deletion stays a W6 post-soak, diagnostics-only step (`deleteLegacyDatabase` reports outcomes instead of throwing); the legacy database itself is untouched.

### Incidental fix

Refreshes `web-gui/app/src/runtime/generated/openapi.ts`, which was stale on `main` relative to `docs/website/reference/openapi.json` (missing the S4 roster-snapshot and S5 projection-snapshot paths); `make web-ci` now passes because this PR touches `web-gui/**`.

## Testing

- New `event-ledger.test.ts` (18 tests, fake-indexeddb devDependency): fresh schema upgrade, versionchange self-close + degradation, blocked-upgrade wait, multi-tab same-version visibility, atomic commit across all record kinds, quota rollback with cursor intact, non-quota abort → uncertain, close/reopen durability, scope/epoch/remote isolation, ordered and bounded event ranges, duplicate idempotency, identity-conflict hard-fail, cursor regression rejection, fresh legacy baseline, unread notice persistence, legacy delete outcomes.
- `make web-ci` (openapi-tools check + npm ci + 356 tests + build) passes locally.