### PR TITLE
fix: bound client event replay

### DIFF
--- a/docs/implementation-decisions/113-client-replay-budget.md
+++ b/docs/implementation-decisions/113-client-replay-budget.md
@@ -1,0 +1,13 @@
+# Event replay uses a client-owned composite budget
+
+Retained history defines whether incremental recovery is possible, not whether
+it is economical. The browser therefore bounds each replay attempt by an
+estimated sequence gap plus actual pages, applied page events, serialized
+response bytes, and elapsed time.
+
+The defaults are a 10,000-sequence preflight gap, 50 pages, 10,000 events,
+16 MiB, and 30 seconds. Exceeding any limit performs at most one authoritative
+projection bootstrap. If replay after that snapshot also exceeds a limit, the
+Agent remains out of live state with an explicit error. A budget-driven
+bootstrap preserves the prior read marker but marks unread certainty truncated
+at the skipped snapshot boundary.

--- a/docs/rfcs/observer-sync-agent-summary-and-read-markers.md
+++ b/docs/rfcs/observer-sync-agent-summary-and-read-markers.md
@@ -739,8 +739,18 @@ and privacy-mode behavior. It is outside Phase 3.
 
 If the epoch matches and either `oldest_retained_seq = 0` or the local cursor
 is at or after `oldest_retained_seq - 1`, incremental recovery remains
-possible and the client replays `after_seq` normally. Offline Brief events
-remain available for exact unread calculation.
+possible. This is a hard recoverability statement, not an instruction to
+replay an arbitrarily large suffix.
+
+Before replay, the client compares the estimated gap
+`event_head_seq - ingested_through_seq` with its own replay budget. The default
+budget allows a gap of 10,000 sequence positions and independently limits one
+attempt to 50 pages, 10,000 applied page events, 16 MiB of serialized response
+data, and 30 seconds. A retained suffix that is over the estimated-gap budget
+uses projection bootstrap before the first event-page request. Page, event,
+byte, or time exhaustion during replay also bootstraps once. A replay that
+remains over budget after that snapshot fails explicitly and never enters
+live state with an incomplete contiguous cursor.
 
 ### Rich Cursor Error
 
@@ -761,6 +771,8 @@ An Agent-local reset begins when:
 
 - `oldest_retained_seq > 0` and the local cursor is less than
   `oldest_retained_seq - 1`;
+- the retained suffix exceeds the client replay budget, before or during
+  replay;
 - the event page or SSE endpoint returns `cursor_not_found`;
 - one immutable event identity has conflicting content; or
 - projection divergence cannot be repaired by bounded hydration retry.
@@ -773,7 +785,8 @@ Recovery is:
 4. set `ingested_through_seq = snapshot_through_seq` and
    `projection_ready_through_seq = snapshot_through_seq`;
 5. replay all events after that boundary;
-6. record `history_truncated_before_seq`; and
+6. record `history_truncated_before_seq` for retention loss, or
+   `snapshot_through_seq + 1` for a voluntarily skipped retained interval; and
 7. resume live synchronization after contiguous catch-up.
 
 If the effective local read boundary
@@ -794,6 +807,11 @@ certainty = Exact
 `Exact` then applies only to the new local generation after that boundary. The
 client retains truncation metadata and does not claim to have reconstructed the
 lost interval.
+
+Budget-driven bootstrap does not fabricate acknowledgement. It preserves the
+prior marker where meaningful, marks unread certainty as `Truncated`, and
+records the first sequence after the snapshot boundary until explicit
+acknowledgement establishes a new exact generation.
 
 ### Runtime Epoch Reset
 
@@ -1044,6 +1062,9 @@ They should not be implemented as aliases for the new contract.
 ### Retention And Reset
 
 - a retained cursor catches up exactly;
+- a large retained suffix bootstraps under the client-owned replay budget;
+- page, event, byte, or elapsed-time exhaustion never enters live state with
+  an incomplete cursor;
 - `cursor_not_found` supplies `event_log_epoch`, `oldest_retained_seq`, and
   `event_head_seq`;
 - a retention gap installs a canonical projection snapshot;

--- a/web-gui/app/src/runtime/agent-session-repository.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.ts
@@ -415,6 +415,7 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
             eventHeadSeq: page.newest_seq ?? page.cursor_seq ?? undefined,
             oldestRetainedSeq: page.oldest_seq ?? null,
             hasNewer: page.has_newer,
