### PR TITLE
fix: bound schema 49 brief linkage backfill

### DIFF
--- a/docs/implementation-decisions/111-schema-49-brief-linkage-backfill.md
+++ b/docs/implementation-decisions/111-schema-49-brief-linkage-backfill.md
@@ -1,0 +1,30 @@
+# Schema 49 brief-linkage backfill
+
+## Choice
+
+Schema 49 materializes all historical `brief_created` audit events into a
+temporary candidate table in one scan, indexes that table by Brief and agent
+identity, and aggregates candidates for every unlinked Brief through the
+temporary index.
+
+The Rust classification loop consumes only the aggregate result. It preserves
+the existing unique, missing, ambiguous, and missing-sequence outcomes and
+drops both temporary tables before the migration transaction completes.
+
+## Reason
+
+The previous backfill queried `audit_events` once per Brief. The candidate
+predicate included JSON extraction and had no matching persistent index, so
+SQLite performed a full audit-event scan for every historical Brief. Large
+runtime databases therefore made daemon startup effectively unbounded.
+
+A persistent expression index would change the runtime schema for a one-time
+migration. Temporary materialization keeps the optimization local to the
+backfill while reducing its work to one audit-event scan plus indexed
+candidate lookups.
+
+## Preserved boundary
+
+The backfill remains atomic and conservative: it never guesses an ambiguous
+link, never rewrites Brief content or timestamps, and still rejects negative
+event sequences before storing the immutable `created_event_seq`.

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3466,15 +3466,50 @@ fn backfill_brief_created_event_linkage(transaction: &Transaction<'_>) -> Result
     if !table_exists_tx(transaction, "briefs")? || !table_exists_tx(transaction, "audit_events")? {
         return Ok(());
     }
-    let rows: Vec<(String, String, String)> = {
-        let mut statement =
-            transaction.prepare("SELECT evidence_id, agent_id, payload_json FROM briefs")?;
+    tracing::info!("materializing brief_created candidates for linkage backfill");
+    transaction.execute_batch(
+        "DROP TABLE IF EXISTS temp._brief_created_candidate_agg;
+         DROP TABLE IF EXISTS temp._brief_created_candidates;
+         CREATE TEMP TABLE _brief_created_candidates AS
+         SELECT audit_event_id,
+                event_seq,
+                agent_id AS agent_id_col,
+                COALESCE(json_extract(data_json, '$.agent_id'), '') AS agent_id_json,
+                COALESCE(json_extract(data_json, '$.brief_id'), '') AS brief_id
+         FROM audit_events
+         WHERE kind = 'brief_created';
+         CREATE INDEX _idx_brief_created_candidates_lookup
+           ON _brief_created_candidates(brief_id, agent_id_col, agent_id_json);
+         CREATE TEMP TABLE _brief_created_candidate_agg AS
+         SELECT briefs.evidence_id,
+                briefs.agent_id,
+                briefs.payload_json,
+                COUNT(candidates.audit_event_id) AS candidate_count,
+                CASE WHEN COUNT(candidates.audit_event_id) = 1
+                     THEN MIN(candidates.event_seq)
+                     ELSE NULL
+                END AS single_event_seq
+         FROM briefs
+         LEFT JOIN _brief_created_candidates AS candidates
+           ON candidates.brief_id = briefs.evidence_id
+          AND (candidates.agent_id_col = briefs.agent_id
+               OR candidates.agent_id_json = briefs.agent_id)
+         WHERE briefs.created_event_seq IS NULL
+         GROUP BY briefs.evidence_id, briefs.agent_id, briefs.payload_json;",
+    )?;
+    let rows: Vec<(String, String, String, i64, Option<i64>)> = {
+        let mut statement = transaction.prepare(
+            "SELECT evidence_id, agent_id, payload_json, candidate_count, single_event_seq
+             FROM _brief_created_candidate_agg",
+        )?;
         let rows = statement
             .query_map([], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
                     row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, Option<i64>>(4)?,
                 ))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -3483,47 +3518,30 @@ fn backfill_brief_created_event_linkage(transaction: &Transaction<'_>) -> Result
     let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
     let mut linked = 0usize;
     let mut uncertain = 0usize;
-    for (evidence_id, agent_id, payload_json) in rows {
-        let candidates: Vec<(String, Option<i64>)> = {
-            let mut statement = transaction.prepare(
-                "SELECT audit_event_id, event_seq FROM audit_events
-                 WHERE kind = 'brief_created'
-                   AND COALESCE(json_extract(data_json, '$.brief_id'), '') = ?1
-                   AND (agent_id = ?2
-                        OR COALESCE(json_extract(data_json, '$.agent_id'), '') = ?2)",
-            )?;
-            let rows = statement
-                .query_map(params![evidence_id, agent_id], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?))
-                })?
-                .collect::<std::result::Result<Vec<_>, _>>()?;
-            rows
-        };
-        let (candidate_count, reason) = if candidates.len() == 1 {
-            match candidates[0].1 {
+    for (evidence_id, agent_id, payload_json, candidate_count, single_event_seq) in rows {
+        let reason = if candidate_count == 1 {
+            match single_event_seq {
                 Some(event_seq) => {
                     let mut brief: crate::types::BriefRecord = serde_json::from_str(&payload_json)
                         .context("decoding brief payload for created_event_seq backfill")?;
-                    if brief.created_event_seq.is_none() {
-                        brief.created_event_seq =
-                            Some(u64::try_from(event_seq).with_context(|| {
-                                format!("brief_created event_seq {event_seq} must be non-negative")
-                            })?);
-                        transaction.execute(
-                            "UPDATE briefs SET created_event_seq = ?1, payload_json = ?2
-                             WHERE evidence_id = ?3",
-                            params![event_seq, serde_json::to_string(&brief)?, evidence_id],
-                        )?;
-                        linked += 1;
-                    }
+                    brief.created_event_seq =
+                        Some(u64::try_from(event_seq).with_context(|| {
+                            format!("brief_created event_seq {event_seq} must be non-negative")
+                        })?);
+                    transaction.execute(
+                        "UPDATE briefs SET created_event_seq = ?1, payload_json = ?2
+                         WHERE evidence_id = ?3 AND created_event_seq IS NULL",
+                        params![event_seq, serde_json::to_string(&brief)?, evidence_id],
+                    )?;
+                    linked += 1;
                     continue;
                 }
-                None => (1, "candidate_event_missing_seq"),
+                None => "candidate_event_missing_seq",
             }
-        } else if candidates.is_empty() {
-            (0, "no_candidate_event")
+        } else if candidate_count == 0 {
+            "no_candidate_event"
         } else {
-            (candidates.len(), "ambiguous_candidate_events")
+            "ambiguous_candidate_events"
         };
         transaction.execute(
             "INSERT INTO brief_created_linkage_uncertain
@@ -3537,6 +3555,10 @@ fn backfill_brief_created_event_linkage(transaction: &Transaction<'_>) -> Result
         )?;
         uncertain += 1;
     }
+    transaction.execute_batch(
+        "DROP TABLE temp._brief_created_candidate_agg;
+         DROP TABLE temp._brief_created_candidates;",
+    )?;
     if linked > 0 || uncertain > 0 {
         tracing::info!(
             linked,

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3524,6 +3524,8 @@ fn backfill_brief_created_event_linkage(transaction: &Transaction<'_>) -> Result
                 Some(event_seq) => {
                     let mut brief: crate::types::BriefRecord = serde_json::from_str(&payload_json)
                         .context("decoding brief payload for created_event_seq backfill")?;
+                    // Schema 49's new column is authoritative: when it is NULL, replace any
+                    // payload-only value with the uniquely matched audit event sequence.
                     brief.created_event_seq =
                         Some(u64::try_from(event_seq).with_context(|| {
                             format!("brief_created event_seq {event_seq} must be non-negative")

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -730,28 +730,31 @@ mod tests {
             let linked = seed_brief("brief-linked", "unique candidate")?;
             let _missing = seed_brief("brief-missing", "no candidate")?;
             let ambiguous = seed_brief("brief-ambiguous", "two candidates")?;
-            let seed_event = |audit_event_id: &str, event_seq: i64, brief_id: &str| -> Result<()> {
-                connection.execute(
-                    "INSERT INTO audit_events (
+            let missing_seq = seed_brief("brief-missing-seq", "candidate without sequence")?;
+            let seed_event =
+                |audit_event_id: &str, event_seq: Option<i64>, brief_id: &str| -> Result<()> {
+                    connection.execute(
+                        "INSERT INTO audit_events (
                            audit_event_id, event_seq, agent_id, kind, created_at, data_json
                          ) VALUES (?1, ?2, ?3, 'brief_created', ?4, ?5)",
-                    params![
-                        audit_event_id,
-                        event_seq,
-                        "agent-a",
-                        timestamp(Utc::now()),
-                        serde_json::json!({
-                            "brief_id": brief_id,
-                            "agent_id": "agent-a",
-                        })
-                        .to_string()
-                    ],
-                )?;
-                Ok(())
-            };
-            seed_event("event-linked", 11, &linked.id)?;
-            seed_event("event-ambiguous-a", 21, &ambiguous.id)?;
-            seed_event("event-ambiguous-b", 22, &ambiguous.id)?;
+                        params![
+                            audit_event_id,
+                            event_seq,
+                            "agent-a",
+                            timestamp(Utc::now()),
+                            serde_json::json!({
+                                "brief_id": brief_id,
+                                "agent_id": "agent-a",
+                            })
+                            .to_string()
+                        ],
+                    )?;
+                    Ok(())
+                };
+            seed_event("event-linked", Some(11), &linked.id)?;
+            seed_event("event-ambiguous-a", Some(21), &ambiguous.id)?;
+            seed_event("event-ambiguous-b", Some(22), &ambiguous.id)?;
+            seed_event("event-missing-seq", None, &missing_seq.id)?;
 
             apply_migration(&mut connection, &MIGRATIONS[48])?;
 
@@ -773,6 +776,7 @@ mod tests {
             for (brief_id, expected_reason) in [
                 ("brief-missing", "no_candidate_event"),
                 ("brief-ambiguous", "ambiguous_candidate_events"),
+                ("brief-missing-seq", "candidate_event_missing_seq"),
             ] {
                 let linkage: Option<i64> = connection.query_row(
                     "SELECT created_event_seq FROM briefs WHERE evidence_id = ?1",
@@ -798,6 +802,134 @@ mod tests {
             let foundations = db.observer_sync_foundations()?;
             assert!(foundations.brief_atomic_linkage_verified);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn migration_49_backfill_is_bounded() -> Result<()> {
+        let (_temp_dir, db_path, _lock_path) = temp_paths()?;
+        let mut connection = open_connection(&db_path)?;
+        migrate_through(&mut connection, 48)?;
+        connection.execute_batch("ALTER TABLE briefs ADD COLUMN created_event_seq INTEGER;")?;
+
+        const BRIEF_COUNT: i64 = 512;
+        const NOISE_EVENT_COUNT: i64 = 4_096;
+        {
+            let transaction = connection.transaction()?;
+            for index in 0..BRIEF_COUNT {
+                let evidence_id = format!("brief-bounded-{index}");
+                let mut brief = BriefRecord::new(
+                    "agent-a",
+                    crate::types::BriefKind::Result,
+                    format!("bounded candidate {index}"),
+                    None,
+                    None,
+                );
+                brief.id = evidence_id.clone();
+                transaction.execute(
+                    "INSERT INTO briefs (
+                       evidence_id, agent_id, created_at, kind, preview, payload_json
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    params![
+                        evidence_id,
+                        brief.agent_id,
+                        timestamp(brief.created_at),
+                        "result",
+                        brief.text,
+                        serde_json::to_string(&brief)?
+                    ],
+                )?;
+                transaction.execute(
+                    "INSERT INTO audit_events (
+                       audit_event_id, event_seq, agent_id, kind, created_at, data_json
+                     ) VALUES (?1, ?2, ?3, 'brief_created', ?4, ?5)",
+                    params![
+                        format!("event-bounded-{index}"),
+                        index + 1,
+                        "agent-a",
+                        timestamp(Utc::now()),
+                        serde_json::json!({
+                            "brief_id": brief.id,
+                            "agent_id": "agent-a",
+                        })
+                        .to_string()
+                    ],
+                )?;
+            }
+            for index in 0..NOISE_EVENT_COUNT {
+                transaction.execute(
+                    "INSERT INTO audit_events (
+                       audit_event_id, event_seq, agent_id, kind, created_at, data_json
+                     ) VALUES (?1, ?2, ?3, 'task_created', ?4, '{}')",
+                    params![
+                        format!("event-noise-{index}"),
+                        BRIEF_COUNT + index + 1,
+                        "agent-a",
+                        timestamp(Utc::now()),
+                    ],
+                )?;
+            }
+            transaction.commit()?;
+        }
+
+        connection.execute_batch(
+            "CREATE TEMP TABLE _brief_created_candidates AS
+             SELECT audit_event_id,
+                    event_seq,
+                    agent_id AS agent_id_col,
+                    COALESCE(json_extract(data_json, '$.agent_id'), '') AS agent_id_json,
+                    COALESCE(json_extract(data_json, '$.brief_id'), '') AS brief_id
+             FROM audit_events
+             WHERE kind = 'brief_created';
+             CREATE INDEX _idx_brief_created_candidates_lookup
+               ON _brief_created_candidates(brief_id, agent_id_col, agent_id_json);",
+        )?;
+        let query_plan = {
+            let mut statement = connection.prepare(
+                "EXPLAIN QUERY PLAN
+                 SELECT briefs.evidence_id,
+                        briefs.agent_id,
+                        briefs.payload_json,
+                        COUNT(candidates.audit_event_id),
+                        CASE WHEN COUNT(candidates.audit_event_id) = 1
+                             THEN MIN(candidates.event_seq)
+                             ELSE NULL
+                        END
+                 FROM briefs
+                 LEFT JOIN _brief_created_candidates AS candidates
+                   ON candidates.brief_id = briefs.evidence_id
+                  AND (candidates.agent_id_col = briefs.agent_id
+                       OR candidates.agent_id_json = briefs.agent_id)
+                 WHERE briefs.created_event_seq IS NULL
+                 GROUP BY briefs.evidence_id, briefs.agent_id, briefs.payload_json",
+            )?;
+            let payloads = statement
+                .query_map([], |row| row.get::<_, String>(3))?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            payloads
+        };
+        assert!(
+            query_plan.iter().any(|detail| {
+                detail
+                    .contains("SEARCH candidates USING INDEX _idx_brief_created_candidates_lookup")
+            }),
+            "candidate aggregation must use the temporary lookup index: {query_plan:?}"
+        );
+        assert!(
+            query_plan
+                .iter()
+                .all(|detail| !detail.contains("audit_events")),
+            "candidate aggregation must not rescan audit_events: {query_plan:?}"
+        );
+        connection.execute_batch("DROP TABLE temp._brief_created_candidates;")?;
+
+        apply_migration(&mut connection, &MIGRATIONS[48])?;
+        let linked_count: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM briefs WHERE created_event_seq IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(linked_count, BRIEF_COUNT);
         Ok(())
     }
 

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -872,6 +872,8 @@ mod tests {
             transaction.commit()?;
         }
 
+        // Keep this candidate table and index SQL aligned with
+        // backfill_brief_created_event_linkage.
         connection.execute_batch(
             "CREATE TEMP TABLE _brief_created_candidates AS
              SELECT audit_event_id,


### PR DESCRIPTION
## Summary

- replace schema 49's per-brief full scan of `audit_events` with a single materialization scan plus indexed temporary tables
- preserve the existing unique/missing/ambiguous linkage semantics, including invalid and absent `event_seq` handling
- add migration regression coverage for missing sequence data and a large-history query-budget guard
- document the implementation decision and complexity boundary

## Runtime concept changed

Schema 49 migration work is now bounded by one scan of `audit_events` plus indexed candidate lookups instead of `O(briefs × audit_events)`. This prevents daemon startup from stalling for hours on large databases while preserving the conservative linkage contract.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test migration_49_ -- --nocapture`
- `git diff --check`

Closes #2633
