### PR TITLE
fix: unify projection event classification

### DIFF
--- a/docs/implementation-decisions/107-event-projection-effect-classification.md
+++ b/docs/implementation-decisions/107-event-projection-effect-classification.md
@@ -10,9 +10,10 @@ task, work-item, and agent-state families are `display_invalidation`;
 Served envelopes carry the field only while `events.projection-effect.v1`
 is advertised (envelope contract version 3). A stored event classifies by
 wire name only when the payload schema identity matches and the payload
-schema version is not newer than the registry's; everything else — legacy
-events, unknown kinds, schema mismatches, unknown versions — is
-conservatively `display_invalidation`.
+schema version is not newer than the registry's. Recognizable legacy
+envelopes, including legacy rows whose wire name is now registry-known, are
+classified conservatively as `display_invalidation`. Unknown typed kinds,
+schema mismatches, and future schema versions remain unsupported.
 
 ## Reason
 
@@ -25,8 +26,9 @@ needlessly blocking readiness for events that reference no record.
 
 Gating emission on the durable `event_projection_effect_complete`
 verification keeps the advertisement honest against databases that contain
-typed-shaped events this binary cannot inventory, instead of serving effects
-that only look authoritative.
+typed-shaped events this binary cannot inventory. Completeness means every
+stored event has a sound classification; it does not require legacy events to
+receive the narrowest possible effect.
 
 ## Preserved boundary
 

--- a/docs/rfcs/observer-sync-agent-summary-and-read-markers.md
+++ b/docs/rfcs/observer-sync-agent-summary-and-read-markers.md
@@ -485,6 +485,13 @@ legacy or otherwise unclassified events default conservatively to
 version; clients still accept older envelopes under the compatibility rules
 below.
 
+Capability verification distinguishes recognizable legacy envelopes from
+unsupported typed shapes. A legacy envelope remains complete when it can be
+soundly classified as `display_invalidation`, even if its wire name is now a
+known registry kind; completeness does not imply the most precise effect.
+Unknown typed kinds, mismatched typed schemas, and future schema versions keep
+the capability disabled.
+
 A known self-contained event may be applied directly. A reference event creates
 or updates durable hydration work. A delete event must include enough tombstone
 identity to complete projection without fetching a record that no longer

