### PR TITLE
fix(memory): resolve ExecCommandBatch top-level output refs

### DIFF
--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -2639,6 +2639,7 @@ fn command_tool_execution_document(
             "ExecCommandBatch",
             None,
             ToolExecutionRefSelector::Output(ToolOutputSelector::Output),
+            // Batch-level refs expose only the aggregate output; stream refs remain per-item.
         ) => Ok(Some(generic_tool_execution_output_document_from_record(
             &record,
         ))),

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -2635,6 +2635,13 @@ fn command_tool_execution_document(
         ("ExecCommand", None, ToolExecutionRefSelector::Output(stream)) => Ok(
             command_output_document(&record, None, stream.as_ref_selector()),
         ),
+        (
+            "ExecCommandBatch",
+            None,
+            ToolExecutionRefSelector::Output(ToolOutputSelector::Output),
+        ) => Ok(Some(generic_tool_execution_output_document_from_record(
+            &record,
+        ))),
         ("ExecCommandBatch", Some(index), ToolExecutionRefSelector::Output(stream)) => Ok(
             command_output_document(&record, Some(index), stream.as_ref_selector()),
         ),
@@ -4972,6 +4979,72 @@ mod tests {
 
         assert!(memory.content.contains("second_batch_output_1246"));
         assert!(!memory.content.contains("first_batch_output_1246"));
+    }
+
+    #[test]
+    fn command_output_resolves_exec_command_batch_top_level_output() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        storage
+            .append_tool_execution(&ToolExecutionRecord {
+                id: "tool-batch-top-output-1246".into(),
+                agent_id: "default".into(),
+                work_item_id: None,
+                turn_index: 0,
+                turn_id: None,
+                tool_name: "ExecCommandBatch".into(),
+                created_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+                duration_ms: 20,
+                authority_class: crate::types::AuthorityClass::OperatorInstruction,
+                status: crate::types::ToolExecutionStatus::Success,
+                input: json!({
+                    "items": [
+                        {"cmd": "echo first"},
+                        {"cmd": "echo second"}
+                    ]
+                }),
+                output: json!({
+                    "envelope": {
+                        "result": {
+                            "completed_count": 2,
+                            "item_count": 2,
+                            "items": [
+                                {"index": 1, "result": {"stdout_preview": "first_batch_top_output_1246\n"}},
+                                {"index": 2, "result": {"stdout_preview": "second_batch_top_output_1246\n"}}
+                            ]
+                        }
+                    },
+                    "is_error": false
+                }),
+                summary: "ExecCommandBatch completed 2/2 items".into(),
+                invocation_surface: None,
+            })
+            .unwrap();
+
+        let memory = get_memory(
+            &storage,
+            "tool_execution:tool-batch-top-output-1246:output",
+            None,
+            Some("ws-holon"),
+        )
+        .unwrap()
+        .expect("top-level batch output should be retrievable");
+
+        assert!(memory.content.contains("first_batch_top_output_1246"));
+        assert!(memory.content.contains("second_batch_top_output_1246"));
+        assert!(memory
+            .content
+            .contains("\"source_type\": \"tool_execution_output\""));
+        assert!(get_memory(
+            &storage,
+            "tool_execution:tool-batch-top-output-1246:stdout",
+            None,
+            Some("ws-holon"),
+        )
+        .unwrap()
+        .is_none());
     }
 
     #[test]

--- a/src/tool/tools/memory_get.rs
+++ b/src/tool/tools/memory_get.rs
@@ -420,6 +420,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn memory_get_tool_accepts_exec_command_batch_top_level_output_ref() {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(StubProvider::new("done")),
+            "default".into(),
+            ContextConfig::default(),
+        )
+        .unwrap();
+        runtime
+            .storage()
+            .append_tool_execution(&ToolExecutionRecord {
+                id: "tool-batch-get-1246".into(),
+                agent_id: "default".into(),
+                work_item_id: None,
+                turn_index: 0,
+                turn_id: None,
+                tool_name: "ExecCommandBatch".into(),
+                created_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+                duration_ms: 10,
+                authority_class: AuthorityClass::OperatorInstruction,
+                status: ToolExecutionStatus::Success,
+                input: json!({
+                    "items": [
+                        {"cmd": "echo first"},
+                        {"cmd": "echo second"}
+                    ]
+                }),
+                output: json!({
+                    "envelope": {
+                        "result": {
+                            "completed_count": 2,
+                            "item_count": 2,
+                            "items": [
+                                {"index": 1, "result": {"stdout_preview": "memory_get_batch_first_1246\n"}},
+                                {"index": 2, "result": {"stdout_preview": "memory_get_batch_second_1246\n"}}
+                            ]
+                        }
+                    },
+                    "is_error": false
+                }),
+                summary: "ExecCommandBatch completed 2/2 items".into(),
+                invocation_surface: None,
+            })
+            .unwrap();
+
+        let result = execute(
+            &runtime,
+            "default",
+            &AuthorityClass::OperatorInstruction,
+            &json!({
+                "source_ref": "tool_execution:tool-batch-get-1246:output"
+            }),
+        )
+        .await
+        .unwrap();
+        let content = result.envelope.result.unwrap()["memory"]["content"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        assert!(content.contains("\"tool_name\": \"ExecCommandBatch\""));
+        assert!(content.contains("memory_get_batch_first_1246"));
+        assert!(content.contains("memory_get_batch_second_1246"));
+    }
+
+    #[tokio::test]
     async fn memory_get_tool_accepts_task_source_refs() {
         let dir = tempdir().unwrap();
         let workspace = tempdir().unwrap();


### PR DESCRIPTION
## Summary

- 让 runtime 已签发的 `tool_execution:<id>:output` 可为 `ExecCommandBatch` 解析
- 从持久化 `ToolExecutionRecord` 生成 batch 顶层 output 文档，不改变既有 per-item refs
- 保持顶层 `:stdout` / `:stderr` / `:cmd` 不可解析，并补充 memory index 与 `MemoryGet` 回归测试

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib command_output_resolves_exec_command_batch_top_level_output`
- `cargo test --lib memory_get_tool_accepts_exec_command_batch_top_level_output_ref`
- `cargo test --lib command_output_resolves_exec_command_batch_envelope_items`
- `git diff --check`

Closes #2636
