### PR TITLE
fix: W4 review nits and roster settle-fresh guard

### DIFF
--- a/web-gui/app/src/features/dashboard/DashboardPage.tsx
+++ b/web-gui/app/src/features/dashboard/DashboardPage.tsx
@@ -6,6 +6,7 @@ import { Card } from "../../components/ui/Card";
 import { EmptyState } from "../../components/ui/EmptyState";
 import { Skeleton } from "../../components/ui/Skeleton";
 import { AgentStateBadge, StatusBadge } from "../../components/ui/StatusChip";
+import { ROSTER_STALE_EXTENDED_RETRY_ATTEMPTS } from "../../runtime/global-sync-coordinator";
 import type { RosterDiscoveryState } from "../../runtime/types";
 import { compactModelRouteDisplay } from "../../lib/model-route-ref";
 import type { AgentSummary, DashboardMetric, RuntimeConnection } from "../../runtime/types";
@@ -52,7 +53,11 @@ export function DashboardPage({ agents, metrics, connection, discovery, loading,
           {discovery?.freshness === "stale" ? (
             <div className="roster-discovery-banner stale" role="status">
               <strong>{t("dashboard.rosterStaleTitle")}</strong>
-              <span>{t("dashboard.rosterStaleBody")}</span>
+              <span>
+                {discovery.retryAttempt >= ROSTER_STALE_EXTENDED_RETRY_ATTEMPTS
+                  ? t("dashboard.rosterStaleExtendedBody", { attempt: discovery.retryAttempt })
+                  : t("dashboard.rosterStaleBody")}
+              </span>
             </div>
           ) : null}
           {discovery?.freshness === "unauthorized" ? (

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -180,6 +180,8 @@ const en = {
     statePreviewBody: "Configure or reach the local Holon API to switch this dashboard to live data.",
     rosterStaleTitle: "Roster connection interrupted",
     rosterStaleBody: "Showing the last complete agent roster while discovery retries in the background.",
+    rosterStaleExtendedBody:
+      "Discovery has retried {{attempt}} times without success. The roster below may be outdated.",
     rosterUnauthorizedTitle: "Authorization lost",
     rosterUnauthorizedBody: "The cached agent roster is no longer currently authorized data. Reauthenticate, then refresh.",
     dashboardAria: "Dashboard",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -182,6 +182,7 @@ const zh: Record<string, any> = {
     statePreviewBody: "配置或连接本地 Holon API，将此仪表盘切换到实时数据。",
     rosterStaleTitle: "智能体列表连接中断",
     rosterStaleBody: "后台正在重试发现流程，当前显示最近一次完整的智能体列表。",
+    rosterStaleExtendedBody: "后台已连续重试 {{attempt}} 次仍未成功，下方列表可能已过期。",
     rosterUnauthorizedTitle: "授权已失效",
     rosterUnauthorizedBody: "缓存的智能体列表已不再是当前授权数据。请重新认证后再刷新。",
     dashboardAria: "仪表盘",

--- a/web-gui/app/src/runtime/global-sync-coordinator.test.ts
+++ b/web-gui/app/src/runtime/global-sync-coordinator.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { ROSTER_STALE_EXTENDED_RETRY_ATTEMPTS } from "./global-sync-coordinator";
 import { useRuntimeStore, type AgentSessionState } from "./runtime-store";
 import { createSessionProjectionState } from "./session-projection";
 
@@ -561,6 +562,77 @@ describe("authoritative discovery cutover", () => {
         freshness: "fresh",
       });
     });
+  });
+
+  it("escalates extended transient snapshot failure streaks without purging the roster", async () => {
+    const retryCallbacks: Array<() => void> = [];
+    vi.stubGlobal("window", {
+      localStorage: new MemoryStorage(),
+      sessionStorage: new MemoryStorage(),
+      setTimeout: (callback: () => void, _delay?: number) => {
+        retryCallbacks.push(callback);
+        return retryCallbacks.length;
+      },
+      clearTimeout: () => undefined,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname.endsWith("/handshake")) {
+        return Promise.resolve(jsonResponse({ capabilities: ["agents.list", "agents.roster-snapshot.v1"] }));
+      }
+      if (url.pathname.endsWith("/agents/list")) {
+        return Promise.resolve(jsonResponse([listEntry("agent-a"), listEntry("agent-b")]));
+      }
+      if (url.pathname.endsWith("/agents/snapshot")) {
+        return Promise.resolve(errorJsonResponse(500, { error: "snapshot assembly failed" }));
+      }
+      if (url.pathname.endsWith("/projection-snapshot")) {
+        return Promise.resolve(errorJsonResponse(503, { error: "capability unavailable", code: "capability_unavailable" }));
+      }
+      if (url.pathname.endsWith("/events/stream")) {
+        return Promise.resolve(sseResponse(init, () => undefined));
+      }
+      if (url.pathname.endsWith("/agents/agent-a/events")) {
+        if (url.searchParams.get("order") === "desc") return Promise.resolve(jsonResponse(baselinePage("agent-a")));
+        return Promise.resolve(jsonResponse(emptyEventsPage("agent-a")));
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+
+    useRuntimeStore.getState().registerAgentForEvents("agent-a");
+
+    await vi.waitFor(() => {
+      expect(useRuntimeStore.getState().discovery).toMatchObject({
+        mode: "authoritative",
+        freshness: "stale",
+        retryAttempt: 1,
+      });
+    });
+    // A long transient streak keeps the previous roster and lets the retry
+    // counter climb past the dashboard's extended-stale threshold.
+    while (
+      (useRuntimeStore.getState().discovery?.retryAttempt ?? 0)
+        < ROSTER_STALE_EXTENDED_RETRY_ATTEMPTS
+    ) {
+      const pending = retryCallbacks.splice(0);
+      expect(pending.length).toBeGreaterThan(0);
+      for (const retry of pending) retry();
+      await vi.waitFor(() => {
+        expect(
+          (useRuntimeStore.getState().discovery?.retryAttempt ?? 0)
+            >= ROSTER_STALE_EXTENDED_RETRY_ATTEMPTS
+            || retryCallbacks.length > 0,
+        ).toBe(true);
+      });
+    }
+    expect(useRuntimeStore.getState().discovery).toMatchObject({
+      mode: "authoritative",
+      freshness: "stale",
+    });
+    expect(useRuntimeStore.getState().bootstrap.agents.map((agent) => agent.id)).toEqual(["agent-a", "agent-b"]);
   });
 
   it("separates authorization failure from transient failure and stops retrying", async () => {

--- a/web-gui/app/src/runtime/global-sync-coordinator.ts
+++ b/web-gui/app/src/runtime/global-sync-coordinator.ts
@@ -97,6 +97,12 @@ const STREAM_RECONNECT_BASE_MS = 1_000;
 const STREAM_RECONNECT_MAX_MS = 15_000;
 const GLOBAL_STREAM_STALE_TIMEOUT_MS = 45_000;
 const GLOBAL_BACKFILL_LIMIT = 100;
+
+// Once transient roster retries pass this attempt count (backoff fully
+// saturated at STREAM_RECONNECT_MAX_MS), the dashboard escalates the stale
+// banner so an extended outage stays visible to the operator.
+export const ROSTER_STALE_EXTENDED_RETRY_ATTEMPTS = 6;
+
 const GLOBAL_BACKFILL_MAX_PAGES = 10;
 const GLOBAL_BACKFILL_CONCURRENCY = 4;
 /** Low-rate safety net: full roster reconciliation at most this often. */
@@ -286,6 +292,7 @@ export class GlobalSyncCoordinator<State extends GlobalSyncStoreState> {
     );
     const cycle = (async () => {
       let refreshAgain = true;
+      let settledFromSnapshot = false;
       while (
         refreshAgain
         && this.dependencies.isCurrentClientRequest(request)
@@ -321,6 +328,7 @@ export class GlobalSyncCoordinator<State extends GlobalSyncStoreState> {
           span.end("skipped", { reason: "capability_absent" });
           return;
         }
+        settledFromSnapshot = true;
         this.clearRosterRetrySchedule();
         this.rosterRetryAttempt = 0;
         const identity: RosterDiscoveryIdentity = {
@@ -348,6 +356,14 @@ export class GlobalSyncCoordinator<State extends GlobalSyncStoreState> {
         this.syncRoster(get, set);
         if (this.rosterDirty) refreshAgain = true;
         span.end("ok", { agentCount: snapshot.agents.length, omitted: omittedAgentIds.length });
+      }
+      // A cycle that never applied a snapshot (for example a roster retry
+      // firing while the stream is down and reconnecting) must not mark
+      // discovery fresh; the previous stale state stays authoritative
+      // until a real snapshot settles.
+      if (!settledFromSnapshot) {
+        span.end("skipped", { reason: "stream_unavailable" });
+        return;
       }
       // Discovery is marked fresh only after the settle of the last
       // (possibly coalesced) successful refresh.

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -974,8 +974,9 @@ function applyRosterSnapshotToStore(
       context.previousIdentity.eventLogEpoch !== identity.eventLogEpoch);
   let omittedAgentIds: string[] = [];
   set((state) => {
+    const cachedAgentsById = cachedAgentsByIdFromState(state);
     const rosterAgents = projectRosterAgents(snapshot).map((agent) => {
-      const cached = cachedAgentsByIdFromState(state)[agent.id];
+      const cached = cachedAgentsById[agent.id];
       return cached ? mergeBootstrapAgentState(agent, cached) : agent;
     });
     const rosterIds = new Set(rosterAgents.map((agent) => agent.id));
@@ -983,7 +984,7 @@ function applyRosterSnapshotToStore(
     omittedAgentIds = identityReset
       ? previousIds
       : previousIds.filter((id) => !rosterIds.has(id));
-    const dropIds = new Set([...omittedAgentIds, ...(identityReset ? previousIds : [])]);
+    const dropIds = new Set(identityReset ? previousIds : omittedAgentIds);
     const sessionsByAgentId = dropIds.size
       ? Object.fromEntries(
           Object.entries(state.sessionsByAgentId).filter(([id]) => !dropIds.has(id)),


### PR DESCRIPTION
Follow-up to #2631 (merged) addressing the holonbot review nits plus a real bug its extended-streak scenario surfaced.

**Review nits addressed**
- `cachedAgentsByIdFromState(state)` is now built once before the per-agent `.map()` in `applyRosterSnapshotToStore`.
- `dropIds` simplifies to a single source set: `new Set(identityReset ? previousIds : omittedAgentIds)` instead of a self-union during identity reset.
- Transient roster retries stay intentionally unbounded for the authoritative path, but the dashboard stale banner now escalates once the streak passes `ROSTER_STALE_EXTENDED_RETRY_ATTEMPTS` (backoff fully saturated), with a new `rosterStaleExtendedBody` string in en and zh-CN.

**Bug fix**
`refreshRosterInner` previously fell through to the settle-fresh write even when its retry cycle never ran (roster retry firing while the global stream is down and reconnecting), marking discovery `fresh` with `retryAttempt: 0` without any successful snapshot and masking a potentially indefinite stale window. The cycle now only settles fresh after it actually applied a snapshot; a skipped cycle leaves the previous stale state untouched and the reconnect's `beginDiscovery` retries normally.

**Testing**
- New coordinator test drives a transient streak past the extended threshold and asserts the roster is never purged while discovery stays stale.
- `npm run typecheck` and `vitest run` (36 files, 399 tests) pass.