--- a/src/http/events.rs
+++ b/src/http/events.rs
@@ -313,6 +313,7 @@ fn stream_event_envelope(
         projection_effect: emit_projection_effect.then(|| {
             crate::runtime_event::projection_effect_of(
                 &event.kind,
+                event.contract_version,
                 &event.payload_schema,
                 event.payload_schema_version,
             )

--- a/src/runtime_db/observer_sync.rs
+++ b/src/runtime_db/observer_sync.rs
@@ -791,10 +791,9 @@ fn verify_brief_atomic_linkage(connection: &Connection) -> Result<bool> {
 
 /// Proves every stored audit event classifies soundly under the registry
 /// classification used for the additive `projection_effect` field. A
-/// registry-known kind must match its declared payload schema identity and
-/// carry a payload schema version this binary knows; an unknown kind must
-/// be recognizably legacy. Events that are neither cannot be inventoried by
-/// this binary, so `events.projection-effect.v1` stays unadvertised.
+/// exact typed and recognizable legacy events are both soundly classified.
+/// Unsupported typed shapes cannot be inventoried by this binary, so
+/// `events.projection-effect.v1` stays unadvertised.
 fn verify_event_projection_effect_inventory(connection: &Connection) -> Result<bool> {
     if !table_exists(connection, "audit_events")? {
         return Ok(false);
@@ -803,7 +802,8 @@ fn verify_event_projection_effect_inventory(connection: &Connection) -> Result<b
         "SELECT kind,
                 COALESCE(json_extract(data_json, '$.payload_schema'), ''),
                 COALESCE(json_extract(data_json, '$.payload_schema_version'), 0),
-                COALESCE(json_extract(data_json, '$.contract_version'), 1)
+                COALESCE(json_extract(data_json, '$.contract_version'), 1),
+                COUNT(*)
          FROM audit_events
          GROUP BY kind,
                   COALESCE(json_extract(data_json, '$.payload_schema'), ''),
@@ -816,27 +816,34 @@ fn verify_event_projection_effect_inventory(connection: &Connection) -> Result<b
             row.get::<_, String>(1)?,
             row.get::<_, i64>(2)?,
             row.get::<_, i64>(3)?,
+            row.get::<_, i64>(4)?,
         ))
     })?;
     let mut unclassified = Vec::new();
     for row in rows {
-        let (kind, payload_schema, payload_schema_version, contract_version) = row?;
-        let sound = match crate::runtime_event::RuntimeEventKind::from_wire_name(&kind) {
-            Some(event_kind) => {
-                let descriptor = event_kind.descriptor();
-                payload_schema_version >= 0
-                    && (payload_schema_version as u64)
-                        <= u64::from(descriptor.payload_schema_version)
-                    && descriptor.payload_schema == payload_schema
+        let (kind, payload_schema, payload_schema_version, contract_version, count) = row?;
+        let classification = match (
+            u32::try_from(contract_version),
+            u32::try_from(payload_schema_version),
+        ) {
+            (Ok(contract_version), Ok(payload_schema_version)) => {
+                crate::runtime_event::classify_projection_effect(
+                    &kind,
+                    contract_version,
+                    &payload_schema,
+                    payload_schema_version,
+                )
             }
-            None => crate::runtime_event::is_legacy_event_shape(
-                &payload_schema,
-                u32::try_from(contract_version.max(0)).unwrap_or(u32::MAX),
+            _ => crate::runtime_event::ProjectionEffectClassification::Unsupported(
+                crate::runtime_event::UnsupportedProjectionEvent::InvalidMetadata,
             ),
         };
-        if !sound {
+        if let crate::runtime_event::ProjectionEffectClassification::Unsupported(reason) =
+            classification
+        {
             unclassified.push(format!(
-                "{kind}@{payload_schema}v{payload_schema_version}/cv{contract_version}"
+                "{kind}@{payload_schema}v{payload_schema_version}/cv{contract_version}\
+                 /reason={reason:?}/count={count}"
             ));
         }
     }

--- a/src/runtime_db/observer_sync.rs
+++ b/src/runtime_db/observer_sync.rs
@@ -790,8 +790,8 @@ fn verify_brief_atomic_linkage(connection: &Connection) -> Result<bool> {
 }
 
 /// Proves every stored audit event classifies soundly under the registry
-/// classification used for the additive `projection_effect` field. A
-/// exact typed and recognizable legacy events are both soundly classified.
+/// classification used for the additive `projection_effect` field. Exact typed
+/// and recognizable legacy events are both soundly classified.
 /// Unsupported typed shapes cannot be inventoried by this binary, so
 /// `events.projection-effect.v1` stays unadvertised.
 fn verify_event_projection_effect_inventory(connection: &Connection) -> Result<bool> {

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -6033,11 +6033,18 @@ CREATE TABLE working_memory_deltas (
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         {
             let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-            let legacy = crate::types::AuditEvent::legacy(
-                "turn_started",
-                serde_json::json!({ "agent_id": "default" }),
-            );
-            db.audit_events().append(Some("default"), &legacy)?;
+            for kind in [
+                "agent_state_changed",
+                "brief_created",
+                "scheduler_diagnostic",
+                "future_legacy_kind",
+            ] {
+                let legacy = crate::types::AuditEvent::legacy(
+                    kind,
+                    serde_json::json!({ "agent_id": "default" }),
+                );
+                db.audit_events().append(Some("default"), &legacy)?;
+            }
             let descriptor = crate::runtime_event::RuntimeEventKind::WorkItemWritten.descriptor();
             let typed = crate::types::AuditEvent {
                 id: "evt_typed_fixture".into(),
@@ -6059,24 +6066,40 @@ CREATE TABLE working_memory_deltas (
     }
 
     #[test]
-    fn observer_sync_event_projection_effect_rejects_unclassifiable_events() -> Result<()> {
-        let (_temp_dir, db_path, lock_path) = temp_paths()?;
-        {
-            let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-            let mut future = crate::types::AuditEvent::legacy(
-                "future_kind",
-                serde_json::json!({ "opaque": true }),
+    fn observer_sync_event_projection_effect_rejects_unsupported_typed_events() -> Result<()> {
+        for (kind, payload_schema, payload_schema_version) in [
+            ("future_kind", "holon.runtime_event.future", 1),
+            ("brief_created", "holon.runtime_event.wrong", 1),
+            (
+                "scheduler_diagnostic",
+                crate::runtime_event::RuntimeEventKind::SchedulerDiagnostic
+                    .descriptor()
+                    .payload_schema,
+                crate::runtime_event::RuntimeEventKind::SchedulerDiagnostic
+                    .descriptor()
+                    .payload_schema_version
+                    + 1,
+            ),
+        ] {
+            let (_temp_dir, db_path, lock_path) = temp_paths()?;
+            {
+                let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+                let mut event =
+                    crate::types::AuditEvent::legacy(kind, serde_json::json!({ "opaque": true }));
+                event.contract_version = crate::runtime_event::RUNTIME_EVENT_CONTRACT_VERSION;
+                event.payload_schema = payload_schema.into();
+                event.payload_schema_version = payload_schema_version;
+                db.audit_events().append(Some("default"), &event)?;
+                // The verification row predates this append; the reopen below
+                // re-verifies against committed contents.
+            }
+            let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+            let foundations = reopened.observer_sync_foundations()?;
+            assert!(
+                !foundations.event_projection_effect_complete,
+                "{kind}@{payload_schema}v{payload_schema_version} must stay unsupported"
             );
-            future.contract_version = crate::runtime_event::RUNTIME_EVENT_CONTRACT_VERSION;
-            future.payload_schema = "holon.runtime_event.future".into();
-            future.payload_schema_version = 1;
-            db.audit_events().append(Some("default"), &future)?;
-            // The verification row predates this append; the reopen below
-            // re-verifies against committed contents.
         }
-        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        let foundations = reopened.observer_sync_foundations()?;
-        assert!(!foundations.event_projection_effect_complete);
         Ok(())
     }
 

--- a/src/runtime_event.rs
+++ b/src/runtime_event.rs
@@ -26,6 +26,27 @@ pub enum ProjectionEffect {
     DisplayInvalidation,
 }
 
+/// Sound classification of one persisted runtime event envelope.
+///
+/// Exact typed events use the registry-declared effect. Recognizable legacy
+/// envelopes are safe but intentionally conservative. Unsupported typed
+/// shapes prevent the durable projection-effect capability from being
+/// advertised.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectionEffectClassification {
+    Exact(ProjectionEffect),
+    ConservativeLegacy(ProjectionEffect),
+    Unsupported(UnsupportedProjectionEvent),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsupportedProjectionEvent {
+    UnknownTypedKind,
+    PayloadSchemaMismatch,
+    FuturePayloadSchemaVersion,
+    InvalidMetadata,
+}
+
 /// Every `RuntimeEventKind` variant, in declaration order. The registry
 /// inventory tests and the durable capability verification use this list to
 /// prove each served event family is classified exactly once.
@@ -223,31 +244,60 @@ pub fn runtime_event_registry() -> &'static [RuntimeEventDescriptor] {
     REGISTRY
 }
 
-/// Classifies one stored audit event for the additive envelope field.
-///
-/// The registry is the source of truth: a kind is classified by its
-/// descriptor only when the payload schema identity matches and the stored
-/// payload schema version is not newer than the registry's. Legacy events,
-/// unknown wire names, unknown schema versions, and schema mismatches all
-/// degrade conservatively to `DisplayInvalidation` so an unclassifiable
-/// event can never silently pass as projection-neutral.
-pub fn projection_effect_of(
+/// Classifies one stored audit event against the registry and legacy
+/// compatibility contract.
+pub fn classify_projection_effect(
     kind: &str,
+    contract_version: u32,
     payload_schema: &str,
     payload_schema_version: u32,
-) -> ProjectionEffect {
+) -> ProjectionEffectClassification {
+    if is_legacy_event_shape(payload_schema, contract_version) {
+        return ProjectionEffectClassification::ConservativeLegacy(
+            ProjectionEffect::DisplayInvalidation,
+        );
+    }
     match RuntimeEventKind::from_wire_name(kind) {
         Some(known) => {
             let descriptor = known.descriptor();
-            if descriptor.payload_schema == payload_schema
-                && payload_schema_version <= descriptor.payload_schema_version
-            {
-                descriptor.projection_effect
+            if descriptor.payload_schema != payload_schema {
+                ProjectionEffectClassification::Unsupported(
+                    UnsupportedProjectionEvent::PayloadSchemaMismatch,
+                )
+            } else if payload_schema_version > descriptor.payload_schema_version {
+                ProjectionEffectClassification::Unsupported(
+                    UnsupportedProjectionEvent::FuturePayloadSchemaVersion,
+                )
             } else {
-                ProjectionEffect::DisplayInvalidation
+                ProjectionEffectClassification::Exact(descriptor.projection_effect)
             }
         }
-        None => ProjectionEffect::DisplayInvalidation,
+        None => ProjectionEffectClassification::Unsupported(
+            UnsupportedProjectionEvent::UnknownTypedKind,
+        ),
+    }
+}
+
+/// Returns the conservative wire effect for a stored event.
+///
+/// Capability verification guarantees this is called only for exact or
+/// recognizable legacy envelopes. The fallback remains defensive so an
+/// unsupported event can never silently pass as projection-neutral.
+pub fn projection_effect_of(
+    kind: &str,
+    contract_version: u32,
+    payload_schema: &str,
+    payload_schema_version: u32,
+) -> ProjectionEffect {
+    match classify_projection_effect(
+        kind,
+        contract_version,
+        payload_schema,
+        payload_schema_version,
+    ) {
+        ProjectionEffectClassification::Exact(effect)
+        | ProjectionEffectClassification::ConservativeLegacy(effect) => effect,
+        ProjectionEffectClassification::Unsupported(_) => ProjectionEffect::DisplayInvalidation,
     }
 }
 
@@ -385,6 +435,7 @@ mod tests {
             assert_eq!(
                 projection_effect_of(
                     entry.wire_name,
+                    RUNTIME_EVENT_CONTRACT_VERSION,
                     entry.payload_schema,
                     entry.payload_schema_version
                 ),
@@ -394,7 +445,12 @@ mod tests {
             );
             // Older payload schema versions of a known schema still classify.
             assert_eq!(
-                projection_effect_of(entry.wire_name, entry.payload_schema, 1),
+                projection_effect_of(
+                    entry.wire_name,
+                    RUNTIME_EVENT_CONTRACT_VERSION,
+                    entry.payload_schema,
+                    1
+                ),
                 entry.projection_effect,
                 "older schema versions of a known schema must stay classified for {}",
                 entry.wire_name
@@ -406,12 +462,22 @@ mod tests {
     fn projection_effect_falls_back_conservatively() {
         // Unknown wire name with a non-legacy schema shape.
         assert_eq!(
-            projection_effect_of("future_kind", "holon.runtime_event.future", 1),
+            projection_effect_of(
+                "future_kind",
+                RUNTIME_EVENT_CONTRACT_VERSION,
+                "holon.runtime_event.future",
+                1
+            ),
             ProjectionEffect::DisplayInvalidation
         );
         // Known wire name with a mismatched payload schema.
         assert_eq!(
-            projection_effect_of("brief_created", "holon.runtime_event.some_other_schema", 1),
+            projection_effect_of(
+                "brief_created",
+                RUNTIME_EVENT_CONTRACT_VERSION,
+                "holon.runtime_event.some_other_schema",
+                1
+            ),
             ProjectionEffect::DisplayInvalidation
         );
         // Known schema identity but a payload schema version newer than the
@@ -420,6 +486,7 @@ mod tests {
         assert_eq!(
             projection_effect_of(
                 brief.wire_name,
+                RUNTIME_EVENT_CONTRACT_VERSION,
                 brief.payload_schema,
                 brief.payload_schema_version + 1
             ),
@@ -427,12 +494,85 @@ mod tests {
         );
         // Legacy markers classify conservatively even for known wire names.
         assert_eq!(
-            projection_effect_of("brief_created", LEGACY_PAYLOAD_SCHEMA, 1),
+            projection_effect_of(
+                "brief_created",
+                LEGACY_RUNTIME_EVENT_CONTRACT_VERSION,
+                LEGACY_PAYLOAD_SCHEMA,
+                1
+            ),
             ProjectionEffect::DisplayInvalidation
         );
         assert!(is_legacy_event_shape(LEGACY_PAYLOAD_SCHEMA, 2));
         assert!(is_legacy_event_shape("holon.runtime_event.other", 1));
         assert!(!is_legacy_event_shape("holon.runtime_event.other", 2));
+    }
+
+    #[test]
+    fn projection_classification_distinguishes_exact_legacy_and_unsupported() {
+        let scheduler = RuntimeEventKind::SchedulerDiagnostic.descriptor();
+        assert_eq!(
+            classify_projection_effect(
+                scheduler.wire_name,
+                RUNTIME_EVENT_CONTRACT_VERSION,
+                scheduler.payload_schema,
+                scheduler.payload_schema_version,
+            ),
+            ProjectionEffectClassification::Exact(ProjectionEffect::None)
+        );
+
+        for kind in [
+            "agent_state_changed",
+            "brief_created",
+            "scheduler_diagnostic",
+            "future_legacy_kind",
+        ] {
+            assert_eq!(
+                classify_projection_effect(
+                    kind,
+                    LEGACY_RUNTIME_EVENT_CONTRACT_VERSION,
+                    LEGACY_PAYLOAD_SCHEMA,
+                    1,
+                ),
+                ProjectionEffectClassification::ConservativeLegacy(
+                    ProjectionEffect::DisplayInvalidation
+                ),
+                "{kind} must remain soundly classifiable as legacy"
+            );
+        }
+
+        assert_eq!(
+            classify_projection_effect(
+                "brief_created",
+                RUNTIME_EVENT_CONTRACT_VERSION,
+                "holon.runtime_event.wrong",
+                1,
+            ),
+            ProjectionEffectClassification::Unsupported(
+                UnsupportedProjectionEvent::PayloadSchemaMismatch
+            )
+        );
+        assert_eq!(
+            classify_projection_effect(
+                scheduler.wire_name,
+                RUNTIME_EVENT_CONTRACT_VERSION,
+                scheduler.payload_schema,
+                scheduler.payload_schema_version + 1,
+            ),
+            ProjectionEffectClassification::Unsupported(
+                UnsupportedProjectionEvent::FuturePayloadSchemaVersion
+            )
+        );
+        assert_eq!(
+            classify_projection_effect(
+                "future_typed_kind",
+                RUNTIME_EVENT_CONTRACT_VERSION,
+                "holon.runtime_event.future",
+                1,
+            ),
+            ProjectionEffectClassification::Unsupported(
+                UnsupportedProjectionEvent::UnknownTypedKind
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 概要

- 统一 runtime `projection_effect` 与 observer-sync inventory verifier 的事件分类契约
- 合法 legacy envelope（包括已知 kind）保守分类为 `display_invalidation`
- 错误 typed schema 与未来 schema version 保持 `unsupported`
- 补充 legacy/unsupported 回归测试，并更新相关 RFC 与 implementation decision

## 边界

- 不启用 W6 capability cutover
- 不删除 legacy path
- 不修改历史事件数据

## 验证

- `cargo fmt --all -- --check`
- `cargo test runtime_event::tests:: --lib`
- `cargo test observer_sync_event_projection_effect --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`