### PR TITLE
fix: reuse audit event verification proof

### DIFF
--- a/docs/implementation-decisions/107-event-projection-effect-classification.md
+++ b/docs/implementation-decisions/107-event-projection-effect-classification.md
@@ -30,6 +30,14 @@ typed-shaped events this binary cannot inventory. Completeness means every
 stored event has a sound classification; it does not require legacy events to
 receive the narrowest possible effect.
 
+The proof records a classifier version, event-log epoch, audit mutation
+generation, and verified generation. Trusted appends classify and advance it
+atomically. Audit inserts or classification-relevant updates outside that path
+advance only the mutation generation, making capability reads fail closed and
+forcing the next database open to run a full inventory. An unchanged current
+proof is reused on open. This keeps steady-state restart cost independent of
+retained event count without trusting untracked database mutation.
+
 ## Preserved boundary
 
 The fallback classification is total but conservative; adding a new event

--- a/docs/rfcs/observer-sync-agent-summary-and-read-markers.md
+++ b/docs/rfcs/observer-sync-agent-summary-and-read-markers.md
@@ -492,6 +492,17 @@ known registry kind; completeness does not imply the most precise effect.
 Unknown typed kinds, mismatched typed schemas, and future schema versions keep
 the capability disabled.
 
+The durable verification proof is keyed by an explicit classifier version,
+`event_log_epoch`, and an audit-event mutation generation. The audit table
+advances that generation for inserts and classification-relevant updates.
+Trusted runtime appends classify the new envelope and advance the verified
+generation in the same transaction; direct SQL, import, or recovery writes
+that bypass the trusted append helper leave the proof stale. Database open
+reuses a current proof and performs the full historical inventory only after a
+classifier/epoch change or a stale mutation generation. `event_seq` is
+Agent-scoped, so the mutation generation is the global verification boundary
+rather than a fabricated global event sequence.
+
 A known self-contained event may be applied directly. A reference event creates
 or updates durable hydration work. A delete event must include enough tombstone
 identity to complete projection without fetching a record that no longer
@@ -878,6 +889,9 @@ a consistency boundary when one record or watermark failed to load.
 - add immutable Brief-to-created-event linkage;
 - make canonical record and event visibility atomic through a transaction or
   durable outbox; and
+- persist the projection-effect classifier version, event-log epoch, audit
+  mutation generation, and verified generation so unchanged history is not
+  re-inventoried on every database open; and
 - keep capabilities disabled until migration verification succeeds.
 
 ### Phase 2: Recovery Endpoints
@@ -967,6 +981,8 @@ They should not be implemented as aliases for the new contract.
 14. Retention loss is represented as truncation, not fabricated exact history.
 15. Epoch and visibility changes partition or clear local state before reuse.
 16. Global SSE is a hint and never the sole correctness source.
+17. A projection-effect capability is advertised only while its classifier,
+    epoch, and verified audit-mutation generation match the current database.
 
 ## Acceptance Matrix
 

--- a/src/runtime_db/evidence.rs
+++ b/src/runtime_db/evidence.rs
@@ -1037,6 +1037,7 @@ fn insert_audit_event_with_sequence_tx(
         event.id,
         event.event_seq
     );
+    crate::runtime_db::observer_sync::record_appended_event_projection_effect(tx, event)?;
     Ok(())
 }
 

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3141,6 +3141,7 @@ ALTER TABLE observer_sync_capability_verifications
   ADD COLUMN event_log_epoch TEXT;
 ALTER TABLE observer_sync_capability_verifications
   ADD COLUMN event_generation INTEGER NOT NULL DEFAULT 0;
+-- -1 means no inventory proof covers the current audit mutation generation.
 ALTER TABLE observer_sync_capability_verifications
   ADD COLUMN verified_event_generation INTEGER NOT NULL DEFAULT -1;
 

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3134,42 +3134,10 @@ CREATE TABLE IF NOT EXISTS brief_created_linkage_uncertain (
     Migration {
         version: 50,
         name: "observer_sync_event_verification_proof",
-        sql: r#"
-ALTER TABLE observer_sync_capability_verifications
-  ADD COLUMN verification_version INTEGER NOT NULL DEFAULT 0;
-ALTER TABLE observer_sync_capability_verifications
-  ADD COLUMN event_log_epoch TEXT;
-ALTER TABLE observer_sync_capability_verifications
-  ADD COLUMN event_generation INTEGER NOT NULL DEFAULT 0;
--- -1 means no inventory proof covers the current audit mutation generation.
-ALTER TABLE observer_sync_capability_verifications
-  ADD COLUMN verified_event_generation INTEGER NOT NULL DEFAULT -1;
-
-INSERT OR IGNORE INTO observer_sync_capability_verifications (
-  capability, verified, verified_at, detail
-) VALUES (
-  'event_projection_effect_complete',
-  0,
-  strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
-  '{"stage":"verification-proof-migration"}'
-);
-
-CREATE TRIGGER audit_events_projection_verification_insert
-AFTER INSERT ON audit_events
-BEGIN
-  UPDATE observer_sync_capability_verifications
-  SET event_generation = event_generation + 1
-  WHERE capability = 'event_projection_effect_complete';
-END;
-
-CREATE TRIGGER audit_events_projection_verification_update
-AFTER UPDATE OF kind, data_json ON audit_events
-BEGIN
-  UPDATE observer_sync_capability_verifications
-  SET event_generation = event_generation + 1
-  WHERE capability = 'event_projection_effect_complete';
-END;
-"#,
+        // Columns and triggers live in
+        // `ensure_observer_sync_event_verification_proof_schema` so
+        // name-accepted and downgrade/re-upgrade paths remain idempotent.
+        sql: "",
     },
 ];
 