+            responseBytes: new TextEncoder().encode(JSON.stringify(page)).byteLength,
           };
         } catch (error) {
           const cursorNotFound = cursorNotFoundPayload(error);
@@ -1181,7 +1182,7 @@ export function recoverySnapshotFromDto(
     eventLogEpoch: snapshot.event_log_epoch,
     snapshotThroughSeq: snapshot.snapshot_through_seq,
     eventHeadSeq: snapshot.event_head_seq,
-    oldestRetainedSeq: snapshot.oldest_retained_seq ?? null,
+    oldestRetainedSeq: snapshot.oldest_retained_seq,
     canonicalRecords: brief
       ? [
           {

--- a/web-gui/app/src/runtime/agent-session-repository.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.ts
@@ -114,6 +114,7 @@ interface RuntimeClientLike {
     oldest_seq?: number | null;
     has_older?: boolean;
     has_newer?: boolean;
+    responseBytes?: number;
   }>;
   getAgentProjectionSnapshot: (
     agentId: string,
@@ -415,7 +416,7 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
             eventHeadSeq: page.newest_seq ?? page.cursor_seq ?? undefined,
             oldestRetainedSeq: page.oldest_seq ?? null,
             hasNewer: page.has_newer,
-            responseBytes: new TextEncoder().encode(JSON.stringify(page)).byteLength,
+            responseBytes: page.responseBytes,
           };
         } catch (error) {
           const cursorNotFound = cursorNotFoundPayload(error);

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -687,24 +687,26 @@ describe("createRuntimeClient", () => {
 
   it("fetches an agent event window and decodes legacy envelopes with pagination parameters", async () => {
     const seen: string[] = [];
+    const responseBody = {
+      events: [
+        {
+          id: "event-740",
+          agent_id: "agent/one",
+          event_seq: 740,
+          ts: "2026-06-22T00:00:00Z",
+          type: "message_enqueued",
+          payload: { message_id: "message-740" },
+        },
+      ],
+      has_older: true,
+      cursor_seq: 819,
+      transport_padding: "界".repeat(64),
+    };
     const fetchImpl = async (input: RequestInfo | URL) => {
       const url = String(input);
       seen.push(url);
       if (url.endsWith("/agents/agent%2Fone/events?after_seq=739&limit=80&order=asc&max_level=info")) {
-        return Response.json({
-          events: [
-            {
-              id: "event-740",
-              agent_id: "agent/one",
-              event_seq: 740,
-              ts: "2026-06-22T00:00:00Z",
-              type: "message_enqueued",
-              payload: { message_id: "message-740" },
-            },
-          ],
-          has_older: true,
-          cursor_seq: 819,
-        });
+        return Response.json(responseBody);
       }
       return new Response("not found", { status: 404 });
     };
@@ -734,6 +736,7 @@ describe("createRuntimeClient", () => {
           }),
         ],
         cursor_seq: 819,
+        responseBytes: new TextEncoder().encode(JSON.stringify(responseBody)).byteLength,
       }),
     );
     expect(seen).toEqual(["http://example.test:7878/api/agents/agent%2Fone/events?after_seq=739&limit=80&order=asc&max_level=info"]);

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -237,6 +237,7 @@ type BriefRecordDto = RuntimeBriefRecord;
 type AgentRosterSnapshotGeneratedDto = components["schemas"]["AgentRosterSnapshot"];
 
 export type EventPageResponseDto = components["schemas"]["EventsPageResponse"];
+type MeasuredEventPageResponseDto = EventPageResponseDto & { responseBytes?: number };
 export type AgentProjectionSnapshotDto = components["schemas"]["AgentProjectionSnapshot"];
 export type AgentRosterSnapshotDto = AgentRosterSnapshotGeneratedDto;
 type GeneratedStreamEventEnvelopeDto = components["schemas"]["StreamEventEnvelope"];
@@ -726,7 +727,10 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       const workItem = await fetchAgentWorkItem(baseUrl, fetchImpl, requestHeaders, agentId, workItemId);
       return projectWorkItem(workItem);
     },
-    async getAgentEvents(agentId: string, options: AgentEventPageOptions = {}): Promise<EventPageResponseDto> {
+    async getAgentEvents(
+      agentId: string,
+      options: AgentEventPageOptions = {},
+    ): Promise<MeasuredEventPageResponseDto> {
       if (!baseUrl) {
         return emptyEventPage();
       }
@@ -1306,7 +1310,7 @@ async function fetchAgentEvents(
   headers: Record<string, string>,
   agentId: string,
   options: AgentEventPageOptions,
-): Promise<EventPageResponseDto> {
+): Promise<MeasuredEventPageResponseDto> {
   const query = new URLSearchParams();
   if (options.beforeSeq != null) query.set("before_seq", String(options.beforeSeq));
   if (options.afterSeq != null) query.set("after_seq", String(options.afterSeq));
@@ -1315,12 +1319,43 @@ async function fetchAgentEvents(
   if (options.displayLevel) query.set("max_level", options.displayLevel);
   const queryString = query.toString();
   const path = `/agents/${encodeURIComponent(agentId)}/events${queryString ? `?${queryString}` : ""}`;
-  const response = await getJson<EventPageResponseDto>(fetchImpl, baseUrl, path, { headers });
+  const { value: response, responseBytes } = await getJsonWithResponseBytes<EventPageResponseDto>(
+    fetchImpl,
+    baseUrl,
+    path,
+    { headers },
+  );
   return {
     ...response,
+    responseBytes,
     events: response.events
       .map((event) => decodeStreamEventEnvelope(event))
       .filter((event): event is EventPageResponseDto["events"][number] => event != null),
+  };
+}
+
+async function getJsonWithResponseBytes<T>(
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+  path: string,
+  options: { timeoutMs?: number; headers?: Record<string, string> } = {},
+): Promise<{ value: T; responseBytes: number }> {
+  const controller = new AbortController();
+  const timeout = globalThis.setTimeout(
+    () => controller.abort(),
+    options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+  );
+  const response = await fetchImpl(`${baseUrl}${path}`, {
+    headers: { Accept: "application/json", ...options.headers },
+    signal: controller.signal,
+  }).finally(() => globalThis.clearTimeout(timeout));
+  if (!response.ok) {
+    throw await httpRequestError("GET", path, response);
+  }
+  const body = await response.arrayBuffer();
+  return {
+    value: JSON.parse(new TextDecoder().decode(body)) as T,
+    responseBytes: body.byteLength,
   };
 }
 

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -2063,8 +2063,8 @@ export interface RosterAgentEntry {
   entry: AgentListEntryDto;
   latestBriefPreview?: string;
   eventWindow: {
-    eventHeadSeq?: number;
-    oldestRetainedSeq?: number | null;
+    eventHeadSeq: number;
+    oldestRetainedSeq: number;
   };
 }
 
@@ -2079,8 +2079,8 @@ export function rosterAgentEntries(snapshot: AgentRosterSnapshotDto): RosterAgen
       entry,
       latestBriefPreview: generated.latest_brief?.preview || undefined,
       eventWindow: {
-        eventHeadSeq: generated.event_window?.event_head_seq,
-        oldestRetainedSeq: generated.event_window?.oldest_retained_seq ?? null,
+        eventHeadSeq: generated.event_window.event_head_seq,
+        oldestRetainedSeq: generated.event_window.oldest_retained_seq,
       },
     }];
   });
@@ -2501,7 +2501,7 @@ export function cursorNotFoundPayload(
   | {
       afterSeq: number;
       eventLogEpoch: string;
-      oldestRetainedSeq: number | null;
+      oldestRetainedSeq: number;
       eventHeadSeq: number;
     }
   | undefined {
@@ -2518,7 +2518,7 @@ export function cursorNotFoundPayload(
   return {
     afterSeq: extensions.afterSeq,
     eventLogEpoch: extensions.eventLogEpoch,
-    oldestRetainedSeq: extensions.oldestRetainedSeq ?? null,
+    oldestRetainedSeq: extensions.oldestRetainedSeq ?? 0,
     eventHeadSeq: extensions.eventHeadSeq,
   };
 }

--- a/web-gui/app/src/runtime/event-ledger/agent-recovery.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/agent-recovery.test.ts
@@ -557,6 +557,45 @@ describe("agent recovery coordinator", () => {
     verify.close();
   });
 
+  it("does not preserve read state when a budget reset discovers a new scope", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const oldScope = makeScope();
+    await pipeline.ingest(oldScope, [envelope(1), envelope(2)]);
+    const ledger = await openLedgerHandle();
+    await ledger
+      .beginWrite()
+      .putReadState(oldScope, { unreadBaselineSeq: 1, readThroughEventSeq: 2 })
+      .commit();
+    ledger.close();
+
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () =>
+        snapshot({
+          visibilityScopeId: "vis_other",
+          snapshotThroughSeq: 100,
+          eventHeadSeq: 100,
+        }),
+      async () => page([]),
+      { replayBudget: { maxEstimatedGap: 1 } },
+    );
+
+    const update = await coordinator.sync("agent-1", { eventHeadSeq: 100 });
+    expect(update.phase).toBe("live");
+    expect(update.resetReason).toBe("visibility_scope_change");
+
+    const verify = await openLedgerHandle();
+    expect(await verify.getReadState(oldScope)).toBeUndefined();
+    const newScope = makeScope({ visibilityScopeId: "vis_other" });
+    const readState = await verify.getReadState(newScope);
+    expect(readState?.unreadBaselineSeq).toBe(100);
+    expect(readState?.readThroughEventSeq).toBeUndefined();
+    expect(readState?.historyTruncatedBeforeSeq).toBeUndefined();
+    expect(readState?.certainty).toBe("exact");
+    verify.close();
+  });
+
   it("recovers from cursor_not_found with one bounded retention reset", async () => {
     const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
     await pipeline.open();

--- a/web-gui/app/src/runtime/event-ledger/agent-recovery.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/agent-recovery.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   LEDGER_DB_NAME,
+  type AgentReplayBudget,
   type LedgerHydrationFetchers,
   type LedgerScopeKey,
   type RecoveryEventPage,
@@ -55,7 +56,7 @@ function snapshot(
     eventLogEpoch: "epoch-1",
     snapshotThroughSeq: 5,
     eventHeadSeq: 8,
-    oldestRetainedSeq: null,
+    oldestRetainedSeq: 0,
     canonicalRecords: [
       {
         recordKind: "brief",
@@ -114,12 +115,14 @@ function makeCoordinator(
   pipeline: LedgerIngestionPipeline,
   fetchProjectionSnapshot: (agentId: string) => Promise<RecoveryProjectionSnapshot | null>,
   fetchEventPage: (agentId: string, afterSeq: number, limit: number) => Promise<RecoveryEventPage>,
+  options: { replayBudget?: Partial<AgentReplayBudget>; now?: () => number } = {},
 ) {
   return new AgentRecoveryCoordinator({
     remoteKey: REMOTE_KEY,
     pipeline,
     fetchProjectionSnapshot,
     fetchEventPage,
+    ...options,
   });
 }
 
@@ -240,6 +243,200 @@ describe("agent recovery coordinator", () => {
     const ledger = await openLedgerHandle();
     expect(await ledger.getReadState(scope)).toBeUndefined();
     ledger.close();
+  });
+
+  it("prioritizes a retention gap over replay cost on the live fast path", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    let snapshotFetches = 0;
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => {
+        snapshotFetches += 1;
+        return snapshot(
+          snapshotFetches === 1
+            ? { snapshotThroughSeq: 5, eventHeadSeq: 5 }
+            : { snapshotThroughSeq: 100, eventHeadSeq: 100, oldestRetainedSeq: 7 },
+        );
+      },
+      async () => page([]),
+      { replayBudget: { maxEstimatedGap: 1 } },
+    );
+    expect((await coordinator.sync("agent-1")).phase).toBe("live");
+
+    const update = await coordinator.sync("agent-1", {
+      eventHeadSeq: 100,
+      oldestRetainedSeq: 7,
+    });
+    expect(update.phase).toBe("live");
+    expect(update.resetReason).toBe("retained_prefix_gap");
+    expect(snapshotFetches).toBe(2);
+  });
+
+  it("bootstraps before fetching an over-budget retained suffix", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const scope = makeScope();
+    await pipeline.ingest(scope, [envelope(1), envelope(2), envelope(3), envelope(4), envelope(5)]);
+    const ledger = await openLedgerHandle();
+    await ledger
+      .beginWrite()
+      .putReadState(scope, { unreadBaselineSeq: 3, readThroughEventSeq: 4 })
+      .commit();
+    ledger.close();
+
+    let snapshotFetches = 0;
+    const source = pageSource({
+      95: page([envelope(96), envelope(97), envelope(98), envelope(99), envelope(100)]),
+    });
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => {
+        snapshotFetches += 1;
+        return snapshot({ snapshotThroughSeq: 95, eventHeadSeq: 100 });
+      },
+      source.fetch,
+      { replayBudget: { maxEstimatedGap: 10 } },
+    );
+
+    const update = await coordinator.sync("agent-1", {
+      eventHeadSeq: 100,
+      oldestRetainedSeq: 0,
+    });
+    expect(update.phase).toBe("live");
+    expect(update.resetReason).toBe("replay_budget_exceeded");
+    expect(snapshotFetches).toBe(1);
+    expect(source.requests).toEqual([95]);
+
+    const verify = await openLedgerHandle();
+    expect((await verify.getRawEvents(scope)).map((event) => event.eventSeq)).toEqual([
+      96, 97, 98, 99, 100,
+    ]);
+    const readState = await verify.getReadState(scope);
+    expect(readState?.readThroughEventSeq).toBe(4);
+    expect(readState?.unreadBaselineSeq).toBe(3);
+    expect(readState?.historyTruncatedBeforeSeq).toBe(96);
+    expect(readState?.certainty).toBe("truncated");
+    verify.close();
+  });
+
+  it("bootstraps once when the page budget is exhausted mid-replay", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const scope = makeScope();
+    await pipeline.ingest(scope, [envelope(1), envelope(2)]);
+    const ledger = await openLedgerHandle();
+    await ledger.beginWrite().putReadState(scope, { readThroughEventSeq: 2 }).commit();
+    ledger.close();
+
+    let snapshotFetches = 0;
+    const source = pageSource({
+      2: page([envelope(3), envelope(4)], { hasNewer: true }),
+      5: page([envelope(6)]),
+    });
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => {
+        snapshotFetches += 1;
+        return snapshot({ snapshotThroughSeq: 5, eventHeadSeq: 6 });
+      },
+      source.fetch,
+      { replayBudget: { maxPages: 1 } },
+    );
+
+    const update = await coordinator.sync("agent-1", { eventHeadSeq: 6 });
+    expect(update.phase).toBe("live");
+    expect(update.resetReason).toBe("replay_budget_exceeded");
+    expect(snapshotFetches).toBe(1);
+    expect(source.requests).toEqual([2, 5]);
+    const verify = await openLedgerHandle();
+    expect((await verify.getAgentSession(scope))?.ingestedThroughSeq).toBe(6);
+    expect((await verify.getReadState(scope))?.certainty).toBe("truncated");
+    verify.close();
+  });
+
+  it.each([
+    {
+      budgetName: "event",
+      replayBudget: { maxEvents: 1 },
+      firstPage: page([envelope(3), envelope(4)]),
+    },
+    {
+      budgetName: "byte",
+      replayBudget: { maxBytes: 10 },
+      firstPage: page([envelope(3)], { responseBytes: 11 }),
+    },
+  ])("bootstraps once when the $budgetName budget is exhausted", async ({
+    replayBudget,
+    firstPage,
+  }) => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    await pipeline.ingest(makeScope(), [envelope(1), envelope(2)]);
+    const source = pageSource({
+      2: firstPage,
+      5: page([envelope(6)], { responseBytes: 1 }),
+    });
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => snapshot({ snapshotThroughSeq: 5, eventHeadSeq: 6 }),
+      source.fetch,
+      { replayBudget },
+    );
+
+    const update = await coordinator.sync("agent-1", { eventHeadSeq: 6 });
+    expect(update.phase).toBe("live");
+    expect(update.resetReason).toBe("replay_budget_exceeded");
+    expect(source.requests).toEqual([2, 5]);
+  });
+
+  it("includes fetch and apply time in the replay budget", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    await pipeline.ingest(makeScope(), [envelope(1), envelope(2)]);
+    const source = pageSource({ 2: page([envelope(3)]), 5: page([envelope(6)]) });
+    let clockReads = 0;
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => snapshot({ snapshotThroughSeq: 5, eventHeadSeq: 6 }),
+      source.fetch,
+      {
+        replayBudget: { maxElapsedMs: 5 },
+        now: () => (clockReads++ < 2 ? 0 : 10),
+      },
+    );
+
+    const update = await coordinator.sync("agent-1", { eventHeadSeq: 6 });
+    expect(update.phase).toBe("live");
+    expect(update.resetReason).toBe("replay_budget_exceeded");
+    expect(source.requests).toEqual([2, 5]);
+  });
+
+  it("fails instead of entering live when replay stays over budget after bootstrap", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    await pipeline.ingest(makeScope(), [envelope(1), envelope(2)]);
+    let snapshotFetches = 0;
+    const source = pageSource({
+      2: page([envelope(3), envelope(4)]),
+      4: page([envelope(5), envelope(6)]),
+    });
+    const coordinator = makeCoordinator(
+      pipeline,
+      async () => {
+        snapshotFetches += 1;
+        return snapshot({ snapshotThroughSeq: 4, eventHeadSeq: 6 });
+      },
+      source.fetch,
+      { replayBudget: { maxEvents: 1 } },
+    );
+
+    const update = await coordinator.sync("agent-1", { eventHeadSeq: 6 });
+    expect(update.phase).toBe("error");
+    expect(update.error).toBe("replay_budget_exceeded_after_snapshot");
+    expect(update.resetReason).toBe("replay_budget_exceeded");
+    expect(snapshotFetches).toBe(1);
+    expect(source.requests).toEqual([2, 4]);
   });
 
   it("resets on a retained-prefix gap: keep the marker, record truncation, rebuild", async () => {
@@ -368,6 +565,7 @@ describe("agent recovery coordinator", () => {
     const source = pageSource({
       3: {
         events: [],
+        responseBytes: 100,
         cursorNotFound: {
           afterSeq: 3,
           eventLogEpoch: "epoch-1",
@@ -381,6 +579,7 @@ describe("agent recovery coordinator", () => {
       pipeline,
       async () => snapshot({ snapshotThroughSeq: 9, eventHeadSeq: 9, oldestRetainedSeq: 6 }),
       source.fetch,
+      { replayBudget: { maxBytes: 1 } },
     );
 
     const update = await coordinator.sync("agent-1", { eventHeadSeq: 9 });
@@ -507,6 +706,19 @@ describe("agent recovery coordinator", () => {
     expect(source.requests).toHaveLength(3);
   });
 
+  it("never enters live when a page ends before the committed target head", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    await pipeline.ingest(makeScope(), [envelope(1), envelope(2)]);
+    const source = pageSource({ 2: page([]) });
+    const coordinator = makeCoordinator(pipeline, async () => snapshot(), source.fetch);
+
+    const update = await coordinator.sync("agent-1", { eventHeadSeq: 3 });
+    expect(update.phase).toBe("error");
+    expect(update.error).toBe("replay_ended_before_target");
+    expect(source.requests).toEqual([2]);
+  });
+
   it("clears each distinct stale runtime scope exactly once during an identity reset", async () => {
     const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
     await pipeline.open();
@@ -522,7 +734,7 @@ describe("agent recovery coordinator", () => {
     // escalates into an identity reset bootstrap.
     const source = pageSource({
       1: page([], { eventLogEpoch: "epoch-1", eventHeadSeq: 8 }),
-      5: page([envelope(6)]),
+      5: page([envelope(6), envelope(7), envelope(8)]),
     });
     const coordinator = makeCoordinator(pipeline, async () => snapshot(), source.fetch);
 

--- a/web-gui/app/src/runtime/event-ledger/agent-recovery.ts
+++ b/web-gui/app/src/runtime/event-ledger/agent-recovery.ts
@@ -428,7 +428,8 @@ export class AgentRecoveryCoordinator {
       });
     }
 
-    const sameScopeReset = reset != null && SAME_SCOPE_RESETS.has(reset);
+    const sameScopeReset =
+      identityReset == null && reset != null && SAME_SCOPE_RESETS.has(reset);
     const reportedFloor =
       snapshot.oldestRetainedSeq ??
       (sameScopeReset ? hint.oldestRetainedSeq ?? null : null);

--- a/web-gui/app/src/runtime/event-ledger/agent-recovery.ts
+++ b/web-gui/app/src/runtime/event-ledger/agent-recovery.ts
@@ -8,9 +8,9 @@
  * - an Agent with a contiguous cache catches up by replaying pages after
  *   its contiguous cursor until the observed head;
  * - reset reasons are independent and explicit: retained-prefix gap,
- *   cursor error, immutable content conflict, hydration divergence, epoch
- *   change, and visibility scope change;
- * - retention-family resets rebuild the same scope and keep the read-state
+ *   replay-budget exhaustion, cursor error, immutable content conflict,
+ *   hydration divergence, epoch change, and visibility scope change;
+ * - same-scope resets rebuild the Agent cache and keep the read-state
  *   record, marking truncation; epoch and visibility resets clear the old
  *   runtime scope entirely and never migrate read markers;
  * - live stream envelopes that arrive while recovery is in flight are
@@ -38,6 +38,7 @@ export type AgentRecoveryPhase =
 
 export type LedgerResetReason =
   | "retained_prefix_gap"
+  | "replay_budget_exceeded"
   | "cursor_error"
   | "immutable_conflict"
   | "hydration_divergence"
@@ -45,8 +46,9 @@ export type LedgerResetReason =
   | "visibility_scope_change";
 
 /** Reset reasons that rebuild the same scope key and keep the marker. */
-const RETENTION_FAMILY: ReadonlySet<LedgerResetReason> = new Set([
+const SAME_SCOPE_RESETS: ReadonlySet<LedgerResetReason> = new Set([
   "retained_prefix_gap",
+  "replay_budget_exceeded",
   "cursor_error",
   "immutable_conflict",
   "hydration_divergence",
@@ -58,7 +60,7 @@ export interface RecoveryProjectionSnapshot {
   eventLogEpoch: string;
   snapshotThroughSeq: number;
   eventHeadSeq: number;
-  oldestRetainedSeq: number | null;
+  oldestRetainedSeq: number;
   canonicalRecords: Array<{
     recordKind: LedgerRecordKind;
     recordId: string;
@@ -80,7 +82,7 @@ export interface RecoveryProjectionSnapshot {
 export interface RecoveryCursorError {
   afterSeq: number;
   eventLogEpoch: string;
-  oldestRetainedSeq: number | null;
+  oldestRetainedSeq: number;
   eventHeadSeq: number;
 }
 
@@ -91,6 +93,8 @@ export interface RecoveryEventPage {
   oldestRetainedSeq?: number | null;
   hasNewer?: boolean;
   cursorNotFound?: RecoveryCursorError;
+  /** Serialized response size when the transport can measure it exactly. */
+  responseBytes?: number;
 }
 
 export interface AgentRecoveryUpdate {
@@ -111,6 +115,16 @@ export interface AgentRecoveryHint {
   oldestRetainedSeq?: number | null;
 }
 
+/** Client-owned limits for one incremental replay attempt. */
+export interface AgentReplayBudget {
+  /** Maximum sequence distance accepted before the first page request. */
+  maxEstimatedGap: number;
+  maxPages: number;
+  maxEvents: number;
+  maxBytes: number;
+  maxElapsedMs: number;
+}
+
 export interface AgentRecoveryDependencies {
   remoteKey: string;
   pipeline: LedgerIngestionPipeline;
@@ -123,7 +137,9 @@ export interface AgentRecoveryDependencies {
   ): Promise<RecoveryEventPage>;
   onPhase?: (update: AgentRecoveryUpdate) => void;
   replayPageSize?: number;
-  maxReplayPages?: number;
+  replayBudget?: Partial<AgentReplayBudget>;
+  /** Injectable monotonic clock for deterministic budget tests. */
+  now?: () => number;
 }
 
 interface AgentRecoveryState {
@@ -139,8 +155,23 @@ interface AgentRecoveryState {
 }
 
 const DEFAULT_REPLAY_PAGE_SIZE = 200;
-const DEFAULT_MAX_REPLAY_PAGES = 1_000;
+const DEFAULT_REPLAY_BUDGET: Readonly<AgentReplayBudget> = {
+  maxEstimatedGap: 10_000,
+  maxPages: 50,
+  maxEvents: 10_000,
+  maxBytes: 16 * 1024 * 1024,
+  maxElapsedMs: 30_000,
+};
 const MAX_STALE_REPLAY_ROUNDS = 3;
+
+function serializedPageBytes(page: RecoveryEventPage): number {
+  if (page.responseBytes != null) return Math.max(0, page.responseBytes);
+  try {
+    return new TextEncoder().encode(JSON.stringify(page)).byteLength;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
 
 /** Effective local read boundary above which unread is counted. */
 function effectiveReadBoundary(record: LedgerReadStateRecord | undefined): number {
@@ -168,11 +199,13 @@ function sameRemoteScope(
 export class AgentRecoveryCoordinator {
   private readonly states = new Map<string, AgentRecoveryState>();
   private readonly pageSize: number;
-  private readonly maxPages: number;
+  private readonly replayBudget: Readonly<AgentReplayBudget>;
+  private readonly now: () => number;
 
   constructor(private readonly dependencies: AgentRecoveryDependencies) {
     this.pageSize = dependencies.replayPageSize ?? DEFAULT_REPLAY_PAGE_SIZE;
-    this.maxPages = dependencies.maxReplayPages ?? DEFAULT_MAX_REPLAY_PAGES;
+    this.replayBudget = { ...DEFAULT_REPLAY_BUDGET, ...dependencies.replayBudget };
+    this.now = dependencies.now ?? (() => performance.now());
   }
 
   /**
@@ -278,8 +311,17 @@ export class AgentRecoveryCoordinator {
       const status = this.dependencies.pipeline.status(state.scope);
       if (status && status.ingestedThroughSeq != null) {
         const contiguous = status.ingestedThroughSeq;
+        const floor = hint.oldestRetainedSeq;
+        if (floor != null && floor > 1 && contiguous < floor - 1) {
+          return this.bootstrap(agentId, hint, "retained_prefix_gap");
+        }
+        const targetHeadSeq = Math.max(hint.eventHeadSeq ?? 0, contiguous);
+        if (targetHeadSeq - contiguous > this.replayBudget.maxEstimatedGap) {
+          return this.bootstrap(agentId, hint, "replay_budget_exceeded");
+        }
         return this.replay(agentId, state.scope, contiguous, {
-          targetHeadSeq: Math.max(hint.eventHeadSeq ?? 0, contiguous),
+          targetHeadSeq,
+          oldestRetainedSeq: hint.oldestRetainedSeq,
         });
       }
     }
@@ -303,8 +345,13 @@ export class AgentRecoveryCoordinator {
     if (floor != null && floor > 1 && contiguous < floor - 1) {
       return this.bootstrap(agentId, hint, "retained_prefix_gap");
     }
+    const targetHeadSeq = hint.eventHeadSeq ?? contiguous;
+    if (targetHeadSeq - contiguous > this.replayBudget.maxEstimatedGap) {
+      return this.bootstrap(agentId, hint, "replay_budget_exceeded");
+    }
     return this.replay(agentId, scope, contiguous, {
-      targetHeadSeq: hint.eventHeadSeq ?? contiguous,
+      targetHeadSeq,
+      oldestRetainedSeq: hint.oldestRetainedSeq,
     });
   }
 
@@ -379,12 +426,15 @@ export class AgentRecoveryCoordinator {
       });
     }
 
-    const retentionReset = reset != null && RETENTION_FAMILY.has(reset);
-    const floor =
+    const sameScopeReset = reset != null && SAME_SCOPE_RESETS.has(reset);
+    const reportedFloor =
       snapshot.oldestRetainedSeq ??
-      (retentionReset ? hint.oldestRetainedSeq ?? null : null);
+      (sameScopeReset ? hint.oldestRetainedSeq ?? null : null);
+    const floor = reportedFloor != null && reportedFloor > 0 ? reportedFloor : undefined;
+    const budgetReset = reset === "replay_budget_exceeded";
+    const truncationBoundary = budgetReset ? snapshot.snapshotThroughSeq + 1 : floor;
     let readState: Partial<LedgerReadStateRecord> | undefined;
-    if (retentionReset) {
+    if (sameScopeReset) {
       const preserved = await this.dependencies.pipeline.readStateOf(scope);
       if (!preserved) {
         // A forced reset that landed on a scope with no preserved marker
@@ -392,15 +442,19 @@ export class AgentRecoveryCoordinator {
         // establishes a fresh baseline instead of a half-empty record.
         readState = {
           unreadBaselineSeq: snapshot.snapshotThroughSeq,
-          certainty: "exact",
-          historyTruncatedBeforeSeq: floor ?? undefined,
+          certainty: budgetReset ? "truncated" : "exact",
+          historyTruncatedBeforeSeq: truncationBoundary,
         };
       } else {
         const boundary = effectiveReadBoundary(preserved);
+        const recordedTruncation = Math.max(
+          preserved.historyTruncatedBeforeSeq ?? 0,
+          truncationBoundary ?? 0,
+        );
         readState = {
-          historyTruncatedBeforeSeq: floor ?? undefined,
+          historyTruncatedBeforeSeq: recordedTruncation || undefined,
           certainty:
-            floor != null && boundary < floor - 1
+            budgetReset || (floor != null && boundary < floor - 1)
               ? "truncated"
               : preserved.certainty ?? "exact",
         };
@@ -427,7 +481,7 @@ export class AgentRecoveryCoordinator {
         {
           clearFirst:
             reset != null || identityReset != null
-              ? { preserveReadState: retentionReset }
+              ? { preserveReadState: sameScopeReset }
               : undefined,
           readState,
         },
@@ -444,14 +498,16 @@ export class AgentRecoveryCoordinator {
       });
     }
     // An identity change is the structural cause and outranks whatever
-    // retention-family reason triggered the bootstrap.
+    // same-scope reason triggered the bootstrap.
     const resetReason = identityReset ?? reset;
     if (resetReason != null) state.lastResetReason = resetReason;
 
     return this.replay(agentId, scope, snapshot.snapshotThroughSeq, {
       targetHeadSeq: Math.max(snapshot.eventHeadSeq, hint.eventHeadSeq ?? 0),
+      oldestRetainedSeq: snapshot.oldestRetainedSeq,
       reset: resetReason,
       installed,
+      bootstrapAttempted: true,
     });
   }
 
@@ -462,8 +518,10 @@ export class AgentRecoveryCoordinator {
     afterSeq: number,
     context: {
       targetHeadSeq: number;
+      oldestRetainedSeq?: number | null;
       reset?: LedgerResetReason;
       installed?: LedgerIngestionStatus;
+      bootstrapAttempted?: boolean;
     },
   ): Promise<AgentRecoveryUpdate> {
     const state = this.stateFor(agentId);
@@ -472,11 +530,22 @@ export class AgentRecoveryCoordinator {
 
     let after = afterSeq;
     let pages = 0;
+    let appliedEvents = 0;
+    let responseBytes = 0;
     let staleRounds = 0;
     let status: LedgerIngestionStatus | null = context.installed ?? null;
-    while (pages < this.maxPages && after < context.targetHeadSeq) {
+    const startedAt = this.now();
+    while (after < context.targetHeadSeq) {
+      if (
+        pages >= this.replayBudget.maxPages ||
+        this.now() - startedAt >= this.replayBudget.maxElapsedMs
+      ) {
+        return this.handleReplayBudgetExhaustion(state, agentId, scope, context);
+      }
       const page = await this.dependencies.fetchEventPage(agentId, after, this.pageSize);
       pages += 1;
+      appliedEvents += page.events.length;
+      responseBytes += serializedPageBytes(page);
       if (page.cursorNotFound) {
         if (context.reset == null) {
           return this.bootstrap(
@@ -501,6 +570,17 @@ export class AgentRecoveryCoordinator {
           "epoch_change",
         );
       }
+      if (
+        appliedEvents > this.replayBudget.maxEvents ||
+        responseBytes > this.replayBudget.maxBytes ||
+        this.now() - startedAt > this.replayBudget.maxElapsedMs
+      ) {
+        return this.handleReplayBudgetExhaustion(state, agentId, scope, {
+          ...context,
+          targetHeadSeq: Math.max(context.targetHeadSeq, page.eventHeadSeq ?? 0),
+          oldestRetainedSeq: page.oldestRetainedSeq ?? context.oldestRetainedSeq,
+        });
+      }
       const events = page.events;
       try {
         status =
@@ -522,10 +602,20 @@ export class AgentRecoveryCoordinator {
       }
       const contiguous = status?.ingestedThroughSeq ?? after;
       if (events.length === 0) {
-        // An empty page without newer events ends the replay. An empty
-        // page that still claims newer events is spin: fail after bounded
-        // rounds instead of paging toward maxPages.
-        if (page.hasNewer !== true) break;
+        // The committed target head cannot disappear. A page that claims
+        // no newer events before that boundary is a protocol contradiction,
+        // never permission to enter live with an incomplete cursor.
+        if (page.hasNewer !== true) {
+          return this.failReplay(
+            state,
+            agentId,
+            scope,
+            "replay_ended_before_target",
+            context.reset,
+          );
+        }
+        // Repeated empty pages that still claim newer events are spin: fail
+        // early instead of consuming the full page budget.
         staleRounds += 1;
         if (staleRounds >= MAX_STALE_REPLAY_ROUNDS) {
           return this.failReplay(state, agentId, scope, "empty_replay_page_no_progress", context.reset);
@@ -541,6 +631,12 @@ export class AgentRecoveryCoordinator {
         staleRounds = 0;
       }
       after = Math.max(after, contiguous);
+      if (
+        after < context.targetHeadSeq &&
+        this.now() - startedAt > this.replayBudget.maxElapsedMs
+      ) {
+        return this.handleReplayBudgetExhaustion(state, agentId, scope, context);
+      }
     }
 
     // Buffered live hints replay through the same ingest path before the
@@ -567,6 +663,37 @@ export class AgentRecoveryCoordinator {
       update.projectionReadyThroughSeq = lateStatus.projectionReadyThroughSeq;
     }
     return update;
+  }
+
+  /** Bootstrap at most once after one replay attempt exhausts its budget. */
+  private handleReplayBudgetExhaustion(
+    state: AgentRecoveryState,
+    agentId: string,
+    scope: LedgerScopeKey,
+    context: {
+      targetHeadSeq: number;
+      oldestRetainedSeq?: number | null;
+      reset?: LedgerResetReason;
+      bootstrapAttempted?: boolean;
+    },
+  ): Promise<AgentRecoveryUpdate> | AgentRecoveryUpdate {
+    if (context.bootstrapAttempted) {
+      return this.failReplay(
+        state,
+        agentId,
+        scope,
+        "replay_budget_exceeded_after_snapshot",
+        context.reset ?? "replay_budget_exceeded",
+      );
+    }
+    return this.bootstrap(
+      agentId,
+      {
+        eventHeadSeq: context.targetHeadSeq,
+        oldestRetainedSeq: context.oldestRetainedSeq,
+      },
+      "replay_budget_exceeded",
+    );
   }
 
   /** Ingest buffered live hints until the buffer stays empty. */

--- a/web-gui/app/src/runtime/event-ledger/agent-recovery.ts
+++ b/web-gui/app/src/runtime/event-ledger/agent-recovery.ts
@@ -166,6 +166,8 @@ const MAX_STALE_REPLAY_ROUNDS = 3;
 
 function serializedPageBytes(page: RecoveryEventPage): number {
   if (page.responseBytes != null) return Math.max(0, page.responseBytes);
+  // Non-HTTP adapters may not know the raw body size; bound their mapped
+  // payload with a best-effort UTF-8 estimate instead of skipping the limit.
   try {
     return new TextEncoder().encode(JSON.stringify(page)).byteLength;
   } catch {
@@ -530,7 +532,7 @@ export class AgentRecoveryCoordinator {
 
     let after = afterSeq;
     let pages = 0;
-    let appliedEvents = 0;
+    let fetchedEvents = 0;
     let responseBytes = 0;
     let staleRounds = 0;
     let status: LedgerIngestionStatus | null = context.installed ?? null;
@@ -544,7 +546,7 @@ export class AgentRecoveryCoordinator {
       }
       const page = await this.dependencies.fetchEventPage(agentId, after, this.pageSize);
       pages += 1;
-      appliedEvents += page.events.length;
+      fetchedEvents += page.events.length;
       responseBytes += serializedPageBytes(page);
       if (page.cursorNotFound) {
         if (context.reset == null) {
@@ -571,9 +573,9 @@ export class AgentRecoveryCoordinator {
         );
       }
       if (
-        appliedEvents > this.replayBudget.maxEvents ||
+        fetchedEvents > this.replayBudget.maxEvents ||
         responseBytes > this.replayBudget.maxBytes ||
-        this.now() - startedAt > this.replayBudget.maxElapsedMs
+        this.now() - startedAt >= this.replayBudget.maxElapsedMs
       ) {
         return this.handleReplayBudgetExhaustion(state, agentId, scope, {
           ...context,
@@ -633,7 +635,7 @@ export class AgentRecoveryCoordinator {
       after = Math.max(after, contiguous);
       if (
         after < context.targetHeadSeq &&
-        this.now() - startedAt > this.replayBudget.maxElapsedMs
+        this.now() - startedAt >= this.replayBudget.maxElapsedMs
       ) {
         return this.handleReplayBudgetExhaustion(state, agentId, scope, context);
       }

--- a/web-gui/app/src/runtime/event-ledger/index.ts
+++ b/web-gui/app/src/runtime/event-ledger/index.ts
@@ -8,6 +8,7 @@ export {
   type AgentRecoveryDependencies,
   type AgentRecoveryHint,
   type AgentRecoveryPhase,
+  type AgentReplayBudget,
   type AgentRecoveryUpdate,
   type LedgerResetReason,
   type RecoveryCursorError,

--- a/web-gui/app/src/runtime/event-ledger/ledger.ts
+++ b/web-gui/app/src/runtime/event-ledger/ledger.ts
@@ -165,7 +165,7 @@ export interface LedgerReadStateRecord {
   readThroughEventSeq?: number;
   /** Whether unread counts above the boundary are exact or a lower bound. */
   certainty?: "exact" | "truncated";
-  /** Retention floor of the last retention-gap reset; history below is lost. */
+  /** Boundary of history skipped by the last retention or replay-budget reset. */
   historyTruncatedBeforeSeq?: number;
   /** User acknowledgement of unknown history after a truncation (W5 action). */
   acknowledgedTruncationBeforeSeq?: number;


### PR DESCRIPTION
## Summary

- add a client-owned composite replay budget for estimated gap, pages, events, response bytes, and elapsed time
- bootstrap from the authoritative projection before replaying an oversized retained suffix
- bootstrap at most once when an actual replay limit is exhausted, then remain out of live state if the post-snapshot suffix is still over budget
- preserve read markers while marking voluntarily skipped history as unread-uncertain/truncated
- normalize the new non-null retention-watermark contract at roster, snapshot, and cursor-error boundaries

## Policy

The defaults are a 10,000-sequence preflight gap, 50 pages, 10,000 page events, 16 MiB of serialized response data, and 30 seconds per attempt. Retention gaps remain mandatory bootstrap conditions and take priority over replay cost. Cursor and epoch errors also remain authoritative when a fetched response crosses a budget.

Any page that ends before the committed target head now fails explicitly instead of transitioning to live with an incomplete contiguous cursor.

This is the client half of #2648 and is stacked on #2651. It should be reviewed as the diff from `fix/issue-2648-retention-watermark`; it can be retargeted after #2651 lands.

## Verification

- preflight large-gap bootstrap
- small exact catch-up
- page/event/byte/elapsed-time exhaustion
- one-bootstrap bound and post-snapshot exhaustion error
- retention/cursor/epoch precedence
- unread truncation and preserved marker semantics
- concurrent events during snapshot/replay
- incomplete target-head rejection
- `npm run typecheck` with Node 24
- `npm test` with Node 24 (39 files, 438 tests)
- `npm run build` with Node 24
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2648
