### PR TITLE
feat: per-agent recovery state machine with bootstrap, catch-up, and resets (W3)

### DIFF
--- a/web-gui/app/src/runtime/agent-session-repository.test.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.test.ts
@@ -9,7 +9,7 @@ import {
   type AgentSessionRepositoryState,
 } from "./agent-session-repository";
 import { LEDGER_DB_NAME, type LedgerScopeKey } from "./event-ledger";
-import type { StreamEventEnvelopeDto } from "./client";
+import type { AgentProjectionSnapshotDto, StreamEventEnvelopeDto } from "./client";
 import { emptyAgentSession } from "./conversation-store";
 import type { AgentSessionState } from "./runtime-store-helpers";
 import type { RuntimeMessageEnvelope } from "./types";
@@ -62,6 +62,9 @@ function createHarness(
       missing_entry_ids: [],
     })),
     getAgentBriefsById: vi.fn(async () => ({ recordsById: {}, notFoundIds: [] })),
+    getAgentProjectionSnapshot: vi.fn(
+      async (_agentId: string): Promise<AgentProjectionSnapshotDto | null> => null,
+    ),
   };
   const mergedPages: Array<{
     events: StreamEventEnvelopeDto[];
@@ -408,5 +411,63 @@ describe("AgentSessionRepository ledger ingestion", () => {
 
     const status = await harness.repository.ingestSessionEvents("agent-a", [event(1)]);
     expect(status).toBeNull();
+  });
+
+  it("catch-up bootstraps the durable ledger through recovery and routes live events through it", async () => {
+    const harness = createHarness(
+      emptyAgentSession(),
+      { ledgerIngestion: ledgerIntegration({ resolveScope: () => null }) },
+    );
+    harness.client.getAgentEvents.mockResolvedValue({
+      events: [event(2)],
+      event_log_epoch: "epoch-1",
+      newest_seq: 2,
+      oldest_seq: 1,
+      has_older: false,
+      has_newer: false,
+    });
+    harness.client.getAgentProjectionSnapshot.mockResolvedValue({
+      agent_id: "agent-a",
+      contract_version: 1,
+      runtime_id: "rt_test",
+      visibility_scope_id: "vis_test",
+      event_log_epoch: "epoch-1",
+      snapshot_through_seq: 2,
+      event_head_seq: 2,
+      oldest_retained_seq: null,
+      projection: {
+        agent: {},
+        conversation: { latest_message_id: null, latest_transcript_entry_id: null },
+        current_work_item: null,
+        hydration_references: [],
+        hydration_tombstones: [],
+        latest_brief: null,
+      },
+    });
+
+    await harness.repository.catchUpEvents("agent-a", "debug");
+
+    // The opportunistic trigger bootstrapped the ledger and registered the
+    // discovered scope even though resolveScope stays dormant.
+    await harness.repository.syncAgentRecovery("agent-a");
+    const scope = harness.repository.knownLedgerScope("agent-a");
+    expect(scope).toMatchObject({
+      runtimeId: "rt_test",
+      visibilityScopeId: "vis_test",
+      eventLogEpoch: "epoch-1",
+      agentId: "agent-a",
+    });
+
+    // Live envelopes now route through the recovery coordinator's offer
+    // path and land in the durable ledger under the discovered scope.
+    const status = await harness.repository.ingestSessionEvents("agent-a", [event(3)]);
+    expect(status?.ingestedThroughSeq).toBe(3);
+    expect(status?.scope).toEqual(scope);
+
+    // A second catch-up in the same generation does not re-trigger sync.
+    const before = harness.client.getAgentProjectionSnapshot.mock.calls.length;
+    await harness.repository.catchUpEvents("agent-a", "debug");
+    await Promise.resolve();
+    expect(harness.client.getAgentProjectionSnapshot.mock.calls.length).toBe(before);
   });
 });