@@ -3416,6 +3384,9 @@ fn apply_migration_transaction(transaction: &Transaction<'_>, migration: &Migrat
     if migration.name == "brief_created_event_linkage" {
         ensure_brief_created_event_linkage_schema(transaction)?;
     }
+    if migration.name == "observer_sync_event_verification_proof" {
+        ensure_observer_sync_event_verification_proof_schema(transaction)?;
+    }
     transaction.execute_batch(migration.sql)?;
     if migration.name == "execution_protocol_authority" {
         backfill_execution_protocol_authority(transaction)?;
@@ -3489,6 +3460,78 @@ fn ensure_brief_created_event_linkage_schema(transaction: &Transaction<'_>) -> R
            ON briefs(agent_id, created_event_seq)
            WHERE created_event_seq IS NOT NULL;",
     )?;
+    Ok(())
+}
+
+/// Adds the event-verification proof columns and mutation triggers. Test and
+/// recovery paths can deliberately remove migration records without reverting
+/// additive schema, while released-name compatibility paths may omit the
+/// historical tables entirely, so every object is discovered before use.
+fn ensure_observer_sync_event_verification_proof_schema(
+    transaction: &Transaction<'_>,
+) -> Result<()> {
+    if !table_exists_tx(transaction, "observer_sync_capability_verifications")? {
+        return Ok(());
+    }
+    let columns = transaction
+        .prepare("PRAGMA table_info(observer_sync_capability_verifications)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    for (column, definition) in [
+        (
+            "verification_version",
+            "verification_version INTEGER NOT NULL DEFAULT 0",
+        ),
+        ("event_log_epoch", "event_log_epoch TEXT"),
+        (
+            "event_generation",
+            "event_generation INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "verified_event_generation",
+            // -1 means no inventory proof covers the current mutation generation.
+            "verified_event_generation INTEGER NOT NULL DEFAULT -1",
+        ),
+    ] {
+        if !columns.iter().any(|existing| existing == column) {
+            transaction.execute_batch(&format!(
+                "ALTER TABLE observer_sync_capability_verifications ADD COLUMN {definition};"
+            ))?;
+        }
+    }
+    transaction.execute_batch(
+        r#"
+INSERT OR IGNORE INTO observer_sync_capability_verifications (
+  capability, verified, verified_at, detail
+) VALUES (
+  'event_projection_effect_complete',
+  0,
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+  '{"stage":"verification-proof-migration"}'
+);
+"#,
+    )?;
+    if table_exists_tx(transaction, "audit_events")? {
+        transaction.execute_batch(
+            r#"
+CREATE TRIGGER IF NOT EXISTS audit_events_projection_verification_insert
+AFTER INSERT ON audit_events
+BEGIN
+  UPDATE observer_sync_capability_verifications
+  SET event_generation = event_generation + 1
+  WHERE capability = 'event_projection_effect_complete';
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_events_projection_verification_update
+AFTER UPDATE OF kind, data_json ON audit_events
+BEGIN
+  UPDATE observer_sync_capability_verifications
+  SET event_generation = event_generation + 1
+  WHERE capability = 'event_projection_effect_complete';
+END;
+"#,
+        )?;
+    }
     Ok(())
 }
 

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3131,6 +3131,45 @@ CREATE TABLE IF NOT EXISTS brief_created_linkage_uncertain (
 );
 "#,
     },
