### PR TITLE
feat: durable raw ingestion pipeline, hydration queue and projection-ready cursor (W2)

### DIFF
--- a/web-gui/app/src/runtime/agent-session-repository.test.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.test.ts
@@ -1,10 +1,14 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   AgentSessionRepository,
+  type LedgerIngestionIntegration,
   type AgentSessionRepositoryDependencies,
   type AgentSessionRepositoryState,
 } from "./agent-session-repository";
+import { LEDGER_DB_NAME, type LedgerScopeKey } from "./event-ledger";
 import type { StreamEventEnvelopeDto } from "./client";
 import { emptyAgentSession } from "./conversation-store";
 import type { AgentSessionState } from "./runtime-store-helpers";
@@ -32,7 +36,10 @@ function event(seq: number): StreamEventEnvelopeDto {
   };
 }
 
-function createHarness(session: AgentSessionState = emptyAgentSession()) {
+function createHarness(
+  session: AgentSessionState = emptyAgentSession(),
+  extra: { ledgerIngestion?: LedgerIngestionIntegration } = {},
+) {
   let generation = 1;
   let state: TestState = {
     route: "agent",
@@ -159,6 +166,7 @@ function createHarness(session: AgentSessionState = emptyAgentSession()) {
     isWorkItemInvalidationEvent: () => false,
     isAgentStateInvalidationEvent: () => false,
     catchUpErrorKind: () => "request_failed",
+    ...(extra.ledgerIngestion ? { ledgerIngestion: extra.ledgerIngestion } : {}),
   };
   return {
     client,
@@ -315,5 +323,90 @@ describe("AgentSessionRepository", () => {
     expect(
       harness.getState().sessionsByAgentId["agent-a"].briefHydrationById["brief-1"]?.attempt,
     ).toBe(2);
+  });
+
+});
+
+describe("AgentSessionRepository ledger ingestion", () => {
+  const scope: LedgerScopeKey = {
+    remoteKey: "http://127.0.0.1:7878",
+    runtimeId: "rt_test",
+    visibilityScopeId: "vis_test",
+    eventLogEpoch: "epoch-1",
+    agentId: "agent-a",
+  };
+
+  function deleteLedger(): Promise<void> {
+    return new Promise((resolve) => {
+      const request = indexedDB.deleteDatabase(LEDGER_DB_NAME);
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+      request.onblocked = () => resolve();
+    });
+  }
+
+  function ledgerIntegration(
+    overrides: Partial<LedgerIngestionIntegration> = {},
+  ): LedgerIngestionIntegration {
+    return {
+      resolveScope: () => scope,
+      fetchers: {
+        fetchCanonicalRecords: async () => ({ recordsById: {}, missingIds: [] }),
+      },
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    await deleteLedger();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await deleteLedger();
+  });
+
+  it("ingests session events through the owned ledger pipeline", async () => {
+    const harness = createHarness(
+      emptyAgentSession(),
+      { ledgerIngestion: ledgerIntegration() },
+    );
+    await harness.repository.initializeLedgerIngestion();
+
+    const status = await harness.repository.ingestSessionEvents("agent-a", [
+      event(1),
+      event(2),
+    ]);
+
+    expect(status?.ingestedThroughSeq).toBe(2);
+    expect(status?.projectionReadyThroughSeq).toBe(2);
+    expect(harness.repository.sessionLedgerStatus("agent-a")?.ingestedThroughSeq).toBe(2);
+    const gate = harness.repository.sessionLedgerReadiness("agent-a");
+    expect(gate?.readyThroughSeq).toBe(2);
+  });
+
+  it("stays dormant when the runtime identity scope is unresolved", async () => {
+    const harness = createHarness(
+      emptyAgentSession(),
+      { ledgerIngestion: ledgerIntegration({ resolveScope: () => null }) },
+    );
+    await harness.repository.initializeLedgerIngestion();
+
+    const status = await harness.repository.ingestSessionEvents("agent-a", [event(1)]);
+    expect(status).toBeNull();
+    expect(harness.repository.sessionLedgerStatus("agent-a")).toBeNull();
+    expect(harness.repository.sessionLedgerReadiness("agent-a")).toBeNull();
+  });
+
+  it("drops the ledger pipeline when switching remotes", async () => {
+    const harness = createHarness(
+      emptyAgentSession(),
+      { ledgerIngestion: ledgerIntegration() },
+    );
+    await harness.repository.initializeLedgerIngestion();
+    harness.repository.switchRemote();
+
+    const status = await harness.repository.ingestSessionEvents("agent-a", [event(1)]);
+    expect(status).toBeNull();
   });
 });

--- a/web-gui/app/src/runtime/agent-session-repository.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.ts
@@ -14,6 +14,13 @@ import {
   startRuntimeSpan,
   type RuntimeTraceContext,
 } from "./runtime-trace";
+import {
+  LedgerIngestionPipeline,
+  type LedgerHydrationFetchers,
+  type LedgerIngestionStatus,
+  type LedgerScopeKey,
+  type ProjectionSnapshotRepairSource,
+} from "./event-ledger";
 import type { AgentSessionState } from "./runtime-store-helpers";
 import type {
   DisplayLevel,
@@ -52,6 +59,21 @@ export interface AgentSessionRepositoryState {
   ) => Promise<void>;
   refreshAgentWorkItems: (agentId: string | undefined) => Promise<void>;
   refreshAgentState: (agentId: string | undefined) => Promise<void>;
+}
+
+/**
+ * Durable ledger ingestion integration (W2). The repository owns the
+ * pipeline lifecycle; scope resolution decides whether a remote already
+ * exposes the stable runtime identity (runtime id + visibility scope) the
+ * correctness key requires. Remotes without it return null and ingest
+ * nothing — the in-memory path is unchanged until the W3/W4 cutover.
+ */
+export interface LedgerIngestionIntegration {
+  /** Full ledger scope for one agent, or null while identity is unknown. */
+  resolveScope: (agentId: string) => LedgerScopeKey | null;
+  fetchers: LedgerHydrationFetchers;
+  snapshotRepair?: ProjectionSnapshotRepairSource;
+  onStatus?: (status: LedgerIngestionStatus) => void;
 }
 
 type StoreSet<State> = (
@@ -174,6 +196,7 @@ export interface AgentSessionRepositoryDependencies<State extends AgentSessionRe
   isWorkItemInvalidationEvent: (event: StreamEventEnvelopeDto) => boolean;
   isAgentStateInvalidationEvent: (event: StreamEventEnvelopeDto) => boolean;
   catchUpErrorKind: (error: unknown) => string;
+  ledgerIngestion?: LedgerIngestionIntegration;
 }
 
 export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
@@ -186,11 +209,17 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
   private readonly briefHydrationInFlight = new Map<string, Set<string>>();
   private readonly briefHydrationRetryTimers = new Map<string, number>();
 
+  private ledgerPipeline: LedgerIngestionPipeline | null = null;
+  private ledgerInitPromise: Promise<void> | null = null;
+
   constructor(private readonly dependencies: AgentSessionRepositoryDependencies<State>) {}
 
   initializeCache(): void {
     if (this.cacheInitPromise) return;
     const context = this.currentCacheContext();
+    // Durable ledger ingestion is independent of the legacy cache: start the
+    // restart scan even when the legacy cache is unavailable.
+    void this.initializeLedgerIngestion();
     const initialization = this.initializeCacheForContext(context);
     this.cacheInitPromise = initialization;
     void initialization.finally(() => {
@@ -288,7 +317,80 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
     void this.cacheWriter?.flush();
     this.cacheWriter = null;
     this.cacheInitPromise = null;
+    this.ledgerPipeline?.dispose();
+    this.ledgerPipeline = null;
+    this.ledgerInitPromise = null;
     this.cancelClientGenerationWork();
+  }
+
+  /**
+   * Open the durable ingestion pipeline and run the restart scan for every
+   * scope of the current remote: pending hydration resumes before any new
+   * readiness claim. Idempotent; safe to call on every cache init.
+   */
+  initializeLedgerIngestion(): Promise<void> {
+    if (!this.dependencies.ledgerIngestion) return Promise.resolve();
+    if (this.ledgerInitPromise) return this.ledgerInitPromise;
+    const integration = this.dependencies.ledgerIngestion;
+    const pipeline = new LedgerIngestionPipeline({
+      fetchers: integration.fetchers,
+      snapshotRepair: integration.snapshotRepair,
+      onStatus: integration.onStatus,
+    });
+    this.ledgerPipeline = pipeline;
+    this.ledgerInitPromise = (async () => {
+      if (!(await pipeline.open())) return;
+      await pipeline.resumeRemote(
+        currentRemoteKey(this.dependencies.getConnectionConfig()),
+      );
+    })().catch((error) => {
+      console.warn("Failed to initialize the event ledger pipeline.", error);
+    });
+    return this.ledgerInitPromise;
+  }
+
+  /**
+   * Ingest raw envelopes for one agent into the durable ledger. Returns
+   * null when ledger ingestion is unavailable or the agent's runtime
+   * identity is not resolvable yet.
+   */
+  async ingestSessionEvents(
+    agentId: string,
+    events: StreamEventEnvelopeDto[],
+  ): Promise<LedgerIngestionStatus | null> {
+    const integration = this.dependencies.ledgerIngestion;
+    if (!integration || !this.ledgerPipeline || events.length === 0) return null;
+    const scope = integration.resolveScope(agentId);
+    if (!scope) return null;
+    await this.initializeLedgerIngestion();
+    return this.ledgerPipeline.ingest(
+      scope,
+      events as Array<Record<string, unknown>>,
+    );
+  }
+
+  /** Current durable ingestion status for one agent, if tracked. */
+  sessionLedgerStatus(agentId: string): LedgerIngestionStatus | null {
+    const integration = this.dependencies.ledgerIngestion;
+    if (!integration || !this.ledgerPipeline) return null;
+    const scope = integration.resolveScope(agentId);
+    return scope ? this.ledgerPipeline.status(scope) : null;
+  }
+
+  /**
+   * Read-marker gate: the highest delivery seq a read state may claim for
+   * this agent without crossing unsatisfied display demand.
+   */
+  sessionLedgerReadiness(agentId: string): {
+    readyThroughSeq: number;
+    ingestedThroughSeq: number;
+    blockedByEventSeq?: number;
+    blockedReason?: "pending_hydration" | "unknown_envelope_version";
+  } | null {
+    const integration = this.dependencies.ledgerIngestion;
+    if (!integration || !this.ledgerPipeline) return null;
+    const scope = integration.resolveScope(agentId);
+    return scope ? this.ledgerPipeline.readinessGate(scope) : null;
   }
 
   cancelClientGenerationWork(): void {

--- a/web-gui/app/src/runtime/event-ledger/classification.ts
+++ b/web-gui/app/src/runtime/event-ledger/classification.ts
@@ -1,0 +1,193 @@
+/**
+ * Envelope classification for durable raw ingestion (W2).
+ *
+ * Classification is the bridge between the server event contract (S2
+ * `projection_effect`, additive) and the ledger's durable demand model:
+ * - `none` events never block projection readiness;
+ * - `display_invalidation` events block readiness until satisfied —
+ *   reference events create durable hydration jobs, self-contained events
+ *   are satisfied by ingestion itself (projection replays deterministically
+ *   from the raw cache), and deletes complete via canonical tombstones;
+ * - envelopes with a contract version above the highest supported version
+ *   block readiness outright: their semantics are unknowable.
+ *
+ * Display level never changes classification. Info/verbose/debug timelines
+ * consume the same raw cache; display level only changes projection and
+ * hydration demand at the render layer.
+ */
+
+import type { LedgerRecordKind } from "./keys";
+import type { RawEventClassification } from "./ledger";
+
+/**
+ * Highest StreamEventEnvelope.contract_version this client understands.
+ * Mirrors RUNTIME_EVENT_CONTRACT_VERSION in `runtime/session-events.ts`;
+ * duplicated here so the ledger layer stays app-layer-independent.
+ */
+export const SUPPORTED_ENVELOPE_CONTRACT_VERSION = 2;
+
+export type EnvelopeProjectionEffect = "none" | "display_invalidation";
+
+/** A canonical record referenced by an event that needs durable hydration. */
+export interface EnvelopeRecordReference {
+  recordKind: LedgerRecordKind;
+  recordId: string;
+  /**
+   * Minimum canonical revision that satisfies the reference, when the event
+   * names one (e.g. `work_item_written` carries `revision`). A newer
+   * canonical revision satisfies an older invalidation.
+   */
+  expectedRevision?: string | number;
+}
+
+/** A canonical record deletion carried by an event. */
+export interface EnvelopeRecordTombstone {
+  recordKind: LedgerRecordKind;
+  recordId: string;
+}
+
+export interface ClassifiedEnvelope {
+  eventSeq: number;
+  classification: RawEventClassification;
+  /**
+   * True when the envelope's contract version is above the highest supported
+   * version. Such events are still stored, but readiness can never pass them
+   * until a client that understands the version upgrades the boundary.
+   */
+  blocksReadiness: boolean;
+  /** Reference demand: create/refresh a durable hydration job. */
+  reference: EnvelopeRecordReference | null;
+  /** Delete demand: complete via canonical tombstone. */
+  tombstone: EnvelopeRecordTombstone | null;
+  /**
+   * True when the event affects display but needs no canonical hydration:
+   * its payload carries the display-relevant state and projection replays
+ * from the raw cache.
+   */
+  selfContained: boolean;
+}
+
+interface EnvelopeLike {
+  event_seq?: number | null;
+  contract_version?: number | null;
+  projection_effect?: EnvelopeProjectionEffect | null;
+  type?: string | null;
+  payload?: unknown;
+}
+
+/**
+ * Classify one raw event envelope for ingestion.
+ *
+ * When the server does not advertise `projection_effect` yet (pre-S2-cutover
+ * remotes), classification falls back to the conservative local registry:
+ * every known event type invalidates display except the explicitly
+ * effect-less diagnostic family. An unrecognized event type with no
+ * `projection_effect` is conservatively treated as display-affecting.
+ */
+export function classifyEnvelope(envelope: EnvelopeLike): ClassifiedEnvelope {
+  const eventSeq = envelope.event_seq;
+  if (typeof eventSeq !== "number" || !Number.isFinite(eventSeq)) {
+    throw new Error("cannot classify envelope without a finite event_seq");
+  }
+  const contractVersion = envelope.contract_version ?? 1;
+  const blocksReadiness = contractVersion > SUPPORTED_ENVELOPE_CONTRACT_VERSION;
+  const advertised = envelope.projection_effect ?? null;
+  const effect: EnvelopeProjectionEffect =
+    advertised ?? localFallbackEffect(envelope.type ?? "");
+
+  const reference = effect === "display_invalidation" ? referenceForEnvelope(envelope) : null;
+  const tombstone =
+    effect === "display_invalidation" ? tombstoneForEnvelope(envelope) : null;
+  return {
+    eventSeq,
+    classification: {
+      projectionEffect: effect,
+      envelopeContractVersion: contractVersion,
+    },
+    blocksReadiness,
+    reference,
+    tombstone,
+    selfContained: effect === "display_invalidation" && reference === null && tombstone === null,
+  };
+}
+
+/**
+ * Reference mapping for known event families. Mirrors the hydration demand
+ * of the render layer: messages, briefs, and transcript entries are fetched
+ * through canonical batch APIs, everything else is self-contained.
+ */
+function referenceForEnvelope(
+  envelope: EnvelopeLike,
+): EnvelopeRecordReference | null {
+  const payload = asRecord(envelope.payload);
+  const eventType = envelope.type ?? "";
+  const expectedRevision = revisionField(payload);
+  if (eventType === "message_enqueued" || eventType === "message_processing_started") {
+    const messageId = stringField(payload, "message_id");
+    return messageId ? { recordKind: "message", recordId: messageId, expectedRevision } : null;
+  }
+  if (eventType === "brief_created") {
+    const briefId = stringField(payload, "brief_id") ?? stringField(payload, "id");
+    return briefId ? { recordKind: "brief", recordId: briefId, expectedRevision } : null;
+  }
+  if (eventType === "assistant_round_recorded") {
+    const entryId = stringField(payload, "assistant_round_id");
+    return entryId ? { recordKind: "transcript_entry", recordId: entryId, expectedRevision } : null;
+  }
+  // Unknown reference shapes stay self-contained: the raw envelope is still
+  // stored and replayable, so no durable demand is lost.
+  return null;
+}
+
+/**
+ * Revision anchor when the event names one (forward-compatible: current
+ * wire payloads do not carry revisions; snapshot and canonical APIs do).
+ */
+function revisionField(
+  payload: Record<string, unknown> | undefined,
+): string | number | undefined {
+  const value = payload?.revision ?? payload?.brief_revision;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.length > 0) return value;
+  return undefined;
+}
+
+/**
+ * Delete mapping. No wire delete event exists yet; the tombstone completion
+ * path is exercised through pipeline APIs and becomes live when the server
+ * contract adds deletion events.
+ */
+function tombstoneForEnvelope(
+  envelope: EnvelopeLike,
+): EnvelopeRecordTombstone | null {
+  const payload = asRecord(envelope.payload);
+  const eventType = envelope.type ?? "";
+  if (eventType !== "canonical_record_deleted") return null;
+  const recordKind = stringField(payload, "record_kind") as LedgerRecordKind | undefined;
+  const recordId = stringField(payload, "record_id");
+  if (!recordKind || !recordId) return null;
+  if (recordKind !== "message" && recordKind !== "brief" && recordKind !== "transcript_entry") {
+    return null;
+  }
+  return { recordKind, recordId };
+}
+
+/** Conservative pre-S2 fallback: diagnostics are inert, everything else displays. */
+function localFallbackEffect(eventType: string): EnvelopeProjectionEffect {
+  if (eventType === "scheduler_diagnostic") return "none";
+  return "display_invalidation";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringField(
+  payload: Record<string, unknown> | undefined,
+  field: string,
+): string | undefined {
+  const value = payload?.[field];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/web-gui/app/src/runtime/event-ledger/index.ts
+++ b/web-gui/app/src/runtime/event-ledger/index.ts
@@ -11,6 +11,14 @@ export {
   deleteLedgerDatabase,
 } from "./db";
 export {
+  classifyEnvelope,
+  SUPPORTED_ENVELOPE_CONTRACT_VERSION,
+  type ClassifiedEnvelope,
+  type EnvelopeProjectionEffect,
+  type EnvelopeRecordReference,
+  type EnvelopeRecordTombstone,
+} from "./classification";
+export {
   LedgerCursorRegressionError,
   LedgerIdentityConflictError,
   LedgerQuotaError,
@@ -46,6 +54,16 @@ export {
   type LedgerRuntimeScopeRecord,
   type RawEventClassification,
 } from "./ledger";
+export {
+  isCanonicalTombstone,
+  LedgerIngestionPipeline,
+  type CanonicalTombstone,
+  type IngestionPipelineDependencies,
+  type LedgerHydrationFetchers,
+  type LedgerIngestionState,
+  type LedgerIngestionStatus,
+  type ProjectionSnapshotRepairSource,
+} from "./ingestion-pipeline";
 export {
   LEGACY_DB_NAME,
   deleteLegacyDatabase,

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
@@ -1,0 +1,542 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  LEDGER_DB_NAME,
+  LedgerIdentityConflictError,
+  type LedgerHydrationFetchers,
+  type LedgerScopeKey,
+} from "./index";
+import { EventLedger } from "./ledger";
+import { LedgerIngestionPipeline } from "./ingestion-pipeline";
+
+function makeScope(overrides: Partial<LedgerScopeKey> = {}): LedgerScopeKey {
+  return {
+    remoteKey: "http://127.0.0.1:7878",
+    runtimeId: "rt_test",
+    visibilityScopeId: "vis_test",
+    eventLogEpoch: "epoch-1",
+    agentId: "agent-1",
+    ...overrides,
+  };
+}
+
+function envelope(
+  seq: number,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    agent_id: "agent-1",
+    contract_version: 2,
+    event_log_epoch: "epoch-1",
+    event_seq: seq,
+    id: `evt-${seq}`,
+    payload: {},
+    payload_schema: "test",
+    payload_schema_version: 1,
+    provenance: {},
+    ts: `2026-08-18T00:00:${String(seq % 60).padStart(2, "0")}Z`,
+    type: "agent_state_changed",
+    ...overrides,
+  };
+}
+
+function briefEvent(seq: number, briefId: string, payload: Record<string, unknown> = {}) {
+  return envelope(seq, {
+    id: `evt-${seq}`,
+    type: "brief_created",
+    payload: { brief_id: briefId, ...payload },
+  });
+}
+
+function emptyFetchers(): LedgerHydrationFetchers {
+  return {
+    fetchCanonicalRecords: async () => ({ recordsById: {}, missingIds: [] }),
+  };
+}
+
+async function openLedgerHandle(): Promise<EventLedger> {
+  const result = await EventLedger.open();
+  if (result.kind !== "available") throw new Error("expected available ledger");
+  return result.ledger;
+}
+
+function deleteLedger(): Promise<void> {
+  return new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase(LEDGER_DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}
+
+describe("ledger ingestion pipeline", () => {
+  beforeEach(async () => {
+    await deleteLedger();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await deleteLedger();
+  });
+
+  it("ingests self-contained events and advances ingestion and readiness together", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    expect(await pipeline.open()).toBe(true);
+    const scope = makeScope();
+
+    const status = await pipeline.ingest(scope, [
+      envelope(1),
+      envelope(2, { type: "scheduler_diagnostic", projection_effect: "none" }),
+      envelope(3),
+    ]);
+
+    expect(status.ingestedThroughSeq).toBe(3);
+    expect(status.projectionReadyThroughSeq).toBe(3);
+    expect(status.state).toBe("idle");
+    expect(status.pendingHydrationJobs).toBe(0);
+
+    const ledger = await openLedgerHandle();
+    const session = await ledger.getAgentSession(scope);
+    expect(session?.ingestedThroughSeq).toBe(3);
+    expect(session?.projectionReadyThroughSeq).toBe(3);
+    const runtimeScope = await ledger.getRuntimeScope({
+      remoteKey: scope.remoteKey,
+      runtimeId: scope.runtimeId,
+      visibilityScopeId: scope.visibilityScopeId,
+      eventLogEpoch: scope.eventLogEpoch,
+    });
+    expect(runtimeScope?.eventHeadSeq).toBe(3);
+    ledger.close();
+  });
+
+  it("keeps the contiguous cursor behind out-of-order gaps", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const scope = makeScope();
+
+    const afterTail = await pipeline.ingest(scope, [envelope(5), envelope(6), envelope(7)]);
+    expect(afterTail.ingestedThroughSeq).toBeUndefined();
+    expect(afterTail.observedEventHeadSeq).toBe(7);
+
+    const afterMid = await pipeline.ingest(scope, [envelope(3), envelope(4)]);
+    expect(afterMid.ingestedThroughSeq).toBeUndefined();
+
+    const afterFill = await pipeline.ingest(scope, [envelope(1), envelope(2)]);
+    expect(afterFill.ingestedThroughSeq).toBe(7);
+    expect(afterFill.projectionReadyThroughSeq).toBe(7);
+  });
+
+  it("treats live duplicate delivery as idempotent without cursor regression", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const scope = makeScope();
+
+    await pipeline.ingest(scope, [envelope(1), envelope(2)]);
+    const duplicate = await pipeline.ingest(scope, [envelope(2), envelope(2)]);
+
+    expect(duplicate.ingestedThroughSeq).toBe(2);
+    expect(duplicate.state).toBe("idle");
+    const ledger = await openLedgerHandle();
+    const events = await ledger.getRawEvents(scope);
+    expect(events.map((event) => event.eventSeq)).toEqual([1, 2]);
+    ledger.close();
+  });
+
+  it("never advances the raw cursor from filtered subsets or semantic fetches", async () => {
+    const fetches: Array<{ kind: string; ids: string[] }> = [];
+    const fetchers: LedgerHydrationFetchers = {
+      fetchCanonicalRecords: async (_agentId, kind, ids) => {
+        fetches.push({ kind, ids });
+        return {
+          recordsById: Object.fromEntries(ids.map((id) => [id, { record: { id } }])),
+          missingIds: [],
+        };
+      },
+    };
+    const pipeline = new LedgerIngestionPipeline({ fetchers });
+    await pipeline.open();
+    const scope = makeScope();
+
+    // A display-filtered page returns only part of the raw range.
+    const filtered = await pipeline.ingest(scope, [envelope(4), envelope(6), envelope(8)]);
+    expect(filtered.ingestedThroughSeq).toBeUndefined();
+
+    // Hydrating referenced records (semantic timeline demand) fetches
+    // canonical bodies but must not move any raw cursor.
+    await pipeline.ingest(scope, [
+      envelope(1),
+      envelope(2),
+      briefEvent(3, "brief-1"),
+    ]);
+    await pipeline.drainHydration(scope);
+    expect(fetches.length).toBeGreaterThan(0);
+
+    const ledger = await openLedgerHandle();
+    const session = await ledger.getAgentSession(scope);
+    // Events 4 and 6/8 are stored but 5 and 7 never arrived: the contiguous
+    // cursor stops at 4, after the gap-filling 1..3 ingest plus the earlier
+    // filtered straggler 4 — never at 8.
+    expect(session?.ingestedThroughSeq).toBe(4);
+    const runtimeScope = await ledger.getRuntimeScope({
+      remoteKey: scope.remoteKey,
+      runtimeId: scope.runtimeId,
+      visibilityScopeId: scope.visibilityScopeId,
+      eventLogEpoch: scope.eventLogEpoch,
+    });
+    expect(runtimeScope?.eventHeadSeq).toBe(8);
+    ledger.close();
+  });
+
+  it("blocks readiness and the read gate on pending reference hydration", async () => {
+    const fetchers: LedgerHydrationFetchers = {
+      fetchCanonicalRecords: async () => ({
+        recordsById: {},
+        missingIds: ["brief-1"],
+      }),
+    };
+    const pipeline = new LedgerIngestionPipeline({ fetchers });
+    await pipeline.open();
+    const scope = makeScope();
+
+    await pipeline.ingest(scope, [envelope(1), briefEvent(2, "brief-1"), envelope(3)]);
+    await pipeline.drainHydration(scope);
+
+    let status = pipeline.status(scope)!;
+    expect(status.ingestedThroughSeq).toBe(3);
+    expect(status.projectionReadyThroughSeq).toBe(1);
+    expect(status.pendingHydrationJobs).toBe(1);
+    expect(status.blockedByEventSeq).toBe(2);
+    expect(status.blockedReason).toBe("pending_hydration");
+
+    const gate = pipeline.readinessGate(scope);
+    expect(gate.readyThroughSeq).toBe(1);
+    expect(gate.blockedByEventSeq).toBe(2);
+
+    const ledger = await openLedgerHandle();
+    const jobs = await ledger.getPendingHydrationJobs(scope);
+    expect(jobs.map((job) => job.jobId)).toEqual(["brief:brief-1"]);
+    ledger.close();
+  });
+
+  it("completes reference hydration atomically and unblocks readiness", async () => {
+    const briefRecord = { id: "brief-1", text: "result" };
+    const fetchers: LedgerHydrationFetchers = {
+      fetchCanonicalRecords: async () => ({
+        recordsById: { "brief-1": { record: briefRecord, revision: 4 } },
+        missingIds: [],
+      }),
+    };
+    const pipeline = new LedgerIngestionPipeline({ fetchers });
+    await pipeline.open();
+    const scope = makeScope();
+
+    await pipeline.ingest(scope, [envelope(1), briefEvent(2, "brief-1"), envelope(3)]);
+    await pipeline.drainHydration(scope);
+
+    const status = pipeline.status(scope)!;
+    expect(status.projectionReadyThroughSeq).toBe(3);
+    expect(status.pendingHydrationJobs).toBe(0);
+    expect(status.state).toBe("idle");
+
+    const ledger = await openLedgerHandle();
+    const record = await ledger.getCanonicalRecord(scope, "brief", "brief-1");
+    expect(record?.record).toEqual(briefRecord);
+    expect(record?.revision).toBe(4);
+    expect(await ledger.getPendingHydrationJobs(scope)).toEqual([]);
+    ledger.close();
+  });
+
+  it("satisfies an older invalidation with a newer canonical revision", async () => {
+    const fetchers: LedgerHydrationFetchers = {
+      fetchCanonicalRecords: async () => ({
+        recordsById: { "brief-1": { record: { id: "brief-1" }, revision: 5 } },
+        missingIds: [],
+      }),
+    };
+    const pipeline = new LedgerIngestionPipeline({ fetchers });
+    await pipeline.open();
+    const scope = makeScope();
+
+    // Two invalidations of the same record; the first names revision 3.
+    await pipeline.ingest(scope, [
+      briefEvent(1, "brief-1", { revision: 3 }),
+      briefEvent(2, "brief-1", { revision: 3 }),
+    ]);
+    await pipeline.drainHydration(scope);
+
+    const status = pipeline.status(scope)!;
+    expect(status.pendingHydrationJobs).toBe(0);
+    expect(status.projectionReadyThroughSeq).toBe(2);
+  });
+
+  it("keeps a revision-expecting job pending until the revision is proven", async () => {
+    const fetchers: LedgerHydrationFetchers = {
+      fetchCanonicalRecords: async () => ({
+        recordsById: { "brief-1": { record: { id: "brief-1" }, revision: 2 } },
+        missingIds: [],
+      }),
+    };
+    const pipeline = new LedgerIngestionPipeline({ fetchers });
+    await pipeline.open();
+    const scope = makeScope();
+
+    await pipeline.ingest(scope, [briefEvent(1, "brief-1", { revision: 3 })]);
+    await pipeline.drainHydration(scope);
+
+    const status = pipeline.status(scope)!;
+    expect(status.pendingHydrationJobs).toBe(1);
+    expect(status.projectionReadyThroughSeq).toBeUndefined();
+    expect(status.blockedReason).toBe("pending_hydration");
+  });
+
+  it("blocks readiness on unknown envelope contract versions", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const scope = makeScope();
+
+    const status = await pipeline.ingest(scope, [
+      envelope(1),
+      envelope(2, { contract_version: 99 }),
+      envelope(3),
+    ]);
+
+    expect(status.ingestedThroughSeq).toBe(3);
+    expect(status.projectionReadyThroughSeq).toBe(1);
+    expect(status.blockedByEventSeq).toBe(2);
+    expect(status.blockedReason).toBe("unknown_envelope_version");
+  });
+
+  it("completes hydration demand atomically via a canonical tombstone", async () => {
+    const fetchers: LedgerHydrationFetchers = {
+      fetchCanonicalRecords: async () => ({ recordsById: {}, missingIds: ["brief-1"] }),
+    };
+    const pipeline = new LedgerIngestionPipeline({ fetchers });
+    await pipeline.open();
+    const scope = makeScope();
+
+    await pipeline.ingest(scope, [briefEvent(1, "brief-1"), envelope(2)]);
+    await pipeline.drainHydration(scope);
+    expect(pipeline.status(scope)!.pendingHydrationJobs).toBe(1);
+
+    await pipeline.applyTombstone(scope, "brief", "brief-1", 1);
+
+    const status = pipeline.status(scope)!;
+    expect(status.pendingHydrationJobs).toBe(0);
+    expect(status.projectionReadyThroughSeq).toBe(2);
+    const ledger = await openLedgerHandle();
+    const record = await ledger.getCanonicalRecord(scope, "brief", "brief-1");
+    expect(record?.record).toMatchObject({ tombstone: true, deletedByEventSeq: 1 });
+    expect(await ledger.getPendingHydrationJobs(scope)).toEqual([]);
+    ledger.close();
+  });
+
+  it("resumes pending hydration after a crash between persistence and hydration", async () => {
+    const scope = makeScope();
+
+    // Phase 1: the fetcher never settles before the "crash".
+    let releaseFetch: (() => void) | null = null;
+    const stalled: LedgerHydrationFetchers = {
+      fetchCanonicalRecords: () =>
+        new Promise(() => {
+          releaseFetch?.();
+        }),
+    };
+    const crashed = new LedgerIngestionPipeline({ fetchers: stalled });
+    await crashed.open();
+    await crashed.ingest(scope, [envelope(1), briefEvent(2, "brief-1")]);
+    crashed.dispose();
+    releaseFetch = null;
+
+    // Phase 2: restart. The restart scan finds the pending job, and the
+    // drain completes it with a working fetcher.
+    const resumed = new LedgerIngestionPipeline({
+      fetchers: {
+        fetchCanonicalRecords: async () => ({
+          recordsById: { "brief-1": { record: { id: "brief-1" } } },
+          missingIds: [],
+        }),
+      },
+    });
+    await resumed.open();
+    const resumeStatus = await resumed.resume(scope);
+    expect(resumeStatus.pendingHydrationJobs).toBe(1);
+    expect(resumeStatus.projectionReadyThroughSeq).toBe(1);
+
+    await resumed.drainHydration(scope);
+    const status = resumed.status(scope)!;
+    expect(status.pendingHydrationJobs).toBe(0);
+    expect(status.projectionReadyThroughSeq).toBe(2);
+    expect(status.ingestedThroughSeq).toBe(2);
+  });
+
+  it("heals stored out-of-order stragglers across a restart", async () => {
+    const scope = makeScope();
+    const first = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await first.open();
+    await first.ingest(scope, [envelope(1), envelope(2), envelope(4)]);
+    first.dispose();
+
+    const second = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await second.open();
+    await second.resume(scope);
+    const status = await second.ingest(scope, [envelope(3)]);
+
+    // The restart scan rediscovered seq 4, so filling seq 3 heals the gap.
+    expect(status.ingestedThroughSeq).toBe(4);
+    expect(status.projectionReadyThroughSeq).toBe(4);
+  });
+
+  it("escalates exhausted retries to snapshot repair and recovers", async () => {
+    const repairFetch = vi.fn(async () => ({
+      snapshotThroughSeq: 2,
+      canonicalRecords: [
+        { recordKind: "brief" as const, recordId: "brief-1", record: { id: "brief-1" } },
+      ],
+    }));
+    const pipeline = new LedgerIngestionPipeline({
+      fetchers: {
+        fetchCanonicalRecords: async () => ({ recordsById: {}, missingIds: ["brief-1"] }),
+      },
+      snapshotRepair: { fetchProjectionSnapshot: repairFetch },
+      maxHydrationAttempts: 2,
+    });
+    await pipeline.open();
+    const scope = makeScope();
+
+    await pipeline.ingest(scope, [envelope(1), briefEvent(2, "brief-1")]);
+    // Each drain call is one bounded retry round.
+    for (let round = 0; round < 3; round += 1) await pipeline.drainHydration(scope);
+
+    expect(repairFetch.mock.calls.length).toBeGreaterThanOrEqual(1);
+    const status = pipeline.status(scope)!;
+    expect(status.state).toBe("idle");
+    expect(status.pendingHydrationJobs).toBe(0);
+    expect(status.projectionReadyThroughSeq).toBe(2);
+
+    const ledger = await openLedgerHandle();
+    expect(await ledger.getPendingHydrationJobs(scope)).toEqual([]);
+    ledger.close();
+  });
+
+  it("reports sync_error when repair cannot explain the divergence", async () => {
+    const statuses: string[] = [];
+    const pipeline = new LedgerIngestionPipeline({
+      fetchers: {
+        fetchCanonicalRecords: async () => ({
+          recordsById: { "brief-a": { record: { id: "brief-a" } } },
+          missingIds: ["brief-b"],
+        }),
+      },
+      snapshotRepair: {
+        fetchProjectionSnapshot: async () => ({
+          // Covers brief-a's event but not brief-b's later event.
+          snapshotThroughSeq: 2,
+          canonicalRecords: [],
+        }),
+      },
+      maxHydrationAttempts: 2,
+      onStatus: (status) => statuses.push(status.state),
+    });
+    await pipeline.open();
+    const scope = makeScope();
+
+    await pipeline.ingest(scope, [
+      envelope(1),
+      briefEvent(2, "brief-a"),
+      briefEvent(3, "brief-b"),
+    ]);
+    for (let round = 0; round < 4; round += 1) await pipeline.drainHydration(scope);
+
+    const status = pipeline.status(scope)!;
+    expect(status.state).toBe("sync_error");
+    expect(statuses).toContain("sync_error");
+    expect(status.lastError).toBe("hydration_diverged_after_snapshot_repair");
+    expect(status.failedHydrationJobs).toBe(1);
+    expect(status.blockedReason).toBe("pending_hydration");
+
+    // The failed job stays durable so a restart surfaces the same error.
+    const ledger = await openLedgerHandle();
+    const jobs = await ledger.getPendingHydrationJobs(scope);
+    expect(jobs.map((job) => [job.jobId, job.state])).toEqual([["brief:brief-b", "failed"]]);
+    ledger.close();
+  });
+
+  it("reports sync_error when no repair source exists", async () => {
+    const pipeline = new LedgerIngestionPipeline({
+      fetchers: {
+        fetchCanonicalRecords: async () => ({ recordsById: {}, missingIds: ["brief-1"] }),
+      },
+      maxHydrationAttempts: 1,
+    });
+    await pipeline.open();
+    const scope = makeScope();
+
+    await pipeline.ingest(scope, [briefEvent(1, "brief-1")]);
+    for (let round = 0; round < 2; round += 1) await pipeline.drainHydration(scope);
+
+    const status = pipeline.status(scope)!;
+    expect(status.state).toBe("sync_error");
+    expect(status.lastError).toBe("hydration_exhausted_without_repair_source");
+  });
+
+  it("never reuses a degraded handle: rebuilds and verifies before claiming exact", async () => {
+    const scope = makeScope();
+    let currentHandle: EventLedger | null = null;
+    let openCalls = 0;
+    const openLedger = async () => {
+      openCalls += 1;
+      const result = await EventLedger.open();
+      if (result.kind !== "available") return result;
+      currentHandle = result.ledger;
+      return result;
+    };
+    const pipeline = new LedgerIngestionPipeline({
+      fetchers: emptyFetchers(),
+      openLedger,
+    });
+    await pipeline.open();
+    await pipeline.ingest(scope, [envelope(1)]);
+    expect(openCalls).toBe(1);
+
+    // Simulate a degraded handle (e.g. superseded by a version change).
+    const degraded = currentHandle!;
+    degraded.noteSuperseded();
+    expect(degraded.durability).toBe("memory_only");
+
+    const status = await pipeline.ingest(scope, [envelope(2)]);
+    // The pipeline discarded the degraded handle, rebuilt, verified, and
+    // completed the ingest on the fresh exact handle.
+    expect(openCalls).toBe(2);
+    expect(status.durability).toBe("exact");
+    expect(status.ingestedThroughSeq).toBe(2);
+
+    const ledger = await openLedgerHandle();
+    const session = await ledger.getAgentSession(scope);
+    expect(session?.ingestedThroughSeq).toBe(2);
+    ledger.close();
+  });
+
+  it("rejects conflicting redelivery of the same event atomically", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const scope = makeScope();
+
+    await pipeline.ingest(scope, [envelope(1, { payload: { status: "a" } })]);
+    await expect(
+      pipeline.ingest(scope, [envelope(1, { payload: { status: "b" } })]),
+    ).rejects.toBeInstanceOf(LedgerIdentityConflictError);
+
+    const ledger = await openLedgerHandle();
+    const session = await ledger.getAgentSession(scope);
+    expect(session?.ingestedThroughSeq).toBe(1);
+    const stored = await ledger.getRawEvent(scope, 1);
+    expect((stored?.envelope as { payload?: { status?: string } }).payload?.status).toBe("a");
+    ledger.close();
+
+    // A fresh ingest after the conflict still works and stays monotonic.
+    const status = await pipeline.ingest(scope, [envelope(2)]);
+    expect(status.ingestedThroughSeq).toBe(2);
+  });
+});

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
@@ -1,0 +1,927 @@
+/**
+ * Durable raw ingestion pipeline (W2).
+ *
+ * Owns the ledger side of observer sync for one browser profile:
+ * - `ingest()` durably stores raw envelopes with their classification and
+ *   advances the contiguous ingestion cursor from stored content only —
+ *   never from page or stream metadata — so out-of-order delivery, live
+ *   duplicates, and filtered/semantic fetches can never fabricate coverage;
+ * - reference events create durable hydration jobs; deletes complete via
+ *   canonical tombstones; self-contained events are satisfied by ingestion;
+ * - `projectionReadyThroughSeq` advances only when every display-affecting
+ *   event below it is satisfied, so read markers (W5) can gate on it;
+ * - `resume()` is the restart scan: it rebuilds cursors from the ledger and
+ *   drains pending hydration before readiness may advance again;
+ * - bounded hydration retries escalate to projection snapshot repair, then
+ *   re-verification, then an explicit `sync_error` state;
+ * - a degraded ledger handle is never reused: writes require an explicit
+ *   rebuild-and-verify cycle before the pipeline may claim exactness again.
+ */
+
+import {
+  EventLedger,
+  type EventLedgerWriteBatch,
+  type LedgerHydrationJobRecord,
+} from "./ledger";
+import type { EventLedgerOpenResult } from "./ledger";
+import type { LedgerDurability } from "./errors";
+import {
+  classifyEnvelope,
+  type ClassifiedEnvelope,
+} from "./classification";
+import type { LedgerRecordKind, LedgerScopeKey } from "./keys";
+
+/** How far above the contiguous cursor resume() scans for stored stragglers. */
+const RESUME_LOOKAHEAD_SEQ = 1_000;
+const DEFAULT_MAX_HYDRATION_ATTEMPTS = 5;
+const DEFAULT_HYDRATION_BATCH_SIZE = 64;
+
+export interface LedgerHydrationFetchers {
+  /**
+   * Fetch canonical records for one record kind. `missingIds` covers ids the
+   * server could not serve; a returned record without a revision cannot
+   * prove satisfaction of jobs that expect a revision.
+   */
+  fetchCanonicalRecords(
+    agentId: string,
+    recordKind: LedgerRecordKind,
+    recordIds: string[],
+  ): Promise<{
+    recordsById: Record<string, { record: unknown; revision?: string | number }>;
+    missingIds: string[];
+  }>;
+}
+
+export interface ProjectionSnapshotRepairSource {
+  /**
+   * Fetch an authoritative projection snapshot for repair. Returns null
+   * when repair is unavailable (capability absent or request failed).
+   */
+  fetchProjectionSnapshot(scope: LedgerScopeKey): Promise<{
+    snapshotThroughSeq: number;
+    canonicalRecords: Array<{
+      recordKind: LedgerRecordKind;
+      recordId: string;
+      record: unknown;
+      revision?: string | number;
+    }>;
+  } | null>;
+}
+
+export type LedgerIngestionState =
+  | "idle"
+  | "draining"
+  | "repairing"
+  | "sync_error"
+  | "memory_only";
+
+export interface LedgerIngestionStatus {
+  scope: LedgerScopeKey;
+  durability: LedgerDurability;
+  state: LedgerIngestionState;
+  ingestedThroughSeq?: number;
+  projectionReadyThroughSeq?: number;
+  observedEventHeadSeq?: number;
+  pendingHydrationJobs: number;
+  failedHydrationJobs: number;
+  blockedByEventSeq?: number;
+  blockedReason?: "pending_hydration" | "unknown_envelope_version";
+  lastError?: string;
+}
+
+export interface IngestionPipelineDependencies {
+  fetchers: LedgerHydrationFetchers;
+  snapshotRepair?: ProjectionSnapshotRepairSource;
+  onStatus?: (status: LedgerIngestionStatus) => void;
+  maxHydrationAttempts?: number;
+  hydrationBatchSize?: number;
+  /**
+   * Ledger handle factory. Production uses the default `EventLedger.open`;
+   * tests inject a controllable opener to observe explicit rebuilds after a
+   * degraded handle is discarded.
+   */
+  openLedger?: () => Promise<EventLedgerOpenResult>;
+}
+
+interface HydrationJobView {
+  jobId: string;
+  recordKind: LedgerRecordKind;
+  recordId: string;
+  createdByEventSeq: number;
+  expectedRevision?: string | number;
+  attemptCount: number;
+  lastErrorKind?: string;
+  lastAttemptAt?: number;
+  state: "pending" | "failed";
+  createdAt: number;
+}
+
+type Blocker =
+  | { kind: "pending_hydration"; jobId: string }
+  | { kind: "unknown_envelope_version" };
+
+interface ScopeTracker {
+  contiguousThrough: number;
+  readyThrough: number;
+  observedHead: number;
+  outOfOrder: Set<number>;
+  blockers: Map<number, Blocker>;
+  jobs: Map<string, HydrationJobView>;
+  state: LedgerIngestionState;
+  lastError?: string;
+  draining: Promise<void> | null;
+  loaded: boolean;
+}
+
+export interface CanonicalTombstone {
+  tombstone: true;
+  deletedAt: number;
+  deletedByEventSeq?: number;
+}
+
+export function isCanonicalTombstone(record: unknown): record is CanonicalTombstone {
+  return (
+    !!record &&
+    typeof record === "object" &&
+    (record as { tombstone?: unknown }).tombstone === true
+  );
+}
+
+function jobIdFor(recordKind: LedgerRecordKind, recordId: string): string {
+  return `${recordKind}:${recordId}`;
+}
+
+function remoteScopeOf(scope: LedgerScopeKey) {
+  return {
+    remoteKey: scope.remoteKey,
+    runtimeId: scope.runtimeId,
+    visibilityScopeId: scope.visibilityScopeId,
+    eventLogEpoch: scope.eventLogEpoch,
+  };
+}
+
+function revisionSatisfies(
+  expected: string | number | undefined,
+  actual: string | number | undefined,
+): boolean {
+  if (expected === undefined) return true;
+  if (actual === undefined) return false;
+  if (typeof expected === "number" && typeof actual === "number") {
+    return actual >= expected;
+  }
+  return String(actual) >= String(expected);
+}
+
+/**
+ * Durable ingestion pipeline over one event ledger. All cursor advances are
+ * computed from stored raw events, committed atomically with the events and
+ * jobs they describe, and never regressed.
+ */
+export class LedgerIngestionPipeline {
+  private ledger: EventLedger | null = null;
+  private readonly trackers = new Map<string, ScopeTracker>();
+  private readonly maxAttempts: number;
+  private readonly batchSize: number;
+
+  constructor(private readonly dependencies: IngestionPipelineDependencies) {
+    this.maxAttempts = dependencies.maxHydrationAttempts ?? DEFAULT_MAX_HYDRATION_ATTEMPTS;
+    this.batchSize = dependencies.hydrationBatchSize ?? DEFAULT_HYDRATION_BATCH_SIZE;
+  }
+
+  /** Open the ledger handle. Returns false when only memory remains. */
+  async open(): Promise<boolean> {
+    if (this.ledger?.durability === "exact") return true;
+    const result = await (this.dependencies.openLedger?.() ?? EventLedger.open());
+    if (result.kind !== "available") return false;
+    this.ledger = result.ledger;
+    return true;
+  }
+
+  /** Close the handle and forget in-memory trackers. */
+  dispose(): void {
+    this.ledger?.close();
+    this.ledger = null;
+    this.trackers.clear();
+  }
+
+  /**
+   * Restart scan for one scope: rebuild cursors, blockers, and pending jobs
+   * from durable state, then drain pending hydration. Readiness never
+   * advances past unsatisfied durable demand, so a crash between event
+   * persistence and hydration simply resumes here.
+   */
+  async resume(scope: LedgerScopeKey): Promise<LedgerIngestionStatus> {
+    const tracker = await this.ensureTracker(scope);
+    if (tracker.jobs.size > 0) {
+      void this.drainHydration(scope).catch(() => undefined);
+    }
+    return this.statusFor(scope, tracker);
+  }
+
+  /**
+   * Restart scan for every known scope of one remote key. Used on cache
+   * (re)initialization to resume pending hydration work after a reload.
+   */
+  async resumeRemote(remoteKey: string): Promise<void> {
+    if (!(await this.ensureExactHandle())) return;
+    const scopes = await this.ledger!.listRuntimeScopesByRemoteKey(remoteKey);
+    for (const runtimeScope of scopes) {
+      const sessions = await this.ledger!.listAgentSessions({
+        remoteKey: runtimeScope.remoteKey,
+        runtimeId: runtimeScope.runtimeId,
+        visibilityScopeId: runtimeScope.visibilityScopeId,
+        eventLogEpoch: runtimeScope.eventLogEpoch,
+      });
+      for (const session of sessions) {
+        await this.resume({
+          remoteKey: session.remoteKey,
+          runtimeId: session.runtimeId,
+          visibilityScopeId: session.visibilityScopeId,
+          eventLogEpoch: session.eventLogEpoch,
+          agentId: session.agentId,
+        });
+      }
+    }
+  }
+
+  /**
+   * Ingest raw envelopes atomically: raw events, hydration jobs, tombstones,
+   * the contiguous ingestion cursor, observed head, and the readiness
+   * cursor land in one transaction or not at all.
+   */
+  async ingest(
+    scope: LedgerScopeKey,
+    envelopes: Array<Record<string, unknown>>,
+  ): Promise<LedgerIngestionStatus> {
+    const tracker = await this.ensureTracker(scope);
+    if (!(await this.ensureExactHandle())) {
+      return this.statusFor(scope, tracker);
+    }
+    const ledger = this.ledger!;
+    const classified = envelopes
+      .map((envelope) => ({ envelope, classified: classifyEnvelope(envelope) }))
+      .sort((a, b) => a.classified.eventSeq - b.classified.eventSeq);
+    if (classified.length === 0) return this.statusFor(scope, tracker);
+
+    const batch = ledger.beginWrite();
+    const jobUpdates = new Map<string, HydrationJobView>();
+    const newSeqs: number[] = [];
+    const now = Date.now();
+
+    for (const item of classified) {
+      batch.putRawEvent(scope, item.classified.eventSeq, item.envelope, item.classified.classification);
+      newSeqs.push(item.classified.eventSeq);
+      if (item.classified.blocksReadiness) {
+        tracker.blockers.set(item.classified.eventSeq, { kind: "unknown_envelope_version" });
+        continue;
+      }
+      if (item.classified.classification.projectionEffect !== "display_invalidation") continue;
+      if (item.classified.tombstone) {
+        const jobId = jobIdFor(item.classified.tombstone.recordKind, item.classified.tombstone.recordId);
+        batch.putCanonicalRecord(
+          scope,
+          item.classified.tombstone.recordKind,
+          item.classified.tombstone.recordId,
+          {
+            tombstone: true,
+            deletedAt: now,
+            deletedByEventSeq: item.classified.eventSeq,
+          } satisfies CanonicalTombstone,
+        );
+        // A delete completes any outstanding hydration demand for the record.
+        this.removeJobAndBlockers(tracker, jobId, batch, scope);
+        continue;
+      }
+      if (item.classified.reference) {
+        const jobId = jobIdFor(item.classified.reference.recordKind, item.classified.reference.recordId);
+        const existing = tracker.jobs.get(jobId) ?? jobUpdates.get(jobId);
+        const merged: HydrationJobView = existing
+          ? {
+              ...existing,
+              createdByEventSeq: Math.min(existing.createdByEventSeq, item.classified.eventSeq),
+              expectedRevision:
+                item.classified.reference.expectedRevision ?? existing.expectedRevision,
+              state: "pending",
+            }
+          : {
+              jobId,
+              recordKind: item.classified.reference.recordKind,
+              recordId: item.classified.reference.recordId,
+              createdByEventSeq: item.classified.eventSeq,
+              expectedRevision: item.classified.reference.expectedRevision,
+              attemptCount: 0,
+              state: "pending",
+              createdAt: now,
+            };
+        jobUpdates.set(jobId, merged);
+        tracker.jobs.set(jobId, merged);
+        tracker.blockers.set(item.classified.eventSeq, { kind: "pending_hydration", jobId });
+        continue;
+      }
+      // Self-contained display events carry their projection payload in the
+      // envelope; ingestion itself satisfies them.
+    }
+
+    for (const job of jobUpdates.values()) {
+      batch.putHydrationJob(scope, this.jobRecordFromView(scope, job));
+    }
+
+    const contiguous = this.advanceContiguity(tracker, newSeqs);
+    if (contiguous > tracker.contiguousThrough) {
+      batch.advanceIngestionCursor(scope, contiguous);
+      tracker.contiguousThrough = contiguous;
+    }
+    const observedHead = Math.max(tracker.observedHead, ...newSeqs);
+    if (observedHead > tracker.observedHead) {
+      batch.putRuntimeScope(remoteScopeOf(scope), { eventHeadSeq: observedHead });
+      tracker.observedHead = observedHead;
+    }
+
+    const ready = this.computeReady(tracker);
+    if (ready > tracker.readyThrough) {
+      batch.applyProjectionChange(scope, { projectionReadyThroughSeq: ready });
+      tracker.readyThrough = ready;
+    }
+
+    try {
+      await batch.commit();
+    } catch (error) {
+      // Durable-first: on failure the tracker's durable view is reloaded so
+      // in-memory cursors never run ahead of committed state.
+      this.trackers.delete(this.trackerKey(scope));
+      if (this.isDurabilityFailure(error)) {
+        return this.statusFor(scope, this.freshTracker());
+      }
+      throw error;
+    }
+
+    const status = this.statusFor(scope, tracker);
+    this.dependencies.onStatus?.(status);
+    if (jobUpdates.size > 0) {
+      void this.drainHydration(scope).catch(() => undefined);
+    }
+    return status;
+  }
+
+  /**
+   * Complete one canonical record via tombstone: the tombstone and the
+   * removal of any outstanding hydration job for the record commit
+   * atomically, and readiness may advance past the satisfied demand.
+   */
+  async applyTombstone(
+    scope: LedgerScopeKey,
+    recordKind: LedgerRecordKind,
+    recordId: string,
+    deletedByEventSeq?: number,
+  ): Promise<void> {
+    const tracker = await this.ensureTracker(scope);
+    if (!(await this.ensureExactHandle())) return;
+    const jobId = jobIdFor(recordKind, recordId);
+    const batch = this.ledger!.beginWrite();
+    batch.putCanonicalRecord(scope, recordKind, recordId, {
+      tombstone: true,
+      deletedAt: Date.now(),
+      deletedByEventSeq,
+    } satisfies CanonicalTombstone);
+    this.removeJobAndBlockers(tracker, jobId, batch, scope);
+    const ready = this.computeReady(tracker);
+    if (ready > tracker.readyThrough) {
+      batch.applyProjectionChange(scope, { projectionReadyThroughSeq: ready });
+    }
+    try {
+      await batch.commit();
+      tracker.readyThrough = ready;
+    } catch (error) {
+      this.trackers.delete(this.trackerKey(scope));
+      if (this.isDurabilityFailure(error)) return;
+      throw error;
+    }
+    this.emit(scope, tracker);
+  }
+
+  /**
+   * Drain pending hydration jobs: fetch canonical records in bounded
+   * batches, complete satisfied jobs atomically with their records, bump
+   * durable retry counters on failures, and escalate exhausted jobs to
+   * snapshot repair followed by re-verification.
+   */
+  async drainHydration(scope: LedgerScopeKey): Promise<void> {
+    const tracker = this.trackers.get(this.trackerKey(scope));
+    if (!tracker) return;
+    if (tracker.draining) return tracker.draining;
+    const run = this.drainHydrationInner(scope, tracker)
+      .finally(() => {
+        if (tracker.draining === run) tracker.draining = null;
+      });
+    tracker.draining = run;
+    return run;
+  }
+
+  private async drainHydrationInner(
+    scope: LedgerScopeKey,
+    tracker: ScopeTracker,
+  ): Promise<void> {
+    // Nothing to drain: leave the tracker's terminal state (idle,
+    // sync_error, memory_only) untouched instead of clobbering it.
+    const hasPendingWork = Array.from(tracker.jobs.values()).some(
+      (job) => job.state === "pending",
+    );
+    if (!hasPendingWork) return;
+    if (!(await this.ensureExactHandle())) return;
+    const ledger = this.ledger!;
+    tracker.state = "draining";
+    this.emit(scope, tracker);
+
+    const pending = () =>
+      Array.from(tracker.jobs.values())
+        .filter((job) => job.state === "pending")
+        .sort((a, b) => a.createdByEventSeq - b.createdByEventSeq);
+
+    let jobs = pending().slice(0, this.batchSize);
+    while (jobs.length > 0) {
+      const byKind = new Map<LedgerRecordKind, HydrationJobView[]>();
+      for (const job of jobs) {
+        const list = byKind.get(job.recordKind) ?? [];
+        list.push(job);
+        byKind.set(job.recordKind, list);
+      }
+
+      const fetched = new Map<
+        string,
+        { record: unknown; revision?: string | number } | undefined
+      >();
+      let fetchError: string | undefined;
+      for (const [recordKind, kindJobs] of byKind) {
+        try {
+          const result = await this.dependencies.fetchers.fetchCanonicalRecords(
+            scope.agentId,
+            recordKind,
+            kindJobs.map((job) => job.recordId),
+          );
+          for (const job of kindJobs) {
+            fetched.set(job.jobId, result.recordsById[job.recordId]);
+          }
+        } catch (error) {
+          fetchError = error instanceof Error ? error.message : String(error);
+        }
+      }
+
+      const completion = ledger.beginWrite();
+      let completed = 0;
+      const retryJobs: HydrationJobView[] = [];
+      for (const job of jobs) {
+        const fetchedRecord = fetchError ? undefined : fetched.get(job.jobId);
+        if (
+          fetchedRecord &&
+          (isCanonicalTombstone(fetchedRecord.record) ||
+            revisionSatisfies(job.expectedRevision, fetchedRecord.revision))
+        ) {
+          completion.putCanonicalRecord(
+            scope,
+            job.recordKind,
+            job.recordId,
+            fetchedRecord.record,
+            fetchedRecord.revision,
+          );
+          completion.deleteHydrationJob(scope, job.jobId);
+          this.removeJobAndBlockers(tracker, job.jobId, null, scope);
+          completed += 1;
+        } else {
+          retryJobs.push({
+            ...job,
+            attemptCount: job.attemptCount + 1,
+            lastAttemptAt: Date.now(),
+            lastErrorKind: fetchError ? "request_failed" : "missing_or_unproven",
+          });
+        }
+      }
+      const ready = this.computeReady(tracker);
+      if (ready > tracker.readyThrough) {
+        completion.applyProjectionChange(scope, { projectionReadyThroughSeq: ready });
+      }
+      if (completed > 0 || ready > tracker.readyThrough) {
+        try {
+          await completion.commit();
+          tracker.readyThrough = ready;
+        } catch (error) {
+          if (this.isDurabilityFailure(error)) {
+            tracker.state = "memory_only";
+            tracker.lastError = String(error);
+            this.emit(scope, tracker);
+            return;
+          }
+          throw error;
+        }
+      }
+      // Persist durable retry bookkeeping (including the failed marker) in
+      // one batch so a restart never resurrects exhausted jobs as fresh.
+      if (retryJobs.length > 0) {
+        const retryBatch = ledger.beginWrite();
+        for (const job of retryJobs) {
+          const exhausted = job.attemptCount >= this.maxAttempts;
+          const updated: HydrationJobView = {
+            ...job,
+            state: exhausted ? "failed" : "pending",
+          };
+          tracker.jobs.set(job.jobId, updated);
+          retryBatch.putHydrationJob(scope, this.jobRecordFromView(scope, updated));
+        }
+        await retryBatch.commit().catch(() => undefined);
+      }
+
+      const hasFailedJobs = Array.from(tracker.jobs.values()).some(
+        (job) => job.state === "failed",
+      );
+      let repairedThisRound = false;
+      if (hasFailedJobs) {
+        const repaired = await this.repairFromSnapshot(scope, tracker);
+        if (!repaired) return;
+        repairedThisRound = true;
+      }
+      jobs = pending().slice(0, this.batchSize);
+      if (jobs.length === 0) break;
+      // Keep looping only while rounds make durable progress (records or
+      // repair); otherwise the next ingest or retry re-triggers the drain.
+      if (completed === 0 && !repairedThisRound) break;
+    }
+
+    const hasFailedJobs = Array.from(tracker.jobs.values()).some(
+      (job) => job.state === "failed",
+    );
+    if (pending().length === 0 && !hasFailedJobs) {
+      tracker.state = "idle";
+    }
+    this.emit(scope, tracker);
+  }
+
+  /**
+   * Bounded-retry escalation: install an authoritative projection snapshot,
+   * clear the jobs it covers, re-verify remaining demand, and fall through
+   * to an explicit sync error when divergence persists.
+   */
+  private async repairFromSnapshot(
+    scope: LedgerScopeKey,
+    tracker: ScopeTracker,
+  ): Promise<boolean> {
+    const repairSource = this.dependencies.snapshotRepair;
+    if (!repairSource) {
+      tracker.state = "sync_error";
+      tracker.lastError = "hydration_exhausted_without_repair_source";
+      this.emit(scope, tracker);
+      return false;
+    }
+    tracker.state = "repairing";
+    this.emit(scope, tracker);
+    let snapshot: Awaited<ReturnType<ProjectionSnapshotRepairSource["fetchProjectionSnapshot"]>>;
+    try {
+      snapshot = await repairSource.fetchProjectionSnapshot(scope);
+    } catch {
+      snapshot = null;
+    }
+    if (!snapshot || !(await this.ensureExactHandle())) {
+      tracker.state = "sync_error";
+      tracker.lastError = snapshot ? "ledger_degraded_during_repair" : "snapshot_repair_unavailable";
+      this.emit(scope, tracker);
+      return false;
+    }
+    const ledger = this.ledger!;
+    const batch = ledger.beginWrite();
+    for (const record of snapshot.canonicalRecords) {
+      batch.putCanonicalRecord(
+        scope,
+        record.recordKind,
+        record.recordId,
+        record.record,
+        record.revision,
+      );
+    }
+    for (const job of tracker.jobs.values()) {
+      if (job.createdByEventSeq <= snapshot.snapshotThroughSeq) {
+        batch.deleteHydrationJob(scope, job.jobId);
+      }
+    }
+    const readyTarget = Math.min(
+      Math.max(tracker.readyThrough, snapshot.snapshotThroughSeq),
+      tracker.contiguousThrough,
+    );
+    if (readyTarget > tracker.readyThrough) {
+      batch.applyProjectionChange(scope, { projectionReadyThroughSeq: readyTarget });
+    }
+    try {
+      await batch.commit();
+    } catch (error) {
+      if (this.isDurabilityFailure(error)) {
+        tracker.state = "memory_only";
+        tracker.lastError = String(error);
+      } else {
+        tracker.state = "sync_error";
+        tracker.lastError = String(error);
+      }
+      this.emit(scope, tracker);
+      return false;
+    }
+    for (const job of Array.from(tracker.jobs.values())) {
+      if (job.createdByEventSeq <= snapshot.snapshotThroughSeq) {
+        this.removeJobAndBlockers(tracker, job.jobId, null, scope);
+      }
+    }
+    tracker.readyThrough = readyTarget;
+    const ready = this.computeReady(tracker);
+    if (ready > tracker.readyThrough) {
+      const advance = ledger.beginWrite();
+      advance.applyProjectionChange(scope, { projectionReadyThroughSeq: ready });
+      await advance.commit().catch(() => undefined);
+      tracker.readyThrough = ready;
+    }
+
+    // Re-verify: leftover demand beyond the snapshot boundary is new work
+    // the snapshot cannot speak to. Pending jobs keep draining; a failed
+    // job beyond the boundary is divergence bounded retries and the
+    // authoritative snapshot both failed to explain.
+    const beyondBoundary = Array.from(tracker.jobs.values()).filter(
+      (job) => job.createdByEventSeq > snapshot.snapshotThroughSeq,
+    );
+    if (beyondBoundary.some((job) => job.state === "failed")) {
+      tracker.state = "sync_error";
+      tracker.lastError = "hydration_diverged_after_snapshot_repair";
+      this.emit(scope, tracker);
+      return false;
+    }
+    tracker.state = beyondBoundary.length > 0 ? "draining" : "idle";
+    this.emit(scope, tracker);
+    return true;
+  }
+
+  /** Current status for one scope; `null` before the scope is known. */
+  status(scope: LedgerScopeKey): LedgerIngestionStatus | null {
+    const tracker = this.trackers.get(this.trackerKey(scope));
+    return tracker ? this.statusFor(scope, tracker) : null;
+  }
+
+  /**
+   * Read-marker gate (W5): the highest delivery seq a read state may claim,
+   * plus the seq and reason readiness is currently blocked at.
+   */
+  readinessGate(
+    scope: LedgerScopeKey,
+  ): {
+    readyThroughSeq: number;
+    ingestedThroughSeq: number;
+    blockedByEventSeq?: number;
+    blockedReason?: "pending_hydration" | "unknown_envelope_version";
+  } {
+    const tracker = this.trackers.get(this.trackerKey(scope)) ?? this.freshTracker();
+    const blockedSeq = Math.min(
+      ...(tracker.blockers.size > 0 ? Array.from(tracker.blockers.keys()) : [Infinity]),
+    );
+    const blocker = Number.isFinite(blockedSeq) ? tracker.blockers.get(blockedSeq) : undefined;
+    return {
+      readyThroughSeq: tracker.readyThrough,
+      ingestedThroughSeq: tracker.contiguousThrough,
+      blockedByEventSeq: Number.isFinite(blockedSeq) ? blockedSeq : undefined,
+      blockedReason: blocker?.kind,
+    };
+  }
+
+  /** Explicitly rebuild a degraded handle and verify it before reuse. */
+  async rebuildHandle(): Promise<boolean> {
+    return this.ensureExactHandle();
+  }
+
+  private async ensureTracker(scope: LedgerScopeKey): Promise<ScopeTracker> {
+    const key = this.trackerKey(scope);
+    const existing = this.trackers.get(key);
+    if (existing?.loaded) return existing;
+    const tracker = this.freshTracker();
+    this.trackers.set(key, tracker);
+    if (!(await this.ensureExactHandle())) {
+      tracker.state = "memory_only";
+      return tracker;
+    }
+    const ledger = this.ledger!;
+    const [session, runtimeScope, jobs] = await Promise.all([
+      ledger.getAgentSession(scope),
+      ledger.getRuntimeScope(remoteScopeOf(scope)),
+      ledger.getPendingHydrationJobs(scope),
+    ]);
+    tracker.contiguousThrough = session?.ingestedThroughSeq ?? 0;
+    tracker.readyThrough = Math.min(
+      session?.projectionReadyThroughSeq ?? 0,
+      tracker.contiguousThrough,
+    );
+    tracker.observedHead = runtimeScope?.eventHeadSeq ?? tracker.contiguousThrough;
+    for (const job of jobs) {
+      const view = this.jobViewFromRecord(job);
+      tracker.jobs.set(view.jobId, view);
+    }
+    // Rebuild blockers for the open window only: everything at or below
+    // readyThrough is satisfied by definition.
+    if (tracker.contiguousThrough > tracker.readyThrough) {
+      const window = await ledger.getRawEventsBetween(
+        scope,
+        tracker.readyThrough + 1,
+        tracker.contiguousThrough,
+      );
+      for (const event of window) {
+        this.registerBlocker(tracker, this.classifyStored(event));
+      }
+    }
+    // Discover stored stragglers above the contiguous cursor so later
+    // gap-filling ingests can count them without re-delivery.
+    const stragglers = await ledger.getRawEventsBetween(
+      scope,
+      tracker.contiguousThrough + 1,
+      tracker.contiguousThrough + RESUME_LOOKAHEAD_SEQ,
+    );
+    for (const event of stragglers) {
+      if (event.eventSeq > tracker.contiguousThrough) {
+        tracker.outOfOrder.add(event.eventSeq);
+      }
+    }
+    tracker.loaded = true;
+    return tracker;
+  }
+
+  private registerBlocker(tracker: ScopeTracker, item: ClassifiedEnvelope): void {
+    if (item.blocksReadiness) {
+      tracker.blockers.set(item.eventSeq, { kind: "unknown_envelope_version" });
+      return;
+    }
+    if (item.classification.projectionEffect !== "display_invalidation") return;
+    if (item.reference) {
+      const jobId = jobIdFor(item.reference.recordKind, item.reference.recordId);
+      // A job that is already gone was satisfied; only pending demand blocks.
+      if (tracker.jobs.has(jobId)) {
+        tracker.blockers.set(item.eventSeq, { kind: "pending_hydration", jobId });
+      }
+    }
+    // Self-contained and tombstoned events never block.
+  }
+
+  private classifyStored(event: {
+    eventSeq: number;
+    envelope: unknown;
+    classification: { projectionEffect: "none" | "display_invalidation"; envelopeContractVersion?: number };
+  }): ReturnType<typeof classifyEnvelope> {
+    return classifyEnvelope({
+      ...(typeof event.envelope === "object" && event.envelope !== null
+        ? (event.envelope as Record<string, unknown>)
+        : {}),
+      event_seq: event.eventSeq,
+      projection_effect: event.classification.projectionEffect,
+      contract_version: event.classification.envelopeContractVersion,
+    });
+  }
+
+  private advanceContiguity(tracker: ScopeTracker, newSeqs: number[]): number {
+    for (const seq of newSeqs) {
+      if (seq > tracker.contiguousThrough) tracker.outOfOrder.add(seq);
+    }
+    let next = tracker.contiguousThrough + 1;
+    while (tracker.outOfOrder.has(next)) {
+      tracker.outOfOrder.delete(next);
+      next += 1;
+    }
+    return next - 1;
+  }
+
+  private computeReady(tracker: ScopeTracker): number {
+    let next = tracker.readyThrough + 1;
+    while (next <= tracker.contiguousThrough && !tracker.blockers.has(next)) {
+      next += 1;
+    }
+    return next - 1;
+  }
+
+  private removeJobAndBlockers(
+    tracker: ScopeTracker,
+    jobId: string,
+    batch: EventLedgerWriteBatch | null,
+    scope: LedgerScopeKey,
+  ): void {
+    tracker.jobs.delete(jobId);
+    if (batch) batch.deleteHydrationJob(scope, jobId);
+    for (const [seq, blocker] of tracker.blockers) {
+      if (blocker.kind === "pending_hydration" && blocker.jobId === jobId) {
+        tracker.blockers.delete(seq);
+      }
+    }
+  }
+
+  private jobRecordFromView(
+    scope: LedgerScopeKey,
+    job: HydrationJobView,
+  ): LedgerHydrationJobRecord {
+    return {
+      ...scope,
+      jobId: job.jobId,
+      recordKind: job.recordKind,
+      recordId: job.recordId,
+      createdByEventSeq: job.createdByEventSeq,
+      expectedRevision: job.expectedRevision,
+      attemptCount: job.attemptCount,
+      lastAttemptAt: job.lastAttemptAt,
+      lastErrorKind: job.lastErrorKind,
+      state: job.state,
+      createdAt: job.createdAt,
+    };
+  }
+
+  private jobViewFromRecord(record: LedgerHydrationJobRecord): HydrationJobView {
+    return {
+      jobId: record.jobId,
+      recordKind: record.recordKind,
+      recordId: record.recordId,
+      createdByEventSeq: record.createdByEventSeq,
+      expectedRevision: record.expectedRevision,
+      attemptCount: record.attemptCount ?? 0,
+      lastErrorKind: record.lastErrorKind,
+      state: record.state === "failed" ? "failed" : "pending",
+      createdAt: record.createdAt,
+    };
+  }
+
+  private async ensureExactHandle(): Promise<boolean> {
+    if (this.ledger?.durability === "exact") return true;
+    // Never reuse a degraded handle (W1 review note): close it, open a new
+    // one, and verify the new handle serves the same durable database.
+    this.ledger?.close();
+    const result = await (this.dependencies.openLedger?.() ?? EventLedger.open());
+    if (result.kind !== "available") return false;
+    this.ledger = result.ledger;
+    try {
+      await this.ledger.getMigrationMeta<{ metaKey: string }>("baseline");
+      return true;
+    } catch {
+      this.ledger.close();
+      this.ledger = null;
+      return false;
+    }
+  }
+
+  private isDurabilityFailure(error: unknown): boolean {
+    const name = error instanceof Error ? error.name : "";
+    return (
+      name === "LedgerQuotaError" ||
+      name === "LedgerTransactionAbortedError" ||
+      name === "LedgerUnavailableError"
+    );
+  }
+
+  private emit(scope: LedgerScopeKey, tracker: ScopeTracker): void {
+    this.dependencies.onStatus?.(this.statusFor(scope, tracker));
+  }
+
+  private statusFor(scope: LedgerScopeKey, tracker: ScopeTracker): LedgerIngestionStatus {
+    const blockedSeq = Math.min(
+      ...(tracker.blockers.size > 0 ? Array.from(tracker.blockers.keys()) : [Infinity]),
+    );
+    const blocker = Number.isFinite(blockedSeq) ? tracker.blockers.get(blockedSeq) : undefined;
+    let pendingJobs = 0;
+    let failedJobs = 0;
+    for (const job of tracker.jobs.values()) {
+      if (job.state === "failed") failedJobs += 1;
+      else pendingJobs += 1;
+    }
+    const durability: LedgerDurability = this.ledger?.durability ?? "memory_only";
+    const state: LedgerIngestionState =
+      durability !== "exact" ? "memory_only" : tracker.state;
+    return {
+      scope,
+      durability,
+      state,
+      ingestedThroughSeq: tracker.contiguousThrough || undefined,
+      projectionReadyThroughSeq: tracker.readyThrough || undefined,
+      observedEventHeadSeq: tracker.observedHead || undefined,
+      pendingHydrationJobs: pendingJobs,
+      failedHydrationJobs: failedJobs,
+      blockedByEventSeq: Number.isFinite(blockedSeq) ? blockedSeq : undefined,
+      blockedReason: blocker?.kind,
+      lastError: tracker.lastError,
+    };
+  }
+
+  private freshTracker(): ScopeTracker {
+    return {
+      contiguousThrough: 0,
+      readyThrough: 0,
+      observedHead: 0,
+      outOfOrder: new Set(),
+      blockers: new Map(),
+      jobs: new Map(),
+      state: "idle",
+      draining: null,
+      loaded: false,
+    };
+  }
+
+  private trackerKey(scope: LedgerScopeKey): string {
+    return [
+      scope.remoteKey,
+      scope.runtimeId,
+      scope.visibilityScopeId,
+      scope.eventLogEpoch,
+      scope.agentId,
+    ].join("\u0000");
+  }
+}

--- a/web-gui/app/src/runtime/event-ledger/ledger.ts
+++ b/web-gui/app/src/runtime/event-ledger/ledger.ts
@@ -82,6 +82,18 @@ export interface LedgerHydrationJobRecord {
   recordKind: LedgerRecordKind;
   recordId: string;
   createdByEventSeq: number;
+  /**
+   * Minimum canonical revision that satisfies this job, when the creating
+   * event names one. A canonical record (or tombstone) with a revision >=
+   * this value completes the job; a fetched record without a revision cannot
+   * prove satisfaction and leaves the job pending.
+   */
+  expectedRevision?: string | number;
+  /** Durable retry bookkeeping; `failed` marks exhausted bounded retries. */
+  attemptCount?: number;
+  lastAttemptAt?: number;
+  lastErrorKind?: string;
+  state?: "pending" | "failed";
   createdAt: number;
 }
 
@@ -106,6 +118,12 @@ export interface LedgerAgentSessionRecord {
   agentId: string;
   /** Contiguous raw ingestion cursor: every event <= this seq is durably stored. */
   ingestedThroughSeq?: number;
+  /**
+   * Projection readiness cursor: every display-affecting event <= this seq
+   * is durably stored AND satisfied (applied directly, hydrated, or
+   * tombstoned). Never exceeds ingestedThroughSeq.
+   */
+  projectionReadyThroughSeq?: number;
   /** Projection revision anchor after applying directly applicable events. */
   projectionRevision?: number;
   projection?: unknown;
@@ -155,6 +173,7 @@ type WriteOperation =
       classification: RawEventClassification;
     }
   | { kind: "hydration_job"; scope: LedgerScopeKey; job: LedgerHydrationJobRecord }
+  | { kind: "hydration_job_delete"; scope: LedgerScopeKey; jobId: string }
   | {
       kind: "canonical_record";
       scope: LedgerScopeKey;
@@ -166,6 +185,19 @@ type WriteOperation =
   | { kind: "agent_session"; scope: LedgerScopeKey; patch: AgentSessionPatch }
   | { kind: "runtime_scope"; scope: LedgerRemoteScopeKey; patch: RuntimeScopePatch }
   | { kind: "read_state"; scope: LedgerScopeKey; patch: ReadStatePatch };
+
+/*
+ * Agent-session patches share one patch channel: per-scope patches inside one
+ * batch coalesce by ordered spread and the merged value is written once. Both
+ * cursors are validated monotonically against the value observed inside the
+ * same transaction, so a coalesced patch can never regress either cursor.
+ */
+type AgentSessionCursorField = "ingestedThroughSeq" | "projectionReadyThroughSeq";
+
+const CURSOR_FIELDS: readonly AgentSessionCursorField[] = [
+  "ingestedThroughSeq",
+  "projectionReadyThroughSeq",
+];
 
 /** Composable write batch; `commit()` runs as one atomic transaction. */
 export class EventLedgerWriteBatch {
@@ -193,6 +225,17 @@ export class EventLedgerWriteBatch {
   putHydrationJob(scope: LedgerScopeKey, job: LedgerHydrationJobRecord): this {
     this.assertNotCommitted();
     this.ops.push({ kind: "hydration_job", scope, job });
+    return this;
+  }
+
+  /**
+   * Remove one durable hydration job. Intended to land in the same
+   * transaction as the canonical record (or tombstone) that satisfies it,
+   * so completion is all-or-nothing.
+   */
+  deleteHydrationJob(scope: LedgerScopeKey, jobId: string): this {
+    this.assertNotCommitted();
+    this.ops.push({ kind: "hydration_job_delete", scope, jobId });
     return this;
   }
 
@@ -259,6 +302,9 @@ export class EventLedgerWriteBatch {
           storeNames.add(AGENT_SESSIONS_STORE);
           break;
         case "hydration_job":
+          storeNames.add(PENDING_HYDRATION_STORE);
+          break;
+        case "hydration_job_delete":
           storeNames.add(PENDING_HYDRATION_STORE);
           break;
         case "canonical_record":
@@ -411,6 +457,14 @@ export class EventLedgerWriteBatch {
           });
           break;
         }
+        case "hydration_job_delete": {
+          const jobs = tx.objectStore(PENDING_HYDRATION_STORE);
+          const del = issue(() => jobs.delete(hydrationJobKey(op.scope, op.jobId)));
+          del?.addEventListener("error", () => {
+            failure = failure ?? (del.error ?? new Error("hydration job delete failed"));
+          });
+          break;
+        }
         case "canonical_record": {
           const records = tx.objectStore(CANONICAL_RECORDS_STORE);
           const put = issue(() =>
@@ -442,10 +496,29 @@ export class EventLedgerWriteBatch {
       if (!get) continue;
       get.onsuccess = () => {
         const existing = get.result;
-        const current = existing?.ingestedThroughSeq;
-        const requested = entry.patch.ingestedThroughSeq;
-        if (current !== undefined && requested !== undefined && requested < current) {
-          failure = failure ?? new LedgerCursorRegressionError(current, requested);
+        for (const field of CURSOR_FIELDS) {
+          const current = existing?.[field];
+          const requested = entry.patch[field];
+          if (
+            typeof current === "number" &&
+            typeof requested === "number" &&
+            requested < current
+          ) {
+            failure = failure ?? new LedgerCursorRegressionError(current, requested);
+            tryAbort(tx);
+            return;
+          }
+        }
+        // Readiness may never claim past the contiguous ingestion cursor.
+        const readyThrough = entry.patch.projectionReadyThroughSeq;
+        const ingestedThrough =
+          entry.patch.ingestedThroughSeq ?? existing?.ingestedThroughSeq;
+        if (
+          typeof readyThrough === "number" &&
+          typeof ingestedThrough === "number" &&
+          readyThrough > ingestedThrough
+        ) {
+          failure = failure ?? new LedgerCursorRegressionError(ingestedThrough, readyThrough);
           tryAbort(tx);
           return;
         }
@@ -608,6 +681,24 @@ export class EventLedger {
       RUNTIME_SCOPES_STORE,
       BY_REMOTE_RUNTIME_INDEX,
       IDBKeyRange.only([remoteKey, runtimeId, visibilityScopeId]),
+    );
+  }
+
+  /**
+   * List every runtime scope of one remote key. Used by the restart scan to
+   * enumerate scopes with durable state without knowing their identities in
+   * advance. Index keys are 3-part arrays; `[remoteKey, []]` sorts after
+   * every string runtime id, so the bound covers the whole remote.
+   */
+  async listRuntimeScopesByRemoteKey(
+    remoteKey: string,
+  ): Promise<LedgerRuntimeScopeRecord[]> {
+    const db = this.requireOpenDb();
+    return collectIndex<LedgerRuntimeScopeRecord>(
+      db,
+      RUNTIME_SCOPES_STORE,
+      BY_REMOTE_RUNTIME_INDEX,
+      IDBKeyRange.bound([remoteKey, ""], [remoteKey, []]),
     );
   }
 
@@ -801,6 +892,7 @@ async function collectRange<T>(
   range: IDBKeyRange,
 ): Promise<T[]> {
   return new Promise<T[]>((resolve, reject) => {
+    let settled = false;
     const tx = db.transaction(storeName, "readonly");
     const results: T[] = [];
     const req = tx.objectStore(storeName).openCursor(range);
@@ -810,11 +902,15 @@ async function collectRange<T>(
         results.push(cursor.value as T);
         cursor.continue();
       } else {
+        settled = true;
         resolve(results);
       }
     };
     req.onerror = () => reject(req.error ?? new Error(`${storeName} cursor failed`));
     tx.onerror = () => reject(tx.error ?? new Error(`${storeName} transaction failed`));
+    tx.onabort = () => {
+      if (!settled) reject(tx.error ?? new Error(`${storeName} transaction aborted`));
+    };
   });
 }
 
@@ -825,6 +921,7 @@ async function collectIndex<T>(
   range: IDBKeyRange,
 ): Promise<T[]> {
   return new Promise<T[]>((resolve, reject) => {
+    let settled = false;
     const tx = db.transaction(storeName, "readonly");
     const results: T[] = [];
     const req = tx.objectStore(storeName).index(indexName).openCursor(range);
@@ -834,10 +931,14 @@ async function collectIndex<T>(
         results.push(cursor.value as T);
         cursor.continue();
       } else {
+        settled = true;
         resolve(results);
       }
     };
     req.onerror = () => reject(req.error ?? new Error(`${storeName} index cursor failed`));
     tx.onerror = () => reject(tx.error ?? new Error(`${storeName} transaction failed`));
+    tx.onabort = () => {
+      if (!settled) reject(tx.error ?? new Error(`${storeName} transaction aborted`));
+    };
   });
 }

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -1078,6 +1078,45 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
     isWorkItemInvalidationEvent: isWorkItemCacheInvalidationEvent,
     isAgentStateInvalidationEvent: isAgentStateCacheInvalidationEvent,
     catchUpErrorKind: agentDetailErrorKind,
+    ledgerIngestion: {
+      // Stable runtime identity (runtime id + visibility scope) reaches the
+      // client with the W3/W4 roster and projection snapshot cutover. Until
+      // then the ledger scope is unresolvable and durable ingestion stays
+      // dormant: the in-memory path is unchanged.
+      resolveScope: () => null,
+      fetchers: {
+        fetchCanonicalRecords: async (agentId, recordKind, recordIds) => {
+          if (recordKind === "message") {
+            const response = await runtimeClient.getAgentMessagesBatch(agentId, recordIds);
+            const recordsById: Record<string, { record: unknown }> = {};
+            for (const message of response.messages ?? []) {
+              if (message?.id) recordsById[message.id] = { record: message };
+            }
+            return { recordsById, missingIds: response.missing_message_ids ?? [] };
+          }
+          if (recordKind === "transcript_entry") {
+            const response = await runtimeClient.getAgentTranscriptEntriesBatch(
+              agentId,
+              recordIds,
+            );
+            const recordsById: Record<string, { record: unknown }> = {};
+            for (const entry of response.entries ?? []) {
+              if (entry?.id) recordsById[entry.id] = { record: entry };
+            }
+            return { recordsById, missingIds: response.missing_entry_ids ?? [] };
+          }
+          const response = await runtimeClient.getAgentBriefsById(agentId, recordIds);
+          const recordsById: Record<string, { record: unknown }> = {};
+          for (const [briefId, record] of Object.entries(response.recordsById ?? {})) {
+            recordsById[briefId] = { record };
+          }
+          return { recordsById, missingIds: response.notFoundIds ?? [] };
+        },
+      },
+      onStatus: () => {
+        // W5 wires unread/read-marker gating to these statuses.
+      },
+    },
   });
 
   return ({


### PR DESCRIPTION
## Summary

Implements the **W2** slice of the approved observer-sync implementation plan (`docs/rfcs/observer-sync-agent-summary-and-read-markers.md`): durable raw ingestion, hydration queue, and the projection-ready cursor on top of the W1 event ledger.

### New modules (`web-gui/app/src/runtime/event-ledger/`)

- **`classification.ts`** — envelope → demand classification:
  - `projection_effect` from the S2 contract, with a conservative local fallback for remotes that do not advertise it yet
  - reference events (message / brief / transcript_entry) map to canonical hydration jobs; forward-compatible `revision` extraction so a newer canonical revision can satisfy an older invalidation
  - envelope `contract_version` above the supported version stores the event but blocks readiness
- **`ingestion-pipeline.ts`** — `LedgerIngestionPipeline`:
  - `ingest()` commits raw events, hydration jobs, tombstones, the contiguous cursor, observed head, and readiness in **one atomic transaction**
  - the contiguous `ingestedThroughSeq` advances **from stored content only** — out-of-order delivery, live duplicates, filtered/semantic fetches can never fabricate coverage
  - `projectionReadyThroughSeq` advances only past satisfied display demand; `readinessGate()` is the W5 read-marker gate
  - `resume()` restart scan rebuilds cursors/blockers/pending jobs and drains pending hydration before readiness may advance again
  - bounded hydration retries escalate to projection **snapshot repair → re-verification → explicit `sync_error`**
  - degraded handles are **never reused**: explicit rebuild-and-verify before claiming `exact` again

### W1 ledger extensions (`ledger.ts`)

- `EventLedgerWriteBatch.deleteHydrationJob()`: job completion is atomic with the canonical record/tombstone that satisfies it
- hydration job retry bookkeeping (`attemptCount`, `state`), `projectionReadyThroughSeq` on agent sessions (monotonic, never above the ingestion cursor), `listRuntimeScopesByRemoteKey()` for the restart scan
- readonly cursor helpers now reject on bare `tx.onabort` (W1 review note)

### Repository ownership

- `AgentSessionRepository` owns the pipeline lifecycle (`initializeLedgerIngestion` restart scan, `ingestSessionEvents`, status/readiness accessors, dispose on remote switch)
- production wiring resolves the ledger scope to `null` until the W3/W4 runtime-identity cutover ships the stable runtime id / visibility scope — the in-memory path is unchanged

## Verification

- `npm run typecheck`, full `npm run test` (35 files / 376 tests, incl. 17 new pipeline tests + 3 repository integration tests), `npm run build` — all green
- acceptance coverage: crash-before-hydration restart resumes; out-of-order/live-duplicate cursor integrity; filtered/semantic never advance the raw cursor; unknown-version and display-invalidation blocking; newer-revision satisfaction; tombstone completion; retry→repair→sync_error escalation; degraded-handle rebuild-verify

Follows #2617 #2619 #2623 #2625 #2626 #2627 #2628. Next: W3 per-agent bootstrap/catch-up/reset.