--- a/web-gui/app/src/runtime/agent-session-repository.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.ts
@@ -1,4 +1,10 @@
-import type { StreamEventEnvelopeDto } from "./client";
+import {
+  cursorNotFoundPayload,
+  isSnapshotAgentMissingError,
+  isSnapshotCapabilityUnavailableError,
+  type AgentProjectionSnapshotDto,
+  type StreamEventEnvelopeDto,
+} from "./client";
 import { cacheDeleteSession } from "./idb-cache";
 import {
   currentRemoteKey,
@@ -14,6 +20,12 @@ import {
   startRuntimeSpan,
   type RuntimeTraceContext,
 } from "./runtime-trace";
+import {
+  AgentRecoveryCoordinator,
+  type AgentRecoveryHint,
+  type AgentRecoveryUpdate,
+  type RecoveryProjectionSnapshot,
+} from "./event-ledger/agent-recovery";
 import {
   LedgerIngestionPipeline,
   type LedgerHydrationFetchers,
@@ -100,6 +112,9 @@ interface RuntimeClientLike {
     has_older?: boolean;
     has_newer?: boolean;
   }>;
+  getAgentProjectionSnapshot: (
+    agentId: string,
+  ) => Promise<AgentProjectionSnapshotDto | null>;
   getAgentMessagesBatch: (
     agentId: string,
     ids: string[],
@@ -211,6 +226,11 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
 
   private ledgerPipeline: LedgerIngestionPipeline | null = null;
   private ledgerInitPromise: Promise<void> | null = null;
+  private recoveryCoordinator: AgentRecoveryCoordinator | null = null;
+  /** agentId -> durable scope discovered by recovery or the restart scan. */
+  private readonly recoveryScopeRegistry = new Map<string, LedgerScopeKey>();
+  /** Agents whose ledger recovery was triggered this generation. */
+  private readonly recoveryTriggered = new Set<string>();
 
   constructor(private readonly dependencies: AgentSessionRepositoryDependencies<State>) {}
 
@@ -320,6 +340,9 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
     this.ledgerPipeline?.dispose();
     this.ledgerPipeline = null;
     this.ledgerInitPromise = null;
+    this.recoveryCoordinator = null;
+    this.recoveryScopeRegistry.clear();
+    this.recoveryTriggered.clear();
     this.cancelClientGenerationWork();
   }
 
@@ -335,18 +358,100 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
     const pipeline = new LedgerIngestionPipeline({
       fetchers: integration.fetchers,
       snapshotRepair: integration.snapshotRepair,
-      onStatus: integration.onStatus,
+      onStatus: (status) => {
+        integration.onStatus?.(status);
+        // Bounded escalation: a durable sync_error that survived the
+        // pipeline's own snapshot repair re-bootstraps once via recovery.
+        if (status.state === "sync_error") {
+          this.recoveryCoordinator?.requestDivergenceReset(status.scope.agentId);
+        }
+      },
     });
     this.ledgerPipeline = pipeline;
+    this.recoveryCoordinator = this.createRecoveryCoordinator(pipeline);
     this.ledgerInitPromise = (async () => {
       if (!(await pipeline.open())) return;
       await pipeline.resumeRemote(
         currentRemoteKey(this.dependencies.getConnectionConfig()),
       );
+      await this.seedRecoveryScopes(pipeline);
     })().catch((error) => {
       console.warn("Failed to initialize the event ledger pipeline.", error);
     });
     return this.ledgerInitPromise;
+  }
+
+  private createRecoveryCoordinator(
+    pipeline: LedgerIngestionPipeline,
+  ): AgentRecoveryCoordinator {
+    const remoteKey = currentRemoteKey(this.dependencies.getConnectionConfig());
+    const client = this.dependencies.getClient();
+    return new AgentRecoveryCoordinator({
+      remoteKey,
+      pipeline,
+      fetchProjectionSnapshot: async (agentId) => {
+        try {
+          const dto = await client.getAgentProjectionSnapshot(agentId);
+          return dto ? recoverySnapshotFromDto(dto) : null;
+        } catch (error) {
+          if (
+            isSnapshotCapabilityUnavailableError(error) ||
+            isSnapshotAgentMissingError(error)
+          ) {
+            return null;
+          }
+          throw error;
+        }
+      },
+      fetchEventPage: async (agentId, afterSeq, limit) => {
+        try {
+          const page = await client.getAgentEvents(agentId, { afterSeq, limit, order: "asc" });
+          return {
+            events: (page.events ?? []) as Array<Record<string, unknown>>,
+            eventLogEpoch: page.event_log_epoch || undefined,
+            eventHeadSeq: page.newest_seq ?? page.cursor_seq ?? undefined,
+            oldestRetainedSeq: page.oldest_seq ?? null,
+            hasNewer: page.has_newer,
+          };
+        } catch (error) {
+          const cursorNotFound = cursorNotFoundPayload(error);
+          if (cursorNotFound) return { events: [], cursorNotFound };
+          throw error;
+        }
+      },
+      onPhase: (update) => {
+        if (update.scope && update.phase !== "idle") {
+          this.recoveryScopeRegistry.set(update.agentId, update.scope);
+        }
+      },
+    });
+  }
+
+  private async seedRecoveryScopes(pipeline: LedgerIngestionPipeline): Promise<void> {
+    const remoteKey = currentRemoteKey(this.dependencies.getConnectionConfig());
+    for (const scope of await pipeline.listKnownScopes(remoteKey)) {
+      if (!this.recoveryScopeRegistry.has(scope.agentId)) {
+        this.recoveryScopeRegistry.set(scope.agentId, scope);
+      }
+    }
+  }
+
+  /** Durable ledger scope for one agent, once recovery discovered it. */
+  knownLedgerScope(agentId: string): LedgerScopeKey | null {
+    return this.recoveryScopeRegistry.get(agentId) ?? null;
+  }
+
+  /** Bring one agent's durable ledger to live state (W3 recovery). */
+  async syncAgentRecovery(
+    agentId: string,
+    hint: AgentRecoveryHint = {},
+  ): Promise<AgentRecoveryUpdate | null> {
+    await this.initializeLedgerIngestion();
+    const coordinator = this.recoveryCoordinator;
+    if (!coordinator) return null;
+    if (coordinator.capabilitySkipped(agentId)) return null;
+    this.recoveryTriggered.add(agentId);
+    return coordinator.sync(agentId, hint);
   }
 
   /**
@@ -360,6 +465,12 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
   ): Promise<LedgerIngestionStatus | null> {
     const integration = this.dependencies.ledgerIngestion;
     if (!integration || !this.ledgerPipeline || events.length === 0) return null;
+    const coordinator = this.recoveryCoordinator;
+    if (coordinator?.scopeOf(agentId)) {
+      // Live hints route through the recovery coordinator so envelopes that
+      // arrive during a bootstrap or reset buffer instead of bypassing it.
+      return coordinator.offer(agentId, events as Array<Record<string, unknown>>);
+    }
     const scope = integration.resolveScope(agentId);
     if (!scope) return null;
     await this.initializeLedgerIngestion();
@@ -574,6 +685,12 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
       append: true,
       eventLogEpoch: tailPage.event_log_epoch,
     });
+    // Opportunistic durable-ledger recovery: the catch-up page already
+    // observed the head and floor, so bootstrap/catch-up can reuse them.
+    this.scheduleLedgerRecovery(agentId, {
+      eventHeadSeq: tailConsumedSeq,
+      oldestRetainedSeq: tailOldestSeq,
+    });
     if (this.dependencies.get().selectedAgentId === agentId) {
       this.hydrateSession(agentId, "debug");
     }
@@ -653,6 +770,22 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
       eventCount,
       pageCount,
     });
+  }
+
+  /**
+   * Trigger durable ledger recovery for one agent at most once per
+   * generation, and only while the remote serves the snapshot contract.
+   */
+  private scheduleLedgerRecovery(
+    agentId: string,
+    hint: AgentRecoveryHint,
+  ): void {
+    const coordinator = this.recoveryCoordinator;
+    if (!coordinator) return;
+    if (this.recoveryTriggered.has(agentId)) return;
+    if (coordinator.capabilitySkipped(agentId)) return;
+    this.recoveryTriggered.add(agentId);
+    void coordinator.sync(agentId, hint).catch(() => undefined);
   }
 
   private scheduleMessageHydration(agentId: string, displayLevel: DisplayLevel): void {
@@ -913,4 +1046,72 @@ function briefHydrationErrorKind(error: unknown): string {
   if (error instanceof DOMException && error.name === "AbortError") return "timeout";
   if (error instanceof Error && /timeout|aborted/i.test(error.message)) return "timeout";
   return "request_failed";
+}
+
+/** Map an S5 projection snapshot DTO into the recovery-layer shape. */
+export function recoverySnapshotFromDto(
+  snapshot: AgentProjectionSnapshotDto,
+): RecoveryProjectionSnapshot {
+  const projection = snapshot.projection ?? {
+    hydration_references: [],
+    hydration_tombstones: [],
+    latest_brief: null,
+  };
+  const brief = projection.latest_brief ?? null;
+  return {
+    runtimeId: snapshot.runtime_id,
+    visibilityScopeId: snapshot.visibility_scope_id,
+    eventLogEpoch: snapshot.event_log_epoch,
+    snapshotThroughSeq: snapshot.snapshot_through_seq,
+    eventHeadSeq: snapshot.event_head_seq,
+    oldestRetainedSeq: snapshot.oldest_retained_seq ?? null,
+    canonicalRecords: brief
+      ? [
+          {
+            recordKind: "brief",
+            recordId: brief.brief_id,
+            record: brief,
+            revision: brief.created_event_seq ?? undefined,
+          },
+        ]
+      : [],
+    hydrationReferences: (projection.hydration_references ?? []).map((key) => ({
+      recordKind: key.record_kind,
+      recordId: key.record_id,
+    })),
+    hydrationTombstones: (projection.hydration_tombstones ?? []).map((key) => ({
+      recordKind: key.record_kind,
+      recordId: key.record_id,
+    })),
+  };
+}
+
+/**
+ * Snapshot repair source over the S5 endpoint. Capability-unavailable and
+ * unknown-agent responses map to null: repair is explicitly absent.
+ */
+export function snapshotRepairFromClient(
+  fetchSnapshot: (agentId: string) => Promise<AgentProjectionSnapshotDto | null>,
+): ProjectionSnapshotRepairSource {
+  return {
+    fetchProjectionSnapshot: async (scope) => {
+      try {
+        const dto = await fetchSnapshot(scope.agentId);
+        if (!dto) return null;
+        const snapshot = recoverySnapshotFromDto(dto);
+        return {
+          snapshotThroughSeq: snapshot.snapshotThroughSeq,
+          canonicalRecords: snapshot.canonicalRecords,
+        };
+      } catch (error) {
+        if (
+          isSnapshotCapabilityUnavailableError(error) ||
+          isSnapshotAgentMissingError(error)
+        ) {
+          return null;
+        }
+        throw error;
+      }
+    },
+  };
 }

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -236,6 +236,7 @@ type WorkItemTransportDto = SlimWorkItemDto | WorkItemDto;
 type BriefRecordDto = RuntimeBriefRecord;
 
 export type EventPageResponseDto = components["schemas"]["EventsPageResponse"];
+export type AgentProjectionSnapshotDto = components["schemas"]["AgentProjectionSnapshot"];
 type GeneratedStreamEventEnvelopeDto = components["schemas"]["StreamEventEnvelope"];
 export type StreamEventEnvelopeDto = Partial<GeneratedStreamEventEnvelopeDto>;
 type EventEnvelopeDto = StreamEventEnvelopeDto;
@@ -726,6 +727,17 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         return emptyEventPage();
       }
       return fetchAgentEvents(baseUrl, fetchImpl, requestHeaders, agentId, options);
+    },
+    async getAgentProjectionSnapshot(agentId: string): Promise<AgentProjectionSnapshotDto | null> {
+      if (!baseUrl) {
+        return null;
+      }
+      return getJson<AgentProjectionSnapshotDto>(
+        fetchImpl,
+        baseUrl,
+        `/agents/${encodeURIComponent(agentId)}/projection-snapshot`,
+        { headers: requestHeaders },
+      );
     },
     async getAgentMessagesBatch(agentId: string, messageIds: string[]): Promise<AgentMessagesBatchGetResponseDto> {
       if (!baseUrl || !messageIds.length) {
@@ -2292,27 +2304,73 @@ function stringValue(value: unknown): string | undefined {
 class RuntimeHttpError extends Error {
   readonly status: number;
   readonly code?: string;
+  /**
+   * Known rich cursor extensions from `cursor_not_found` bodies (S2): the
+   * recovery layer uses them to distinguish a retained-prefix gap from an
+   * epoch change.
+   */
+  readonly cursorExtensions?: {
+    afterSeq?: number;
+    eventLogEpoch?: string;
+    oldestRetainedSeq?: number | null;
+    eventHeadSeq?: number;
+  };
 
-  constructor(method: string, path: string, status: number, reason?: string, code?: string) {
+  constructor(
+    method: string,
+    path: string,
+    status: number,
+    reason?: string,
+    code?: string,
+    cursorExtensions?: RuntimeHttpError["cursorExtensions"],
+  ) {
     super(reason ? `${method} ${path} failed with ${status}: ${reason}` : `${method} ${path} failed with ${status}`);
     this.name = "RuntimeHttpError";
     this.status = status;
     this.code = code;
+    this.cursorExtensions = cursorExtensions;
   }
 }
 
 async function httpRequestError(method: string, path: string, response: Response): Promise<RuntimeHttpError> {
   const envelope = await readErrorEnvelope(response);
-  return new RuntimeHttpError(method, path, response.status, envelope?.error, envelope?.code);
+  return new RuntimeHttpError(
+    method,
+    path,
+    response.status,
+    envelope?.error,
+    envelope?.code,
+    envelope?.extensions,
+  );
 }
 
-async function readErrorEnvelope(response: Response): Promise<{ error?: string; code?: string } | undefined> {
+async function readErrorEnvelope(
+  response: Response,
+): Promise<
+  | { error?: string; code?: string; extensions?: RuntimeHttpError["cursorExtensions"] }
+  | undefined
+> {
   const contentType = response.headers.get("content-type") ?? "";
   if (!contentType.includes("application/json")) return undefined;
   try {
     const value = await response.json();
     const record = asRecord(value);
-    return record ? { error: stringValue(record.error), code: stringValue(record.code) } : undefined;
+    if (!record) return undefined;
+    const numberValue = (input: unknown): number | undefined =>
+      typeof input === "number" && Number.isFinite(input) ? input : undefined;
+    const extensions: RuntimeHttpError["cursorExtensions"] = {
+      afterSeq: numberValue(record.after_seq),
+      eventLogEpoch: stringValue(record.event_log_epoch),
+      oldestRetainedSeq:
+        record.oldest_retained_seq == null ? null : numberValue(record.oldest_retained_seq),
+      eventHeadSeq: numberValue(record.event_head_seq),
+    };
+    const hasExtensions = Object.values(extensions).some((entry) => entry !== undefined);
+    return {
+      error: stringValue(record.error),
+      code: stringValue(record.code),
+      extensions: hasExtensions ? extensions : undefined,
+    };
   } catch {
     return undefined;
   }
@@ -2324,6 +2382,49 @@ function isAuthRequiredError(error: unknown): boolean {
 
 export function isProjectionBusyError(error: unknown): boolean {
   return error instanceof RuntimeHttpError && error.status === 429 && error.code === "projection_busy";
+}
+
+/** True when the remote does not serve the projection snapshot contract. */
+export function isSnapshotCapabilityUnavailableError(error: unknown): boolean {
+  return (
+    error instanceof RuntimeHttpError &&
+    error.status === 503 &&
+    error.code === "capability_unavailable"
+  );
+}
+
+/** True when the snapshot target agent is unknown or not a member. */
+export function isSnapshotAgentMissingError(error: unknown): boolean {
+  return error instanceof RuntimeHttpError && error.status === 404;
+}
+
+/** Extract a rich cursor_not_found payload, when the error carries one. */
+export function cursorNotFoundPayload(
+  error: unknown,
+):
+  | {
+      afterSeq: number;
+      eventLogEpoch: string;
+      oldestRetainedSeq: number | null;
+      eventHeadSeq: number;
+    }
+  | undefined {
+  if (!(error instanceof RuntimeHttpError) || error.code !== "cursor_not_found") return undefined;
+  const extensions = error.cursorExtensions;
+  if (
+    !extensions ||
+    extensions.afterSeq == null ||
+    !extensions.eventLogEpoch ||
+    extensions.eventHeadSeq == null
+  ) {
+    return undefined;
+  }
+  return {
+    afterSeq: extensions.afterSeq,
+    eventLogEpoch: extensions.eventLogEpoch,
+    oldestRetainedSeq: extensions.oldestRetainedSeq ?? null,
+    eventHeadSeq: extensions.eventHeadSeq,
+  };
 }
 
 function buildDisconnectedBootstrap(

--- a/web-gui/app/src/runtime/event-ledger/agent-recovery.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/agent-recovery.test.ts
@@ -1,0 +1,454 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  LEDGER_DB_NAME,
+  type LedgerHydrationFetchers,
+  type LedgerScopeKey,
+  type RecoveryEventPage,
+  type RecoveryProjectionSnapshot,
+} from "./index";
+import { EventLedger } from "./ledger";
+import { LedgerIngestionPipeline } from "./ingestion-pipeline";
+import { AgentRecoveryCoordinator } from "./agent-recovery";
+
+const REMOTE_KEY = "http://127.0.0.1:7878";
+
+function makeScope(overrides: Partial<LedgerScopeKey> = {}): LedgerScopeKey {
+  return {
+    remoteKey: REMOTE_KEY,
+    runtimeId: "rt_test",
+    visibilityScopeId: "vis_test",
+    eventLogEpoch: "epoch-1",
+    agentId: "agent-1",
+    ...overrides,
+  };
+}
+
+function envelope(
+  seq: number,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    agent_id: "agent-1",
+    contract_version: 2,
+    event_log_epoch: "epoch-1",
+    id: `evt-${seq}`,
+    event_seq: seq,
+    payload: {},
+    payload_schema: "test",
+    payload_schema_version: 1,
+    provenance: {},
+    ts: `2026-08-18T00:00:${String(seq % 60).padStart(2, "0")}Z`,
+    type: "agent_state_changed",
+    ...overrides,
+  };
+}
+
+function snapshot(
+  overrides: Partial<RecoveryProjectionSnapshot> = {},
+): RecoveryProjectionSnapshot {
+  return {
+    runtimeId: "rt_test",
+    visibilityScopeId: "vis_test",
+    eventLogEpoch: "epoch-1",
+    snapshotThroughSeq: 5,
+    eventHeadSeq: 8,
+    oldestRetainedSeq: null,
+    canonicalRecords: [
+      {
+        recordKind: "brief",
+        recordId: "brief-5",
+        record: { brief_id: "brief-5", preview: "latest" },
+        revision: 5,
+      },
+    ],
+    hydrationReferences: [{ recordKind: "message", recordId: "msg-1" }],
+    hydrationTombstones: [{ recordKind: "message", recordId: "msg-gone" }],
+    ...overrides,
+  };
+}
+
+function emptyFetchers(): LedgerHydrationFetchers {
+  return {
+    fetchCanonicalRecords: async () => ({ recordsById: {}, missingIds: [] }),
+  };
+}
+
+function page(
+  events: Array<Record<string, unknown>>,
+  overrides: Partial<RecoveryEventPage> = {},
+): RecoveryEventPage {
+  return { events, hasNewer: false, ...overrides };
+}
+
+/** Scripted event pages keyed by the afterSeq they were requested with. */
+function pageSource(pages: Record<number, RecoveryEventPage>) {
+  const requests: number[] = [];
+  return {
+    requests,
+    fetch: async (_agentId: string, afterSeq: number): Promise<RecoveryEventPage> => {
+      requests.push(afterSeq);
+      return pages[afterSeq] ?? page([]);
+    },
+  };
+}
+
+async function openLedgerHandle(): Promise<EventLedger> {
+  const result = await EventLedger.open();
+  if (result.kind !== "available") throw new Error("expected available ledger");
+  return result.ledger;
+}
+
+function deleteLedger(): Promise<void> {
+  return new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase(LEDGER_DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}
+
+function makeCoordinator(
+  pipeline: LedgerIngestionPipeline,
+  fetchProjectionSnapshot: (agentId: string) => Promise<RecoveryProjectionSnapshot | null>,
+  fetchEventPage: (agentId: string, afterSeq: number, limit: number) => Promise<RecoveryEventPage>,
+) {
+  return new AgentRecoveryCoordinator({
+    remoteKey: REMOTE_KEY,
+    pipeline,
+    fetchProjectionSnapshot,
+    fetchEventPage,
+  });
+}
+
+describe("agent recovery coordinator", () => {
+  beforeEach(async () => {
+    await deleteLedger();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await deleteLedger();
+  });
+
+  it("bootstraps a new visible agent: install, baseline, replay, live", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const source = pageSource({ 5: page([envelope(6), envelope(7), envelope(8)]) });
+    const coordinator = makeCoordinator(pipeline, async () => snapshot(), source.fetch);
+
+    const update = await coordinator.sync("agent-1");
+    expect(update.phase).toBe("live");
+    expect(update.scope).toEqual(makeScope());
+    expect(update.ingestedThroughSeq).toBe(8);
+    expect(source.requests).toEqual([5]);
+
+    const ledger = await openLedgerHandle();
+    const session = await ledger.getAgentSession(makeScope());
+    expect(session?.ingestedThroughSeq).toBe(8);
+    expect(session?.projectionReadyThroughSeq).toBe(8);
+    const readState = await ledger.getReadState(makeScope());
+    expect(readState?.unreadBaselineSeq).toBe(5);
+    expect(readState?.certainty).toBe("exact");
+    expect(readState?.readThroughEventSeq).toBeUndefined();
+    const brief = await ledger.getCanonicalRecord(makeScope(), "brief", "brief-5");
+    expect(brief?.revision).toBe(5);
+    const gone = await ledger.getCanonicalRecord(makeScope(), "message", "msg-gone");
+    expect(gone?.record).toEqual({
+      tombstone: true,
+      deletedAt: expect.any(Number),
+      deletedByEventSeq: 5,
+    });
+    const jobs = await ledger.getPendingHydrationJobs(makeScope());
+    expect(jobs.map((job) => job.jobId)).toContain("message:msg-1");
+    expect(jobs.find((job) => job.jobId === "message:msg-1")?.createdByEventSeq).toBe(5);
+    const runtimeScope = await ledger.getRuntimeScope({
+      remoteKey: REMOTE_KEY,
+      runtimeId: "rt_test",
+      visibilityScopeId: "vis_test",
+      eventLogEpoch: "epoch-1",
+    });
+    expect(runtimeScope?.eventHeadSeq).toBe(8);
+    ledger.close();
+  });
+
+  it("skips bootstrap when the snapshot capability is absent", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const coordinator = makeCoordinator(pipeline, async () => null, async () => page([]));
+
+    const update = await coordinator.sync("agent-1");
+    expect(update.phase).toBe("idle");
+    expect(update.skipped).toBe("capability_absent");
+    expect(coordinator.capabilitySkipped("agent-1")).toBe(true);
+
+    const ledger = await openLedgerHandle();
+    expect(await ledger.getAgentSession(makeScope())).toBeUndefined();
+    ledger.close();
+  });
+
+  it("buffers live hints during recovery and replays them without loss or duplication", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    let releaseSnapshot: ((value: RecoveryProjectionSnapshot) => void) | null = null;
+    const snapshotGate = new Promise<RecoveryProjectionSnapshot>((resolve) => {
+      releaseSnapshot = resolve;
+    });
+    const coordinator = makeCoordinator(
+      pipeline,
+      () => snapshotGate,
+      async () => page([envelope(6), envelope(7), envelope(8)]),
+    );
+
+    const syncPromise = coordinator.sync("agent-1");
+    await vi.waitFor(() => expect(coordinator.phaseOf("agent-1")).toBe("fetching_snapshot"));
+    // A live event arrives while the snapshot fetch is still in flight.
+    const buffered = await coordinator.offer("agent-1", [envelope(9)]);
+    expect(buffered).toBeNull();
+    releaseSnapshot!(snapshot());
+    const update = await syncPromise;
+    expect(update.phase).toBe("live");
+    expect(update.ingestedThroughSeq).toBe(9);
+
+    // Duplicates stay idempotent after live.
+    const duplicate = await coordinator.offer("agent-1", [envelope(9)]);
+    expect(duplicate?.ingestedThroughSeq).toBe(9);
+
+    const ledger = await openLedgerHandle();
+    const events = await ledger.getRawEvents(makeScope());
+    expect(events.filter((event) => event.eventSeq === 9)).toHaveLength(1);
+    const session = await ledger.getAgentSession(makeScope());
+    expect(session?.ingestedThroughSeq).toBe(9);
+    ledger.close();
+  });
+
+  it("catches up an existing contiguous cache exactly to the observed head", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const scope = makeScope();
+    await pipeline.ingest(scope, [envelope(1), envelope(2), envelope(3), envelope(4), envelope(5)]);
+    const source = pageSource({ 5: page([envelope(6), envelope(7)]), 7: page([envelope(8)]) });
+    const coordinator = makeCoordinator(pipeline, async () => snapshot(), source.fetch);
+
+    const update = await coordinator.sync("agent-1", { eventHeadSeq: 8 });
+    expect(update.phase).toBe("live");
+    expect(update.ingestedThroughSeq).toBe(8);
+    expect(source.requests).toEqual([5, 7]);
+    // A plain catch-up never installs a read baseline.
+    const ledger = await openLedgerHandle();
+    expect(await ledger.getReadState(scope)).toBeUndefined();
+    ledger.close();
+  });
+
+  it("resets on a retained-prefix gap: keep the marker, record truncation, rebuild", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const scope = makeScope();
+    await pipeline.ingest(scope, [envelope(1), envelope(2), envelope(3), envelope(4), envelope(5)]);
+    const ledger = await openLedgerHandle();
+    await ledger
+      .beginWrite()
+      .putReadState(scope, { unreadBaselineSeq: 3, readThroughEventSeq: 4 })
+      .commit();
+    ledger.close();
+
+    const source = pageSource({ 8: page([]) });
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => snapshot({ snapshotThroughSeq: 8, eventHeadSeq: 8, oldestRetainedSeq: 7 }),
+      source.fetch,
+    );
+
+    const update = await coordinator.sync("agent-1", { eventHeadSeq: 8, oldestRetainedSeq: 7 });
+    expect(update.phase).toBe("live");
+    expect(update.resetReason).toBe("retained_prefix_gap");
+
+    const verify = await openLedgerHandle();
+    const readState = await verify.getReadState(scope);
+    // Marker survives; truncation is recorded; certainty drops to truncated
+    // because the effective boundary (4) is below the floor - 1 (6).
+    expect(readState?.readThroughEventSeq).toBe(4);
+    expect(readState?.unreadBaselineSeq).toBe(3);
+    expect(readState?.historyTruncatedBeforeSeq).toBe(7);
+    expect(readState?.certainty).toBe("truncated");
+    expect(await verify.getRawEvents(scope)).toEqual([]);
+    expect((await verify.getAgentSession(scope))?.ingestedThroughSeq).toBe(8);
+    verify.close();
+  });
+
+  it("resets a runtime epoch: clears the old scope and never migrates markers", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const oldScope = makeScope();
+    await pipeline.ingest(oldScope, [envelope(1), envelope(2)]);
+    const ledger = await openLedgerHandle();
+    await ledger
+      .beginWrite()
+      .putReadState(oldScope, { unreadBaselineSeq: 1, readThroughEventSeq: 2 })
+      .commit();
+    ledger.close();
+
+    // Catch-up pages reveal a rotated epoch before any data is applied.
+    const source = pageSource({
+      2: page([], { eventLogEpoch: "epoch-2", eventHeadSeq: 6 }),
+      6: page([]),
+    });
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => snapshot({ eventLogEpoch: "epoch-2", snapshotThroughSeq: 6, eventHeadSeq: 6 }),
+      source.fetch,
+    );
+
+    const update = await coordinator.sync("agent-1", { eventHeadSeq: 6 });
+    expect(update.phase).toBe("live");
+    expect(update.resetReason).toBe("epoch_change");
+
+    const verify = await openLedgerHandle();
+    expect(await verify.getAgentSession(oldScope)).toBeUndefined();
+    expect(await verify.getReadState(oldScope)).toBeUndefined();
+    expect(await verify.getRawEvents(oldScope)).toEqual([]);
+    expect(
+      await verify.getRuntimeScope({
+        remoteKey: REMOTE_KEY,
+        runtimeId: "rt_test",
+        visibilityScopeId: "vis_test",
+        eventLogEpoch: "epoch-1",
+      }),
+    ).toBeUndefined();
+    const newScope = makeScope({ eventLogEpoch: "epoch-2" });
+    const readState = await verify.getReadState(newScope);
+    expect(readState?.unreadBaselineSeq).toBe(6);
+    expect(readState?.readThroughEventSeq).toBeUndefined();
+    expect(readState?.certainty).toBe("exact");
+    expect((await verify.getAgentSession(newScope))?.ingestedThroughSeq).toBe(6);
+    verify.close();
+  });
+
+  it("clears an old visibility scope before exposing the new scope", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const oldScope = makeScope();
+    await pipeline.ingest(oldScope, [envelope(1)]);
+    const ledger = await openLedgerHandle();
+    await ledger.beginWrite().putReadState(oldScope, { unreadBaselineSeq: 1 }).commit();
+    ledger.close();
+
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => snapshot({ visibilityScopeId: "vis_other", snapshotThroughSeq: 4, eventHeadSeq: 4 }),
+      async () => page([]),
+    );
+
+    // A forced divergence re-bootstrap discovers the rotated visibility.
+    const update = await coordinator.sync("agent-1", {}, {
+      forceReset: "hydration_divergence",
+    });
+    expect(update.phase).toBe("live");
+    expect(update.resetReason).toBe("visibility_scope_change");
+    expect(update.scope).toEqual(makeScope({ visibilityScopeId: "vis_other" }));
+
+    const verify = await openLedgerHandle();
+    // Old scope's accessible cache is gone before new data is visible.
+    expect(await verify.getAgentSession(oldScope)).toBeUndefined();
+    expect(await verify.getReadState(oldScope)).toBeUndefined();
+    expect(await verify.getRawEvents(oldScope)).toEqual([]);
+    const newScope = makeScope({ visibilityScopeId: "vis_other" });
+    expect((await verify.getAgentSession(newScope))?.ingestedThroughSeq).toBe(4);
+    expect((await verify.getReadState(newScope))?.unreadBaselineSeq).toBe(4);
+    verify.close();
+  });
+
+  it("recovers from cursor_not_found with one bounded retention reset", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const scope = makeScope();
+    await pipeline.ingest(scope, [envelope(1), envelope(2), envelope(3)]);
+    const source = pageSource({
+      3: {
+        events: [],
+        cursorNotFound: {
+          afterSeq: 3,
+          eventLogEpoch: "epoch-1",
+          oldestRetainedSeq: 6,
+          eventHeadSeq: 9,
+        },
+      },
+      9: page([]),
+    });
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => snapshot({ snapshotThroughSeq: 9, eventHeadSeq: 9, oldestRetainedSeq: 6 }),
+      source.fetch,
+    );
+
+    const update = await coordinator.sync("agent-1", { eventHeadSeq: 9 });
+    expect(update.phase).toBe("live");
+    expect(update.resetReason).toBe("cursor_error");
+
+    const verify = await openLedgerHandle();
+    // No marker existed before the reset, so the rebuilt generation gets a
+    // fresh exact baseline while the truncation boundary stays recorded.
+    const readState = await verify.getReadState(scope);
+    expect(readState?.historyTruncatedBeforeSeq).toBe(6);
+    expect(readState?.certainty).toBe("exact");
+    expect(readState?.unreadBaselineSeq).toBe(9);
+    expect((await verify.getAgentSession(scope))?.ingestedThroughSeq).toBe(9);
+    verify.close();
+  });
+
+  it("recovers from an immutable content conflict via re-bootstrap", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const scope = makeScope();
+    await pipeline.ingest(scope, [envelope(1), envelope(2, { payload: { original: true } })]);
+
+    const source = pageSource({
+      2: page([envelope(3), envelope(2, { payload: { rewritten: true } })]),
+      1: page([envelope(2, { payload: { rewritten: true } }), envelope(3)]),
+    });
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => snapshot({ snapshotThroughSeq: 1, eventHeadSeq: 3 }),
+      source.fetch,
+    );
+
+    const update = await coordinator.sync("agent-1", { eventHeadSeq: 3 });
+    expect(update.phase).toBe("live");
+    expect(update.resetReason).toBe("immutable_conflict");
+
+    const verify = await openLedgerHandle();
+    expect((await verify.getAgentSession(scope))?.ingestedThroughSeq).toBe(3);
+    expect(await verify.getRawEvent(scope, 2)).toMatchObject({
+      envelope: { payload: { rewritten: true } },
+    });
+    verify.close();
+  });
+
+  it("re-bootstraps once on hydration divergence escalation", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+
+    let snapshotFetches = 0;
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => {
+        snapshotFetches += 1;
+        return snapshot({ snapshotThroughSeq: 2, eventHeadSeq: 2 });
+      },
+      async () => page([]),
+    );
+    const first = await coordinator.sync("agent-1");
+    expect(first.phase).toBe("live");
+    expect(snapshotFetches).toBe(1);
+
+    expect(coordinator.requestDivergenceReset("agent-1")).toBe(true);
+    await vi.waitFor(async () => {
+      expect(snapshotFetches).toBe(2);
+    });
+    expect(coordinator.phaseOf("agent-1")).toBe("live");
+    // A second escalation before another live stretch is refused.
+    expect(coordinator.requestDivergenceReset("agent-1")).toBe(false);
+  });
+});

