### PR TITLE
test(web): add deterministic Chromium E2E foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/
 coverage/
 .DS_Store
 target/
+web-gui/app/playwright-report/
+web-gui/app/test-results/
 /bin/
 _testwork/
 __pycache__/

--- a/web-gui/app/e2e/assert-production-bundle.mjs
+++ b/web-gui/app/e2e/assert-production-bundle.mjs
@@ -1,0 +1,23 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const distDir = new URL("../dist/", import.meta.url);
+const marker = "__HOLON_E2E__";
+
+async function filesUnder(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  return (await Promise.all(entries.map(async (entry) => {
+    const child = new URL(entry.name, directory);
+    return entry.isDirectory() ? filesUnder(new URL(`${entry.name}/`, directory)) : [child];
+  }))).flat();
+}
+
+const files = await filesUnder(distDir);
+for (const file of files) {
+  if (![".html", ".js", ".css"].includes(path.extname(file.pathname))) continue;
+  if ((await readFile(file, "utf8")).includes(marker)) {
+    throw new Error(`production bundle contains E2E diagnostics marker in ${file.pathname}`);
+  }
+}
+
+console.log("production bundle excludes the E2E diagnostics bridge");

--- a/web-gui/app/e2e/cold-start.spec.ts
+++ b/web-gui/app/e2e/cold-start.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+interface DiagnosticsSnapshot {
+  bootstrapLoading: boolean;
+  bootstrapError?: string;
+  globalStreamStatus: string;
+  discovery: { mode: string; freshness: string };
+  agentIds: string[];
+}
+
+test("cold start bootstraps and applies a live roster event", async ({ page, request }, testInfo) => {
+  const session = `${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${testInfo.retry}`;
+  const controlPath = (path: string) => `${path}?session=${encodeURIComponent(session)}`;
+  await page.context().addCookies([{
+    name: "holon_e2e_session",
+    value: session,
+    domain: "127.0.0.1",
+    path: "/",
+  }]);
+  await page.goto("/");
+
+  await expect(page.locator('aside[aria-label="Holon navigation"]')).toBeVisible();
+  await expect(page.locator('nav[aria-label="Global navigation"]')).toBeVisible();
+  await expect(page.getByText("1 agents · all clear", { exact: true })).toBeVisible();
+
+  await expect.poll(async () => page.evaluate(() => window.__HOLON_E2E__?.snapshot()))
+    .toMatchObject({
+      bootstrapLoading: false,
+      globalStreamStatus: "streaming",
+      discovery: { mode: "authoritative", freshness: "fresh" },
+      agentIds: ["bootstrap-agent"],
+    } satisfies Partial<DiagnosticsSnapshot>);
+
+  const initialRequests = await request.get(controlPath("/__e2e__/requests"))
+    .then((response) => response.json());
+  expect(initialRequests.requests).toEqual(expect.arrayContaining([
+    "GET /api/handshake",
+    "GET /api/agents/list",
+    "GET /api/agents/snapshot",
+    "GET /api/events/stream",
+  ]));
+  expect(initialRequests.requests.indexOf("GET /api/handshake"))
+    .toBeLessThan(initialRequests.requests.indexOf("GET /api/agents/list"));
+
+  await request.post(controlPath("/__e2e__/emit-agent"));
+
+  await expect(page.getByText("2 agents · all clear", { exact: true })).toBeVisible();
+  await expect.poll(async () => page.evaluate(() => window.__HOLON_E2E__?.snapshot().agentIds))
+    .toEqual(["bootstrap-agent", "e2e-agent"]);
+
+  const finalRequests = await request.get(controlPath("/__e2e__/requests"))
+    .then((response) => response.json());
+  expect(finalRequests.requests.filter((entry: string) => entry === "GET /api/agents/snapshot")).toHaveLength(2);
+  expect(finalRequests.requests.filter((entry: string) => entry === "GET /api/events/stream")).toHaveLength(1);
+  expect(finalRequests.requests.filter(
+    (entry: string) => entry === "GET /api/agents/e2e-agent/projection-snapshot",
+  )).toHaveLength(1);
+  expect(finalRequests.requests.filter(
+    (entry: string) => entry === "GET /api/agents/e2e-agent/events?after_seq=0&limit=100&order=asc",
+  )).toHaveLength(1);
+  expect(finalRequests.requests.filter(
+    (entry: string) => entry === "GET /api/agents/e2e-agent/events?limit=100&order=desc",
+  )).toHaveLength(1);
+});