+    Migration {
+        version: 50,
+        name: "observer_sync_event_verification_proof",
+        sql: r#"
+ALTER TABLE observer_sync_capability_verifications
+  ADD COLUMN verification_version INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE observer_sync_capability_verifications
+  ADD COLUMN event_log_epoch TEXT;
+ALTER TABLE observer_sync_capability_verifications
+  ADD COLUMN event_generation INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE observer_sync_capability_verifications
+  ADD COLUMN verified_event_generation INTEGER NOT NULL DEFAULT -1;
+
+INSERT OR IGNORE INTO observer_sync_capability_verifications (
+  capability, verified, verified_at, detail
+) VALUES (
+  'event_projection_effect_complete',
+  0,
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+  '{"stage":"verification-proof-migration"}'
+);
+
+CREATE TRIGGER audit_events_projection_verification_insert
+AFTER INSERT ON audit_events
+BEGIN
+  UPDATE observer_sync_capability_verifications
+  SET event_generation = event_generation + 1
+  WHERE capability = 'event_projection_effect_complete';
+END;
+
+CREATE TRIGGER audit_events_projection_verification_update
+AFTER UPDATE OF kind, data_json ON audit_events
+BEGIN
+  UPDATE observer_sync_capability_verifications
+  SET event_generation = event_generation + 1
+  WHERE capability = 'event_projection_effect_complete';
+END;
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/observer_sync.rs
+++ b/src/runtime_db/observer_sync.rs
@@ -295,28 +295,33 @@ pub(crate) fn verify_observer_sync_foundations(connection: &mut Connection) -> R
         &now,
         &reserved_detail,
     )?;
