### PR TITLE
feat: restore GLM-5.3 catalog entries for volcengine and DashScope marketplace

### DIFF
--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -2360,6 +2360,9 @@ mod tests {
             .get(&ModelRef::parse("dashscope/ZHIPU/GLM-5.2").unwrap())
             .is_some());
         assert!(catalog
+            .get(&ModelRef::parse("dashscope/ZHIPU/GLM-5.3").unwrap())
+            .is_some());
+        assert!(catalog
             .get(&ModelRef::parse("dashscope/kimi-k2.6").unwrap())
             .is_some());
         assert!(catalog
@@ -3076,7 +3079,11 @@ mod tests {
         for unsupported in [
             "dashscope@token-plan/ZHIPU/GLM-5.2",
             "dashscope@token-plan/MiniMax/MiniMax-M3",
+            // GLM-5.3 is not part of the DashScope subscription plans yet:
+            // the token-plan endpoint reports "Model not exist" (verified 2026-08).
+            "dashscope@token-plan/glm-5.3",
             "dashscope@coding-plan/glm-5.2",
+            "dashscope@coding-plan/glm-5.3",
             "dashscope@coding-plan/kimi-k2.7-code",
         ] {
             assert!(
@@ -3563,7 +3570,7 @@ mod tests {
             );
         }
 
-        for route_ref in ["volcengine@plan/glm-5.2"] {
+        for route_ref in ["volcengine@plan/glm-5.2", "volcengine@plan/glm-5.3"] {
             let policy = catalog.resolve_route_policy(
                 &ModelRouteRef::parse(route_ref).unwrap(),
                 &HashMap::new(),
@@ -3584,7 +3591,9 @@ mod tests {
         for route_ref in [
             "volcengine@default/doubao-seed-2-0-pro-260215",
             "volcengine@coding/glm-5.2",
+            "volcengine@coding/glm-5.3",
             "volcengine@plan/glm-5.2",
+            "volcengine@plan/glm-5.3",
         ] {
             let policy = catalog.resolve_route_policy(
                 &ModelRouteRef::parse(route_ref).unwrap(),

--- a/src/model_catalog/providers/china.rs
+++ b/src/model_catalog/providers/china.rs
@@ -173,6 +173,7 @@ pub(super) fn route_definitions() -> Vec<BuiltInModelRouteDefinition> {
             ("deepseek-v4-flash", None),
             ("kimi-k2.6", None),
             ("kimi-k2.7-code", None),
+            ("glm-5.3", None),
             ("glm-5.2", None),
         ]
         .into_iter()
@@ -484,6 +485,15 @@ pub(super) fn late_entries() -> Vec<BuiltInModelMetadata> {
             262_144,
             // Volcengine API rejects max_tokens > 32768 for kimi-k2.7-code
             32_768,
+            true,
+            false,
+        ),
+        catalog_model(
+            "volcengine-coding",
+            "glm-5.3",
+            "GLM-5.3",
+            204_800,
+            128_000,
             true,
             false,
         ),
@@ -877,6 +887,15 @@ pub(super) fn late_entries() -> Vec<BuiltInModelMetadata> {
             "DeepSeek V4 Flash 0731",
             1_000_000,
             384_000,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope",
+            "ZHIPU/GLM-5.3",
+            "ZHIPU/GLM-5.3",
+            1_000_000,
+            131_072,
             true,
             false,
         ),


### PR DESCRIPTION
## What changed

Volcengine Ark Agent/Coding Plan now officially supports GLM-5.3, so this restores the entries removed by #2587 for that provider:

- `volcengine@plan/glm-5.3` route (Ark Agent plan routing list)
- `volcengine@coding/glm-5.3` catalog metadata (204,800 context / 128,000 max output, anthropic-compatible output limits)

It also adds the DashScope marketplace model announced on Aliyun Model Studio:

- `dashscope/ZHIPU/GLM-5.3` catalog metadata (1,000,000 context / 131,072 max output), mirroring `ZHIPU/GLM-5.2`

## DashScope subscription plan status (verified 2026-08)

- `dashscope@token-plan/glm-5.3`: **not supported** — the token-plan endpoint reports `Model not exist` and the models list does not include glm-5.3. Recorded in the catalog test's unsupported list.
- `dashscope@coding-plan/glm-5.3`: no evidence of support; stays unsupported.
- Default DashScope (Anthropic-compatible endpoint) first-class models only go up to glm-5.2; GLM-5.3 is available there as the marketplace model `ZHIPU/GLM-5.3`.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets` (warning-free)
- `cargo test --lib model_catalog` — all catalog tests pass, including updated route-policy and unsupported-model assertions