--- a/web-gui/app/e2e/fixture-server.mjs
+++ b/web-gui/app/e2e/fixture-server.mjs
@@ -1,0 +1,201 @@
+import http from "node:http";
+import { createServer as createViteServer } from "vite";
+
+const requestedPort = Number(process.argv[process.argv.indexOf("--port") + 1]);
+if (!Number.isInteger(requestedPort) || requestedPort <= 0) {
+  throw new Error("fixture server requires --port <port>");
+}
+
+const sessions = new Map();
+
+const vite = await createViteServer({
+  appType: "spa",
+  mode: "e2e",
+  server: { middlewareMode: true },
+});
+
+function record(req, url) {
+  if (url.pathname.startsWith("/api/")) {
+    sessionFor(req, url).requests.push(`${req.method} ${url.pathname}${url.search}`);
+  }
+}
+
+function sessionId(req, url) {
+  const controlSession = url.searchParams.get("session");
+  if (controlSession) return controlSession;
+  const cookie = req.headers.cookie
+    ?.split(";")
+    .map((entry) => entry.trim().split("="))
+    .find(([name]) => name === "holon_e2e_session");
+  return cookie ? decodeURIComponent(cookie.slice(1).join("=")) : "default";
+}
+
+function sessionFor(req, url) {
+  const id = sessionId(req, url);
+  let session = sessions.get(id);
+  if (!session) {
+    session = {
+      requests: [],
+      globalStreams: new Set(),
+      agentStreams: new Set(),
+      visibleAgentIds: ["bootstrap-agent"],
+    };
+    sessions.set(id, session);
+  }
+  return session;
+}
+
+function json(res, body, status = 200) {
+  res.writeHead(status, {
+    "Cache-Control": "no-store",
+    "Content-Type": "application/json",
+  });
+  res.end(JSON.stringify(body));
+}
+
+function openEventStream(req, res, clients) {
+  res.writeHead(200, {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "Content-Type": "text/event-stream",
+  });
+  res.write(": connected\n\n");
+  clients.add(res);
+  req.on("close", () => clients.delete(res));
+}
+
+function listEntry(agentId) {
+  return {
+    identity: {
+      agent_id: agentId,
+      visibility: "public",
+      ownership: "self_owned",
+      profile_preset: "public_named",
+    },
+    status: "awake_idle",
+    pending: 0,
+  };
+}
+
+function rosterSnapshot(visibleAgentIds) {
+  return {
+    contract_version: 1,
+    runtime_id: "e2e-runtime",
+    event_log_epoch: "e2e-epoch",
+    visibility_scope_id: "e2e-scope",
+    agents: visibleAgentIds.map((agentId) => ({
+          agent: listEntry(agentId),
+          event_window: { event_head_seq: agentId === "e2e-agent" ? 1 : 0, oldest_retained_seq: 0 },
+          latest_brief: null,
+        })),
+  };
+}
+
+function emptyEventPage(agentId) {
+  return {
+    events: [],
+    event_log_epoch: "e2e-epoch",
+    has_older: false,
+    has_newer: false,
+    order: "asc",
+    limit: 100,
+    agent_id: agentId,
+  };
+}
+
+async function handleControl(req, res, url) {
+  if (url.pathname === "/__e2e__/health") {
+    json(res, { ok: true });
+    return true;
+  }
+  if (url.pathname === "/__e2e__/requests") {
+    json(res, { requests: sessionFor(req, url).requests });
+    return true;
+  }
+  if (url.pathname === "/__e2e__/emit-agent" && req.method === "POST") {
+    const { globalStreams, visibleAgentIds } = sessionFor(req, url);
+    if (!visibleAgentIds.includes("e2e-agent")) visibleAgentIds.push("e2e-agent");
+    const envelope = {
+      id: "e2e-event-1",
+      event_seq: 1,
+      event_log_epoch: "e2e-epoch",
+      contract_version: 1,
+      ts: "2026-08-25T00:00:00Z",
+      agent_id: "e2e-agent",
+      type: "agent_state_changed",
+      payload_schema: "holon.runtime_event.legacy",
+      payload_schema_version: 1,
+      payload: {},
+    };
+    const frame = `data: ${JSON.stringify(envelope)}\n\n`;
+    for (const stream of globalStreams) stream.write(frame);
+    json(res, { emitted: true });
+    return true;
+  }
+  return false;
+}
+
+function handleApi(req, res, url) {
+  record(req, url);
+  const session = sessionFor(req, url);
+  if (url.pathname === "/api/handshake") {
+    json(res, { auth: { mode: "none" }, capabilities: ["agents.list", "agents.roster-snapshot.v1"] });
+    return true;
+  }
+  if (url.pathname === "/api/agents/list") {
+    json(res, session.visibleAgentIds.map(listEntry));
+    return true;
+  }
+  if (url.pathname === "/api/agents/snapshot") {
+    json(res, rosterSnapshot(session.visibleAgentIds));
+    return true;
+  }
+  if (url.pathname === "/api/events/stream") {
+    openEventStream(req, res, session.globalStreams);
+    return true;
+  }
+  const projectionMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/projection-snapshot$/);
+  if (projectionMatch) {
+    json(res, { error: "capability unavailable", code: "capability_unavailable" }, 503);
+    return true;
+  }
+  const eventsMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/events$/);
+  if (eventsMatch) {
+    json(res, emptyEventPage(decodeURIComponent(eventsMatch[1])));
+    return true;
+  }
+  if (/^\/api\/agents\/[^/]+\/events\/stream$/.test(url.pathname)) {
+    openEventStream(req, res, session.agentStreams);
+    return true;
+  }
+  return false;
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+  if (await handleControl(req, res, url)) return;
+  if (url.pathname.startsWith("/api/")) {
+    if (!handleApi(req, res, url)) json(res, { error: `unexpected fixture request: ${url.pathname}` }, 404);
+    return;
+  }
+  vite.middlewares(req, res, () => {
+    res.writeHead(404);
+    res.end("not found");
+  });
+});
+
+await new Promise((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(requestedPort, "127.0.0.1", resolve);
+});
+
+async function shutdown() {
+  for (const session of sessions.values()) {
+    for (const stream of [...session.globalStreams, ...session.agentStreams]) stream.end();
+  }
+  await vite.close();
+  await new Promise((resolve) => server.close(resolve));
+}
+
+process.once("SIGINT", () => void shutdown());
+process.once("SIGTERM", () => void shutdown());

