### PR TITLE
fix: scope brief event linkage by agent

### DIFF
--- a/src/runtime_db/audit.rs
+++ b/src/runtime_db/audit.rs
@@ -601,7 +601,8 @@ classified AS (
      OR (
        b.created_event_seq IS NOT NULL
        AND (SELECT COUNT(*) FROM briefs shared
-            WHERE shared.created_event_seq = b.created_event_seq) > 1
+            WHERE shared.agent_id = b.agent_id
+              AND shared.created_event_seq = b.created_event_seq) > 1
      )
   UNION ALL
   SELECT b.agent_id, 'D', b.evidence_id, b.created_at
@@ -729,6 +730,35 @@ mod tests {
             params![id, seq, agent_id, kind, created_at, data_json],
         )?;
         Ok(())
+    }
+
+    fn insert_linked_brief(
+        connection: &Connection,
+        agent_id: &str,
+        brief_id: &str,
+        event_id: &str,
+        event_seq: i64,
+    ) -> Result<()> {
+        connection.execute(
+            "INSERT INTO briefs (
+               evidence_id, agent_id, created_at, kind, preview, payload_json, created_event_seq
+             ) VALUES (
+               ?1, ?2, '2026-01-01T00:00:00.000Z', 'result', 'bounded preview', '{}', ?3
+             )",
+            params![brief_id, agent_id, event_seq],
+        )?;
+        insert_event(
+            connection,
+            event_id,
+            event_seq,
+            agent_id,
+            "brief_created",
+            "2026-01-01T00:00:00.000Z",
+            &serde_json::json!({
+                "data": {"agent_id": agent_id, "brief_id": brief_id}
+            })
+            .to_string(),
+        )
     }
 
     #[test]
@@ -936,6 +966,76 @@ mod tests {
         assert!(!category("E").observable_offline);
         assert!(category("E").sample_ids.is_empty());
         assert!(report.has_new_violations());
+        Ok(())
+    }
+
+    #[test]
+    fn brief_integrity_scopes_shared_sequences_by_agent() -> Result<()> {
+        let (_temp_dir, db) = temp_db()?;
+        let connection = db.connection()?;
+        insert_linked_brief(&connection, "alpha", "brief_alpha", "event_alpha", 1)?;
+        insert_linked_brief(&connection, "beta", "brief_beta", "event_beta", 1)?;
+        connection.execute_batch(
+            "DROP INDEX briefs_agent_created_event_seq;
+             DROP INDEX idx_audit_events_agent_event_seq_unique;",
+        )?;
+        insert_linked_brief(
+            &connection,
+            "gamma",
+            "brief_gamma_one",
+            "event_gamma_one",
+            1,
+        )?;
+        insert_linked_brief(
+            &connection,
+            "gamma",
+            "brief_gamma_two",
+            "event_gamma_two",
+            1,
+        )?;
+        drop(connection);
+
+        let report = db.audit(RuntimeDbAuditOptions {
+            check: RuntimeDbAuditCheck::BriefIntegrity,
+            baseline_through: None,
+            sample_limit: 10,
+        })?;
+        let audit = report.brief_integrity.as_ref().expect("brief audit");
+        for agent_id in ["alpha", "beta"] {
+            let agent = audit
+                .agents
+                .iter()
+                .find(|agent| agent.agent_id == agent_id)
+                .expect("agent audit");
+            assert_eq!(agent.counts.valid_linked_briefs, 1);
+            assert_eq!(agent.counts.missing_or_ambiguous_linkage, 0);
+            assert_eq!(
+                agent
+                    .categories
+                    .iter()
+                    .find(|category| category.category == "C")
+                    .expect("category C")
+                    .new_violation,
+                0
+            );
+        }
+        let gamma = audit
+            .agents
+            .iter()
+            .find(|agent| agent.agent_id == "gamma")
+            .expect("gamma audit");
+        assert_eq!(gamma.counts.valid_linked_briefs, 2);
+        assert_eq!(gamma.counts.missing_or_ambiguous_linkage, 2);
+        let category_c = gamma
+            .categories
+            .iter()
+            .find(|category| category.category == "C")
+            .expect("category C");
+        assert_eq!(category_c.new_violation, 2);
+        assert_eq!(
+            category_c.sample_ids,
+            ["brief_gamma_one", "brief_gamma_two"]
+        );
         Ok(())
     }
 

--- a/src/runtime_db/observer_sync.rs
+++ b/src/runtime_db/observer_sync.rs
@@ -742,8 +742,9 @@ fn collect_agent_roster_rows(connection: &Connection) -> Result<AgentRosterSnaps
 /// Proves the stored Brief linkage is sound for the atomic created-event
 /// contract: every `created_event_seq` resolves to exactly one
 /// `brief_created` audit event of the same Agent referencing that Brief,