--- a/web-gui/app/src/runtime/event-ledger/agent-recovery.ts
+++ b/web-gui/app/src/runtime/event-ledger/agent-recovery.ts
@@ -1,0 +1,574 @@
+/**
+ * Per-Agent recovery state machine (W3).
+ *
+ * Owns the observer-sync recovery decisions above the ingestion pipeline:
+ * - a newly visible Agent bootstraps from its authoritative projection
+ *   snapshot: install, boundary cursors, fresh unread baseline, replay
+ *   beyond the boundary, then live;
+ * - an Agent with a contiguous cache catches up by replaying pages after
+ *   its contiguous cursor until the observed head;
+ * - reset reasons are independent and explicit: retained-prefix gap,
+ *   cursor error, immutable content conflict, hydration divergence, epoch
+ *   change, and visibility scope change;
+ * - retention-family resets rebuild the same scope and keep the read-state
+ *   record, marking truncation; epoch and visibility resets clear the old
+ *   runtime scope entirely and never migrate read markers;
+ * - live stream envelopes that arrive while recovery is in flight are
+ *   buffered hints: they replay through the same ingest path when
+ *   recovery settles and never bypass the state machine.
+ */
+
+import type { LedgerIngestionPipeline, LedgerIngestionStatus } from "./ingestion-pipeline";
+import type { LedgerReadStateRecord } from "./ledger";
+import { LedgerIdentityConflictError } from "./errors";
+import type {
+  LedgerRecordKind,
+  LedgerRemoteScopeKey,
+  LedgerScopeKey,
+} from "./keys";
+
+export type AgentRecoveryPhase =
+  | "idle"
+  | "fetching_snapshot"
+  | "installing"
+  | "replaying"
+  | "live"
+  | "error";
+
+export type LedgerResetReason =
+  | "retained_prefix_gap"
+  | "cursor_error"
+  | "immutable_conflict"
+  | "hydration_divergence"
+  | "epoch_change"
+  | "visibility_scope_change";
+
+/** Reset reasons that rebuild the same scope key and keep the marker. */
+const RETENTION_FAMILY: ReadonlySet<LedgerResetReason> = new Set([
+  "retained_prefix_gap",
+  "cursor_error",
+  "immutable_conflict",
+  "hydration_divergence",
+]);
+
+export interface RecoveryProjectionSnapshot {
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  snapshotThroughSeq: number;
+  eventHeadSeq: number;
+  oldestRetainedSeq: number | null;
+  canonicalRecords: Array<{
+    recordKind: LedgerRecordKind;
+    recordId: string;
+    record: unknown;
+    revision?: string | number;
+  }>;
+  hydrationReferences: Array<{
+    recordKind: LedgerRecordKind;
+    recordId: string;
+    revision?: string | number;
+  }>;
+  hydrationTombstones: Array<{
+    recordKind: LedgerRecordKind;
+    recordId: string;
+  }>;
+}
+
+/** Rich `cursor_not_found` payload from one event page request. */
+export interface RecoveryCursorError {
+  afterSeq: number;
+  eventLogEpoch: string;
+  oldestRetainedSeq: number | null;
+  eventHeadSeq: number;
+}
+
+export interface RecoveryEventPage {
+  events: Array<Record<string, unknown>>;
+  eventLogEpoch?: string;
+  eventHeadSeq?: number;
+  oldestRetainedSeq?: number | null;
+  hasNewer?: boolean;
+  cursorNotFound?: RecoveryCursorError;
+}
+
+export interface AgentRecoveryUpdate {
+  agentId: string;
+  scope: LedgerScopeKey | null;
+  phase: AgentRecoveryPhase;
+  ingestedThroughSeq?: number;
+  projectionReadyThroughSeq?: number;
+  /** Set when this sync performed (or reacted to) a reset. */
+  resetReason?: LedgerResetReason;
+  /** Snapshot capability absent or agent unknown: nothing was installed. */
+  skipped?: "capability_absent";
+  error?: string;
+}
+
+export interface AgentRecoveryHint {
+  eventHeadSeq?: number;
+  oldestRetainedSeq?: number | null;
+}
+
+export interface AgentRecoveryDependencies {
+  remoteKey: string;
+  pipeline: LedgerIngestionPipeline;
+  /** Null when the remote does not advertise the snapshot capability. */
+  fetchProjectionSnapshot(agentId: string): Promise<RecoveryProjectionSnapshot | null>;
+  fetchEventPage(
+    agentId: string,
+    afterSeq: number,
+    limit: number,
+  ): Promise<RecoveryEventPage>;
+  onPhase?: (update: AgentRecoveryUpdate) => void;
+  replayPageSize?: number;
+  maxReplayPages?: number;
+}
+
+interface AgentRecoveryState {
+  agentId: string;
+  scope: LedgerScopeKey | null;
+  phase: AgentRecoveryPhase;
+  syncPromise: Promise<AgentRecoveryUpdate> | null;
+  /** Live envelopes received while recovery was in flight. */
+  pendingHints: Array<Record<string, unknown>>;
+  lastResetReason?: LedgerResetReason;
+  capabilitySkipped: boolean;
+  error?: string;
+}
+
+const DEFAULT_REPLAY_PAGE_SIZE = 200;
+const DEFAULT_MAX_REPLAY_PAGES = 1_000;
+const MAX_STALE_REPLAY_ROUNDS = 3;
+
+/** Effective local read boundary above which unread is counted. */
+function effectiveReadBoundary(record: LedgerReadStateRecord | undefined): number {
+  if (!record) return 0;
+  return Math.max(record.unreadBaselineSeq ?? 0, record.readThroughEventSeq ?? 0);
+}
+
+function sameRemoteScope(
+  scope: LedgerScopeKey,
+  remoteScope: LedgerRemoteScopeKey,
+): boolean {
+  return (
+    scope.remoteKey === remoteScope.remoteKey &&
+    scope.runtimeId === remoteScope.runtimeId &&
+    scope.visibilityScopeId === remoteScope.visibilityScopeId &&
+    scope.eventLogEpoch === remoteScope.eventLogEpoch
+  );
+}
+
+/**
+ * Recovery coordinator over one remote's ledger pipeline. One instance per
+ * remote connection; dispose by dropping the reference together with the
+ * pipeline it shares.
+ */
+export class AgentRecoveryCoordinator {
+  private readonly states = new Map<string, AgentRecoveryState>();
+  private readonly pageSize: number;
+  private readonly maxPages: number;
+
+  constructor(private readonly dependencies: AgentRecoveryDependencies) {
+    this.pageSize = dependencies.replayPageSize ?? DEFAULT_REPLAY_PAGE_SIZE;
+    this.maxPages = dependencies.maxReplayPages ?? DEFAULT_MAX_REPLAY_PAGES;
+  }
+
+  /**
+   * Bring one agent to live state: bootstrap when it has no durable cache,
+   * otherwise catch up from the contiguous cursor. Concurrent calls join
+   * the in-flight sync.
+   */
+  sync(
+    agentId: string,
+    hint: AgentRecoveryHint = {},
+    options: { forceReset?: LedgerResetReason } = {},
+  ): Promise<AgentRecoveryUpdate> {
+    const state = this.stateFor(agentId);
+    if (state.syncPromise) return state.syncPromise;
+    const promise = this.syncInner(agentId, hint, options)
+      .catch((error): AgentRecoveryUpdate => {
+        state.phase = "error";
+        state.error = error instanceof Error ? error.message : String(error);
+        return this.emit(state, {
+          agentId,
+          scope: state.scope,
+          phase: "error",
+          error: state.error,
+        });
+      })
+      .finally(() => {
+        if (state.syncPromise === promise) state.syncPromise = null;
+      });
+    state.syncPromise = promise;
+    return promise;
+  }
+
+  /**
+   * Offer live stream envelopes. While recovery is in flight they are
+   * buffered and replayed when recovery settles, so concurrent live events
+   * are never lost and never bypass the state machine; duplicates remain
+   * idempotent by immutable identity.
+   */
+  async offer(
+    agentId: string,
+    envelopes: Array<Record<string, unknown>>,
+  ): Promise<LedgerIngestionStatus | null> {
+    if (envelopes.length === 0) return null;
+    const state = this.states.get(agentId);
+    if (!state) return null;
+    // Buffer whenever recovery owns the agent — including the snapshot
+    // fetch, before the scope is even known, so nothing offered during a
+    // bootstrap or reset is applied around the state machine.
+    const recoveryOwnsAgent =
+      state.syncPromise != null ||
+      (state.phase !== "idle" && state.phase !== "live" && state.phase !== "error");
+    if (recoveryOwnsAgent) {
+      state.pendingHints.push(...envelopes);
+      return null;
+    }
+    if (!state.scope) return null;
+    return this.dependencies.pipeline.ingest(state.scope, envelopes);
+  }
+
+  phaseOf(agentId: string): AgentRecoveryPhase {
+    return this.states.get(agentId)?.phase ?? "idle";
+  }
+
+  scopeOf(agentId: string): LedgerScopeKey | null {
+    return this.states.get(agentId)?.scope ?? null;
+  }
+
+  /** True when the remote answered without the snapshot capability. */
+  capabilitySkipped(agentId: string): boolean {
+    return this.states.get(agentId)?.capabilitySkipped ?? false;
+  }
+
+  /**
+   * Request a divergence reset: re-bootstrap from the authoritative
+   * snapshot after the pipeline's own bounded repair escalated to
+   * sync_error. Bounded once per live stretch so persistent divergence
+   * surfaces as an error instead of looping.
+   */
+  requestDivergenceReset(agentId: string): boolean {
+    const state = this.states.get(agentId);
+    if (!state) return false;
+    if (state.lastResetReason === "hydration_divergence") return false;
+    if (state.syncPromise) return false;
+    void this.sync(agentId, {}, { forceReset: "hydration_divergence" }).catch(
+      () => undefined,
+    );
+    return true;
+  }
+
+  private async syncInner(
+    agentId: string,
+    hint: AgentRecoveryHint,
+    options: { forceReset?: LedgerResetReason },
+  ): Promise<AgentRecoveryUpdate> {
+    const state = this.stateFor(agentId);
+    state.error = undefined;
+    const sessions = await this.dependencies.pipeline.findAgentSessions(
+      this.dependencies.remoteKey,
+      agentId,
+    );
+    if (sessions.length === 0 || options.forceReset) {
+      return this.bootstrap(agentId, hint, options.forceReset);
+    }
+
+    // The newest local session is the current scope candidate; identity
+    // drift (epoch/visibility) is detected from page metadata or snapshot.
+    const current = sessions.reduce((a, b) =>
+      (b.ingestedThroughSeq ?? 0) > (a.ingestedThroughSeq ?? 0) ? b : a,
+    );
+    const scope = current.scope;
+    state.scope = scope;
+    const contiguous = current.ingestedThroughSeq ?? 0;
+    const floor = hint.oldestRetainedSeq;
+    if (floor != null && floor > 1 && contiguous < floor - 1) {
+      return this.bootstrap(agentId, hint, "retained_prefix_gap");
+    }
+    return this.replay(agentId, scope, contiguous, {
+      targetHeadSeq: hint.eventHeadSeq ?? contiguous,
+    });
+  }
+
+  /** Bootstrap from the authoritative snapshot; `reset` names the cause. */
+  private async bootstrap(
+    agentId: string,
+    hint: AgentRecoveryHint,
+    reset: LedgerResetReason | undefined,
+  ): Promise<AgentRecoveryUpdate> {
+    const state = this.stateFor(agentId);
+    state.phase = "fetching_snapshot";
+    this.emit(state, { agentId, scope: state.scope, phase: "fetching_snapshot", resetReason: reset });
+
+    const snapshot = await this.dependencies.fetchProjectionSnapshot(agentId);
+    if (!snapshot) {
+      state.capabilitySkipped = true;
+      // Nothing was installed, so hints buffered during the declined fetch
+      // belong to no durable scope and are dropped, not half-applied.
+      state.pendingHints.length = 0;
+      state.phase = "idle";
+      return this.emit(state, {
+        agentId,
+        scope: state.scope,
+        phase: "idle",
+        skipped: "capability_absent",
+      });
+    }
+
+    const scope: LedgerScopeKey = {
+      remoteKey: this.dependencies.remoteKey,
+      runtimeId: snapshot.runtimeId,
+      visibilityScopeId: snapshot.visibilityScopeId,
+      eventLogEpoch: snapshot.eventLogEpoch,
+      agentId,
+    };
+
+    // Identity resets: clear whole runtime scopes that no longer match the
+    // server's identity before any new data becomes visible. Read markers
+    // never migrate across scopes, and buffered hints from the old scope
+    // are dropped instead of joined with the new one.
+    const stale = await this.dependencies.pipeline.findAgentSessions(
+      this.dependencies.remoteKey,
+      agentId,
+    );
+    let identityReset: LedgerResetReason | undefined;
+    for (const session of stale) {
+      if (sameRemoteScope(session.scope, scope)) continue;
+      const remoteScope: LedgerRemoteScopeKey = {
+        remoteKey: session.scope.remoteKey,
+        runtimeId: session.scope.runtimeId,
+        visibilityScopeId: session.scope.visibilityScopeId,
+        eventLogEpoch: session.scope.eventLogEpoch,
+      };
+      await this.dependencies.pipeline.clearRuntimeScope(remoteScope);
+      identityReset =
+        session.scope.runtimeId === scope.runtimeId &&
+        session.scope.visibilityScopeId === scope.visibilityScopeId
+          ? "epoch_change"
+          : "visibility_scope_change";
+      state.pendingHints.length = 0;
+      this.emit(state, {
+        agentId,
+        scope,
+        phase: "fetching_snapshot",
+        resetReason: identityReset,
+      });
+    }
+
+    const retentionReset = reset != null && RETENTION_FAMILY.has(reset);
+    const floor =
+      snapshot.oldestRetainedSeq ??
+      (retentionReset ? hint.oldestRetainedSeq ?? null : null);
+    let readState: Partial<LedgerReadStateRecord> | undefined;
+    if (retentionReset) {
+      const preserved = await this.dependencies.pipeline.readStateOf(scope);
+      if (!preserved) {
+        // A forced reset that landed on a scope with no preserved marker
+        // (for example a divergence reset that also rotated identity)
+        // establishes a fresh baseline instead of a half-empty record.
+        readState = {
+          unreadBaselineSeq: snapshot.snapshotThroughSeq,
+          certainty: "exact",
+          historyTruncatedBeforeSeq: floor ?? undefined,
+        };
+      } else {
+        const boundary = effectiveReadBoundary(preserved);
+        readState = {
+          historyTruncatedBeforeSeq: floor ?? undefined,
+          certainty:
+            floor != null && boundary < floor - 1
+              ? "truncated"
+              : preserved.certainty ?? "exact",
+        };
+      }
+    } else {
+      // Fresh visible agent or identity reset: new scope, fresh baseline.
+      readState = { unreadBaselineSeq: snapshot.snapshotThroughSeq, certainty: "exact" };
+    }
+
+    state.phase = "installing";
+    state.scope = scope;
+    this.emit(state, { agentId, scope, phase: "installing", resetReason: reset ?? identityReset });
+    let installed: LedgerIngestionStatus;
+    try {
+      installed = await this.dependencies.pipeline.installProjectionSnapshot(
+        scope,
+        {
+          snapshotThroughSeq: snapshot.snapshotThroughSeq,
+          eventHeadSeq: snapshot.eventHeadSeq,
+          canonicalRecords: snapshot.canonicalRecords,
+          hydrationReferences: snapshot.hydrationReferences,
+          hydrationTombstones: snapshot.hydrationTombstones,
+        },
+        {
+          clearFirst:
+            reset != null || identityReset != null
+              ? { preserveReadState: retentionReset }
+              : undefined,
+          readState,
+        },
+      );
+    } catch (error) {
+      state.phase = "error";
+      state.error = error instanceof Error ? error.message : String(error);
+      return this.emit(state, {
+        agentId,
+        scope,
+        phase: "error",
+        error: state.error,
+        resetReason: reset ?? identityReset,
+      });
+    }
+    // An identity change is the structural cause and outranks whatever
+    // retention-family reason triggered the bootstrap.
+    const resetReason = identityReset ?? reset;
+    if (resetReason != null) state.lastResetReason = resetReason;
+
+    return this.replay(agentId, scope, snapshot.snapshotThroughSeq, {
+      targetHeadSeq: Math.max(snapshot.eventHeadSeq, hint.eventHeadSeq ?? 0),
+      reset: resetReason,
+      installed,
+    });
+  }
+
+  /** Replay pages after the cursor until the target head, then go live. */
+  private async replay(
+    agentId: string,
+    scope: LedgerScopeKey,
+    afterSeq: number,
+    context: {
+      targetHeadSeq: number;
+      reset?: LedgerResetReason;
+      installed?: LedgerIngestionStatus;
+    },
+  ): Promise<AgentRecoveryUpdate> {
+    const state = this.stateFor(agentId);
+    state.phase = "replaying";
+    this.emit(state, { agentId, scope, phase: "replaying", resetReason: context.reset });
+
+    let after = afterSeq;
+    let pages = 0;
+    let staleRounds = 0;
+    let status: LedgerIngestionStatus | null = context.installed ?? null;
+    while (pages < this.maxPages && after < context.targetHeadSeq) {
+      const page = await this.dependencies.fetchEventPage(agentId, after, this.pageSize);
+      pages += 1;
+      if (page.cursorNotFound) {
+        if (context.reset == null) {
+          return this.bootstrap(
+            agentId,
+            {
+              eventHeadSeq: page.cursorNotFound.eventHeadSeq,
+              oldestRetainedSeq: page.cursorNotFound.oldestRetainedSeq,
+            },
+            "cursor_error",
+          );
+        }
+        return this.failReplay(state, agentId, scope, "cursor_not_found_after_reset", context.reset);
+      }
+      if (
+        page.eventLogEpoch != null &&
+        page.eventLogEpoch !== scope.eventLogEpoch &&
+        context.reset !== "epoch_change"
+      ) {
+        return this.bootstrap(
+          agentId,
+          { eventHeadSeq: page.eventHeadSeq, oldestRetainedSeq: page.oldestRetainedSeq },
+          "epoch_change",
+        );
+      }
+      const events = page.events;
+      try {
+        status =
+          events.length > 0
+            ? await this.dependencies.pipeline.ingest(scope, events)
+            : status;
+      } catch (error) {
+        // Immutable content for a stored (epoch, agent, seq) is a protocol
+        // error: one bounded re-bootstrap from the authoritative snapshot;
+        // a persistent conflict surfaces as an explicit error.
+        if (error instanceof LedgerIdentityConflictError && context.reset == null) {
+          return this.bootstrap(
+            agentId,
+            { eventHeadSeq: page.eventHeadSeq, oldestRetainedSeq: page.oldestRetainedSeq },
+            "immutable_conflict",
+          );
+        }
+        throw error;
+      }
+      const contiguous = status?.ingestedThroughSeq ?? after;
+      if (events.length > 0 && contiguous <= after) {
+        staleRounds += 1;
+        if (staleRounds >= MAX_STALE_REPLAY_ROUNDS) {
+          return this.failReplay(state, agentId, scope, "replay_page_did_not_advance", context.reset);
+        }
+      } else {
+        staleRounds = 0;
+      }
+      after = Math.max(after, contiguous);
+      if (events.length === 0 && page.hasNewer !== true) break;
+    }
+
+    // Buffered live hints replay through the same ingest path before the
+    // live transition, so concurrent activity is not lost and cannot
+    // duplicate (immutable identity is idempotent).
+    const hints = state.pendingHints.splice(0);
+    if (hints.length > 0) {
+      status = await this.dependencies.pipeline.ingest(scope, hints);
+    }
+
+    state.phase = "live";
+    state.lastResetReason = context.reset;
+    return this.emit(state, {
+      agentId,
+      scope,
+      phase: "live",
+      ingestedThroughSeq: status?.ingestedThroughSeq,
+      projectionReadyThroughSeq: status?.projectionReadyThroughSeq,
+      resetReason: context.reset,
+    });
+  }
+
+  private failReplay(
+    state: AgentRecoveryState,
+    agentId: string,
+    scope: LedgerScopeKey,
+    error: string,
+    reset: LedgerResetReason | undefined,
+  ): AgentRecoveryUpdate {
+    state.phase = "error";
+    state.error = error;
+    return this.emit(state, {
+      agentId,
+      scope,
+      phase: "error",
+      error,
+      resetReason: reset,
+    });
+  }
+
+  private stateFor(agentId: string): AgentRecoveryState {
+    const existing = this.states.get(agentId);
+    if (existing) return existing;
+    const state: AgentRecoveryState = {
+      agentId,
+      scope: null,
+      phase: "idle",
+      syncPromise: null,
+      pendingHints: [],
+      capabilitySkipped: false,
+    };
+    this.states.set(agentId, state);
+    return state;
+  }
+
+  private emit(state: AgentRecoveryState, update: AgentRecoveryUpdate): AgentRecoveryUpdate {
+    state.phase = update.phase;
+    if (update.scope) state.scope = update.scope;
+    this.dependencies.onPhase?.(update);
+    return update;
+  }
+}