--- a/web-gui/app/package-lock.json
+++ b/web-gui/app/package-lock.json
@@ -21,6 +21,7 @@
         "zustand": "^5.0.14"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/vite": "^4.3.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -152,6 +153,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2809,6 +2826,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web-gui/app/package.json
+++ b/web-gui/app/package.json
@@ -6,8 +6,11 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "npm run typecheck && vite build",
+    "build:e2e": "npm run typecheck && vite build --mode e2e",
     "preview": "vite preview --host 127.0.0.1",
     "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:production-bundle": "npm run build && node e2e/assert-production-bundle.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json --pretty false && tsc --noEmit -p tsconfig.node.json --pretty false"
   },
   "dependencies": {
@@ -24,6 +27,7 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/vite": "^4.3.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/web-gui/app/playwright.config.ts
+++ b/web-gui/app/playwright.config.ts
@@ -1,0 +1,56 @@
+import net from "node:net";
+
+import { defineConfig, devices } from "@playwright/test";
+
+async function reservePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to allocate an E2E server port"));
+        return;
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+const inheritedPort = Number(process.env.HOLON_E2E_PORT);
+const port = Number.isInteger(inheritedPort) && inheritedPort > 0
+  ? inheritedPort
+  : await reservePort();
+process.env.HOLON_E2E_PORT = String(port);
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  outputDir: "test-results",
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["line"], ["html", { open: "never" }]] : "line",
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: `node e2e/fixture-server.mjs --port ${port}`,
+    url: `${baseURL}/__e2e__/health`,
+    reuseExistingServer: false,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/web-gui/app/src/e2e/diagnostics-bridge.ts
+++ b/web-gui/app/src/e2e/diagnostics-bridge.ts
@@ -1,0 +1,56 @@
+import { useRuntimeStore } from "../runtime/runtime-store";
+
+export interface HolonE2eSnapshot {
+  route: string;
+  bootstrapLoading: boolean;
+  bootstrapError?: string;
+  globalStreamStatus: string;
+  discovery: {
+    mode: string;
+    freshness: string;
+  };
+  connection: {
+    mode: string;
+    source: string;
+    summary: string;
+  };
+  agentIds: string[];
+}
+
+export interface HolonE2eDiagnostics {
+  snapshot(): HolonE2eSnapshot;
+  subscribe(listener: (snapshot: HolonE2eSnapshot) => void): () => void;
+}
+
+declare global {
+  interface Window {
+    __HOLON_E2E__?: HolonE2eDiagnostics;
+  }
+}
+
+function snapshot(): HolonE2eSnapshot {
+  const state = useRuntimeStore.getState();
+  return {
+    route: state.route,
+    bootstrapLoading: state.bootstrapLoading,
+    bootstrapError: state.bootstrapError,
+    globalStreamStatus: state.globalStreamStatus,
+    discovery: {
+      mode: state.discovery.mode,
+      freshness: state.discovery.freshness,
+    },
+    connection: {
+      mode: state.bootstrap.connection.mode,
+      source: state.bootstrap.connection.source,
+      summary: state.bootstrap.connection.summary,
+    },
+    agentIds: state.bootstrap.agents.map((agent) => agent.id),
+  };
+}
+
+window.__HOLON_E2E__ = Object.freeze({
+  snapshot,
+  subscribe(listener: (value: HolonE2eSnapshot) => void) {
+    return useRuntimeStore.subscribe(() => listener(snapshot()));
+  },
+});