-/// and no sequence is claimed by two Briefs. Events whose records were
-/// pruned by retention carry no linkage and therefore stay acceptable.
+/// and no Agent-scoped sequence is claimed by two Briefs. Events whose
+/// records were pruned by retention carry no linkage and therefore stay
+/// acceptable.
 fn verify_brief_atomic_linkage(connection: &Connection) -> Result<bool> {
     if !table_exists(connection, "briefs")? || !table_exists(connection, "audit_events")? {
         return Ok(false);
@@ -771,9 +772,9 @@ fn verify_brief_atomic_linkage(connection: &Connection) -> Result<bool> {
     )?;
     let shared_sequences: i64 = connection.query_row(
         "SELECT COUNT(*) FROM (
-           SELECT created_event_seq FROM briefs
+           SELECT agent_id, created_event_seq FROM briefs
            WHERE created_event_seq IS NOT NULL
-           GROUP BY created_event_seq HAVING COUNT(*) > 1
+           GROUP BY agent_id, created_event_seq HAVING COUNT(*) > 1
          )",
         [],
         |row| row.get(0),
@@ -787,6 +788,73 @@ fn verify_brief_atomic_linkage(connection: &Connection) -> Result<bool> {
         return Ok(false);
     }
     Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+
+    fn insert_linked_brief(
+        connection: &Connection,
+        agent_id: &str,
+        brief_id: &str,
+        event_id: &str,
+        event_seq: i64,
+    ) -> Result<()> {
+        connection.execute(
+            "INSERT INTO briefs (
+               evidence_id, agent_id, created_at, kind, preview, payload_json, created_event_seq
+             ) VALUES (?1, ?2, '2026-01-01T00:00:00.000Z', 'result', 'preview', '{}', ?3)",
+            params![brief_id, agent_id, event_seq],
+        )?;
+        connection.execute(
+            "INSERT INTO audit_events (
+               audit_event_id, event_seq, agent_id, kind, created_at, data_json
+             ) VALUES (
+               ?1, ?2, ?3, 'brief_created', '2026-01-01T00:00:00.000Z',
+               json_object('data', json_object('agent_id', ?3, 'brief_id', ?4))
+             )",
+            params![event_id, event_seq, agent_id, brief_id],
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn brief_atomic_linkage_scopes_shared_sequences_by_agent() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db = crate::runtime_db::RuntimeDb::open_and_migrate(
+            temp_dir.path().join("state/runtime.sqlite"),
+            temp_dir.path().join("state/runtime.lock"),
+        )?;
+        let connection = db.connection()?;
+
+        insert_linked_brief(&connection, "alpha", "brief_alpha", "event_alpha", 1)?;
+        insert_linked_brief(&connection, "beta", "brief_beta", "event_beta", 1)?;
+
+        assert!(verify_brief_atomic_linkage(&connection)?);
+        Ok(())
+    }
+
+    #[test]
+    fn brief_atomic_linkage_rejects_same_agent_shared_sequence() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db = crate::runtime_db::RuntimeDb::open_and_migrate(
+            temp_dir.path().join("state/runtime.sqlite"),
+            temp_dir.path().join("state/runtime.lock"),
+        )?;
+        let connection = db.connection()?;
+        connection.execute_batch(
+            "DROP INDEX briefs_agent_created_event_seq;
+             DROP INDEX idx_audit_events_agent_event_seq_unique;",
+        )?;
+
+        insert_linked_brief(&connection, "alpha", "brief_one", "event_one", 1)?;
+        insert_linked_brief(&connection, "alpha", "brief_two", "event_two", 1)?;
+
+        assert!(!verify_brief_atomic_linkage(&connection)?);
+        Ok(())
+    }
 }
 
 /// Proves every stored audit event classifies soundly under the registry


### PR DESCRIPTION
## 变更
- 将 Brief atomic linkage 的 shared sequence 判定从全局 `created_event_seq` 改为 `(agent_id, created_event_seq)`
- 同步修正 `holon debug runtime-db audit` 的 Brief 完整性查询
- 补充跨 Agent 复用相同 sequence 合法、同 Agent 重复 linkage 非法的回归测试

## 边界
- 不修改或回填历史数据
- 不启用 W6 capability cutover

## 验证
- `cargo fmt --all -- --check`
- `cargo test runtime_db::observer_sync::tests --lib`
- `cargo test runtime_db::audit::tests --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
