### PR TITLE
fix(web-gui): accept v3 session events

### DIFF
--- a/src/runtime_event.rs
+++ b/src/runtime_event.rs
@@ -363,6 +363,18 @@ mod tests {
     }
 
     #[test]
+    fn web_gui_supports_current_runtime_event_contract() {
+        let session_events = include_str!("../web-gui/app/src/runtime/session-events.ts");
+        let expected =
+            format!("const RUNTIME_EVENT_CONTRACT_VERSION = {RUNTIME_EVENT_CONTRACT_VERSION};");
+
+        assert!(
+            session_events.contains(&expected),
+            "Web GUI runtime event contract must match backend version {RUNTIME_EVENT_CONTRACT_VERSION}"
+        );
+    }
+
+    #[test]
     fn typed_constructor_rejects_mismatched_payload_schema() {
         #[derive(Serialize)]
         struct WrongPayload;

--- a/web-gui/app/src/runtime/session-events.test.ts
+++ b/web-gui/app/src/runtime/session-events.test.ts
@@ -3,21 +3,46 @@ import { describe, expect, it } from "vitest";
 import { canApplySessionEvent } from "./session-events";
 
 describe("runtime event schema compatibility", () => {
-  it("applies legacy events and only matching v2 registry schemas", () => {
+  it("applies legacy events and matching current registry schemas", () => {
     expect(canApplySessionEvent({ type: "future_event" })).toBe(true);
+
+    const currentEvents = [
+      ["message_enqueued", "holon.runtime_event.message_lifecycle"],
+      ["message_processing_started", "holon.runtime_event.message_lifecycle"],
+      ["brief_created", "holon.runtime_event.brief_created"],
+      ["task_created", "holon.runtime_event.task_lifecycle"],
+      ["task_status_updated", "holon.runtime_event.task_lifecycle"],
+      ["task_result_received", "holon.runtime_event.task_lifecycle"],
+      ["work_item_written", "holon.runtime_event.work_item_lifecycle"],
+      ["agent_state_changed", "holon.runtime_event.agent_state_changed"],
+    ] as const;
+
+    for (const [type, payloadSchema] of currentEvents) {
+      expect(
+        canApplySessionEvent({
+          type,
+          contract_version: 3,
+          payload_schema: payloadSchema,
+          payload_schema_version: 1,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects mismatched schemas and future contract versions", () => {
     expect(
       canApplySessionEvent({
         type: "brief_created",
-        contract_version: 2,
-        payload_schema: "holon.runtime_event.brief_created",
+        contract_version: 3,
+        payload_schema: "holon.runtime_event.future_brief",
         payload_schema_version: 1,
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       canApplySessionEvent({
         type: "brief_created",
-        contract_version: 2,
-        payload_schema: "holon.runtime_event.future_brief",
+        contract_version: 4,
+        payload_schema: "holon.runtime_event.brief_created",
         payload_schema_version: 1,
       }),
     ).toBe(false);
@@ -26,7 +51,7 @@ describe("runtime event schema compatibility", () => {
         type: "brief_created",
         contract_version: 3,
         payload_schema: "holon.runtime_event.brief_created",
-        payload_schema_version: 1,
+        payload_schema_version: 2,
       }),
     ).toBe(false);
   });

--- a/web-gui/app/src/runtime/session-events.ts
+++ b/web-gui/app/src/runtime/session-events.ts
@@ -2,7 +2,7 @@ import type { components } from "./generated/openapi";
 
 export type SessionEventEnvelope = Partial<components["schemas"]["StreamEventEnvelope"]>;
 
-const RUNTIME_EVENT_CONTRACT_VERSION = 2;
+const RUNTIME_EVENT_CONTRACT_VERSION = 3;
 const runtimeEventSchemas: Record<string, string> = {
   message_enqueued: "holon.runtime_event.message_lifecycle",
   message_processing_started: "holon.runtime_event.message_lifecycle",

--- a/web-gui/app/src/runtime/session-projection.test.ts
+++ b/web-gui/app/src/runtime/session-projection.test.ts
@@ -24,6 +24,20 @@ function event(
   };
 }
 
+function currentEvent(
+  eventSeq: number,
+  type: string,
+  payloadSchema: string,
+  payload: Record<string, unknown>,
+): ProjectionEvent {
+  return {
+    ...event(eventSeq, type, payload),
+    contract_version: 3,
+    payload_schema: payloadSchema,
+    payload_schema_version: 1,
+  };
+}
+
 function receive(
   projection: SessionProjectionState,
   events: ProjectionEvent[],
@@ -119,12 +133,17 @@ describe("SessionProjectionState", () => {
       }),
     ]);
     const promoted = receive(recorded, [
-      event(7, "brief_created", {
-        brief_id: "brief-1",
-        finalizes_assistant_round_id: "round-1",
-        kind: "result",
-        text: "Complete result.",
-      }),
+      currentEvent(
+        7,
+        "brief_created",
+        "holon.runtime_event.brief_created",
+        {
+          brief_id: "brief-1",
+          finalizes_assistant_round_id: "round-1",
+          kind: "result",
+          text: "Complete result.",
+        },
+      ),
     ]);
 
     expect(promoted.domain.rounds).toHaveLength(1);

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -11,14 +11,14 @@ import {
 } from "./session-reducer";
 
 describe("reduceAgentSessionTimeline", () => {
-  it("preserves unknown v2 schemas outside the domain projection", () => {
+  it("preserves unknown current schemas outside the domain projection", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {
         events: [
           {
             id: "event-unknown-schema",
             event_seq: 1,
-            contract_version: 2,
+            contract_version: 3,
             payload_schema: "holon.runtime_event.future_message",
             payload_schema_version: 1,
             ts: "2026-07-16T10:00:00Z",

--- a/web-gui/app/src/runtime/timeline-event-diagnostics.test.ts
+++ b/web-gui/app/src/runtime/timeline-event-diagnostics.test.ts
@@ -85,7 +85,7 @@ describe("timeline event diagnostics", () => {
     expect(diagnoseTimelineEvent(accepted, projection, []).disposition).toBe("hidden");
     expect(diagnoseTimelineEvent(event({ event_seq: 2, id: "event-2" }), projection, []).disposition).toBe("unhandled");
     expect(diagnoseTimelineEvent(event({
-      contract_version: 2,
+      contract_version: 3,
       payload_schema: "unsupported",
     }), projection, []).disposition).toBe("rejected");
   });


### PR DESCRIPTION
## Summary

- update the Web GUI runtime event contract version from v2 to the backend's current v3 contract
- cover all current registry event schemas and reject mismatched schemas or future versions
- add a Brief projection regression test using a real v3 `brief_created` envelope
- add a Rust guard test to prevent backend and Web GUI contract versions from drifting again

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test runtime_event::tests::web_gui_supports_current_runtime_event_contract`
- `npx --yes -p node@22 node node_modules/typescript/bin/tsc --noEmit -p tsconfig.json --pretty false`
- `npx --yes -p node@22 node node_modules/vitest/vitest.mjs run src/runtime/session-events.test.ts src/runtime/session-projection.test.ts` (10 tests passed)

Closes #2657
