### PR TITLE
fix: verify persisted observer sync payload shapes

### DIFF
--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3474,8 +3474,8 @@ fn backfill_brief_created_event_linkage(transaction: &Transaction<'_>) -> Result
          SELECT audit_event_id,
                 event_seq,
                 agent_id AS agent_id_col,
-                COALESCE(json_extract(data_json, '$.agent_id'), '') AS agent_id_json,
-                COALESCE(json_extract(data_json, '$.brief_id'), '') AS brief_id
+                COALESCE(json_extract(data_json, '$.data.agent_id'), '') AS agent_id_json,
+                COALESCE(json_extract(data_json, '$.data.brief_id'), '') AS brief_id
          FROM audit_events
          WHERE kind = 'brief_created';
          CREATE INDEX _idx_brief_created_candidates_lookup

--- a/src/runtime_db/observer_sync.rs
+++ b/src/runtime_db/observer_sync.rs
@@ -763,8 +763,8 @@ fn verify_brief_atomic_linkage(connection: &Connection) -> Result<bool> {
            SELECT COUNT(*) FROM audit_events e
            WHERE e.kind = 'brief_created'
              AND e.event_seq = b.created_event_seq
-             AND COALESCE(e.agent_id, json_extract(e.data_json, '$.agent_id')) = b.agent_id
-             AND json_extract(e.data_json, '$.brief_id') = b.evidence_id
+             AND COALESCE(e.agent_id, json_extract(e.data_json, '$.data.agent_id')) = b.agent_id
+             AND json_extract(e.data_json, '$.data.brief_id') = b.evidence_id
          ) != 1",
         [],
         |row| row.get(0),
@@ -892,7 +892,7 @@ fn count_agent_state_identity_mismatches(connection: &Connection) -> Result<u64>
             .ok()
             .and_then(|payload| {
                 payload
-                    .get("agent_id")
+                    .get("id")
                     .and_then(serde_json::Value::as_str)
                     .map(str::to_string)
             });

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -740,7 +740,10 @@ mod tests {
             let ambiguous = seed_brief("brief-ambiguous", "two candidates")?;
             let missing_seq = seed_brief("brief-missing-seq", "candidate without sequence")?;
             let seed_event =
-                |audit_event_id: &str, event_seq: Option<i64>, brief_id: &str| -> Result<()> {
+                |audit_event_id: &str, event_seq: Option<i64>, brief: &BriefRecord| -> Result<()> {
+                    let mut event = crate::types::brief_created_event_for(brief)?;
+                    event.id = audit_event_id.into();
+                    event.event_seq = event_seq.unwrap_or_default() as u64;
                     connection.execute(
                         "INSERT INTO audit_events (
                            audit_event_id, event_seq, agent_id, kind, created_at, data_json
@@ -750,19 +753,15 @@ mod tests {
                             event_seq,
                             "agent-a",
                             timestamp(Utc::now()),
-                            serde_json::json!({
-                                "brief_id": brief_id,
-                                "agent_id": "agent-a",
-                            })
-                            .to_string()
+                            serde_json::to_string(&event)?
                         ],
                     )?;
                     Ok(())
                 };
-            seed_event("event-linked", Some(11), &linked.id)?;
-            seed_event("event-ambiguous-a", Some(21), &ambiguous.id)?;
-            seed_event("event-ambiguous-b", Some(22), &ambiguous.id)?;
-            seed_event("event-missing-seq", None, &missing_seq.id)?;
+            seed_event("event-linked", Some(11), &linked)?;
+            seed_event("event-ambiguous-a", Some(21), &ambiguous)?;
+            seed_event("event-ambiguous-b", Some(22), &ambiguous)?;
+            seed_event("event-missing-seq", None, &missing_seq)?;
 
             apply_migration(&mut connection, &MIGRATIONS[48])?;
 
@@ -834,6 +833,9 @@ mod tests {
                     None,
                 );
                 brief.id = evidence_id.clone();
+                let mut event = crate::types::brief_created_event_for(&brief)?;
+                event.id = format!("event-bounded-{index}");
+                event.event_seq = (index + 1) as u64;
                 transaction.execute(
                     "INSERT INTO briefs (
                        evidence_id, agent_id, created_at, kind, preview, payload_json
@@ -852,15 +854,11 @@ mod tests {
                        audit_event_id, event_seq, agent_id, kind, created_at, data_json
                      ) VALUES (?1, ?2, ?3, 'brief_created', ?4, ?5)",
                     params![
-                        format!("event-bounded-{index}"),
+                        event.id,
                         index + 1,
                         "agent-a",
                         timestamp(Utc::now()),
-                        serde_json::json!({
-                            "brief_id": brief.id,
-                            "agent_id": "agent-a",
-                        })
-                        .to_string()
+                        serde_json::to_string(&event)?
                     ],
                 )?;
             }
@@ -887,8 +885,8 @@ mod tests {
              SELECT audit_event_id,
                     event_seq,
                     agent_id AS agent_id_col,
-                    COALESCE(json_extract(data_json, '$.agent_id'), '') AS agent_id_json,
-                    COALESCE(json_extract(data_json, '$.brief_id'), '') AS brief_id
+                    COALESCE(json_extract(data_json, '$.data.agent_id'), '') AS agent_id_json,
+                    COALESCE(json_extract(data_json, '$.data.brief_id'), '') AS brief_id
              FROM audit_events
              WHERE kind = 'brief_created';
              CREATE INDEX _idx_brief_created_candidates_lookup

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -6722,7 +6722,7 @@ CREATE TABLE working_memory_deltas (
             )?;
             connection.execute(
                 "INSERT INTO agent_states (agent_id, status, updated_at, payload_json) VALUES
-                    ('agent-state-only', 'idle', ?1, '{\"agent_id\":\"agent-state-only\"}')",
+                    ('agent-state-only', 'idle', ?1, '{\"id\":\"agent-state-only\"}')",
                 [now],
             )?;
             connection.execute(
@@ -6805,7 +6805,7 @@ CREATE TABLE working_memory_deltas (
             let now = "2026-01-01T00:00:00.000Z";
             connection.execute(
                 "INSERT INTO agent_states (agent_id, status, updated_at, payload_json) VALUES
-                    ('agent-broken', 'idle', ?1, '{\"agent_id\":\"agent-other\"}')",
+                    ('agent-broken', 'idle', ?1, '{\"id\":\"agent-other\"}')",
                 [now],
             )?;
             connection.execute(

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -655,6 +655,14 @@ mod tests {
             .brief_by_id("agent-a", &brief.id)?
             .expect("brief stored");
         assert_eq!(stored.created_event_seq, Some(commit.event.event_seq));
+
+        drop(db);
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert!(
+            reopened
+                .observer_sync_foundations()?
+                .brief_atomic_linkage_verified
+        );
         Ok(())
     }
 
@@ -6608,6 +6616,27 @@ CREATE TABLE working_memory_deltas (
         let second = RuntimeDb::open_and_migrate(&second_path, &second_lock)?;
         assert_ne!(first.runtime_id()?, second.runtime_id()?);
         assert_ne!(first.event_log_epoch()?, second.event_log_epoch()?);
+        Ok(())
+    }
+
+    #[test]
+    fn observer_sync_agent_identity_verification_accepts_persisted_agent_state_shape() -> Result<()>
+    {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        {
+            let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+            db.agent_identities()
+                .upsert(&agent_identity("agent-state-shape", 0))?;
+            db.agent_states()
+                .upsert(&AgentState::new("agent-state-shape"))?;
+        }
+
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert!(
+            reopened
+                .observer_sync_foundations()?
+                .agent_identity_reserved
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- verify `agent_states.data_json` identity using the persisted `id` field
- verify `brief_created` linkage through the actual `data_json.data.*` envelope
- align migration 49's historical linkage backfill and bounded mirror query with the production `AuditEvent` envelope
- add regressions that reopen the runtime DB and exercise capability verification and migration backfill with production serialization shapes

## Migration note
Migration 49 has not shipped in a release (`RELEASE_BASELINE_TARGET` is 45). Development databases that already ran the pre-fix migration 49 may retain NULL historical linkage and conservative uncertainty records; rebuild those development databases, or use a future corrective migration if preserving them is required.

## Verification
- `cargo test --lib -- migration_49_backfills_unique_linkage observer_sync_agent_identity_verification append_brief_with_created_event`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
