### PR TITLE
fix: persist audit retention watermarks

### DIFF
--- a/docs/implementation-decisions/112-audit-event-retention-watermark.md
+++ b/docs/implementation-decisions/112-audit-event-retention-watermark.md
@@ -1,0 +1,12 @@
+# Audit-event retention uses a separate durable floor
+
+The committed event head remains `runtime_sequences.last_value`. Retention
+stores its hard recovery boundary separately in
+`audit_event_retention_watermarks`, keyed by the same `agent:<id>` or `host`
+scope key.
+
+An actual prefix deletion through `D` advances the floor to `MAX(existing,
+D + 1)` in the delete transaction. No row means `0`: no deletion is known to
+have occurred. This keeps allocation and deletion provenance distinct, keeps
+the floor monotonic when no event survives, and lets recovery reads avoid
+aggregating the retained event ledger.

--- a/docs/rfcs/observer-sync-agent-summary-and-read-markers.md
+++ b/docs/rfcs/observer-sync-agent-summary-and-read-markers.md
@@ -319,7 +319,7 @@ struct AgentRosterEntry {
 
 struct AgentEventWindow {
     event_head_seq: u64,
-    oldest_retained_seq: Option<u64>,
+    oldest_retained_seq: u64,
 }
 
 struct AgentLatestBrief {
@@ -346,13 +346,17 @@ entitlement should keep it stable. A principal, entitlement, or policy change
 must rotate it. Local unauthenticated mode uses a runtime-local public scope.
 
 `event_head_seq` is the greatest committed `event_seq` visible in the response
-read view. It must not come from an in-memory watcher or the next value in a
-sequence allocator.
+read view. It comes from the Agent's committed `runtime_sequences` row, not an
+in-memory watcher, the allocator's next value, or an aggregate over retained
+events.
 
-`oldest_retained_seq` is the first raw event still replayable in that same read
-view. An Agent with no events has `event_head_seq = 0` and
-`oldest_retained_seq = None`. Retention may advance after the response, so the
-event page's `cursor_not_found` response remains authoritative.
+`oldest_retained_seq` is the durable hard recovery floor. `0` means no retained
+prefix is known to have been deleted, including for an Agent with no events.
+A positive value is the earliest sequence that may still be replayable after
+retention; it may equal `event_head_seq + 1` when no raw event survives. The
+value comes from the per-Agent retention watermark, not `MIN(event_seq)`.
+Retention may advance after the response, so the event page's
+`cursor_not_found` response remains authoritative.
 
 `latest_brief` is derived from canonical Brief storage, not a second UI-summary
 table. `preview` has a documented length limit. Full Brief content remains
@@ -412,7 +416,7 @@ struct AgentProjectionSnapshot {
     agent_id: String,
     snapshot_through_seq: u64,
     event_head_seq: u64,
-    oldest_retained_seq: Option<u64>,
+    oldest_retained_seq: u64,
     projection: AgentCanonicalProjection,
 }
 ```
@@ -733,9 +737,10 @@ and privacy-mode behavior. It is outside Phase 3.
 
 ### Normal Catch-Up
 
-If the epoch matches and the local cursor is at or after
-`oldest_retained_seq - 1`, the client replays `after_seq` normally. Offline
-Brief events remain available for exact unread calculation.
+If the epoch matches and either `oldest_retained_seq = 0` or the local cursor
+is at or after `oldest_retained_seq - 1`, incremental recovery remains
+possible and the client replays `after_seq` normally. Offline Brief events
+remain available for exact unread calculation.
 
 ### Rich Cursor Error
 
@@ -754,7 +759,8 @@ select the correct reset path.
 
 An Agent-local reset begins when:
 
-- the local cursor is less than `oldest_retained_seq - 1`;
+- `oldest_retained_seq > 0` and the local cursor is less than
+  `oldest_retained_seq - 1`;
 - the event page or SSE endpoint returns `cursor_not_found`;
 - one immutable event identity has conflicting content; or
 - projection divergence cannot be repaired by bounded hydration retry.
@@ -968,7 +974,9 @@ They should not be implemented as aliases for the new contract.
 3. `agent_id` is not reused for a different Agent within one epoch.
 4. A roster snapshot is complete for the active-public visibility scope or
    fails entirely.
-5. Roster event head and retained floor name committed events in one read view.
+5. Roster event head and durable retained floor come from one committed read
+   view; floor `0` means no known deletion and a positive floor may be one past
+   the head after full-prefix deletion.
 6. A projection snapshot and `snapshot_through_seq` share one consistency
    boundary.
 7. A client applies only events greater than an installed snapshot boundary.

--- a/docs/rfcs/runtime-db-retention.md
+++ b/docs/rfcs/runtime-db-retention.md
@@ -26,6 +26,10 @@ turn tail are protected by typed business logic.
 Online maintenance uses bounded transactions and optional incremental vacuum.
 Full `VACUUM` is an explicit offline operation.
 
+Every deleted audit-event prefix also advances a durable scope watermark in
+`audit_event_retention_watermarks`. The watermark makes recovery-window reads
+independent of the size of retained history.
+
 ## Goals
 
 - stop unbounded growth after an operator enables a retention policy;
@@ -107,8 +111,22 @@ sequence is the earlier of:
 
 Only rows before that sequence may be deleted. Timestamp disorder therefore
 widens retention rather than creating a sequence hole. `runtime_sequences`
-and `event_log_epoch` are not modified. A cursor older than the retained
-prefix continues to use the existing `cursor_not_found` recovery contract.
+and `event_log_epoch` are not modified.
+
+When one bounded transaction deletes through sequence `D`, that same
+transaction advances the scope's `oldest_retained_seq` to at least `D + 1`.
+The value never moves backwards and remains present when the retained suffix
+is empty. A missing watermark row reads as `0`, meaning no retained prefix is
+known to have been deleted; it does not mean the scope has events. Agent
+scopes use `agent:<agent_id>` and the host scope uses `host`, matching
+`runtime_sequences`.
+
+The schema migration creates no rows and does not infer deletion from gaps in
+existing history. After migration, roster, projection, and cursor-error
+recovery windows read the current head from
+`runtime_sequences.last_value` and the hard recovery floor from the watermark;
+they do not aggregate retained `audit_events`. A cursor below a positive floor
+continues to use the authoritative `cursor_not_found` recovery contract.
 
 ### Transcript and tool evidence
 
@@ -154,6 +172,7 @@ The dry-run and execution paths share a typed report containing:
 - effective policy and cutoffs;
 - observed, candidate, protected, and deleted rows by table;
 - audit-scope skip counts;
+- durable event heads and retention floors on observer recovery surfaces;
 - page size, page count, freelist pages, and estimated reclaimable bytes;
 - incremental-vacuum result;
 - elapsed time.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -507,16 +507,9 @@
             "type": "integer"
           },
           "oldest_retained_seq": {
-            "description": "First raw event still replayable in that view; null when the Agent has no events (event_head_seq = 0).",
-            "oneOf": [
-              {
-                "minimum": 0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "description": "Durable retention floor. Zero means no retained prefix has ever been deleted; a positive value is the earliest sequence that may still be replayable.",
+            "minimum": 0,
+            "type": "integer"
           }
         },
         "required": [
@@ -609,15 +602,9 @@
             "type": "string"
           },
           "oldest_retained_seq": {
-            "oneOf": [
-              {
-                "minimum": 0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "description": "Durable retention floor; zero means no retained prefix has ever been deleted.",
+            "minimum": 0,
+            "type": "integer"
           },
           "projection": {
             "$ref": "#/components/schemas/AgentCanonicalProjection"
@@ -2899,15 +2886,9 @@
             "type": "boolean"
           },
           "oldest_retained_seq": {
-            "oneOf": [
-              {
-                "minimum": 0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "description": "Durable retention floor; zero means no retained prefix has ever been deleted.",
+            "minimum": 0,
+            "type": "integer"
           }
         },
         "required": [

--- a/src/host.rs
+++ b/src/host.rs
@@ -86,7 +86,7 @@ pub(crate) struct AgentRosterSnapshotData {
 pub(crate) struct AgentRosterEntryData {
     pub agent: AgentListEntry,
     pub event_head_seq: u64,
-    pub oldest_retained_seq: Option<u64>,
+    pub oldest_retained_seq: u64,
     pub latest_brief: Option<AgentRosterLatestBriefData>,
 }
 
@@ -112,7 +112,7 @@ pub(crate) struct AgentProjectionSnapshotData {
     /// commits its canonical record no later than its event.
     pub snapshot_through_seq: u64,
     pub event_head_seq: u64,
-    pub oldest_retained_seq: Option<u64>,
+    pub oldest_retained_seq: u64,
     pub agent: AgentListEntry,
     pub current_work_item: Option<AgentWorkItemAnchorData>,
     pub conversation: ConversationRevisionAnchorsData,

--- a/src/http/observer_sync.rs
+++ b/src/http/observer_sync.rs
@@ -127,9 +127,8 @@ pub(crate) struct AgentRosterEntry {
 pub(crate) struct AgentEventWindow {
     /// Greatest committed `event_seq` visible in the response read view.
     pub(crate) event_head_seq: u64,
-    /// First raw event still replayable in that view; `null` when the Agent
-    /// has no events (`event_head_seq = 0`).
-    pub(crate) oldest_retained_seq: Option<u64>,
+    /// Retention floor; `0` means no retained prefix has ever been deleted.
+    pub(crate) oldest_retained_seq: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -159,7 +158,7 @@ pub(crate) struct AgentProjectionSnapshot {
     /// May be greater than `snapshot_through_seq`; names a committed event
     /// available through the event page.
     pub(crate) event_head_seq: u64,
-    pub(crate) oldest_retained_seq: Option<u64>,
+    pub(crate) oldest_retained_seq: u64,
     pub(crate) projection: AgentCanonicalProjection,
 }
 
@@ -230,7 +229,7 @@ pub(crate) struct RichCursorNotFoundError {
     pub(crate) code: String,
     pub(crate) after_seq: u64,
     pub(crate) event_log_epoch: String,
-    pub(crate) oldest_retained_seq: Option<u64>,
+    pub(crate) oldest_retained_seq: u64,
     pub(crate) event_head_seq: u64,
 }
 
@@ -1118,7 +1117,7 @@ mod tests {
             assert!(head >= 2);
             // One committed view: the boundary equals the head it read.
             assert_eq!(body["snapshot_through_seq"].as_u64().unwrap(), head);
-            assert_eq!(body["oldest_retained_seq"].as_u64().unwrap_or(1), 1);
+            assert_eq!(body["oldest_retained_seq"].as_u64(), Some(0));
             assert!(body["visibility_scope_id"]
                 .as_str()
                 .is_some_and(|scope| scope.starts_with("vscope1_")));

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -868,11 +868,9 @@ fn component_schemas() -> Value {
             "properties": {
                 "event_head_seq": { "type": "integer", "minimum": 0, "description": "Greatest committed event_seq visible in the response read view." },
                 "oldest_retained_seq": {
-                    "oneOf": [
-                        { "type": "integer", "minimum": 0 },
-                        { "type": "null" }
-                    ],
-                    "description": "First raw event still replayable in that view; null when the Agent has no events (event_head_seq = 0)."
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Durable retention floor. Zero means no retained prefix has ever been deleted; a positive value is the earliest sequence that may still be replayable."
                 }
             },
             "required": ["event_head_seq", "oldest_retained_seq"],
@@ -914,10 +912,9 @@ fn component_schemas() -> Value {
                 "snapshot_through_seq": { "type": "integer", "minimum": 0, "description": "Every event with event_seq <= snapshot_through_seq that affects current canonical state is already reflected in the projection or its revision anchors." },
                 "event_head_seq": { "type": "integer", "minimum": 0, "description": "May exceed snapshot_through_seq; names a committed event available through the event page. Clients replay (snapshot_through_seq, event_head_seq] and later events." },
                 "oldest_retained_seq": {
-                    "oneOf": [
-                        { "type": "integer", "minimum": 0 },
-                        { "type": "null" }
-                    ]
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Durable retention floor; zero means no retained prefix has ever been deleted."
                 },
                 "projection": { "$ref": "#/components/schemas/AgentCanonicalProjection" }
             },
@@ -1026,10 +1023,9 @@ fn component_schemas() -> Value {
                 "after_seq": { "type": "integer", "minimum": 0 },
                 "event_log_epoch": { "type": "string" },
                 "oldest_retained_seq": {
-                    "oneOf": [
-                        { "type": "integer", "minimum": 0 },
-                        { "type": "null" }
-                    ]
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Durable retention floor; zero means no retained prefix has ever been deleted."
                 },
                 "event_head_seq": { "type": "integer", "minimum": 0 }
             },

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3139,6 +3139,16 @@ CREATE TABLE IF NOT EXISTS brief_created_linkage_uncertain (
         // name-accepted and downgrade/re-upgrade paths remain idempotent.
         sql: "",
     },
+    Migration {
+        version: 51,
+        name: "audit_event_retention_watermarks",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS audit_event_retention_watermarks (
+  scope_key TEXT PRIMARY KEY,
+  oldest_retained_seq INTEGER NOT NULL CHECK (oldest_retained_seq > 0)
+);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/observer_sync.rs
+++ b/src/runtime_db/observer_sync.rs
@@ -52,7 +52,7 @@ pub struct AgentRosterRow {
     pub identity_json: String,
     pub agent_state_json: Option<String>,
     pub event_head_seq: u64,
-    pub oldest_retained_seq: Option<u64>,
+    pub oldest_retained_seq: u64,
     pub latest_brief: Option<AgentRosterLatestBriefRow>,
 }
 
@@ -97,7 +97,7 @@ pub struct AgentProjectionSnapshotRow {
     pub agent_state_json: Option<String>,
     /// Greatest committed `event_seq` for the Agent in this view.
     pub event_head_seq: u64,
-    pub oldest_retained_seq: Option<u64>,
+    pub oldest_retained_seq: u64,
     /// Current focused WorkItem, or the most recently updated open one.
     pub current_work_item: Option<AgentProjectionWorkItemRow>,
     /// Latest message record id resolvable through the batch API.
@@ -163,8 +163,8 @@ struct EventProjectionEffectProof {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentEventRecoveryWindow {
     pub event_log_epoch: String,
-    /// First raw event still replayable; `None` when the Agent has no events.
-    pub oldest_retained_seq: Option<u64>,
+    /// Retention floor; `0` means no retained prefix has ever been deleted.
+    pub oldest_retained_seq: u64,
     /// Greatest committed `event_seq` in the same read view.
     pub event_head_seq: u64,
 }
@@ -377,7 +377,14 @@ pub(crate) fn verify_observer_sync_foundations(connection: &mut Connection) -> R
 /// A row that cannot assemble would fail a whole snapshot response, so the
 /// capability degrades instead.
 fn verify_roster_snapshot_view(connection: &Connection) -> Result<bool> {
-    for table in ["agent_identities", "agent_states", "audit_events", "briefs"] {
+    for table in [
+        "agent_identities",
+        "agent_states",
+        "audit_events",
+        "audit_event_retention_watermarks",
+        "runtime_sequences",
+        "briefs",
+    ] {
         if !table_exists(connection, table)? {
             return Ok(false);
         }
@@ -397,7 +404,7 @@ fn verify_roster_snapshot_view(connection: &Connection) -> Result<bool> {
             })?;
         }
         anyhow::ensure!(
-            row.event_head_seq >= row.oldest_retained_seq.unwrap_or(0),
+            row.event_head_seq.saturating_add(1) >= row.oldest_retained_seq,
             "roster event window for {} is inverted",
             row.agent_id
         );
@@ -415,6 +422,8 @@ fn verify_projection_snapshot_view(connection: &Connection) -> Result<bool> {
         "agent_identities",
         "agent_states",
         "audit_events",
+        "audit_event_retention_watermarks",
+        "runtime_sequences",
         "briefs",
         "work_items",
         "messages",
@@ -471,7 +480,7 @@ fn verify_projection_snapshot_view(connection: &Connection) -> Result<bool> {
             })?;
         }
         anyhow::ensure!(
-            row.event_head_seq >= row.oldest_retained_seq.unwrap_or(0),
+            row.event_head_seq.saturating_add(1) >= row.oldest_retained_seq,
             "projection event window for {} is inverted",
             row.agent_id
         );
@@ -527,16 +536,21 @@ fn collect_agent_projection_anchors(
         });
     };
 
-    let (oldest, head): (Option<i64>, Option<i64>) = connection.query_row(
-        "SELECT (SELECT MIN(event_seq) FROM audit_events WHERE agent_id = ?1),
-                (SELECT MAX(event_seq) FROM audit_events WHERE agent_id = ?1)",
+    let (oldest, head): (i64, i64) = connection.query_row(
+        "SELECT
+           COALESCE((
+             SELECT oldest_retained_seq FROM audit_event_retention_watermarks
+             WHERE scope_key = 'agent:' || ?1
+           ), 0),
+           COALESCE((
+             SELECT last_value FROM runtime_sequences
+             WHERE domain = 'audit_event' AND scope_key = 'agent:' || ?1
+           ), 0)",
         [agent_id],
         |row| Ok((row.get(0)?, row.get(1)?)),
     )?;
-    let to_seq = |value: Option<i64>| -> Result<Option<u64>> {
-        value
-            .map(|seq| u64::try_from(seq).context("stored audit event sequence is negative"))
-            .transpose()
+    let to_seq = |value: i64| -> Result<u64> {
+        u64::try_from(value).context("stored audit event sequence is negative")
     };
 
     // Current WorkItem anchor: the focused row wins; without focus the
@@ -605,7 +619,7 @@ fn collect_agent_projection_anchors(
             agent_id: agent_id.to_string(),
             identity_json,
             agent_state_json,
-            event_head_seq: to_seq(head)?.unwrap_or(0),
+            event_head_seq: to_seq(head)?,
             oldest_retained_seq: to_seq(oldest)?,
             current_work_item,
             latest_message_id,
@@ -646,37 +660,29 @@ fn collect_agent_roster_rows(connection: &Connection) -> Result<AgentRosterSnaps
     let mut identities = Vec::new();
     {
         let mut statement = connection.prepare(
-            "SELECT i.agent_id, i.payload_json FROM agent_identities i
+            "SELECT i.agent_id,
+                    i.payload_json,
+                    COALESCE(sequences.last_value, 0),
+                    COALESCE(watermarks.oldest_retained_seq, 0)
+             FROM agent_identities i
+             LEFT JOIN runtime_sequences sequences
+               ON sequences.domain = 'audit_event'
+              AND sequences.scope_key = 'agent:' || i.agent_id
+             LEFT JOIN audit_event_retention_watermarks watermarks
+               ON watermarks.scope_key = 'agent:' || i.agent_id
              WHERE i.status = 'active' AND i.visibility = 'public'
              ORDER BY i.agent_id",
         )?;
         let rows = statement.query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?;
-        for row in rows {
-            identities.push(row?);
-        }
-    }
-
-    let mut event_windows: HashMap<String, (Option<i64>, Option<i64>)> = HashMap::new();
-    {
-        let mut statement = connection.prepare(
-            "SELECT e.agent_id, MIN(e.event_seq), MAX(e.event_seq)
-             FROM audit_events e
-             JOIN agent_identities i ON i.agent_id = e.agent_id
-             WHERE i.status = 'active' AND i.visibility = 'public'
-             GROUP BY e.agent_id",
-        )?;
-        let rows = statement.query_map([], |row| {
             Ok((
                 row.get::<_, String>(0)?,
-                row.get::<_, Option<i64>>(1)?,
-                row.get::<_, Option<i64>>(2)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
             ))
         })?;
         for row in rows {
-            let (agent_id, oldest, head) = row?;
-            event_windows.insert(agent_id, (oldest, head));
+            identities.push(row?);
         }
     }
 
@@ -734,17 +740,14 @@ fn collect_agent_roster_rows(connection: &Connection) -> Result<AgentRosterSnaps
         }
     }
 
-    let to_seq = |value: Option<i64>| -> Result<Option<u64>> {
-        value
-            .map(|seq| u64::try_from(seq).context("stored audit event sequence is negative"))
-            .transpose()
+    let to_seq = |value: i64| -> Result<u64> {
+        u64::try_from(value).context("stored audit event sequence is negative")
     };
     let rows = identities
         .into_iter()
-        .map(|(agent_id, identity_json)| {
-            let (oldest, head) = event_windows.remove(&agent_id).unwrap_or((None, None));
+        .map(|(agent_id, identity_json, head, oldest)| {
             Ok(AgentRosterRow {
-                event_head_seq: to_seq(head)?.unwrap_or(0),
+                event_head_seq: to_seq(head)?,
                 oldest_retained_seq: to_seq(oldest)?,
                 latest_brief: latest_briefs.remove(&agent_id),
                 agent_state_json: agent_states.remove(&agent_id),
@@ -1302,40 +1305,27 @@ impl crate::runtime_db::RuntimeDb {
         agent_id: Option<&str>,
     ) -> Result<AgentEventRecoveryWindow> {
         let connection = self.connection()?;
-        // Scoped storages read their own agent rows while unscoped storages
-        // read the runtime-level rows (`agent_id IS NULL`), matching the
-        // retention queries. A plain `agent_id = ?1` would silently match no
-        // rows for a NULL scope; folding both cases into one
-        // `OR (?1 IS NULL ...)` predicate would defeat the index seek that
-        // backs the MIN/MAX subselects.
-        let window_sql = |predicate: &str| {
-            format!(
-                "SELECT
-                    (SELECT value FROM runtime_metadata WHERE key = 'event_log_epoch'),
-                    (SELECT MIN(event_seq) FROM audit_events WHERE {predicate}),
-                    (SELECT MAX(event_seq) FROM audit_events WHERE {predicate})"
-            )
-        };
-        let window_row = |row: &rusqlite::Row<'_>| Ok((row.get(0)?, row.get(1)?, row.get(2)?));
-        let (epoch, oldest, head): (String, Option<i64>, Option<i64>) = match agent_id {
-            Some(agent_id) => connection.query_row(
-                window_sql("agent_id = ?1").as_str(),
-                [agent_id],
-                window_row,
-            )?,
-            None => {
-                connection.query_row(window_sql("agent_id IS NULL").as_str(), [], window_row)?
-            }
-        };
-        let to_seq = |value: Option<i64>| -> Result<Option<u64>> {
-            value
-                .map(|seq| u64::try_from(seq).context("stored audit event sequence is negative"))
-                .transpose()
-        };
+        let scope_key = crate::runtime_db::evidence::audit_event_sequence_scope(agent_id);
+        let (epoch, oldest, head): (String, i64, i64) = connection.query_row(
+            "SELECT
+               (SELECT value FROM runtime_metadata WHERE key = 'event_log_epoch'),
+               COALESCE((
+                 SELECT oldest_retained_seq FROM audit_event_retention_watermarks
+                 WHERE scope_key = ?1
+               ), 0),
+               COALESCE((
+                 SELECT last_value FROM runtime_sequences
+                 WHERE domain = 'audit_event' AND scope_key = ?1
+               ), 0)",
+            [scope_key],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
         Ok(AgentEventRecoveryWindow {
             event_log_epoch: epoch,
-            oldest_retained_seq: to_seq(oldest)?,
-            event_head_seq: to_seq(head)?.unwrap_or(0),
+            oldest_retained_seq: u64::try_from(oldest)
+                .context("stored audit retention watermark is negative")?,
+            event_head_seq: u64::try_from(head)
+                .context("stored audit event sequence is negative")?,
         })
     }
 }

--- a/src/runtime_db/retention.rs
+++ b/src/runtime_db/retention.rs
@@ -16,8 +16,9 @@ use serde_json::Value;
 
 use crate::{
     runtime_db::{
-        evidence::insert_runtime_index_changes_tx, write_queue::RuntimeDbWriteContext, RuntimeDb,
-        RuntimeDbLock, RuntimeIndexChange, RuntimeIndexOperation,
+        evidence::{audit_event_sequence_scope, insert_runtime_index_changes_tx},
+        write_queue::RuntimeDbWriteContext,
+        RuntimeDb, RuntimeDbLock, RuntimeIndexChange, RuntimeIndexOperation,
     },
     tool::helpers::{command_output_source_ref, command_receipt_source_ref},
     types::{
@@ -483,27 +484,60 @@ fn delete_audit_prefix(
     limit: u64,
 ) -> Result<usize> {
     let limit = i64::try_from(limit).unwrap_or(i64::MAX);
-    if let Some(agent_id) = agent_id {
-        tx.execute(
-            "DELETE FROM audit_events WHERE audit_event_id IN (
-               SELECT audit_event_id FROM audit_events
+    let deleted_through: Option<i64> = if let Some(agent_id) = agent_id {
+        tx.query_row(
+            "SELECT MAX(event_seq) FROM (
+               SELECT event_seq FROM audit_events
                WHERE agent_id = ?1 AND event_seq < ?2
                ORDER BY event_seq ASC LIMIT ?3
              )",
             params![agent_id, first_retained_seq, limit],
-        )
-        .map_err(Into::into)
+            |row| row.get(0),
+        )?
     } else {
-        tx.execute(
-            "DELETE FROM audit_events WHERE audit_event_id IN (
-               SELECT audit_event_id FROM audit_events
+        tx.query_row(
+            "SELECT MAX(event_seq) FROM (
+               SELECT event_seq FROM audit_events
                WHERE agent_id IS NULL AND event_seq < ?1
                ORDER BY event_seq ASC LIMIT ?2
              )",
             params![first_retained_seq, limit],
-        )
-        .map_err(Into::into)
+            |row| row.get(0),
+        )?
+    };
+    let Some(deleted_through) = deleted_through else {
+        return Ok(0);
+    };
+    let oldest_retained_seq = deleted_through
+        .checked_add(1)
+        .context("audit retention watermark exceeds SQLite integer range")?;
+    let deleted = if let Some(agent_id) = agent_id {
+        tx.execute(
+            "DELETE FROM audit_events
+             WHERE agent_id = ?1 AND event_seq <= ?2",
+            params![agent_id, deleted_through],
+        )?
+    } else {
+        tx.execute(
+            "DELETE FROM audit_events
+             WHERE agent_id IS NULL AND event_seq <= ?1",
+            [deleted_through],
+        )?
+    };
+    if deleted > 0 {
+        let scope_key = audit_event_sequence_scope(agent_id);
+        tx.execute(
+            "INSERT INTO audit_event_retention_watermarks (scope_key, oldest_retained_seq)
+             VALUES (?1, ?2)
+             ON CONFLICT(scope_key) DO UPDATE SET
+               oldest_retained_seq = MAX(
+                 audit_event_retention_watermarks.oldest_retained_seq,
+                 excluded.oldest_retained_seq
+               )",
+            params![scope_key, oldest_retained_seq],
+        )?;
     }
+    Ok(deleted)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1063,6 +1097,11 @@ mod tests {
                     params![format!("audit-{sequence}"), sequence, old],
                 )?;
             }
+            tx.execute(
+                "INSERT INTO runtime_sequences (domain, scope_key, last_value)
+                 VALUES ('audit_event', 'agent:agent-a', 515)",
+                [],
+            )?;
             Ok(())
         })?;
 
@@ -1080,6 +1119,60 @@ mod tests {
         assert_eq!(sequences.len(), crate::http::MAX_EVENT_STREAM_WINDOW);
         assert_eq!(sequences.first().copied(), Some(4));
         assert_eq!(sequences.last().copied(), Some(515));
+        let window = db.agent_event_recovery_window(Some("agent-a"))?;
+        assert_eq!(window.event_head_seq, 515);
+        assert_eq!(window.oldest_retained_seq, 4);
+        Ok(())
+    }
+
+    #[test]
+    fn audit_retention_watermark_is_monotonic_after_full_prefix_deletion() -> Result<()> {
+        let (_directory, db) = runtime_db()?;
+        db.transaction(|tx| {
+            for sequence in 1..=6_i64 {
+                tx.execute(
+                    "INSERT INTO audit_events (
+                       audit_event_id, event_seq, agent_id, kind, created_at, data_json
+                     ) VALUES (?1, ?2, 'agent-a', 'test', ?3, '{}')",
+                    params![format!("audit-{sequence}"), sequence, timestamp(Utc::now())],
+                )?;
+            }
+            tx.execute(
+                "INSERT INTO runtime_sequences (domain, scope_key, last_value)
+                 VALUES ('audit_event', 'agent:agent-a', 6)",
+                [],
+            )?;
+
+            assert_eq!(delete_audit_prefix(tx, Some("agent-a"), 7, 2)?, 2);
+            let first_floor: i64 = tx.query_row(
+                "SELECT oldest_retained_seq FROM audit_event_retention_watermarks
+                 WHERE scope_key = 'agent:agent-a'",
+                [],
+                |row| row.get(0),
+            )?;
+            assert_eq!(first_floor, 3);
+
+            assert_eq!(delete_audit_prefix(tx, Some("agent-a"), 7, 100)?, 4);
+            tx.execute(
+                "INSERT INTO audit_events (
+                   audit_event_id, event_seq, agent_id, kind, created_at, data_json
+                 ) VALUES ('audit-old-out-of-band', 2, 'agent-a', 'test', ?1, '{}')",
+                [timestamp(Utc::now())],
+            )?;
+            assert_eq!(delete_audit_prefix(tx, Some("agent-a"), 7, 100)?, 1);
+            Ok(())
+        })?;
+
+        let connection = db.connection()?;
+        let remaining: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM audit_events WHERE agent_id = 'agent-a'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(remaining, 0);
+        let window = db.agent_event_recovery_window(Some("agent-a"))?;
+        assert_eq!(window.event_head_seq, 6);
+        assert_eq!(window.oldest_retained_seq, 7);
         Ok(())
     }
 

--- a/src/runtime_db/retention.rs
+++ b/src/runtime_db/retention.rs
@@ -1126,7 +1126,8 @@ mod tests {
     }
 
     #[test]
-    fn audit_retention_watermark_is_monotonic_after_full_prefix_deletion() -> Result<()> {
+    fn audit_retention_watermark_stays_monotonic_after_full_prefix_and_stale_row_deletion(
+    ) -> Result<()> {
         let (_directory, db) = runtime_db()?;
         db.transaction(|tx| {
             for sequence in 1..=6_i64 {

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -513,6 +513,7 @@ mod tests {
             "runtime_metadata",
             "agents",
             "audit_events",
+            "audit_event_retention_watermarks",
             "runtime_sequences",
             "work_items",
             "tasks",
@@ -1724,7 +1725,7 @@ INSERT INTO storage_domains (
         assert!(
             error
                 .to_string()
-                .contains("supports runtime db schemas 46 through 50, found 45"),
+                .contains("supports runtime db schemas 46 through 51, found 45"),
             "{error:#}"
         );
         Ok(())
@@ -1847,7 +1848,7 @@ INSERT INTO scheduler_rollout_command_results (
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
 
         let connection = open_connection(&db_path)?;
-        assert_eq!(current_schema_version(&connection)?, 50);
+        assert_eq!(current_schema_version(&connection)?, 51);
         for table in RETIRED_SCHEDULER_TABLES {
             assert!(
                 !table_exists(&connection, table)?,
@@ -2001,7 +2002,7 @@ INSERT INTO scheduler_rollout_command_results (
 
             RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             let connection = open_connection(&db_path)?;
-            assert_eq!(current_schema_version(&connection)?, 50);
+            assert_eq!(current_schema_version(&connection)?, 51);
             for table in RETIRED_SCHEDULER_TABLES {
                 assert!(
                     !table_exists(&connection, table)?,
@@ -2115,7 +2116,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 50);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 51);
         Ok(())
     }
 
@@ -2222,7 +2223,7 @@ INSERT INTO scheduler_rollout_command_results (
             RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             assert_eq!(
                 current_schema_version(&open_connection(&db_path)?)?,
-                50,
+                51,
                 "{case}"
             );
         }
@@ -2281,7 +2282,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 50);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 51);
         Ok(())
     }
 
@@ -2341,7 +2342,7 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 50);
+        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 51);
         Ok(())
     }
 
@@ -6265,7 +6266,7 @@ CREATE TABLE working_memory_deltas (
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
         let empty = db.agent_event_recovery_window(Some("default"))?;
         assert_eq!(empty.event_head_seq, 0);
-        assert_eq!(empty.oldest_retained_seq, None);
+        assert_eq!(empty.oldest_retained_seq, 0);
         assert!(empty.event_log_epoch.starts_with("epoch_"));
         for index in 1..=3 {
             let event = crate::types::AuditEvent::legacy(
@@ -6276,7 +6277,7 @@ CREATE TABLE working_memory_deltas (
         }
         let window = db.agent_event_recovery_window(Some("default"))?;
         assert_eq!(window.event_head_seq, 3);
-        assert_eq!(window.oldest_retained_seq, Some(1));
+        assert_eq!(window.oldest_retained_seq, 0);
         assert_eq!(window.event_log_epoch, db.event_log_epoch()?);
         for index in 1..=2 {
             let event = crate::types::AuditEvent::legacy(
@@ -6290,11 +6291,56 @@ CREATE TABLE working_memory_deltas (
         // nothing behind a `agent_id = NULL` comparison.
         let scoped = db.agent_event_recovery_window(Some("default"))?;
         assert_eq!(scoped.event_head_seq, 3);
-        assert_eq!(scoped.oldest_retained_seq, Some(1));
+        assert_eq!(scoped.oldest_retained_seq, 0);
         let unscoped = db.agent_event_recovery_window(None)?;
         assert_eq!(unscoped.event_head_seq, 2);
-        assert_eq!(unscoped.oldest_retained_seq, Some(1));
+        assert_eq!(unscoped.oldest_retained_seq, 0);
         assert_eq!(unscoped.event_log_epoch, db.event_log_epoch()?);
+        Ok(())
+    }
+
+    #[test]
+    fn observer_sync_windows_use_durable_head_and_floor_after_full_prefix_deletion() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.agent_identities().upsert(&agent_identity("member", 0))?;
+        for index in 1..=3 {
+            db.audit_events().append(
+                Some("member"),
+                &crate::types::AuditEvent::legacy(
+                    format!("legacy_{index}"),
+                    serde_json::json!({ "index": index }),
+                ),
+            )?;
+        }
+        db.transaction(|tx| {
+            tx.execute("DELETE FROM audit_events WHERE agent_id = 'member'", [])?;
+            tx.execute(
+                "INSERT INTO audit_event_retention_watermarks (
+                   scope_key, oldest_retained_seq
+                 ) VALUES ('agent:member', 4)",
+                [],
+            )?;
+            Ok(())
+        })?;
+
+        let recovery = db.agent_event_recovery_window(Some("member"))?;
+        assert_eq!(recovery.event_head_seq, 3);
+        assert_eq!(recovery.oldest_retained_seq, 4);
+        let roster = db.agent_roster_snapshot_rows()?;
+        let roster_row = roster
+            .rows
+            .iter()
+            .find(|row| row.agent_id == "member")
+            .expect("member roster row");
+        assert_eq!(roster_row.event_head_seq, 3);
+        assert_eq!(roster_row.oldest_retained_seq, 4);
+        let projection = db
+            .agent_projection_snapshot_rows("member")?
+            .row
+            .expect("member projection row");
+        assert_eq!(projection.event_head_seq, 3);
+        assert_eq!(projection.oldest_retained_seq, 4);
         Ok(())
     }
 
@@ -6398,7 +6444,7 @@ CREATE TABLE working_memory_deltas (
 
         let row = &snapshot.rows[0];
         assert_eq!(row.event_head_seq, 3);
-        assert_eq!(row.oldest_retained_seq, Some(1));
+        assert_eq!(row.oldest_retained_seq, 0);
         let brief = row.latest_brief.as_ref().expect("latest brief anchor");
         assert_eq!(brief.brief_id, "brief-newer");
         assert_eq!(brief.created_event_seq, Some(2));
@@ -6417,7 +6463,7 @@ CREATE TABLE working_memory_deltas (
             .find(|row| row.agent_id == "member-empty")
             .expect("empty member row");
         assert_eq!(empty.event_head_seq, 0);
-        assert_eq!(empty.oldest_retained_seq, None);
+        assert_eq!(empty.oldest_retained_seq, 0);
         assert_eq!(empty.latest_brief, None);
         assert_eq!(empty.agent_state_json, None);
         Ok(())
@@ -6621,7 +6667,7 @@ CREATE TABLE working_memory_deltas (
         let row = snapshot.row.expect("member anchors");
         assert_eq!(row.agent_id, "member");
         assert_eq!(row.event_head_seq, 3);
-        assert_eq!(row.oldest_retained_seq, Some(1));
+        assert_eq!(row.oldest_retained_seq, 0);
         let work_item = row.current_work_item.expect("current work item anchor");
         assert_eq!(work_item.work_item_id, "work-focused");
         assert_eq!(work_item.state, "open");

--- a/tests/fixtures/observer_sync/agent_roster_snapshot.json
+++ b/tests/fixtures/observer_sync/agent_roster_snapshot.json
@@ -71,7 +71,7 @@
       },
       "event_window": {
         "event_head_seq": 0,
-        "oldest_retained_seq": null
+        "oldest_retained_seq": 0
       },
       "latest_brief": null
     }

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -1225,9 +1225,7 @@ pub async fn events_stream_with_missing_cursor_returns_not_found() -> Result<()>
         .as_str()
         .is_some_and(|epoch| !epoch.is_empty()));
     assert!(body["event_head_seq"].as_u64().is_some());
-    assert!(
-        body["oldest_retained_seq"].is_null() || body["oldest_retained_seq"].as_u64().is_some()
-    );
+    assert_eq!(body["oldest_retained_seq"].as_u64(), Some(0));
     if let Some(head) = body["event_head_seq"].as_u64() {
         assert!(head < 999, "after_seq 999 is beyond the head {head}");
     }
@@ -1352,7 +1350,6 @@ pub async fn events_page_and_stream_emit_matching_projection_effects() -> Result
     assert_eq!(matched.data["projection_effect"], "none");
 
     // The rich cursor error reports the same committed window the page sees.
-    let oldest = page["oldest_seq"].as_u64().expect("oldest_seq");
     let head = page["cursor_seq"].as_u64().expect("cursor_seq");
     let missing = client
         .get(format!(
@@ -1365,7 +1362,7 @@ pub async fn events_page_and_stream_emit_matching_projection_effects() -> Result
     let body: serde_json::Value = missing.json().await?;
     assert_eq!(body["code"], "cursor_not_found");
     assert_eq!(body["event_head_seq"].as_u64(), Some(head));
-    assert_eq!(body["oldest_retained_seq"].as_u64(), Some(oldest));
+    assert_eq!(body["oldest_retained_seq"].as_u64(), Some(0));
     assert_eq!(
         body["event_log_epoch"].as_str(),
         page["event_log_epoch"].as_str()

--- a/web-gui/app/src/runtime/agent-session-repository.test.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.test.ts
@@ -492,7 +492,7 @@ describe("AgentSessionRepository ledger ingestion", () => {
       event_log_epoch: "epoch-1",
       snapshot_through_seq: 2,
       event_head_seq: 2,
-      oldest_retained_seq: null,
+      oldest_retained_seq: 0,
       projection: {
         agent: {},
         conversation: { latest_message_id: null, latest_transcript_entry_id: null },

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -2173,8 +2173,8 @@ export interface components {
         AgentEventWindow: {
             /** @description Greatest committed event_seq visible in the response read view. */
             event_head_seq: number;
-            /** @description First raw event still replayable in that view; null when the Agent has no events (event_head_seq = 0). */
-            oldest_retained_seq: number | null;
+            /** @description Durable retention floor. Zero means no retained prefix has ever been deleted; a positive value is the earliest sequence that may still be replayable. */
+            oldest_retained_seq: number;
         };
         /** @description Identifies one canonical record for hydration termination (tombstone) or batch resolution (reference). */
         AgentHydrationKey: {
@@ -2204,7 +2204,8 @@ export interface components {
             /** @description May exceed snapshot_through_seq; names a committed event available through the event page. Clients replay (snapshot_through_seq, event_head_seq] and later events. */
             event_head_seq: number;
             event_log_epoch: string;
-            oldest_retained_seq: number | null;
+            /** @description Durable retention floor; zero means no retained prefix has ever been deleted. */
+            oldest_retained_seq: number;
             projection: components["schemas"]["AgentCanonicalProjection"];
             runtime_id: string;
             /** @description Every event with event_seq <= snapshot_through_seq that affects current canonical state is already reflected in the projection or its revision anchors. */
@@ -2360,6 +2361,17 @@ export interface components {
                         /** @enum {string} */
                         kind: "completed" | "aborted" | "baseline_over_budget" | "deferred_to_fallback" | "provider_failed_needs_recovery";
                         last_assistant_message?: string | null;
+                        no_brief_reason?: ({
+                            /** @constant */
+                            kind: "reducer_only";
+                            reason: string;
+                        } | {
+                            /** @constant */
+                            kind: "aborted";
+                        } | {
+                            /** @constant */
+                            kind: "tool_only_wait";
+                        }) | null;
                         reason?: string | null;
                         turn_id?: string;
                         /** Format: uint64 */
@@ -2483,6 +2495,17 @@ export interface components {
                     /** @enum {string} */
                     kind: "completed" | "aborted" | "baseline_over_budget" | "deferred_to_fallback" | "provider_failed_needs_recovery";
                     last_assistant_message?: string | null;
+                    no_brief_reason?: ({
+                        /** @constant */
+                        kind: "reducer_only";
+                        reason: string;
+                    } | {
+                        /** @constant */
+                        kind: "aborted";
+                    } | {
+                        /** @constant */
+                        kind: "tool_only_wait";
+                    }) | null;
                     reason?: string | null;
                     turn_id?: string;
                     /** Format: uint64 */
@@ -2782,7 +2805,8 @@ export interface components {
             event_log_epoch: string;
             /** @constant */
             ok: false;
-            oldest_retained_seq: number | null;
+            /** @description Durable retention floor; zero means no retained prefix has ever been deleted. */
+            oldest_retained_seq: number;
         } & {
             [key: string]: unknown;
         };

--- a/web-gui/app/src/runtime/global-sync-coordinator.test.ts
+++ b/web-gui/app/src/runtime/global-sync-coordinator.test.ts
@@ -303,7 +303,7 @@ describe("authoritative discovery cutover", () => {
       visibility_scope_id: "vis-1",
       agents: agentIds.map((agentId) => ({
         agent: listEntry(agentId),
-        event_window: { event_head_seq: 5, oldest_retained_seq: null },
+        event_window: { event_head_seq: 5, oldest_retained_seq: 0 },
         latest_brief: null,
       })),
       ...overrides,
@@ -811,4 +811,3 @@ function errorJsonResponse(status: number, body: unknown): Response {
     headers: { "content-type": "application/json" },
   });
 }
-


### PR DESCRIPTION
## Summary

- add a durable, monotonic audit-event retention watermark per sequence scope
- advance the watermark atomically with each bounded prefix deletion
- read observer event heads from `runtime_sequences` and floors from the watermark, defaulting a missing row to `0`
- remove roster/projection/recovery-window `MIN/MAX(audit_events.event_seq)` scans
- publish the non-null sentinel contract through OpenAPI and generated transport types

## Design

Migration 51 only creates the watermark table. It does not scan historical events or infer that a gap means retention occurred. An actual deletion through `D` writes `MAX(existing, D + 1)` in the same transaction, including when no event survives.

This PR is intentionally limited to the server half of #2648. Client-owned replay budgets will follow separately.

This is stacked on #2650 and should be reviewed as the diff from `fix/issue-2647-observer-verification`; it can be retargeted to `main` after #2650 lands.

## Verification

- retention watermark monotonicity and full-prefix deletion tests
- observer roster/projection/recovery window tests, including missing watermark = `0`
- runtime DB fresh migration, release baseline, and retired-schema cleanup/re-upgrade tests
- HTTP cursor error tests
- `make transport-types-check`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

Refs #2648