--- a/web-gui/app/src/runtime/event-ledger/classification.ts
+++ b/web-gui/app/src/runtime/event-ledger/classification.ts
@@ -11,6 +11,11 @@
  * - envelopes with a contract version above the highest supported version
  *   block readiness outright: their semantics are unknowable.
  *
+ * One explicit exception: an authoritative projection snapshot install
+ * (repair or bootstrap) may move readiness past an
+ * `unknown_envelope_version` blocker below the snapshot boundary, because
+ * the snapshot already encodes the server's semantics for that window.
+ *
  * Display level never changes classification. Info/verbose/debug timelines
  * consume the same raw cache; display level only changes projection and
  * hydration demand at the render layer.

--- a/web-gui/app/src/runtime/event-ledger/index.ts
+++ b/web-gui/app/src/runtime/event-ledger/index.ts
@@ -4,6 +4,18 @@
  */
 
 export {
+  AgentRecoveryCoordinator,
+  type AgentRecoveryDependencies,
+  type AgentRecoveryHint,
+  type AgentRecoveryPhase,
+  type AgentRecoveryUpdate,
+  type LedgerResetReason,
+  type RecoveryCursorError,
+  type RecoveryEventPage,
+  type RecoveryProjectionSnapshot,
+} from "./agent-recovery";
+
+export {
   LEDGER_DB_NAME,
   LEDGER_DB_VERSION,
   LEDGER_STORES,
@@ -62,6 +74,8 @@ export {
   type LedgerHydrationFetchers,
   type LedgerIngestionState,
   type LedgerIngestionStatus,
+  type ProjectionSnapshotInstall,
+  type ProjectionInstallOptions,
   type ProjectionSnapshotRepairSource,
 } from "./ingestion-pipeline";
 export {

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
@@ -271,6 +271,32 @@ describe("ledger ingestion pipeline", () => {
     expect(status.projectionReadyThroughSeq).toBe(2);
   });
 
+  it("keeps the strictest expected revision when a lower revision arrives late", async () => {
+    const pipeline = new LedgerIngestionPipeline({
+      fetchers: {
+        fetchCanonicalRecords: async () => ({
+          recordsById: { "brief-1": { record: { id: "brief-1" }, revision: 3 } },
+          missingIds: [],
+        }),
+      },
+    });
+    await pipeline.open();
+    const scope = makeScope();
+
+    // A later event names revision 5; a late lower-revision invalidation
+    // for the same record must not weaken the merged demand back to 2.
+    await pipeline.ingest(scope, [briefEvent(10, "brief-1", { revision: 5 })]);
+    const status = await pipeline.ingest(scope, [
+      briefEvent(3, "brief-1", { revision: 2 }),
+    ]);
+
+    expect(status.blockedReason).toBe("pending_hydration");
+    const ledger = await openLedgerHandle();
+    const jobs = await ledger.getPendingHydrationJobs(scope);
+    expect(jobs.find((job) => job.jobId === "brief:brief-1")?.expectedRevision).toBe(5);
+    ledger.close();
+  });
+
   it("keeps a revision-expecting job pending until the revision is proven", async () => {
     const fetchers: LedgerHydrationFetchers = {
       fetchCanonicalRecords: async () => ({

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
@@ -22,6 +22,7 @@ import {
   EventLedger,
   type EventLedgerWriteBatch,
   type LedgerHydrationJobRecord,
+  type LedgerReadStateRecord,
 } from "./ledger";
 import type { EventLedgerOpenResult } from "./ledger";
 import type { LedgerDurability } from "./errors";
@@ -29,6 +30,7 @@ import {
   classifyEnvelope,
   type ClassifiedEnvelope,
 } from "./classification";
+import { remoteScopeKeyParts, type LedgerRemoteScopeKey } from "./keys";
 import type { LedgerRecordKind, LedgerScopeKey } from "./keys";
 
 /** How far above the contiguous cursor resume() scans for stored stragglers. */
@@ -66,6 +68,48 @@ export interface ProjectionSnapshotRepairSource {
       revision?: string | number;
     }>;
   } | null>;
+}
+
+/** Projection snapshot content for a bootstrap install (W3 recovery). */
+export interface ProjectionSnapshotInstall {
+  /** Authoritative boundary: every display event <= it is in the snapshot. */
+  snapshotThroughSeq: number;
+  /** Committed event head named by the snapshot; may exceed the boundary. */
+  eventHeadSeq: number;
+  /** Canonical records carried by the snapshot (e.g. the latest Brief). */
+  canonicalRecords: Array<{
+    recordKind: LedgerRecordKind;
+    recordId: string;
+    record: unknown;
+    revision?: string | number;
+  }>;
+  /** Records the projection references but the snapshot does not carry. */
+  hydrationReferences: Array<{
+    recordKind: LedgerRecordKind;
+    recordId: string;
+    revision?: string | number;
+  }>;
+  /** Records deleted at or before the boundary; they end hydration demand. */
+  hydrationTombstones: Array<{
+    recordKind: LedgerRecordKind;
+    recordId: string;
+  }>;
+}
+
+/** Read-state fields installable with a snapshot in the same transaction. */
+export type ProjectionInstallReadState = Partial<{
+  unreadBaselineSeq: number;
+  readThroughEventSeq: number;
+  certainty: "exact" | "truncated";
+  historyTruncatedBeforeSeq: number;
+  acknowledgedTruncationBeforeSeq: number;
+}>;
+
+export interface ProjectionInstallOptions {
+  /** Discard the agent's raw/projection cache first (reset path). */
+  clearFirst?: { preserveReadState?: boolean };
+  /** Browser-local read-state patch committed atomically with the install. */
+  readState?: ProjectionInstallReadState;
 }
 
 export type LedgerIngestionState =
@@ -170,6 +214,21 @@ function revisionSatisfies(
     return actual >= expected;
   }
   return String(actual) >= String(expected);
+}
+
+/**
+ * Merge two expected revisions by keeping whichever demands more: an
+ * out-of-order invalidation carrying a lower revision must never weaken a
+ * demand already merged from a later event (W2 review note).
+ */
+function strictestRevision(
+  a: string | number | undefined,
+  b: string | number | undefined,
+): string | number | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  // a is the strictest when it already covers b's demand.
+  return revisionSatisfies(b, a) ? a : b;
 }
 
 /**
@@ -299,8 +358,12 @@ export class LedgerIngestionPipeline {
           ? {
               ...existing,
               createdByEventSeq: Math.min(existing.createdByEventSeq, item.classified.eventSeq),
-              expectedRevision:
-                item.classified.reference.expectedRevision ?? existing.expectedRevision,
+              // Strictest (max) revision across every merged event, so a
+              // late out-of-order invalidation cannot weaken the job.
+              expectedRevision: strictestRevision(
+                item.classified.reference.expectedRevision,
+                existing.expectedRevision,
+              ),
               state: "pending",
             }
           : {
@@ -397,6 +460,168 @@ export class LedgerIngestionPipeline {
       throw error;
     }
     this.emit(scope, tracker);
+  }
+
+  /**
+   * Atomically install an authoritative projection snapshot (W3 bootstrap):
+   * canonical records, tombstones, boundary hydration jobs, both cursors at
+   * the snapshot boundary, the observed event head, and the browser-local
+   * read baseline land in one transaction. An optional `clearFirst` discards
+   * a previous cache for the same scope key inside the same transaction, so
+   * a reset followed by the install is all-or-nothing.
+   */
+  async installProjectionSnapshot(
+    scope: LedgerScopeKey,
+    install: ProjectionSnapshotInstall,
+    options: ProjectionInstallOptions = {},
+  ): Promise<LedgerIngestionStatus> {
+    if (!(await this.ensureExactHandle())) {
+      return this.statusFor(scope, this.freshTracker());
+    }
+    const ledger = this.ledger!;
+    const now = Date.now();
+    const batch = ledger.beginWrite();
+    if (options.clearFirst) {
+      batch.clearAgentScope(scope, { preserveReadState: options.clearFirst.preserveReadState });
+    }
+    for (const record of install.canonicalRecords) {
+      batch.putCanonicalRecord(
+        scope,
+        record.recordKind,
+        record.recordId,
+        record.record,
+        record.revision,
+      );
+    }
+    for (const tombstone of install.hydrationTombstones) {
+      batch.putCanonicalRecord(scope, tombstone.recordKind, tombstone.recordId, {
+        tombstone: true,
+        deletedAt: now,
+        deletedByEventSeq: install.snapshotThroughSeq,
+      } satisfies CanonicalTombstone);
+    }
+    for (const reference of install.hydrationReferences) {
+      batch.putHydrationJob(scope, {
+        ...scope,
+        jobId: jobIdFor(reference.recordKind, reference.recordId),
+        recordKind: reference.recordKind,
+        recordId: reference.recordId,
+        createdByEventSeq: install.snapshotThroughSeq,
+        expectedRevision: reference.revision,
+        attemptCount: 0,
+        state: "pending",
+        createdAt: now,
+      });
+    }
+    // The snapshot is authoritative through its boundary: both cursors sit
+    // at the boundary regardless of any prior cache for this scope key.
+    batch.advanceIngestionCursor(scope, install.snapshotThroughSeq);
+    batch.applyProjectionChange(scope, { projectionReadyThroughSeq: install.snapshotThroughSeq });
+    batch.putRuntimeScope(remoteScopeOf(scope), { eventHeadSeq: install.eventHeadSeq });
+    if (options.readState) {
+      batch.putReadState(scope, options.readState);
+    }
+    try {
+      await batch.commit();
+    } catch (error) {
+      this.trackers.delete(this.trackerKey(scope));
+      if (this.isDurabilityFailure(error)) {
+        return this.statusFor(scope, this.freshTracker());
+      }
+      throw error;
+    }
+    // Reload the tracker from the installed durable state; boundary
+    // references become ordinary pending demand the drain can service.
+    this.trackers.delete(this.trackerKey(scope));
+    const tracker = await this.ensureTracker(scope);
+    if (tracker.jobs.size > 0) {
+      void this.drainHydration(scope).catch(() => undefined);
+    }
+    const status = this.statusFor(scope, tracker);
+    this.dependencies.onStatus?.(status);
+    return status;
+  }
+
+  /**
+   * Clear an entire runtime scope durably (epoch or visibility reset) and
+   * forget its in-memory trackers. Old-scope data must never join the new
+   * scope's projection, so this removes sessions, raw events, jobs,
+   * canonical records, and read states in one transaction.
+   */
+  async clearRuntimeScope(remoteScope: LedgerRemoteScopeKey): Promise<void> {
+    if (!(await this.ensureExactHandle())) return;
+    const batch = this.ledger!.beginWrite();
+    batch.clearRuntimeScope(remoteScope);
+    await batch.commit();
+    this.forgetRuntimeScope(remoteScope);
+  }
+
+  /** Stored sessions for one agent under one remote, across scopes. */
+  async findAgentSessions(
+    remoteKey: string,
+    agentId: string,
+  ): Promise<Array<{ scope: LedgerScopeKey; ingestedThroughSeq?: number; projectionReadyThroughSeq?: number }>> {
+    if (!(await this.ensureExactHandle())) return [];
+    const sessions = await this.ledger!.findAgentSessionsByAgent(remoteKey, agentId);
+    return sessions.map((session) => ({
+      scope: {
+        remoteKey: session.remoteKey,
+        runtimeId: session.runtimeId,
+        visibilityScopeId: session.visibilityScopeId,
+        eventLogEpoch: session.eventLogEpoch,
+        agentId: session.agentId,
+      },
+      ingestedThroughSeq: session.ingestedThroughSeq,
+      projectionReadyThroughSeq: session.projectionReadyThroughSeq,
+    }));
+  }
+
+  /** Forget the in-memory tracker of one agent scope (after a clear). */
+  forgetAgentScope(scope: LedgerScopeKey): void {
+    this.trackers.delete(this.trackerKey(scope));
+  }
+
+  /** Browser-local read state of one scope, if recorded. */
+  async readStateOf(scope: LedgerScopeKey): Promise<LedgerReadStateRecord | undefined> {
+    if (!(await this.ensureExactHandle())) return undefined;
+    return this.ledger!.getReadState(scope);
+  }
+
+  /**
+   * Every agent scope with durable state under one remote. Used to seed the
+   * repository's scope registry from the restart scan without knowing the
+   * server's roster in advance.
+   */
+  async listKnownScopes(remoteKey: string): Promise<LedgerScopeKey[]> {
+    if (!(await this.ensureExactHandle())) return [];
+    const runtimeScopes = await this.ledger!.listRuntimeScopesByRemoteKey(remoteKey);
+    const result: LedgerScopeKey[] = [];
+    for (const runtimeScope of runtimeScopes) {
+      const sessions = await this.ledger!.listAgentSessions({
+        remoteKey: runtimeScope.remoteKey,
+        runtimeId: runtimeScope.runtimeId,
+        visibilityScopeId: runtimeScope.visibilityScopeId,
+        eventLogEpoch: runtimeScope.eventLogEpoch,
+      });
+      for (const session of sessions) {
+        result.push({
+          remoteKey: session.remoteKey,
+          runtimeId: session.runtimeId,
+          visibilityScopeId: session.visibilityScopeId,
+          eventLogEpoch: session.eventLogEpoch,
+          agentId: session.agentId,
+        });
+      }
+    }
+    return result;
+  }
+
+  /** Forget every in-memory tracker under one runtime scope. */
+  forgetRuntimeScope(remoteScope: LedgerRemoteScopeKey): void {
+    const prefix = `${remoteScopeKeyParts(remoteScope).join("\u0000")}\u0000`;
+    for (const key of Array.from(this.trackers.keys())) {
+      if (key.startsWith(prefix)) this.trackers.delete(key);
+    }
   }
 
   /**

--- a/web-gui/app/src/runtime/event-ledger/keys.ts
+++ b/web-gui/app/src/runtime/event-ledger/keys.ts
@@ -39,6 +39,11 @@ export function remoteScopeKeyParts(key: LedgerRemoteScopeKey): string[] {
   return [key.remoteKey, key.runtimeId, key.visibilityScopeId, key.eventLogEpoch];
 }
 
+/** Primary key of one runtime scope record. */
+export function remoteScopeRecordKey(key: LedgerRemoteScopeKey): IDBValidKey {
+  return remoteScopeKeyParts(key);
+}
+
 /** Compound in-line key for agent-scoped records. */
 export function agentRecordKey(key: LedgerScopeKey): IDBValidKey {
   return scopeKeyParts(key);

--- a/web-gui/app/src/runtime/event-ledger/ledger.ts
+++ b/web-gui/app/src/runtime/event-ledger/ledger.ts
@@ -44,6 +44,7 @@ import {
   canonicalRecordKey,
   computeEnvelopeFingerprint,
   hydrationJobKey,
+  remoteScopeRecordKey,
   rawEventKey,
   rawEventRange,
   rawEventRangeBetween,
@@ -147,6 +148,20 @@ export interface LedgerReadStateRecord {
   agentId: string;
   lastReadDeliverySeq?: number;
   lastUnreadDeliverySeq?: number;
+  /**
+   * RFC LocalReadState (observer sync): fresh unread baseline established
+   * at bootstrap. Unread is counted from qualifying brief events above
+   * `max(unreadBaselineSeq, readThroughEventSeq ?? 0)`.
+   */
+  unreadBaselineSeq?: number;
+  /** Highest delivery seq the reader has consumed; absent until first read. */
+  readThroughEventSeq?: number;
+  /** Whether unread counts above the boundary are exact or a lower bound. */
+  certainty?: "exact" | "truncated";
+  /** Retention floor of the last retention-gap reset; history below is lost. */
+  historyTruncatedBeforeSeq?: number;
+  /** User acknowledgement of unknown history after a truncation (W5 action). */
+  acknowledgedTruncationBeforeSeq?: number;
   updatedAt: number;
 }
 
@@ -184,7 +199,15 @@ type WriteOperation =
     }
   | { kind: "agent_session"; scope: LedgerScopeKey; patch: AgentSessionPatch }
   | { kind: "runtime_scope"; scope: LedgerRemoteScopeKey; patch: RuntimeScopePatch }
-  | { kind: "read_state"; scope: LedgerScopeKey; patch: ReadStatePatch };
+  | { kind: "read_state"; scope: LedgerScopeKey; patch: ReadStatePatch }
+  /**
+   * Discard every durable record of one agent scope (raw events, hydration
+   * jobs, canonical records, session). Read state survives when preserved:
+   * retention resets keep the marker to record truncation against it.
+   */
+  | { kind: "clear_agent_scope"; scope: LedgerScopeKey; preserveReadState: boolean }
+  /** Discard every agent scope and the runtime scope record itself. */
+  | { kind: "clear_runtime_scope"; scope: LedgerRemoteScopeKey };
 
 /*
  * Agent-session patches share one patch channel: per-scope patches inside one
@@ -281,6 +304,37 @@ export class EventLedgerWriteBatch {
   }
 
   /**
+   * Clear one agent scope: raw events, hydration jobs, canonical records,
+   * and the agent session land in one transaction with everything else in
+   * this batch, so a reset followed by an install is all-or-nothing. Read
+   * state is preserved for retention resets and discarded for identity
+   * resets, which must not migrate markers.
+   */
+  clearAgentScope(
+    scope: LedgerScopeKey,
+    options: { preserveReadState?: boolean } = {},
+  ): this {
+    this.assertNotCommitted();
+    this.ops.push({
+      kind: "clear_agent_scope",
+      scope,
+      preserveReadState: options.preserveReadState ?? false,
+    });
+    return this;
+  }
+
+  /**
+   * Clear an entire runtime scope: every agent scope under it plus the
+   * runtime scope record. Used for epoch and visibility resets, where no
+   * old-scope data may ever join the new scope's projection.
+   */
+  clearRuntimeScope(scope: LedgerRemoteScopeKey): this {
+    this.assertNotCommitted();
+    this.ops.push({ kind: "clear_runtime_scope", scope });
+    return this;
+  }
+
+  /**
    * Commit atomically. Rejects with a typed error on any failure; on
    * conflict, regression, or storage failure nothing is committed,
    * including the cursor.
@@ -318,6 +372,21 @@ export class EventLedgerWriteBatch {
           break;
         case "read_state":
           storeNames.add(READ_STATES_STORE);
+          break;
+        case "clear_agent_scope":
+          storeNames.add(RAW_EVENTS_STORE);
+          storeNames.add(PENDING_HYDRATION_STORE);
+          storeNames.add(CANONICAL_RECORDS_STORE);
+          storeNames.add(AGENT_SESSIONS_STORE);
+          storeNames.add(READ_STATES_STORE);
+          break;
+        case "clear_runtime_scope":
+          storeNames.add(RAW_EVENTS_STORE);
+          storeNames.add(PENDING_HYDRATION_STORE);
+          storeNames.add(CANONICAL_RECORDS_STORE);
+          storeNames.add(AGENT_SESSIONS_STORE);
+          storeNames.add(READ_STATES_STORE);
+          storeNames.add(RUNTIME_SCOPES_STORE);
           break;
       }
     }
@@ -482,6 +551,69 @@ export class EventLedgerWriteBatch {
           });
           break;
         }
+      }
+    }
+
+    /** Range-delete agent-scoped rows through the byScope index. */
+    const deleteByScopeRange = (storeName: LedgerStoreName, range: IDBKeyRange) => {
+      const index = tx.objectStore(storeName).index(BY_SCOPE_INDEX);
+      const scan = issue(() => index.openCursor(range));
+      if (!scan) return;
+      scan.onsuccess = () => {
+        const cursor = scan.result;
+        if (!cursor) return;
+        const del = issue(() => cursor.delete());
+        del?.addEventListener("error", () => {
+          failure = failure ?? (del.error ?? new Error(`${storeName} scope clear failed`));
+        });
+        try {
+          cursor.continue();
+        } catch (error) {
+          failure = failure ?? error;
+          tryAbort(tx);
+        }
+      };
+      scan.addEventListener("error", () => {
+        failure = failure ?? (scan.error ?? new Error(`${storeName} scope scan failed`));
+      });
+    };
+
+    for (const op of this.ops) {
+      if (op.kind === "clear_agent_scope") {
+        const scopeOnly = IDBKeyRange.only(scopeKeyParts(op.scope));
+        deleteByScopeRange(RAW_EVENTS_STORE, scopeOnly);
+        deleteByScopeRange(PENDING_HYDRATION_STORE, scopeOnly);
+        deleteByScopeRange(CANONICAL_RECORDS_STORE, scopeOnly);
+        const sessionDelete = issue(() =>
+          tx.objectStore(AGENT_SESSIONS_STORE).delete(agentRecordKey(op.scope)),
+        );
+        sessionDelete?.addEventListener("error", () => {
+          failure =
+            failure ?? (sessionDelete.error ?? new Error("agent session clear failed"));
+        });
+        if (!op.preserveReadState) {
+          const stateDelete = issue(() =>
+            tx.objectStore(READ_STATES_STORE).delete(agentRecordKey(op.scope)),
+          );
+          stateDelete?.addEventListener("error", () => {
+            failure =
+              failure ?? (stateDelete.error ?? new Error("read state clear failed"));
+          });
+        }
+      } else if (op.kind === "clear_runtime_scope") {
+        const scopeRange = agentScopeRange(op.scope);
+        deleteByScopeRange(RAW_EVENTS_STORE, scopeRange);
+        deleteByScopeRange(PENDING_HYDRATION_STORE, scopeRange);
+        deleteByScopeRange(CANONICAL_RECORDS_STORE, scopeRange);
+        deleteByScopeRange(AGENT_SESSIONS_STORE, scopeRange);
+        deleteByScopeRange(READ_STATES_STORE, scopeRange);
+        const runtimeDelete = issue(() =>
+          tx.objectStore(RUNTIME_SCOPES_STORE).delete(remoteScopeRecordKey(op.scope)),
+        );
+        runtimeDelete?.addEventListener("error", () => {
+          failure =
+            failure ?? (runtimeDelete.error ?? new Error("runtime scope clear failed"));
+        });
       }
     }
 
@@ -773,6 +905,32 @@ export class EventLedger {
       BY_SCOPE_INDEX,
       IDBKeyRange.only(scopeKeyParts(scope)),
     );
+  }
+
+  /**
+   * Every stored session for one agent id under one remote, across runtime
+   * scopes, epochs, and visibility scopes. Recovery uses this to find the
+   * current scope and to detect identity changes that require a reset.
+   */
+  async findAgentSessionsByAgent(
+    remoteKey: string,
+    agentId: string,
+  ): Promise<LedgerAgentSessionRecord[]> {
+    const db = this.requireOpenDb();
+    const scopes = await this.listRuntimeScopesByRemoteKey(remoteKey);
+    const result: LedgerAgentSessionRecord[] = [];
+    for (const runtimeScope of scopes) {
+      const sessions = await this.listAgentSessions({
+        remoteKey: runtimeScope.remoteKey,
+        runtimeId: runtimeScope.runtimeId,
+        visibilityScopeId: runtimeScope.visibilityScopeId,
+        eventLogEpoch: runtimeScope.eventLogEpoch,
+      });
+      for (const session of sessions) {
+        if (session.agentId === agentId) result.push(session);
+      }
+    }
+    return result;
   }
 
   async getReadState(scope: LedgerScopeKey): Promise<LedgerReadStateRecord | undefined> {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -10,6 +10,7 @@ import {
 import {
   AgentSessionRepository,
   isSessionCacheContextCurrent,
+  snapshotRepairFromClient,
 } from "./agent-session-repository";
 import {
   applyProjectionAction,
@@ -1079,11 +1080,15 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
     isAgentStateInvalidationEvent: isAgentStateCacheInvalidationEvent,
     catchUpErrorKind: agentDetailErrorKind,
     ledgerIngestion: {
-      // Stable runtime identity (runtime id + visibility scope) reaches the
-      // client with the W3/W4 roster and projection snapshot cutover. Until
-      // then the ledger scope is unresolvable and durable ingestion stays
-      // dormant: the in-memory path is unchanged.
-      resolveScope: () => null,
+      // Stable runtime identity (runtime id + visibility scope) is learned
+      // from the per-Agent projection snapshot during W3 recovery; the
+      // repository also seeds it from the durable restart scan. The
+      // registry stays empty for remotes without the snapshot capability,
+      // so the in-memory path is unchanged until the W4/W6 cutover.
+      resolveScope: (agentId) => agentSessionRepository.knownLedgerScope(agentId),
+      snapshotRepair: snapshotRepairFromClient((agentId) =>
+        runtimeClient.getAgentProjectionSnapshot(agentId),
+      ),
       fetchers: {
         fetchCanonicalRecords: async (agentId, recordKind, recordIds) => {
           if (recordKind === "message") {


### PR DESCRIPTION
## Summary

Implements the **W3** slice of the approved observer-sync implementation plan (`docs/rfcs/observer-sync-agent-summary-and-read-markers.md`): per-Agent bootstrap, catch-up, and retention/epoch/visibility reset over the W1 event ledger and the W2 ingestion pipeline.

### Runtime concept changed

The browser now owns a per-Agent **recovery state machine** above durable ingestion:

- **Bootstrap of a newly visible Agent**: fetch the S5 projection snapshot → atomically install canonical records, boundary hydration references/tombstones, both cursors at `snapshot_through_seq`, the observed event head, and a fresh unread baseline → replay raw events beyond the boundary → enter live once contiguous.
- **Exact retained catch-up**: an existing contiguous cache replays `after_seq` pages toward the observed roster/page head without touching read state.
- **Independent reset reasons**: `retained_prefix_gap`, `cursor_error`, `immutable_conflict`, `hydration_divergence`, `epoch_change`, `visibility_scope_change`.
  - Retention-family resets preserve the read-state record, record `history_truncated_before_seq`, and downgrade certainty to `truncated` only when the effective boundary fell below `oldest_retained_seq - 1`.
  - Epoch and visibility resets clear the entire old runtime scope (sessions, raw events, jobs, canonical records, read states) before any new-scope data is installed; read markers never migrate.
- **Streams as buffered hints**: live envelopes offered while recovery is in flight (including during the snapshot fetch, before the scope is known) buffer and replay through the same ingest path; duplicates stay idempotent by immutable identity.

### Supporting changes

- Ledger clear primitives `clearAgentScope`/`clearRuntimeScope` execute in the same atomic transaction as the install that follows, so a reset + install is all-or-nothing.
- `LedgerReadStateRecord` gains the RFC `LocalReadState` fields (`unreadBaselineSeq`, `readThroughEventSeq`, `certainty`, `historyTruncatedBeforeSeq`, `acknowledgedTruncationBeforeSeq`).
- Client learns `getAgentProjectionSnapshot` and captures rich `cursor_not_found` extensions (`oldest_retained_seq`, `event_head_seq`, `event_log_epoch`) so a retained-prefix gap is distinguishable from an epoch change; the W2 snapshot-repair source is wired over the same endpoint.
- `AgentSessionRepository` owns the coordinator lifecycle: an opportunistic recovery trigger from the ordinary catch-up flow (once per generation, skipped when the capability is absent), a discovered-scope registry behind `resolveScope`, and one bounded `sync_error` → divergence re-bootstrap escalation.
- W2 review follow-up: reference-job `expectedRevision` merging now keeps the strictest (max) revision instead of last-writer-wins, plus the classification.ts comment documenting that an authoritative snapshot install may pass `unknown_envelope_version` blockers below its boundary.

### Dormancy boundary

`resolveScope` only resolves scopes the recovery layer actually discovered, so remotes without `agents.projection-snapshot.v1` keep the in-memory path unchanged; the authoritative discovery cutover is W4 and the default-on cutover is W6.

## Test plan

- [x] `web-gui/app/src/runtime/event-ledger/agent-recovery.test.ts` (10 tests): bootstrap install/baseline/replay/live; capability-absent skip; buffered hints with no loss and no duplicate projection; exact retained catch-up; retention truncation with preserved marker; epoch reset clearing the old scope without marker migration; visibility rotation clearing old cache before new data; `cursor_not_found` bounded retention reset; immutable-conflict re-bootstrap; bounded divergence escalation.
- [x] Ingestion pipeline regression: late lower-revision invalidation cannot weaken the merged hydration job.
- [x] Repository integration: catch-up triggers durable bootstrap, registers the discovered scope, and routes live envelopes through the coordinator.
- [x] `npm run typecheck`, `npm run test` (388 tests), `npm run build` all green.