-    if reusable_event_projection_effect_verification(connection, &event_log_epoch)?.is_none() {
-        let inventory = verify_event_projection_effect_inventory(connection);
-        let inventory_detail = match &inventory {
-            Ok(complete) => serde_json::json!({
-                "source": "full_inventory",
-                "registry_kinds": crate::runtime_event::ALL_RUNTIME_EVENT_KINDS.len(),
-                "complete": complete,
-            })
-            .to_string(),
-            Err(error) => serde_json::json!({
-                "source": "full_inventory",
-                "error": format!("{error:#}"),
-            })
-            .to_string(),
-        };
-        persist_event_projection_effect_verification(
-            connection,
-            inventory.unwrap_or(false),
-            &event_log_epoch,
-            &now,
-            &inventory_detail,
-        )?;
+    {
+        let transaction = connection.transaction()?;
+        if reusable_event_projection_effect_verification(&transaction, &event_log_epoch)?.is_none()
+        {
+            let inventory = verify_event_projection_effect_inventory(&transaction);
+            let inventory_detail = match &inventory {
+                Ok(complete) => serde_json::json!({
+                    "source": "full_inventory",
+                    "registry_kinds": crate::runtime_event::ALL_RUNTIME_EVENT_KINDS.len(),
+                    "complete": complete,
+                })
+                .to_string(),
+                Err(error) => serde_json::json!({
+                    "source": "full_inventory",
+                    "error": format!("{error:#}"),
+                })
+                .to_string(),
+            };
+            persist_event_projection_effect_verification(
+                &transaction,
+                inventory.unwrap_or(false),
+                &event_log_epoch,
+                &now,
+                &inventory_detail,
+            )?;
+        }
+        transaction.commit()?;
     }
     let linkage = verify_brief_atomic_linkage(connection);
     let linkage_detail = match &linkage {
@@ -1041,10 +1046,10 @@ pub(crate) fn record_appended_event_projection_effect(
         event.payload_schema_version,
     );
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-    match classification {
+    let updated = match classification {
         crate::runtime_event::ProjectionEffectClassification::Exact(_)
-        | crate::runtime_event::ProjectionEffectClassification::ConservativeLegacy(_) => {
-            connection.execute(
+        | crate::runtime_event::ProjectionEffectClassification::ConservativeLegacy(_) => connection
+            .execute(
                 "UPDATE observer_sync_capability_verifications
                  SET verified_event_generation = event_generation,
                      verified_at = ?1
@@ -1061,8 +1066,7 @@ pub(crate) fn record_appended_event_projection_effect(
                     proof.event_generation,
                     proof.verified_event_generation,
                 ],
-            )?;
-        }
+            )?,
         crate::runtime_event::ProjectionEffectClassification::Unsupported(reason) => {
             let detail = serde_json::json!({
                 "source": "trusted_append",
@@ -1091,8 +1095,16 @@ pub(crate) fn record_appended_event_projection_effect(
                     proof.event_generation,
                     proof.verified_event_generation,
                 ],
-            )?;
+            )?
         }
+    };
+    if updated == 0 {
+        tracing::debug!(
+            event_id = %event.id,
+            event_generation = proof.event_generation,
+            verified_event_generation = proof.verified_event_generation,
+            "projection-effect proof did not advance after trusted append"
+        );
     }
     Ok(())
 }

--- a/src/runtime_db/observer_sync.rs
+++ b/src/runtime_db/observer_sync.rs
@@ -1220,29 +1220,46 @@ impl crate::runtime_db::RuntimeDb {
     /// read as false; load errors should degrade, not fail, the caller.
     pub fn observer_sync_foundations(&self) -> Result<ObserverSyncFoundationVerification> {
         let connection = self.connection()?;
-        let event_log_epoch = read_metadata(&connection, "event_log_epoch")?;
-        let verified = |capability: &str| -> Result<bool> {
-            Ok(connection
+        let verified = |capability: &str| -> bool {
+            match connection
                 .query_row(
                     "SELECT verified FROM observer_sync_capability_verifications
                      WHERE capability = ?1",
                     [capability],
                     |row| row.get::<_, i64>(0),
                 )
-                .optional()?
-                .is_some_and(|value| value != 0))
+                .optional()
+            {
+                Ok(value) => value.is_some_and(|value| value != 0),
+                Err(error) => {
+                    tracing::debug!(
+                        capability,
+                        %error,
+                        "failed to load observer sync capability verification"
+                    );
+                    false
+                }
+            }
         };
+        let event_projection_effect_complete = read_metadata(&connection, "event_log_epoch")
+            .and_then(|event_log_epoch| {
+                reusable_event_projection_effect_verification(&connection, &event_log_epoch)
+            })
+            .unwrap_or_else(|error| {
+                tracing::debug!(
+                    %error,
+                    "failed to load observer sync event projection verification proof"
+                );
+                None
+            })
+            .unwrap_or(false);
         Ok(ObserverSyncFoundationVerification {
-            runtime_identity_stable: verified(RUNTIME_IDENTITY_STABLE)?,
-            agent_identity_reserved: verified(AGENT_IDENTITY_RESERVED)?,
-            roster_snapshot_verified: verified(ROSTER_SNAPSHOT_VERIFIED)?,
-            projection_snapshot_verified: verified(PROJECTION_SNAPSHOT_VERIFIED)?,
-            event_projection_effect_complete: reusable_event_projection_effect_verification(
-                &connection,
-                &event_log_epoch,
-            )?
-            .unwrap_or(false),
-            brief_atomic_linkage_verified: verified(BRIEF_ATOMIC_LINKAGE_VERIFIED)?,
+            runtime_identity_stable: verified(RUNTIME_IDENTITY_STABLE),
+            agent_identity_reserved: verified(AGENT_IDENTITY_RESERVED),
+            roster_snapshot_verified: verified(ROSTER_SNAPSHOT_VERIFIED),
+            projection_snapshot_verified: verified(PROJECTION_SNAPSHOT_VERIFIED),
+            event_projection_effect_complete,
+            brief_atomic_linkage_verified: verified(BRIEF_ATOMIC_LINKAGE_VERIFIED),
         })
     }
 

--- a/src/runtime_db/observer_sync.rs
+++ b/src/runtime_db/observer_sync.rs
@@ -3,9 +3,9 @@
 //! S1 of the observer-sync plan introduces the verification source the S0
 //! capability evaluator requires: a capability may be advertised only while
 //! its storage and consistency invariants hold for the current database.
-//! Verification re-runs on every migration/open, and a failed check records
-//! `verified = 0` durably instead of failing the open, so a degraded database
-//! degrades advertisement rather than startup.
+//! Verification runs after migrations. Projection-effect inventory results
+//! carry a durable verifier/epoch/mutation proof so an unchanged database can
+//! reuse them instead of scanning the complete event log on every open.
 
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior};
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use crate::runtime_db::evidence::upsert_agent_identity_tx;
 use crate::types::{
     AgentIdentityRecord, AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
-    AgentVisibility,
+    AgentVisibility, AuditEvent,
 };
 
 pub(crate) const RUNTIME_IDENTITY_STABLE: &str = "runtime_identity_stable";
@@ -23,6 +23,7 @@ pub(crate) const EVENT_PROJECTION_EFFECT_COMPLETE: &str = "event_projection_effe
 pub(crate) const BRIEF_ATOMIC_LINKAGE_VERIFIED: &str = "brief_atomic_linkage_verified";
 pub(crate) const ROSTER_SNAPSHOT_VERIFIED: &str = "roster_snapshot_verified";
 pub(crate) const PROJECTION_SNAPSHOT_VERIFIED: &str = "projection_snapshot_verified";
+pub(crate) const EVENT_PROJECTION_EFFECT_VERIFIER_VERSION: i64 = 1;
 
 /// Principal and entitlement used to derive the runtime-local public scope
 /// for unauthenticated local mode.
@@ -145,6 +146,15 @@ pub struct ObserverSyncFoundationVerification {
     /// linkage resolves to exactly one matching event. Retention-pruned
     /// history with no linkage stays acceptable.
     pub brief_atomic_linkage_verified: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EventProjectionEffectProof {
+    verified: bool,
+    verification_version: i64,
+    event_log_epoch: Option<String>,
+    event_generation: i64,
+    verified_event_generation: i64,
 }
 
 /// Per-Agent committed event recovery window used by the rich
@@ -285,22 +295,29 @@ pub(crate) fn verify_observer_sync_foundations(connection: &mut Connection) -> R
         &now,
         &reserved_detail,
     )?;
-    let inventory = verify_event_projection_effect_inventory(connection);
-    let inventory_detail = match &inventory {
-        Ok(complete) => serde_json::json!({
-            "registry_kinds": crate::runtime_event::ALL_RUNTIME_EVENT_KINDS.len(),
-            "complete": complete,
-        })
-        .to_string(),
-        Err(error) => serde_json::json!({ "error": format!("{error:#}") }).to_string(),
-    };
-    persist_verification(
-        connection,
-        EVENT_PROJECTION_EFFECT_COMPLETE,
-        inventory.unwrap_or(false),
-        &now,
-        &inventory_detail,
-    )?;
+    if reusable_event_projection_effect_verification(connection, &event_log_epoch)?.is_none() {
+        let inventory = verify_event_projection_effect_inventory(connection);
+        let inventory_detail = match &inventory {
+            Ok(complete) => serde_json::json!({
+                "source": "full_inventory",
+                "registry_kinds": crate::runtime_event::ALL_RUNTIME_EVENT_KINDS.len(),
+                "complete": complete,
+            })
+            .to_string(),
+            Err(error) => serde_json::json!({
+                "source": "full_inventory",
+                "error": format!("{error:#}"),
+            })
+            .to_string(),
+        };
+        persist_event_projection_effect_verification(
+            connection,
+            inventory.unwrap_or(false),
+            &event_log_epoch,
+            &now,
+            &inventory_detail,
+        )?;
+    }
     let linkage = verify_brief_atomic_linkage(connection);
     let linkage_detail = match &linkage {
         Ok(verified) => serde_json::json!({
@@ -926,6 +943,160 @@ fn verify_event_projection_effect_inventory(connection: &Connection) -> Result<b
     Ok(false)
 }
 
+fn event_projection_effect_proof(
+    connection: &Connection,
+) -> Result<Option<EventProjectionEffectProof>> {
+    connection
+        .query_row(
+            "SELECT verified, verification_version, event_log_epoch,
+                    event_generation, verified_event_generation
+             FROM observer_sync_capability_verifications
+             WHERE capability = ?1",
+            [EVENT_PROJECTION_EFFECT_COMPLETE],
+            |row| {
+                Ok(EventProjectionEffectProof {
+                    verified: row.get::<_, i64>(0)? != 0,
+                    verification_version: row.get(1)?,
+                    event_log_epoch: row.get(2)?,
+                    event_generation: row.get(3)?,
+                    verified_event_generation: row.get(4)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(Into::into)
+}
+
+fn reusable_event_projection_effect_verification(
+    connection: &Connection,
+    event_log_epoch: &str,
+) -> Result<Option<bool>> {
+    Ok(
+        event_projection_effect_proof(connection)?.and_then(|proof| {
+            (proof.verification_version == EVENT_PROJECTION_EFFECT_VERIFIER_VERSION
+                && proof.event_log_epoch.as_deref() == Some(event_log_epoch)
+                && proof.event_generation >= 0
+                && proof.event_generation == proof.verified_event_generation)
+                .then_some(proof.verified)
+        }),
+    )
+}
+
+fn persist_event_projection_effect_verification(
+    connection: &Connection,
+    verified: bool,
+    event_log_epoch: &str,
+    verified_at: &str,
+    detail: &str,
+) -> Result<()> {
+    connection.execute(
+        "INSERT INTO observer_sync_capability_verifications (
+             capability, verified, verified_at, detail, verification_version,
+             event_log_epoch, event_generation, verified_event_generation
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, 0)
+         ON CONFLICT(capability) DO UPDATE SET
+           verified = excluded.verified,
+           verified_at = excluded.verified_at,
+           detail = excluded.detail,
+           verification_version = excluded.verification_version,
+           event_log_epoch = excluded.event_log_epoch,
+           verified_event_generation =
+             observer_sync_capability_verifications.event_generation",
+        rusqlite::params![
+            EVENT_PROJECTION_EFFECT_COMPLETE,
+            verified,
+            verified_at,
+            detail,
+            EVENT_PROJECTION_EFFECT_VERIFIER_VERSION,
+            event_log_epoch,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Advances the durable projection-effect proof for one event inserted by the
+/// trusted append path. The insert trigger has already advanced
+/// `event_generation`; only a proof that covered the immediately preceding
+/// generation may advance. Writes outside the trusted helper therefore leave
+/// a stale proof and force fail-closed full re-verification on next open.
+pub(crate) fn record_appended_event_projection_effect(
+    connection: &Connection,
+    event: &AuditEvent,
+) -> Result<()> {
+    let Some(proof) = event_projection_effect_proof(connection)? else {
+        return Ok(());
+    };
+    if proof.verification_version != EVENT_PROJECTION_EFFECT_VERIFIER_VERSION
+        || proof.event_log_epoch.as_deref() != Some(event.event_log_epoch.as_str())
+        || proof.event_generation <= 0
+        || proof.verified_event_generation != proof.event_generation - 1
+    {
+        return Ok(());
+    }
+
+    let classification = crate::runtime_event::classify_projection_effect(
+        &event.kind,
+        event.contract_version,
+        &event.payload_schema,
+        event.payload_schema_version,
+    );
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    match classification {
+        crate::runtime_event::ProjectionEffectClassification::Exact(_)
+        | crate::runtime_event::ProjectionEffectClassification::ConservativeLegacy(_) => {
+            connection.execute(
+                "UPDATE observer_sync_capability_verifications
+                 SET verified_event_generation = event_generation,
+                     verified_at = ?1
+                 WHERE capability = ?2
+                   AND verification_version = ?3
+                   AND event_log_epoch = ?4
+                   AND event_generation = ?5
+                   AND verified_event_generation = ?6",
+                rusqlite::params![
+                    now,
+                    EVENT_PROJECTION_EFFECT_COMPLETE,
+                    EVENT_PROJECTION_EFFECT_VERIFIER_VERSION,
+                    event.event_log_epoch,
+                    proof.event_generation,
+                    proof.verified_event_generation,
+                ],
+            )?;
+        }
+        crate::runtime_event::ProjectionEffectClassification::Unsupported(reason) => {
+            let detail = serde_json::json!({
+                "source": "trusted_append",
+                "complete": false,
+                "kind": event.kind,
+                "reason": format!("{reason:?}"),
+            })
+            .to_string();
+            connection.execute(
+                "UPDATE observer_sync_capability_verifications
+                 SET verified = 0,
+                     verified_at = ?1,
+                     detail = ?2,
+                     verified_event_generation = event_generation
+                 WHERE capability = ?3
+                   AND verification_version = ?4
+                   AND event_log_epoch = ?5
+                   AND event_generation = ?6
+                   AND verified_event_generation = ?7",
+                rusqlite::params![
+                    now,
+                    detail,
+                    EVENT_PROJECTION_EFFECT_COMPLETE,
+                    EVENT_PROJECTION_EFFECT_VERIFIER_VERSION,
+                    event.event_log_epoch,
+                    proof.event_generation,
+                    proof.verified_event_generation,
+                ],
+            )?;
+        }
+    }
+    Ok(())
+}
+
 /// Proves the creation guard is wired into the registry write path: an
 /// Active identity write for a retired reservation must be rejected, while
 /// re-asserting the tombstone stays legal. Runs inside a transaction that is
@@ -1037,6 +1208,7 @@ impl crate::runtime_db::RuntimeDb {
     /// read as false; load errors should degrade, not fail, the caller.
     pub fn observer_sync_foundations(&self) -> Result<ObserverSyncFoundationVerification> {
         let connection = self.connection()?;
+        let event_log_epoch = read_metadata(&connection, "event_log_epoch")?;
         let verified = |capability: &str| -> Result<bool> {
             Ok(connection
                 .query_row(
@@ -1053,7 +1225,11 @@ impl crate::runtime_db::RuntimeDb {
             agent_identity_reserved: verified(AGENT_IDENTITY_RESERVED)?,
             roster_snapshot_verified: verified(ROSTER_SNAPSHOT_VERIFIED)?,
             projection_snapshot_verified: verified(PROJECTION_SNAPSHOT_VERIFIED)?,
-            event_projection_effect_complete: verified(EVENT_PROJECTION_EFFECT_COMPLETE)?,
+            event_projection_effect_complete: reusable_event_projection_effect_verification(
+                &connection,
+                &event_log_epoch,
+            )?
+            .unwrap_or(false),
             brief_atomic_linkage_verified: verified(BRIEF_ATOMIC_LINKAGE_VERIFIED)?,
         })
     }

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -89,6 +89,7 @@ mod tests {
             WorkStatus,
         },
         runtime_db::migrations::{RETAINED_SCHEDULER_AUDIT_TABLES, RETIRED_SCHEDULER_TABLES},
+        runtime_db::observer_sync::EVENT_PROJECTION_EFFECT_VERIFIER_VERSION,
         runtime_db::repositories::{enum_string, slim_task_record_for_payload},
         runtime_db::transitions::{
             AgentStateMutation, QueueHeadNoProgressCommand, QueueHeadNoProgressOutcome,
@@ -1723,7 +1724,7 @@ INSERT INTO storage_domains (
         assert!(
             error
                 .to_string()
-                .contains("supports runtime db schemas 46 through 49, found 45"),
+                .contains("supports runtime db schemas 46 through 50, found 45"),
             "{error:#}"
         );
         Ok(())
@@ -1846,7 +1847,7 @@ INSERT INTO scheduler_rollout_command_results (
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
 
         let connection = open_connection(&db_path)?;
-        assert_eq!(current_schema_version(&connection)?, 49);
+        assert_eq!(current_schema_version(&connection)?, 50);
         for table in RETIRED_SCHEDULER_TABLES {
             assert!(
                 !table_exists(&connection, table)?,
@@ -2000,7 +2001,7 @@ INSERT INTO scheduler_rollout_command_results (
 
             RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             let connection = open_connection(&db_path)?;
-            assert_eq!(current_schema_version(&connection)?, 49);
+            assert_eq!(current_schema_version(&connection)?, 50);
             for table in RETIRED_SCHEDULER_TABLES {
                 assert!(
                     !table_exists(&connection, table)?,
@@ -2114,7 +2115,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 49);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 50);
         Ok(())
     }
 
@@ -2280,7 +2281,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 49);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 50);
         Ok(())
     }
 
@@ -2340,7 +2341,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 49);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 50);
         Ok(())
     }
 
@@ -6058,6 +6059,20 @@ CREATE TABLE working_memory_deltas (
                 data: serde_json::from_str(descriptor.fixture_json)?,
             };
             db.audit_events().append(Some("default"), &typed)?;
+            let proof: (i64, i64, i64) = db.connection()?.query_row(
+                "SELECT verified, event_generation, verified_event_generation
+                 FROM observer_sync_capability_verifications
+                 WHERE capability = 'event_projection_effect_complete'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )?;
+            assert_eq!(proof.0, 1);
+            assert_eq!(proof.1, 5);
+            assert_eq!(proof.2, proof.1);
+            assert!(
+                db.observer_sync_foundations()?
+                    .event_projection_effect_complete
+            );
         }
         let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
         let foundations = reopened.observer_sync_foundations()?;
@@ -6090,8 +6105,11 @@ CREATE TABLE working_memory_deltas (
                 event.payload_schema = payload_schema.into();
                 event.payload_schema_version = payload_schema_version;
                 db.audit_events().append(Some("default"), &event)?;
-                // The verification row predates this append; the reopen below
-                // re-verifies against committed contents.
+                assert!(
+                    !db.observer_sync_foundations()?
+                        .event_projection_effect_complete,
+                    "unsupported trusted append must disable the capability immediately"
+                );
             }
             let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             let foundations = reopened.observer_sync_foundations()?;
@@ -6100,6 +6118,128 @@ CREATE TABLE working_memory_deltas (
                 "{kind}@{payload_schema}v{payload_schema_version} must stay unsupported"
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn observer_sync_event_projection_effect_reuses_current_proof_on_reopen() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        {
+            let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+            db.connection()?.execute(
+                "UPDATE observer_sync_capability_verifications
+                 SET detail = 'proof-reuse-sentinel'
+                 WHERE capability = 'event_projection_effect_complete'",
+                [],
+            )?;
+        }
+
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let proof: (i64, String, i64, i64, i64) = reopened.connection()?.query_row(
+            "SELECT verified, detail, verification_version,
+                    event_generation, verified_event_generation
+             FROM observer_sync_capability_verifications
+             WHERE capability = 'event_projection_effect_complete'",
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )?;
+        assert_eq!(proof.0, 1);
+        assert_eq!(proof.1, "proof-reuse-sentinel");
+        assert_eq!(proof.2, EVENT_PROJECTION_EFFECT_VERIFIER_VERSION);
+        assert_eq!(proof.3, proof.4);
+        Ok(())
+    }
+
+    #[test]
+    fn observer_sync_event_projection_effect_reverifies_stale_version_or_epoch() -> Result<()> {
+        for stale_column in ["verification_version", "event_log_epoch"] {
+            let (_temp_dir, db_path, lock_path) = temp_paths()?;
+            {
+                let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+                let sql = format!(
+                    "UPDATE observer_sync_capability_verifications
+                     SET {stale_column} = ?1, detail = 'stale-proof-sentinel'
+                     WHERE capability = 'event_projection_effect_complete'"
+                );
+                let stale_value = if stale_column == "verification_version" {
+                    "0"
+                } else {
+                    "epoch_stale"
+                };
+                db.connection()?.execute(&sql, [stale_value])?;
+            }
+
+            let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+            let (version, epoch, detail): (i64, String, String) =
+                reopened.connection()?.query_row(
+                    "SELECT verification_version, event_log_epoch, detail
+                     FROM observer_sync_capability_verifications
+                     WHERE capability = 'event_projection_effect_complete'",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )?;
+            assert_eq!(version, EVENT_PROJECTION_EFFECT_VERIFIER_VERSION);
+            assert_eq!(epoch, reopened.event_log_epoch()?);
+            assert!(detail.contains("full_inventory"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn observer_sync_event_projection_effect_direct_write_invalidates_proof() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        {
+            let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+            let epoch = db.event_log_epoch()?;
+            let event = crate::types::AuditEvent {
+                id: "evt_direct_unsupported".into(),
+                event_seq: 1,
+                event_log_epoch: epoch,
+                created_at: chrono::Utc::now(),
+                kind: "future_typed_kind".into(),
+                contract_version: crate::runtime_event::RUNTIME_EVENT_CONTRACT_VERSION,
+                payload_schema: "holon.runtime_event.future".into(),
+                payload_schema_version: 1,
+                data: serde_json::json!({ "opaque": true }),
+            };
+            db.connection()?.execute(
+                "INSERT INTO audit_events (
+                   audit_event_id, event_seq, agent_id, kind, created_at, data_json
+                 ) VALUES (?1, ?2, 'default', ?3, ?4, ?5)",
+                rusqlite::params![
+                    event.id,
+                    event.event_seq,
+                    event.kind,
+                    timestamp(event.created_at),
+                    serde_json::to_string(&event)?,
+                ],
+            )?;
+            assert!(
+                !db.observer_sync_foundations()?
+                    .event_projection_effect_complete,
+                "the insert trigger must make an untrusted write fail closed"
+            );
+        }
+
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let proof: (i64, i64, i64, String) = reopened.connection()?.query_row(
+            "SELECT verified, event_generation, verified_event_generation, detail
+             FROM observer_sync_capability_verifications
+             WHERE capability = 'event_projection_effect_complete'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )?;
+        assert_eq!(proof.0, 0);
+        assert_eq!(proof.1, proof.2);
+        assert!(proof.3.contains("full_inventory"));
         Ok(())
     }
 

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -2222,7 +2222,7 @@ INSERT INTO scheduler_rollout_command_results (
             RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             assert_eq!(
                 current_schema_version(&open_connection(&db_path)?)?,
-                49,
+                50,
                 "{case}"
             );
         }

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -6159,6 +6159,22 @@ CREATE TABLE working_memory_deltas (
     }
 
     #[test]
+    fn observer_sync_foundations_degrade_when_event_proof_metadata_is_unreadable() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.connection()?.execute(
+            "DELETE FROM runtime_metadata WHERE key = 'event_log_epoch'",
+            [],
+        )?;
+
+        let foundations = db.observer_sync_foundations()?;
+        assert!(foundations.runtime_identity_stable);
+        assert!(foundations.agent_identity_reserved);
+        assert!(!foundations.event_projection_effect_complete);
+        Ok(())
+    }
+
+    #[test]
     fn observer_sync_event_projection_effect_reverifies_stale_version_or_epoch() -> Result<()> {
         for stale_column in ["verification_version", "event_log_epoch"] {
             let (_temp_dir, db_path, lock_path) = temp_paths()?;


### PR DESCRIPTION
## Summary

- add schema 50 provenance for the durable projection-effect verification proof
- reuse a current classifier/epoch/event-generation proof instead of scanning all retained audit events on every database open
- advance the proof atomically for trusted appends and fail closed for unsupported or out-of-band mutations
- document the verification boundary and add migration/proof invalidation coverage

## Runtime contract

`event_seq` is Agent-scoped, so the implementation uses a global audit mutation generation as the durable verification boundary. Audit inserts and classification-relevant updates advance that generation through SQLite triggers. The trusted append path classifies the committed event and advances the verified generation in the same transaction. A classifier version change, epoch change, or untracked mutation makes capability reads fail closed and causes the next open to run the historical inventory once.

## Verification

- `cargo test observer_sync_event_projection_effect -- --nocapture`
- `cargo test runtime_db::tests::tests::migration_ -- --nocapture`
- `cargo test runtime_db_fresh_migration_creates_foundation_schema -- --nocapture`
- `cargo test runtime_db_migration_is_idempotent -- --nocapture`
- `cargo test release_baseline_matches_compatibility_migration_schema -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2647
