### PR TITLE
fix: keep cached model catalog selectable

### DIFF
--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -348,6 +348,12 @@ fn resolved_model_availability_entry(
         .as_str()
         .or_else(|| availability["failure_kind"].as_str())
         .map(ToString::to_string);
+    let failure_kind = availability["failure_kind"]
+        .as_str()
+        .map(ToString::to_string);
+    let failure_disposition = availability["disposition"]
+        .as_str()
+        .map(ToString::to_string);
     let unavailable_reason = if available {
         None
     } else if !provider_configured {
@@ -387,6 +393,8 @@ fn resolved_model_availability_entry(
         credential_configured: credential_configured || available,
         available,
         unavailable_reason,
+        failure_kind,
+        failure_disposition,
         policy,
         resolved_capabilities,
     }
@@ -642,6 +650,7 @@ mod tests {
             openai.unavailable_reason.as_deref(),
             Some("credential_missing")
         );
+        assert_eq!(openai.failure_disposition.as_deref(), Some("fail_fast"));
     }
 
     #[test]

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -290,6 +290,8 @@ mod tests {
             credential_configured: available,
             available,
             unavailable_reason: (!available).then_some("credential_missing".into()),
+            failure_kind: None,
+            failure_disposition: None,
             policy: policy(model, display_name, reasoning),
             resolved_capabilities: None,
         }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -312,6 +312,8 @@ fn sample_model_availability(
         credential_configured: available,
         available,
         unavailable_reason: (!available).then_some("credential_missing".into()),
+        failure_kind: None,
+        failure_disposition: None,
         policy: crate::model_catalog::ResolvedRuntimeModelPolicy {
             model_ref,
             display_name: display_name.into(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -4887,6 +4887,10 @@ pub struct ResolvedModelAvailability {
     pub available: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unavailable_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_disposition: Option<String>,
     pub policy: ResolvedRuntimeModelPolicy,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_capabilities: Option<crate::config::ResolvedModelCapabilities>,

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -313,9 +313,23 @@ export function App() {
   }, [openAgent, openSkill, openTemplate, setRoute]);
 
   useEffect(() => {
-    if ((route !== "agent" && route !== "settings") || modelCatalogLoading || modelCatalog.options.length > 0) return;
+    if (
+      (route !== "agent" && route !== "settings") ||
+      modelCatalogLoading ||
+      modelCatalog.source === "http" ||
+      (modelCatalog.source !== "cache" && modelCatalog.cachedAt !== undefined) ||
+      Boolean(modelCatalog.error)
+    ) return;
     void refreshModelCatalog();
-  }, [modelCatalog.options.length, modelCatalogLoading, refreshModelCatalog, route]);
+  }, [
+    modelCatalog.cachedAt,
+    modelCatalog.error,
+    modelCatalog.source,
+    modelCatalog.stale,
+    modelCatalogLoading,
+    refreshModelCatalog,
+    route,
+  ]);
 
   useEffect(() => {
     if (route !== "settings" || runtimeConfigLoading || runtimeConfig.surface) return;

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -982,7 +982,12 @@ export function AgentPage({
                           {modelCatalogLoading ? t("common.loading") : t("common.refresh")}
                         </Button>
                       </div>
-                      {modelCatalogError ? (
+                      {modelCatalog.stale ? (
+                        <div className="model-picker-status" role="alert">
+                          {t("agent.cachedModelCatalog")}
+                          {modelCatalogError ? ` ${modelCatalogError}` : ""}
+                        </div>
+                      ) : modelCatalogError ? (
                         <div className="model-picker-status" role="alert">
                           {modelCatalogError}
                         </div>
@@ -1033,7 +1038,7 @@ export function AgentPage({
                                 key={option.routeRef}
                                 type="button"
                                 disabled={!option.available || changingModel !== null}
-                                title={option.unavailableReason ?? option.model}
+                                title={option.unavailableReason ?? option.availabilityWarning ?? option.model}
                                 onClick={() => void handleSelectModel(option)}
                               >
                                 <span>
@@ -1042,6 +1047,7 @@ export function AgentPage({
                                 </span>
                                 <span className="model-option-meta">
                                   {option.supportsReasoningEffort ? <small>{t("agent.reasoningMeta")}</small> : null}
+                                  {option.availabilityWarning ? <small>{t("agent.availabilityWarningMeta")}</small> : null}
                                   {!option.available ? <small>{t("agent.unavailableMeta")}</small> : null}
                                   {changingModel === option.routeRef ? <em>{t("common.saving")}</em> : null}
                                 </span>

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -909,7 +909,7 @@ const en = {
     available: "available",
     reasoningMeta: "reasoning",
     unavailableMeta: "unavailable",
-    availabilityWarningMeta: "check unavailable",
+    availabilityWarningMeta: "availability check pending",
     cachedModelCatalog: "Showing cached models because the latest refresh did not complete.",
     // Turn labels
     operatorTurn: "Operator turn",

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -909,6 +909,8 @@ const en = {
     available: "available",
     reasoningMeta: "reasoning",
     unavailableMeta: "unavailable",
+    availabilityWarningMeta: "check unavailable",
+    cachedModelCatalog: "Showing cached models because the latest refresh did not complete.",
     // Turn labels
     operatorTurn: "Operator turn",
     turn: "Turn",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -910,6 +910,8 @@ const zh: Record<string, any> = {
     available: "可用",
     reasoningMeta: "推理",
     unavailableMeta: "不可用",
+    availabilityWarningMeta: "检查暂不可用",
+    cachedModelCatalog: "最新刷新未完成，当前显示并允许使用缓存模型。",
     // 轮次标签
     operatorTurn: "操作者轮次",
     turn: "轮次",

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -206,6 +206,67 @@ describe("projectModelOptions", () => {
       }),
     );
   });
+
+  it("keeps cached catalog models selectable when a runtime check fails retryably", () => {
+    const options = projectModelOptions({
+      available_models: [{
+        model: "openai/gpt-5.4",
+        provider: "openai",
+        display_name: "GPT-5.4",
+      }],
+      model_availability: [{
+        model: "openai/gpt-5.4",
+        provider: "openai",
+        available: false,
+        unavailable_reason: "connection failed",
+        failure_kind: "connection",
+        failure_disposition: "retryable",
+      }],
+    });
+
+    expect(options[0]).toEqual(expect.objectContaining({
+      available: true,
+      availabilityWarning: "connection failed",
+      unavailableReason: undefined,
+    }));
+  });
+
+  it("keeps deterministic configuration failures unavailable", () => {
+    const options = projectModelOptions({
+      available_models: ["openai/gpt-5.4"],
+      model_availability: [{
+        model: "openai/gpt-5.4",
+        provider: "openai",
+        available: false,
+        unavailable_reason: "credential_missing",
+        failure_kind: "auth_error",
+        failure_disposition: "fail_fast",
+      }],
+    });
+
+    expect(options[0]).toEqual(expect.objectContaining({
+      available: false,
+      unavailableReason: "credential_missing",
+      availabilityWarning: undefined,
+    }));
+  });
+
+  it("does not drop catalog models that lack an availability entry", () => {
+    const options = projectModelOptions({
+      available_models: ["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"],
+      model_availability: [{
+        model: "openai/gpt-5.4",
+        provider: "openai",
+        available: true,
+      }],
+    });
+
+    expect(options.map((option) => option.model)).toEqual([
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-5.4",
+    ]);
+    expect(options.every((option) => option.available)).toBe(true);
+  });
 });
 
 describe("createRuntimeClient", () => {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -316,6 +316,8 @@ interface ModelAvailabilityDto {
   display_name?: string;
   available?: boolean;
   unavailable_reason?: string;
+  failure_kind?: string;
+  failure_disposition?: "retryable" | "fail_fast";
   policy?: {
     supported_parameters?: string[];
     reasoning_effort_options?: string[];
@@ -2190,33 +2192,46 @@ function sortableTime(value: string | undefined): number {
 }
 
 export function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOption[] {
-  if (response.model_availability?.length) {
-    return response.model_availability
-      .filter((entry): entry is ModelAvailabilityDto & { model: string } => Boolean(entry.model))
-      .map((entry) => {
-        const provider = entry.provider ?? entry.model.split("/")[0] ?? "unknown";
-        const providerFamily = entry.provider_family ?? provider;
-        const endpoint = entry.endpoint ?? "default";
-        return {
-          model: entry.model,
-          routeRef: modelRouteRef(entry.model, providerFamily, endpoint),
-          provider,
-          providerFamily,
-          endpoint,
-          routeProvider: entry.route_provider ?? provider,
-          displayName: entry.display_name ?? entry.model,
-          available: entry.available ?? false,
-          unavailableReason: entry.unavailable_reason,
-          supportsImageInput: entry.policy?.capabilities?.image_input ?? false,
-          supportsImageGeneration: entry.policy?.capabilities?.image_generation ?? false,
-          supportsReasoningEffort: supportsReasoningEffort(entry),
-          reasoningEffortOptions: reasoningEffortOptions(entry),
-        };
-      })
-      .sort(compareModelOptions);
+  const optionsByRoute = new Map<string, RuntimeModelOption>();
+  for (const option of projectAvailableModels(response.available_models ?? [])) {
+    optionsByRoute.set(option.routeRef, option);
   }
 
-  return (response.available_models ?? [])
+  for (const entry of response.model_availability ?? []) {
+    if (!entry.model) continue;
+    const provider = entry.provider ?? entry.model.split("/")[0] ?? "unknown";
+    const providerFamily = entry.provider_family ?? provider;
+    const endpoint = entry.endpoint ?? "default";
+    const routeRef = modelRouteRef(entry.model, providerFamily, endpoint);
+    const existing = optionsByRoute.get(routeRef);
+    const retryableFailure = entry.available === false && entry.failure_disposition === "retryable";
+    optionsByRoute.set(routeRef, {
+      model: entry.model,
+      routeRef,
+      provider,
+      providerFamily,
+      endpoint,
+      routeProvider: entry.route_provider ?? provider,
+      displayName: entry.display_name ?? existing?.displayName ?? entry.model,
+      available: retryableFailure ? true : (entry.available ?? existing?.available ?? false),
+      unavailableReason: retryableFailure ? undefined : entry.unavailable_reason,
+      availabilityWarning: retryableFailure ? (entry.unavailable_reason ?? entry.failure_kind) : undefined,
+      supportsImageInput: entry.policy?.capabilities?.image_input ?? existing?.supportsImageInput ?? false,
+      supportsImageGeneration: entry.policy?.capabilities?.image_generation ?? existing?.supportsImageGeneration ?? false,
+      supportsReasoningEffort: supportsReasoningEffort(entry) || (existing?.supportsReasoningEffort ?? false),
+      reasoningEffortOptions: reasoningEffortOptions(entry).length
+        ? reasoningEffortOptions(entry)
+        : (existing?.reasoningEffortOptions ?? []),
+    });
+  }
+
+  return [...optionsByRoute.values()].sort(compareModelOptions);
+}
+
+function projectAvailableModels(
+  entries: Array<string | RuntimeAvailableModelDto>,
+): RuntimeModelOption[] {
+  return entries
     .map((entry) => {
       const model = typeof entry === "string" ? entry : entry.model;
       if (!model) return undefined;
@@ -2238,8 +2253,7 @@ export function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOpt
         reasoningEffortOptions: typeof entry === "string" ? [] : reasoningEffortOptions(entry),
       };
     })
-    .filter((entry): entry is RuntimeModelOption => Boolean(entry))
-    .sort(compareModelOptions);
+    .filter((entry): entry is RuntimeModelOption => Boolean(entry));
 }
 
 function modelRouteRef(model: string, providerFamily: string, endpoint: string): string {

--- a/web-gui/app/src/runtime/idb-cache.ts
+++ b/web-gui/app/src/runtime/idb-cache.ts
@@ -7,10 +7,11 @@
  */
 
 const DB_NAME = "holon-webgui-cache";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 export const CACHE_SCHEMA_VERSION = 5;
 const SESSIONS_STORE = "sessions";
 const META_STORE = "meta";
+const MODEL_CATALOG_STORE = "modelCatalog";
 
 export interface CachedSyncCoverage {
   eventLogEpoch?: string;
@@ -53,6 +54,13 @@ export interface CachedAgentSession {
   cachedAt: number;
 }
 
+export interface CachedModelCatalog {
+  remoteKey: string;
+  schemaVersion: number;
+  options: unknown[];
+  cachedAt: number;
+}
+
 let dbPromise: Promise<IDBDatabase | null> | null = null;
 
 function openDB(): Promise<IDBDatabase | null> {
@@ -78,6 +86,9 @@ function openDB(): Promise<IDBDatabase | null> {
       }
       if (!db.objectStoreNames.contains(META_STORE)) {
         db.createObjectStore(META_STORE, { keyPath: "remoteKey" });
+      }
+      if (!db.objectStoreNames.contains(MODEL_CATALOG_STORE)) {
+        db.createObjectStore(MODEL_CATALOG_STORE, { keyPath: "remoteKey" });
       }
     };
     request.onsuccess = () => resolve(request.result);
@@ -154,6 +165,29 @@ export async function cacheDeleteSession(remoteKey: string, agentId: string): Pr
     await runRequest(db, SESSIONS_STORE, "readwrite", (store) => store.delete([remoteKey, agentId]));
   } catch {
     // Silent fallback.
+  }
+}
+
+export async function cachePutModelCatalog(catalog: CachedModelCatalog): Promise<void> {
+  const db = await openDB();
+  if (!db) return;
+  try {
+    await runRequest(db, MODEL_CATALOG_STORE, "readwrite", (store) => store.put(catalog));
+  } catch {
+    // Silent fallback — cache is best-effort.
+  }
+}
+
+export async function cacheGetModelCatalog(remoteKey: string): Promise<CachedModelCatalog | undefined> {
+  const db = await openDB();
+  if (!db) return undefined;
+  try {
+    const catalog = await runRequest<CachedModelCatalog>(db, MODEL_CATALOG_STORE, "readonly", (store) =>
+      store.get(remoteKey),
+    );
+    return catalog?.schemaVersion === CACHE_SCHEMA_VERSION ? catalog : undefined;
+  } catch {
+    return undefined;
   }
 }
 

--- a/web-gui/app/src/runtime/idb-cache.ts
+++ b/web-gui/app/src/runtime/idb-cache.ts
@@ -195,22 +195,39 @@ export async function cacheClearRemote(remoteKey: string): Promise<void> {
   const db = await openDB();
   if (!db) return;
   try {
-    const store = db.transaction(SESSIONS_STORE, "readwrite").objectStore(SESSIONS_STORE);
-    const index = store.index("byRemoteKey");
-    const range = IDBKeyRange.only(remoteKey);
-    await new Promise<void>((resolve, reject) => {
-      const request = index.openCursor(range);
-      request.onsuccess = () => {
-        const cursor = request.result;
-        if (cursor) {
-          cursor.delete();
-          cursor.continue();
-        } else {
-          resolve();
-        }
-      };
-      request.onerror = () => reject(request.error);
-    });
+    await Promise.all([
+      new Promise<void>((resolve, reject) => {
+        const store = db.transaction(SESSIONS_STORE, "readwrite").objectStore(SESSIONS_STORE);
+        const request = store.index("byRemoteKey").openCursor(IDBKeyRange.only(remoteKey));
+        request.onsuccess = () => {
+          const cursor = request.result;
+          if (cursor) {
+            cursor.delete();
+            cursor.continue();
+          } else {
+            resolve();
+          }
+        };
+        request.onerror = () => reject(request.error);
+      }),
+      new Promise<void>((resolve, reject) => {
+        const store = db.transaction(MODEL_CATALOG_STORE, "readwrite").objectStore(MODEL_CATALOG_STORE);
+        const request = store.openCursor();
+        request.onsuccess = () => {
+          const cursor = request.result;
+          if (cursor) {
+            const catalog = cursor.value as CachedModelCatalog;
+            if (catalog.remoteKey === remoteKey || catalog.remoteKey.startsWith(`${remoteKey}#`)) {
+              cursor.delete();
+            }
+            cursor.continue();
+          } else {
+            resolve();
+          }
+        };
+        request.onerror = () => reject(request.error);
+      }),
+    ]);
   } catch {
     // Silent fallback.
   }

--- a/web-gui/app/src/runtime/model-catalog-cache.test.ts
+++ b/web-gui/app/src/runtime/model-catalog-cache.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   CACHE_SCHEMA_VERSION,
+  cacheClearRemote,
   cacheGetModelCatalog,
   cachePutModelCatalog,
 } from "./idb-cache";
@@ -42,5 +43,33 @@ describe("model catalog cache", () => {
     });
 
     expect(await cacheGetModelCatalog("incompatible-schema")).toBeUndefined();
+  });
+
+  it("clears all credential-scoped catalogs for a disconnected runtime", async () => {
+    const runtimeKey = "http://runtime-clear.test";
+    await cachePutModelCatalog({
+      remoteKey: `${runtimeKey}#anonymous`,
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      options: [{ routeRef: "openai@default/gpt-5.4" }],
+      cachedAt: 10,
+    });
+    await cachePutModelCatalog({
+      remoteKey: `${runtimeKey}#auth-12345678`,
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      options: [{ routeRef: "anthropic@default/claude-sonnet-4-6" }],
+      cachedAt: 20,
+    });
+    await cachePutModelCatalog({
+      remoteKey: "http://runtime-clear.test-other#anonymous",
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      options: [{ routeRef: "google@default/gemini-3.1-pro-preview" }],
+      cachedAt: 30,
+    });
+
+    await cacheClearRemote(runtimeKey);
+
+    expect(await cacheGetModelCatalog(`${runtimeKey}#anonymous`)).toBeUndefined();
+    expect(await cacheGetModelCatalog(`${runtimeKey}#auth-12345678`)).toBeUndefined();
+    expect(await cacheGetModelCatalog("http://runtime-clear.test-other#anonymous")).toBeDefined();
   });
 });

--- a/web-gui/app/src/runtime/model-catalog-cache.test.ts
+++ b/web-gui/app/src/runtime/model-catalog-cache.test.ts
@@ -1,0 +1,46 @@
+import "fake-indexeddb/auto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CACHE_SCHEMA_VERSION,
+  cacheGetModelCatalog,
+  cachePutModelCatalog,
+} from "./idb-cache";
+
+describe("model catalog cache", () => {
+  it("persists catalogs independently for each runtime key", async () => {
+    await cachePutModelCatalog({
+      remoteKey: "http://runtime-a.test",
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      options: [{ routeRef: "openai@default/gpt-5.4" }],
+      cachedAt: 10,
+    });
+    await cachePutModelCatalog({
+      remoteKey: "http://runtime-b.test",
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      options: [{ routeRef: "anthropic@default/claude-sonnet-4-6" }],
+      cachedAt: 20,
+    });
+
+    expect(await cacheGetModelCatalog("http://runtime-a.test")).toEqual(expect.objectContaining({
+      cachedAt: 10,
+      options: [{ routeRef: "openai@default/gpt-5.4" }],
+    }));
+    expect(await cacheGetModelCatalog("http://runtime-b.test")).toEqual(expect.objectContaining({
+      cachedAt: 20,
+      options: [{ routeRef: "anthropic@default/claude-sonnet-4-6" }],
+    }));
+  });
+
+  it("ignores catalogs from an incompatible schema", async () => {
+    await cachePutModelCatalog({
+      remoteKey: "incompatible-schema",
+      schemaVersion: CACHE_SCHEMA_VERSION - 1,
+      options: [{ routeRef: "openai@default/gpt-5.4" }],
+      cachedAt: 10,
+    });
+
+    expect(await cacheGetModelCatalog("incompatible-schema")).toBeUndefined();
+  });
+});

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -12,6 +12,7 @@ import {
   materializeProjectionDetail,
   mergeBootstrapAgentState,
   mergeTimelineEventPage,
+  modelCatalogCacheKey,
   missingBriefIdsForHydration,
   readStoredRemoteConnectionProfiles,
   resetSessionsForResume,
@@ -81,6 +82,26 @@ describe("skillDetailCacheKey", () => {
     expect(skillDetailCacheKey("workspace:root:demo", "agent-a")).toBe(
       "agent-a\u0000workspace:root:demo",
     );
+  });
+});
+
+describe("modelCatalogCacheKey", () => {
+  it("isolates model catalogs by runtime and credential without storing the token", () => {
+    const first = modelCatalogCacheKey({
+      mode: "remote",
+      baseUrl: "https://runtime.example/",
+      token: "secret-a",
+    });
+    const second = modelCatalogCacheKey({
+      mode: "remote",
+      baseUrl: "https://runtime.example",
+      token: "secret-b",
+    });
+
+    expect(first).not.toBe(second);
+    expect(first).toContain("https://runtime.example#auth-");
+    expect(first).not.toContain("secret-a");
+    expect(modelCatalogCacheKey({ mode: "local" })).toBe("local#anonymous");
   });
 });
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -52,6 +52,11 @@ import {
   type LedgerUnreadView,
 } from "./read-state";
 import { ReadStateBus } from "./event-ledger";
+import {
+  CACHE_SCHEMA_VERSION,
+  cacheGetModelCatalog,
+  cachePutModelCatalog,
+} from "./idb-cache";
 import { ResumeReconciliationCoordinator } from "./resume-reconciliation";
 import { currentRemoteKey } from "./session-cache";
 import {
@@ -921,6 +926,54 @@ const emptyModelCatalog: RuntimeModelCatalog = {
   options: [],
 };
 
+function freshModelCatalog(catalog: RuntimeModelCatalog): RuntimeModelCatalog {
+  return {
+    ...catalog,
+    source: catalog.source === "fixture" ? "fixture" : "http",
+    stale: false,
+    cachedAt: Date.now(),
+    error: undefined,
+  };
+}
+
+function persistModelCatalog(config: RuntimeConnectionConfig, catalog: RuntimeModelCatalog): void {
+  if (catalog.source !== "http" || catalog.error) return;
+  void cachePutModelCatalog({
+    remoteKey: modelCatalogCacheKey(config),
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    options: catalog.options,
+    cachedAt: catalog.cachedAt ?? Date.now(),
+  });
+}
+
+async function hydrateCachedModelCatalog(
+  config: RuntimeConnectionConfig,
+  generation: number,
+): Promise<void> {
+  const cached = await cacheGetModelCatalog(modelCatalogCacheKey(config));
+  if (!cached || !isCurrentClientGeneration(generation)) return;
+  useRuntimeStore.setState({
+    modelCatalog: {
+      source: "cache",
+      options: cached.options as RuntimeModelCatalog["options"],
+      stale: true,
+      cachedAt: cached.cachedAt,
+    },
+    modelCatalogError: undefined,
+  });
+}
+
+export function modelCatalogCacheKey(config: RuntimeConnectionConfig): string {
+  const token = config.token?.trim();
+  if (!token) return `${currentRemoteKey(config)}#anonymous`;
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < token.length; index += 1) {
+    hash ^= token.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${currentRemoteKey(config)}#auth-${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
 const emptyRuntimeConfig: RuntimeConfigState = {
   source: "fixture",
 };
@@ -1783,6 +1836,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
 
   setRuntimeConnection: async (config) => {
     nextClientGeneration();
+    const generation = clientGeneration;
     cancelClientGenerationWork();
     const normalizedBaseUrl = config.mode === "remote" ? normalizeConnectionBaseUrl(config.baseUrl) : "";
     const retainedToken =
@@ -1870,6 +1924,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
       route: "dashboard",
       resumeRevision: get().resumeRevision + 1,
     });
+    await hydrateCachedModelCatalog(normalizedConfig, generation);
     await get().refreshBootstrap();
     // Initialize cache for the new remote (async, non-blocking).
     agentSessionRepository.initializeCache();
@@ -2039,14 +2094,15 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
     const request = captureClientRequest();
     set({ modelCatalogLoading: true, modelCatalogError: undefined });
     try {
-      const modelCatalog = await request.client.getModels();
+      const modelCatalog = freshModelCatalog(await request.client.getModels());
       if (!isCurrentClientRequest(request)) return;
       set({ modelCatalog, modelCatalogLoading: false, modelCatalogError: modelCatalog.error });
+      persistModelCatalog(runtimeConnectionConfig, modelCatalog);
     } catch (error) {
       if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
-        modelCatalog: { ...state.modelCatalog, error: message },
+        modelCatalog: { ...state.modelCatalog, stale: state.modelCatalog.options.length > 0, error: message },
         modelCatalogLoading: false,
         modelCatalogError: message,
       }));
@@ -2081,14 +2137,15 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
       if (runtimeConfig.changed && !runtimeConfig.error) {
         set({ modelCatalogLoading: true, modelCatalogError: undefined });
         try {
-          const modelCatalog = await request.client.getModels();
+          const modelCatalog = freshModelCatalog(await request.client.getModels());
           if (!isCurrentClientRequest(request)) return runtimeConfig;
           set({ modelCatalog, modelCatalogLoading: false, modelCatalogError: modelCatalog.error });
+          persistModelCatalog(runtimeConnectionConfig, modelCatalog);
         } catch (modelError) {
           if (!isCurrentClientRequest(request)) return runtimeConfig;
           const message = modelError instanceof Error ? modelError.message : String(modelError);
           set((state) => ({
-            modelCatalog: { ...state.modelCatalog, error: message },
+            modelCatalog: { ...state.modelCatalog, stale: state.modelCatalog.options.length > 0, error: message },
             modelCatalogLoading: false,
             modelCatalogError: message,
           }));
@@ -2566,12 +2623,13 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
     const request = captureClientRequest();
     try {
       const result = await request.client.setCredential(profile, kind, material);
-      const [credentialStore, runtimeConfig, modelCatalog] = await Promise.all([
+      const [credentialStore, runtimeConfig, fetchedModelCatalog] = await Promise.all([
         request.client.listCredentials(),
         request.client.getRuntimeConfig(),
         request.client.getModels(),
       ]);
       if (!isCurrentClientRequest(request)) return undefined;
+      const modelCatalog = freshModelCatalog(fetchedModelCatalog);
       set({
         credentialStore,
         credentialStoreError: undefined,
@@ -2580,6 +2638,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
         modelCatalog,
         modelCatalogError: modelCatalog.error,
       });
+      persistModelCatalog(runtimeConnectionConfig, modelCatalog);
       return result;
     } catch (error) {
       if (!isCurrentClientRequest(request)) return undefined;
@@ -2593,12 +2652,13 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
     const request = captureClientRequest();
     try {
       await request.client.deleteCredential(profile);
-      const [credentialStore, runtimeConfig, modelCatalog] = await Promise.all([
+      const [credentialStore, runtimeConfig, fetchedModelCatalog] = await Promise.all([
         request.client.listCredentials(),
         request.client.getRuntimeConfig(),
         request.client.getModels(),
       ]);
       if (!isCurrentClientRequest(request)) return;
+      const modelCatalog = freshModelCatalog(fetchedModelCatalog);
       set({
         credentialStore,
         credentialStoreError: undefined,
@@ -2607,6 +2667,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
         modelCatalog,
         modelCatalogError: modelCatalog.error,
       });
+      persistModelCatalog(runtimeConnectionConfig, modelCatalog);
     } catch (error) {
       if (!isCurrentClientRequest(request)) return;
       const message = error instanceof Error ? error.message : String(error);
@@ -2645,12 +2706,13 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
           const job = await request.client.getJob(jobId);
           if (!isCurrentClientRequest(request)) return;
           if (job.status === "completed") {
-            const [credentialStore, runtimeConfig, modelCatalog] = await Promise.all([
+            const [credentialStore, runtimeConfig, fetchedModelCatalog] = await Promise.all([
               request.client.listCredentials(),
               request.client.getRuntimeConfig(),
               request.client.getModels(),
             ]);
             if (!isCurrentClientRequest(request)) return;
+            const modelCatalog = freshModelCatalog(fetchedModelCatalog);
             set({
               codexDeviceLogin: { status: "completed" },
               credentialStore,
@@ -2660,6 +2722,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
               modelCatalog,
               modelCatalogError: modelCatalog.error,
             });
+            persistModelCatalog(runtimeConnectionConfig, modelCatalog);
             return;
           }
           if (job.status === "failed") {
@@ -3499,6 +3562,13 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
 // Initialize session cache on first load.
 if (typeof window !== "undefined") {
   installRuntimeTraceDebugApi();
+  const modelCatalogHydrationGeneration = clientGeneration;
+  useRuntimeStore.setState({ modelCatalogLoading: true });
+  void hydrateCachedModelCatalog(runtimeConnectionConfig, modelCatalogHydrationGeneration).finally(() => {
+    if (isCurrentClientGeneration(modelCatalogHydrationGeneration)) {
+      useRuntimeStore.setState({ modelCatalogLoading: false });
+    }
+  });
   agentSessionRepository.initializeCache();
   resumeReconciliationCoordinator = installResumeReconciliationListeners();
   void resumeReconciliationCoordinator;

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -363,6 +363,7 @@ export interface RuntimeModelOption {
   displayName: string;
   available: boolean;
   unavailableReason?: string;
+  availabilityWarning?: string;
   supportsImageInput: boolean;
   supportsImageGeneration: boolean;
   supportsReasoningEffort: boolean;
@@ -370,8 +371,10 @@ export interface RuntimeModelOption {
 }
 
 export interface RuntimeModelCatalog {
-  source: "http" | "fixture";
+  source: "http" | "cache" | "fixture";
   options: RuntimeModelOption[];
+  stale?: boolean;
+  cachedAt?: number;
   error?: string;
 }
 


### PR DESCRIPTION
## Summary

- separate catalog presence from retryable runtime availability diagnostics so transient checks do not disable known models
- persist the last successful model catalog in IndexedDB with runtime and credential isolation, then restore it as stale while refreshing
- keep deterministic configuration failures unavailable and show non-blocking stale/check warnings in the model picker

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib resolved_model_availability_`
- Web GUI typecheck
- Web GUI full test suite: 428 tests passed
- Web GUI production build (Node 22)

Closes #2641