--- a/web-gui/app/src/main.tsx
+++ b/web-gui/app/src/main.tsx
@@ -6,6 +6,10 @@ import { App } from "./app/App";
 import "./styles/tokens.css";
 import "./styles/global.css";
 
+if (__HOLON_E2E_DIAGNOSTICS__) {
+  void import("./e2e/diagnostics-bridge");
+}
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <I18nProvider>

--- a/web-gui/app/src/vite-env.d.ts
+++ b/web-gui/app/src/vite-env.d.ts
@@ -1,3 +1,4 @@
 /// <reference types="vite/client" />
 
 declare const __HOLON_GUI_VERSION__: string;
+declare const __HOLON_E2E_DIAGNOSTICS__: boolean;

--- a/web-gui/app/vite.config.ts
+++ b/web-gui/app/vite.config.ts
@@ -1,3 +1,5 @@
+/// <reference types="vitest/config" />
+
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig, loadEnv } from "vite";
@@ -12,8 +14,12 @@ export default defineConfig(({ mode }) => {
   return {
     define: {
       __HOLON_GUI_VERSION__: JSON.stringify(packageJson.version),
+      __HOLON_E2E_DIAGNOSTICS__: JSON.stringify(mode === "e2e"),
     },
     plugins: [tailwindcss(), react()],
+    test: {
+      exclude: ["e2e/**", "node_modules/**"],
+    },
     server: {
       host: "127.0.0.1",
       port: 5173,


### PR DESCRIPTION
## Summary

- add Playwright Chromium infrastructure with isolated random ports and failure artifacts
- add a deterministic HTTP/SSE protocol fixture and E2E-01 coverage for cold bootstrap plus a live roster event
- expose a read-only `window.__HOLON_E2E__` diagnostics bridge only in Vite `e2e` mode
- assert that production bundles do not contain the diagnostics bridge marker

## Isolation

The E2E suite does not depend on an existing daemon, user configuration, fixed ports, or external network access. Parallel workers receive isolated fixture sessions while exercising the application's real HTTP/SSE request paths.

## Verification

- `npm test`
- `npm run build`
- `npm run test:e2e:production-bundle`
- `npm run test:e2e`
- `npm run test:e2e -- --repeat-each=20` (20/20 passed with 20 workers)
