### PR TITLE
fix: bound roster latest brief lookup

### DIFF
--- a/src/runtime_db/observer_sync.rs
+++ b/src/runtime_db/observer_sync.rs
@@ -24,6 +24,16 @@ pub(crate) const BRIEF_ATOMIC_LINKAGE_VERIFIED: &str = "brief_atomic_linkage_ver
 pub(crate) const ROSTER_SNAPSHOT_VERIFIED: &str = "roster_snapshot_verified";
 pub(crate) const PROJECTION_SNAPSHOT_VERIFIED: &str = "projection_snapshot_verified";
 pub(crate) const EVENT_PROJECTION_EFFECT_VERIFIER_VERSION: i64 = 1;
+pub(crate) const AGENT_ROSTER_LATEST_BRIEFS_SQL: &str =
+    "SELECT b.agent_id, b.evidence_id, b.created_event_seq, b.created_at, b.preview
+     FROM agent_identities i
+     JOIN briefs b ON b.evidence_id = (
+         SELECT b2.evidence_id FROM briefs b2
+         WHERE b2.agent_id = i.agent_id
+         ORDER BY b2.created_at DESC, b2.evidence_id DESC
+         LIMIT 1
+     )
+     WHERE i.status = 'active' AND i.visibility = 'public'";
 
 /// Principal and entitlement used to derive the runtime-local public scope
 /// for unauthenticated local mode.
@@ -688,18 +698,10 @@ fn collect_agent_roster_rows(connection: &Connection) -> Result<AgentRosterSnaps
 
     let mut latest_briefs: HashMap<String, AgentRosterLatestBriefRow> = HashMap::new();
     {
-        let mut statement = connection.prepare(
-            "SELECT b.agent_id, b.evidence_id, b.created_event_seq, b.created_at, b.preview
-             FROM briefs b
-             JOIN agent_identities i ON i.agent_id = b.agent_id
-             WHERE i.status = 'active' AND i.visibility = 'public'
-               AND b.evidence_id = (
-                   SELECT b2.evidence_id FROM briefs b2
-                   WHERE b2.agent_id = b.agent_id
-                   ORDER BY b2.created_at DESC, b2.evidence_id DESC
-                   LIMIT 1
-               )",
-        )?;
+        // Drive the lookup from the bounded public roster so SQLite selects
+        // one latest Brief per member instead of repeating the selector for
+        // every historical Brief belonging to that member.
+        let mut statement = connection.prepare(AGENT_ROSTER_LATEST_BRIEFS_SQL)?;
         let rows = statement.query_map([], |row| {
             Ok((
                 row.get::<_, String>(0)?,

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -89,7 +89,9 @@ mod tests {
             WorkStatus,
         },
         runtime_db::migrations::{RETAINED_SCHEDULER_AUDIT_TABLES, RETIRED_SCHEDULER_TABLES},
-        runtime_db::observer_sync::EVENT_PROJECTION_EFFECT_VERIFIER_VERSION,
+        runtime_db::observer_sync::{
+            AGENT_ROSTER_LATEST_BRIEFS_SQL, EVENT_PROJECTION_EFFECT_VERIFIER_VERSION,
+        },
         runtime_db::repositories::{enum_string, slim_task_record_for_payload},
         runtime_db::transitions::{
             AgentStateMutation, QueueHeadNoProgressCommand, QueueHeadNoProgressOutcome,
@@ -6489,6 +6491,38 @@ CREATE TABLE working_memory_deltas (
         assert_eq!(
             snapshot.rows[0].latest_brief.as_ref().unwrap().brief_id,
             "brief-z"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn agent_roster_latest_brief_query_is_driven_by_public_membership() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.agent_identities().upsert(&agent_identity("member", 0))?;
+
+        let connection = db.connection()?;
+        let query_plan = {
+            let mut statement = connection.prepare(&format!(
+                "EXPLAIN QUERY PLAN {AGENT_ROSTER_LATEST_BRIEFS_SQL}"
+            ))?;
+            let details = statement
+                .query_map([], |row| row.get::<_, String>(3))?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            details
+        };
+
+        assert!(
+            query_plan.iter().any(|detail| {
+                detail.contains("SEARCH b USING INDEX sqlite_autoindex_briefs_1 (evidence_id=?)")
+            }),
+            "roster latest-Brief lookup must probe one Brief by primary key per public member: {query_plan:?}"
+        );
+        assert!(
+            query_plan
+                .iter()
+                .all(|detail| !detail.contains("SEARCH b USING INDEX idx_briefs_agent_turn")),
+            "roster latest-Brief lookup must not visit every historical Brief: {query_plan:?}"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

- drive latest-Brief roster selection from active public identities instead of every historical Brief
- preserve deterministic `created_at` / `evidence_id` ordering and the existing single-view snapshot contract
- add an `EXPLAIN QUERY PLAN` regression test that requires one primary-key Brief probe per public member

## Runtime impact

On the local 16.9 GB runtime database (4.29M audit events, 35,131 Briefs, 30 active public Agents):

- `holon daemon status`: >38s before (terminated) -> 3.09s with the candidate, 1.66s after restart
- pre-server runtime preparation: 10m19s before -> 1.75s
- full systemd restart to listener: 19m12s before -> about 10s
- `/api/agents/list`: >30s before (terminated) -> 0.71s, 30 Agents

The event projection verification proof remained reusable; this change does not add a migration or rebuild indexes.

## Verification

- `cargo test agent_roster_ --lib`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- installed `holon 0.32.0 (179e2573)` and restarted `holon.service` under `systemd --user`
- service healthy, `NRestarts=0`