### PR TITLE
test(web): cover browser lifecycle recovery

### DIFF
--- a/web-gui/app/e2e/browser-lifecycle.spec.ts
+++ b/web-gui/app/e2e/browser-lifecycle.spec.ts
@@ -1,0 +1,338 @@
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type BrowserContext,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+
+interface LedgerSnapshot {
+  agentId: string;
+  ingestedThroughSeq: number;
+  projectionReadyThroughSeq: number;
+  pendingHydrationJobs: number;
+  failedHydrationJobs: number;
+  blockedByEventSeq?: number;
+  blockedReason?: "pending_hydration";
+  readThroughEventSeq?: number;
+  unreadCount?: number;
+  readGateDecision: {
+    mayAdvance: boolean;
+    candidateSeq?: number;
+    reason?: string;
+  };
+  readGateContext: {
+    route: string;
+    selectedAgentId: string;
+    documentVisible: boolean;
+    discoveryFreshness: string;
+    sessionLoading?: boolean;
+    sessionSyncStatus?: string;
+    sessionLiveStatus?: string;
+    sessionGapCount?: number;
+    pendingProjectionHydrationCount?: number;
+  };
+}
+
+function sessionFor(testInfo: TestInfo): string {
+  return `${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${testInfo.retry}`;
+}
+
+function controlPath(session: string, path: string): string {
+  return `${path}?session=${encodeURIComponent(session)}`;
+}
+
+async function attachSession(context: BrowserContext, session: string): Promise<void> {
+  await context.addCookies([{
+    name: "holon_e2e_session",
+    value: session,
+    domain: "127.0.0.1",
+    path: "/",
+  }]);
+}
+
+async function configure(
+  request: APIRequestContext,
+  session: string,
+  body: Record<string, unknown>,
+): Promise<void> {
+  const response = await request.post(controlPath(session, "/__e2e__/configure"), { data: body });
+  expect(response.ok()).toBe(true);
+}
+
+function envelope(
+  agentId: string,
+  eventSeq: number,
+  type = "agent_state_changed",
+  payload: Record<string, unknown> = {},
+) {
+  return {
+    id: `${agentId}-event-${eventSeq}`,
+    event_seq: eventSeq,
+    event_log_epoch: "e2e-epoch",
+    contract_version: 2,
+    ts: `2026-08-25T00:00:${String(eventSeq).padStart(2, "0")}Z`,
+    agent_id: agentId,
+    type,
+    payload_schema: `holon.runtime_event.${type}`,
+    payload_schema_version: 1,
+    payload,
+  };
+}
+
+function brief(agentId: string, eventSeq: number) {
+  return {
+    id: `brief-${eventSeq}`,
+    agent_id: agentId,
+    workspace_id: "agent_home",
+    created_at: `2026-08-25T00:00:${String(eventSeq).padStart(2, "0")}Z`,
+    created_event_seq: eventSeq,
+    kind: "result",
+    content_source: { kind: "inline" },
+    text: `Brief ${eventSeq}`,
+  };
+}
+
+async function ledger(page: Page, agentId: string): Promise<LedgerSnapshot | null> {
+  return page.evaluate((id) => window.__HOLON_E2E__?.ledger(id) ?? null, agentId);
+}
+
+async function openAgent(page: Page, agentId: string): Promise<void> {
+  const button = page.getByRole("button", { name: `Open ${agentId}`, exact: true });
+  await expect.poll(async () => {
+    const current = await ledger(page, agentId);
+    if (
+      current?.readGateContext.route === "agent"
+      && current.readGateContext.selectedAgentId === agentId
+    ) {
+      return "selected";
+    }
+    return await button.isVisible() ? "ready" : "waiting";
+  }).not.toBe("waiting");
+
+  const current = await ledger(page, agentId);
+  if (
+    current?.readGateContext.route !== "agent"
+    || current.readGateContext.selectedAgentId !== agentId
+  ) {
+    await button.click();
+  }
+  await expect.poll(async () => (await ledger(page, agentId))?.readGateContext)
+    .toMatchObject({ route: "agent", selectedAgentId: agentId });
+}
+
+test("reconnect applies the authoritative roster before cached event catch-up", async ({
+  page,
+  request,
+}, testInfo) => {
+  const session = sessionFor(testInfo);
+  await attachSession(page.context(), session);
+  await page.goto("/");
+  await expect.poll(async () => page.evaluate(() => window.__HOLON_E2E__?.snapshot()))
+    .toMatchObject({
+      globalStreamStatus: "streaming",
+      discovery: { mode: "authoritative", freshness: "fresh" },
+      agentIds: ["bootstrap-agent"],
+    });
+
+  const beforeDisconnect = await request.get(controlPath(session, "/__e2e__/state"))
+    .then((response) => response.json());
+  await request.post(controlPath(session, "/__e2e__/disconnect-streams"));
+  await configure(request, session, {
+    visibleAgentIds: ["bootstrap-agent", "offline-agent"],
+    ledgerEnabledAgentIds: ["offline-agent"],
+    eventsByAgentId: {
+      "offline-agent": [envelope("offline-agent", 1)],
+    },
+  });
+
+  await expect.poll(async () => page.evaluate(() => window.__HOLON_E2E__?.snapshot()))
+    .toMatchObject({
+      globalStreamStatus: "streaming",
+      discovery: { mode: "authoritative", freshness: "fresh" },
+      agentIds: ["bootstrap-agent", "offline-agent"],
+    });
+  await expect.poll(() => ledger(page, "offline-agent")).toMatchObject({
+    ingestedThroughSeq: 1,
+    projectionReadyThroughSeq: 1,
+  });
+  await expect.poll(async () => request.get(controlPath(session, "/__e2e__/state"))
+    .then((response) => response.json())
+    .then((state) => state.streamGeneration))
+    .toBeGreaterThan(beforeDisconnect.streamGeneration);
+
+  await request.post(controlPath(session, "/__e2e__/disconnect-streams"));
+  await configure(request, session, {
+    visibleAgentIds: ["offline-agent"],
+  });
+  await expect.poll(async () => page.evaluate(() => window.__HOLON_E2E__?.snapshot()))
+    .toMatchObject({
+      globalStreamStatus: "streaming",
+      discovery: { mode: "authoritative", freshness: "fresh" },
+      agentIds: ["offline-agent"],
+    });
+});
+
+test("read markers converge across tabs in one context and stay isolated across contexts", async ({
+  browser,
+  context,
+  page,
+  request,
+}, testInfo) => {
+  const session = sessionFor(testInfo);
+  const agentId = "read-agent";
+  await configure(request, session, {
+    visibleAgentIds: [agentId],
+    ledgerEnabledAgentIds: [agentId],
+    eventsByAgentId: {
+      [agentId]: [
+        envelope(agentId, 1),
+        envelope(agentId, 2, "brief_created", { brief_id: "brief-2" }),
+      ],
+    },
+    briefsById: {
+      "brief-2": brief(agentId, 2),
+      "brief-4": brief(agentId, 4),
+    },
+  });
+  await attachSession(context, session);
+
+  const sibling = await context.newPage();
+  expect(sibling.context()).toBe(page.context());
+  await sibling.goto("/");
+  await sibling.bringToFront();
+  await openAgent(sibling, agentId);
+  await expect.poll(async () => (await ledger(sibling, agentId))?.readGateDecision)
+    .toEqual({ mayAdvance: true, candidateSeq: 2 });
+  await page.goto("/");
+  await page.bringToFront();
+  await openAgent(page, agentId);
+  await expect.poll(async () => {
+    const snapshot = await ledger(page, agentId);
+    return {
+      decision: snapshot?.readGateDecision,
+      context: snapshot?.readGateContext,
+      ingestedThroughSeq: snapshot?.ingestedThroughSeq,
+      projectionReadyThroughSeq: snapshot?.projectionReadyThroughSeq,
+    };
+  }).toEqual({
+    decision: { mayAdvance: true, candidateSeq: 2 },
+    context: expect.any(Object),
+    ingestedThroughSeq: 2,
+    projectionReadyThroughSeq: 2,
+  });
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    projectionReadyThroughSeq: 2,
+    readThroughEventSeq: 2,
+  });
+  await request.post(controlPath(session, "/__e2e__/append-event"), {
+    data: { envelope: envelope(agentId, 3), broadcast: false },
+  });
+  await page.reload();
+  await openAgent(page, agentId);
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    ingestedThroughSeq: 3,
+    projectionReadyThroughSeq: 3,
+    readThroughEventSeq: 3,
+  });
+  await expect.poll(() => ledger(sibling, agentId)).toMatchObject({
+    readThroughEventSeq: 3,
+  });
+
+  await request.post(controlPath(session, "/__e2e__/append-event"), {
+    data: {
+      envelope: envelope(agentId, 4, "brief_created", { brief_id: "brief-4" }),
+      broadcast: false,
+    },
+  });
+  await sibling.reload();
+  await sibling.bringToFront();
+  await openAgent(sibling, agentId);
+  await expect.poll(() => ledger(sibling, agentId)).toMatchObject({
+    ingestedThroughSeq: 4,
+    projectionReadyThroughSeq: 4,
+    readThroughEventSeq: 4,
+  });
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    readThroughEventSeq: 4,
+  });
+
+  await page.close();
+  const reopened = await context.newPage();
+  await reopened.goto("/");
+  await expect.poll(() => ledger(reopened, agentId)).toMatchObject({
+    readThroughEventSeq: 4,
+  });
+
+  const isolatedContext = await browser.newContext();
+  try {
+    await attachSession(isolatedContext, session);
+    const isolatedPage = await isolatedContext.newPage();
+    await isolatedPage.goto("/");
+    await expect.poll(() => ledger(isolatedPage, agentId)).toMatchObject({
+      ingestedThroughSeq: 4,
+    });
+    expect((await ledger(isolatedPage, agentId))?.readThroughEventSeq).toBeUndefined();
+  } finally {
+    await isolatedContext.close();
+  }
+});
+
+test("pending hydration survives reload and close without crossing the read gate", async ({
+  context,
+  page,
+  request,
+}, testInfo) => {
+  const session = sessionFor(testInfo);
+  const agentId = "hydration-agent";
+  await configure(request, session, {
+    visibleAgentIds: [agentId],
+    ledgerEnabledAgentIds: [agentId],
+    eventsByAgentId: {
+      [agentId]: [
+        envelope(agentId, 1),
+        envelope(agentId, 2, "brief_created", { brief_id: "brief-2" }),
+        envelope(agentId, 3),
+      ],
+    },
+    briefsById: { "brief-2": brief(agentId, 2) },
+    blockedBriefIds: ["brief-2"],
+  });
+  await attachSession(context, session);
+  await page.goto("/");
+  await openAgent(page, agentId);
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    ingestedThroughSeq: 3,
+    projectionReadyThroughSeq: 1,
+    pendingHydrationJobs: 1,
+    blockedByEventSeq: 2,
+    blockedReason: "pending_hydration",
+  });
+  expect((await ledger(page, agentId))?.readThroughEventSeq).toBeUndefined();
+
+  await page.reload();
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    ingestedThroughSeq: 3,
+    projectionReadyThroughSeq: 1,
+    pendingHydrationJobs: 1,
+    blockedByEventSeq: 2,
+  });
+  expect((await ledger(page, agentId))?.readThroughEventSeq).toBeUndefined();
+
+  await page.close();
+  await request.post(controlPath(session, "/__e2e__/release-briefs"), {
+    data: { briefIds: ["brief-2"] },
+  });
+  const reopened = await context.newPage();
+  await reopened.goto("/");
+  await openAgent(reopened, agentId);
+  await expect.poll(() => ledger(reopened, agentId)).toMatchObject({
+    ingestedThroughSeq: 3,
+    projectionReadyThroughSeq: 3,
+    pendingHydrationJobs: 0,
+    failedHydrationJobs: 0,
+    readThroughEventSeq: 3,
+  });
+  await expect(reopened.getByText("Brief 2", { exact: true })).toHaveCount(1);
+});

--- a/web-gui/app/e2e/cold-start.spec.ts
+++ b/web-gui/app/e2e/cold-start.spec.ts
@@ -48,6 +48,17 @@ test("cold start bootstraps and applies a live roster event", async ({ page, req
   await expect.poll(async () => page.evaluate(() => window.__HOLON_E2E__?.snapshot().agentIds))
     .toEqual(["bootstrap-agent", "e2e-agent"]);
 
+  await expect.poll(async () => {
+    const finalRequests = await request.get(controlPath("/__e2e__/requests"))
+      .then((response) => response.json());
+    return finalRequests.requests;
+  }).toEqual(expect.arrayContaining([
+    "GET /api/agents/snapshot",
+    "GET /api/agents/e2e-agent/projection-snapshot",
+    "GET /api/agents/e2e-agent/events?after_seq=1&limit=100&order=asc",
+    "GET /api/agents/e2e-agent/events?limit=100&order=desc",
+  ]));
+
   const finalRequests = await request.get(controlPath("/__e2e__/requests"))
     .then((response) => response.json());
   expect(finalRequests.requests.filter((entry: string) => entry === "GET /api/agents/snapshot")).toHaveLength(2);
@@ -56,7 +67,7 @@ test("cold start bootstraps and applies a live roster event", async ({ page, req
     (entry: string) => entry === "GET /api/agents/e2e-agent/projection-snapshot",
   )).toHaveLength(1);
   expect(finalRequests.requests.filter(
-    (entry: string) => entry === "GET /api/agents/e2e-agent/events?after_seq=0&limit=100&order=asc",
+    (entry: string) => entry === "GET /api/agents/e2e-agent/events?after_seq=1&limit=100&order=asc",
   )).toHaveLength(1);
   expect(finalRequests.requests.filter(
     (entry: string) => entry === "GET /api/agents/e2e-agent/events?limit=100&order=desc",

--- a/web-gui/app/e2e/fixture-server.mjs
+++ b/web-gui/app/e2e/fixture-server.mjs
@@ -39,10 +39,22 @@ function sessionFor(req, url) {
       globalStreams: new Set(),
       agentStreams: new Set(),
       visibleAgentIds: ["bootstrap-agent"],
+      ledgerEnabledAgentIds: new Set(),
+      eventsByAgentId: new Map(),
+      briefsById: new Map(),
+      blockedBriefIds: new Set(),
+      streamGeneration: 0,
     };
     sessions.set(id, session);
   }
   return session;
+}
+
+async function requestBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  if (!chunks.length) return {};
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
 }
 
 function json(res, body, status = 200) {
@@ -64,6 +76,13 @@ function openEventStream(req, res, clients) {
   req.on("close", () => clients.delete(res));
 }
 
+function eventHead(session, agentId) {
+  return Math.max(
+    0,
+    ...(session.eventsByAgentId.get(agentId) ?? []).map((event) => event.event_seq),
+  );
+}
+
 function listEntry(agentId) {
   return {
     identity: {
@@ -77,30 +96,107 @@ function listEntry(agentId) {
   };
 }
 
-function rosterSnapshot(visibleAgentIds) {
+function agentState(agentId) {
+  return {
+    agent: {
+      identity: {
+        ...listEntry(agentId).identity,
+        kind: "named",
+        status: "active",
+        is_default_agent: false,
+      },
+      agent: {
+        id: agentId,
+        status: "awake_idle",
+        current_run_id: null,
+        pending: 0,
+        attached_workspaces: [],
+        turn_index: 0,
+      },
+      scheduling_posture: { posture: "idle", reason: "idle" },
+      active_task_count: 0,
+      lifecycle: { accepts_external_messages: true },
+      model: {
+        source: "runtime_default",
+        runtime_default_model: "e2e/model",
+        effective_model: "e2e/model",
+        fallback_active: false,
+      },
+      closure: { outcome: "completed", runtime_posture: "awake" },
+    },
+    session: { current_run_id: null, pending_count: 0, last_turn: null },
+    tasks: [],
+    timers: [],
+    work_items: [],
+    external_triggers: [],
+    workspace: { workspaces: [] },
+  };
+}
+
+function rosterSnapshot(session) {
   return {
     contract_version: 1,
     runtime_id: "e2e-runtime",
     event_log_epoch: "e2e-epoch",
     visibility_scope_id: "e2e-scope",
-    agents: visibleAgentIds.map((agentId) => ({
+    agents: session.visibleAgentIds.map((agentId) => ({
           agent: listEntry(agentId),
-          event_window: { event_head_seq: agentId === "e2e-agent" ? 1 : 0, oldest_retained_seq: 0 },
+          event_window: { event_head_seq: eventHead(session, agentId), oldest_retained_seq: 0 },
           latest_brief: null,
         })),
   };
 }
 
-function emptyEventPage(agentId) {
+function eventPage(session, agentId, url) {
+  const order = url.searchParams.get("order") === "desc" ? "desc" : "asc";
+  const afterSeq = Number(url.searchParams.get("after_seq") ?? 0);
+  const limit = Number(url.searchParams.get("limit") ?? 100);
+  const all = [...(session.eventsByAgentId.get(agentId) ?? [])]
+    .filter((event) => order === "desc" || event.event_seq > afterSeq)
+    .sort((left, right) =>
+      order === "desc"
+        ? right.event_seq - left.event_seq
+        : left.event_seq - right.event_seq
+    );
+  const events = all.slice(0, limit);
   return {
-    events: [],
+    events,
     event_log_epoch: "e2e-epoch",
     has_older: false,
     has_newer: false,
-    order: "asc",
-    limit: 100,
+    order,
+    limit,
     agent_id: agentId,
+    cursor_seq: eventHead(session, agentId),
+    newest_seq: eventHead(session, agentId),
+    oldest_seq: all.length ? Math.min(...all.map((event) => event.event_seq)) : null,
   };
+}
+
+function projectionSnapshot(session, agentId) {
+  return {
+    contract_version: 1,
+    runtime_id: "e2e-runtime",
+    visibility_scope_id: "e2e-scope",
+    event_log_epoch: "e2e-epoch",
+    agent_id: agentId,
+    snapshot_through_seq: 0,
+    event_head_seq: eventHead(session, agentId),
+    oldest_retained_seq: 0,
+    projection: {
+      agent: listEntry(agentId),
+      conversation: { latest_message_id: null, latest_transcript_entry_id: null },
+      current_work_item: null,
+      hydration_references: [],
+      hydration_tombstones: [],
+      latest_brief: null,
+    },
+  };
+}
+
+function writeEvent(streams, envelope) {
+  const frame = `data: ${JSON.stringify(envelope)}\n\n`;
+  for (const stream of streams) stream.write(frame);
 }
 
 async function handleControl(req, res, url) {
@@ -112,8 +208,81 @@ async function handleControl(req, res, url) {
     json(res, { requests: sessionFor(req, url).requests });
     return true;
   }
+  if (url.pathname === "/__e2e__/state") {
+    const session = sessionFor(req, url);
+    json(res, {
+      requests: session.requests,
+      visibleAgentIds: session.visibleAgentIds,
+      globalStreamCount: session.globalStreams.size,
+      agentStreamCount: session.agentStreams.size,
+      streamGeneration: session.streamGeneration,
+      blockedBriefIds: [...session.blockedBriefIds],
+    });
+    return true;
+  }
+  if (url.pathname === "/__e2e__/disconnect-streams" && req.method === "POST") {
+    const session = sessionFor(req, url);
+    for (const stream of [...session.globalStreams, ...session.agentStreams]) {
+      stream.end();
+    }
+    session.globalStreams.clear();
+    session.agentStreams.clear();
+    json(res, { disconnected: true });
+    return true;
+  }
+  if (url.pathname === "/__e2e__/configure" && req.method === "POST") {
+    const session = sessionFor(req, url);
+    const body = await requestBody(req);
+    if (Array.isArray(body.visibleAgentIds)) {
+      session.visibleAgentIds = [...body.visibleAgentIds];
+    }
+    if (Array.isArray(body.ledgerEnabledAgentIds)) {
+      session.ledgerEnabledAgentIds = new Set(body.ledgerEnabledAgentIds);
+    }
+    if (body.eventsByAgentId && typeof body.eventsByAgentId === "object") {
+      session.eventsByAgentId = new Map(
+        Object.entries(body.eventsByAgentId).map(([agentId, events]) => [
+          agentId,
+          Array.isArray(events) ? [...events] : [],
+        ]),
+      );
+    }
+    if (body.briefsById && typeof body.briefsById === "object") {
+      session.briefsById = new Map(Object.entries(body.briefsById));
+    }
+    if (Array.isArray(body.blockedBriefIds)) {
+      session.blockedBriefIds = new Set(body.blockedBriefIds);
+    }
+    json(res, { configured: true });
+    return true;
+  }
+  if (url.pathname === "/__e2e__/append-event" && req.method === "POST") {
+    const session = sessionFor(req, url);
+    const body = await requestBody(req);
+    const envelope = body.envelope;
+    if (!envelope?.agent_id || !Number.isFinite(envelope.event_seq)) {
+      json(res, { error: "append-event requires an envelope" }, 400);
+      return true;
+    }
+    const events = session.eventsByAgentId.get(envelope.agent_id) ?? [];
+    if (!events.some((event) => event.event_seq === envelope.event_seq)) {
+      events.push(envelope);
+      session.eventsByAgentId.set(envelope.agent_id, events);
+    }
+    if (body.broadcast !== false) writeEvent(session.globalStreams, envelope);
+    json(res, { appended: true });
+    return true;
+  }
+  if (url.pathname === "/__e2e__/release-briefs" && req.method === "POST") {
+    const session = sessionFor(req, url);
+    const body = await requestBody(req);
+    for (const briefId of body.briefIds ?? []) session.blockedBriefIds.delete(briefId);
+    json(res, { released: true });
+    return true;
+  }
   if (url.pathname === "/__e2e__/emit-agent" && req.method === "POST") {
-    const { globalStreams, visibleAgentIds } = sessionFor(req, url);
+    const session = sessionFor(req, url);
+    const { globalStreams, visibleAgentIds } = session;
     if (!visibleAgentIds.includes("e2e-agent")) visibleAgentIds.push("e2e-agent");
     const envelope = {
       id: "e2e-event-1",
@@ -127,15 +296,17 @@ async function handleControl(req, res, url) {
       payload_schema_version: 1,
       payload: {},
     };
-    const frame = `data: ${JSON.stringify(envelope)}\n\n`;
-    for (const stream of globalStreams) stream.write(frame);
+    const events = session.eventsByAgentId.get("e2e-agent") ?? [];
+    events.push(envelope);
+    session.eventsByAgentId.set("e2e-agent", events);
+    writeEvent(globalStreams, envelope);
     json(res, { emitted: true });
     return true;
   }
   return false;
 }
 
-function handleApi(req, res, url) {
+async function handleApi(req, res, url) {
   record(req, url);
   const session = sessionFor(req, url);
   if (url.pathname === "/api/handshake") {
@@ -147,21 +318,49 @@ function handleApi(req, res, url) {
     return true;
   }
   if (url.pathname === "/api/agents/snapshot") {
-    json(res, rosterSnapshot(session.visibleAgentIds));
+    json(res, rosterSnapshot(session));
+    return true;
+  }
+  const stateMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/state$/);
+  if (stateMatch) {
+    json(res, agentState(decodeURIComponent(stateMatch[1])));
     return true;
   }
   if (url.pathname === "/api/events/stream") {
+    session.streamGeneration += 1;
     openEventStream(req, res, session.globalStreams);
     return true;
   }
   const projectionMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/projection-snapshot$/);
   if (projectionMatch) {
+    const agentId = decodeURIComponent(projectionMatch[1]);
+    if (session.ledgerEnabledAgentIds.has(agentId)) {
+      json(res, projectionSnapshot(session, agentId));
+      return true;
+    }
     json(res, { error: "capability unavailable", code: "capability_unavailable" }, 503);
     return true;
   }
   const eventsMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/events$/);
   if (eventsMatch) {
-    json(res, emptyEventPage(decodeURIComponent(eventsMatch[1])));
+    json(res, eventPage(session, decodeURIComponent(eventsMatch[1]), url));
+    return true;
+  }
+  const briefsMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/briefs:batchGet$/);
+  if (briefsMatch && req.method === "POST") {
+    const body = await requestBody(req);
+    const briefIds = Array.isArray(body.brief_ids) ? body.brief_ids : [];
+    if (briefIds.some((briefId) => session.blockedBriefIds.has(briefId))) {
+      return true;
+    }
+    const briefs = briefIds.flatMap((briefId) => {
+      const brief = session.briefsById.get(briefId);
+      return brief ? [brief] : [];
+    });
+    json(res, {
+      briefs,
+      missing_brief_ids: briefIds.filter((briefId) => !session.briefsById.has(briefId)),
+    });
     return true;
   }
   if (/^\/api\/agents\/[^/]+\/events\/stream$/.test(url.pathname)) {
@@ -175,7 +374,9 @@ const server = http.createServer(async (req, res) => {
   const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
   if (await handleControl(req, res, url)) return;
   if (url.pathname.startsWith("/api/")) {
-    if (!handleApi(req, res, url)) json(res, { error: `unexpected fixture request: ${url.pathname}` }, 404);
+    if (!(await handleApi(req, res, url))) {
+      json(res, { error: `unexpected fixture request: ${url.pathname}` }, 404);
+    }
     return;
   }
   vite.middlewares(req, res, () => {

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -107,14 +107,32 @@ export function App() {
   const selectedAgent = useRuntimeStore(selectSelectedAgent);
   const rosterActivityByAgentId = useRuntimeStore((state) => state.rosterActivityByAgentId);
   const ledgerUnreadByAgentId = useRuntimeStore((state) => state.ledgerUnreadByAgentId);
+  const ledgerReadinessRevisionByAgentId = useRuntimeStore(
+    (state) => state.ledgerReadinessRevisionByAgentId,
+  );
+  const discoveryFreshness = useRuntimeStore((state) => state.discovery.freshness);
   const activeAgentId = route === "agent" ? selectedAgent?.id ?? selectedAgentId : undefined;
+  const activeAgentLedgerUnread = activeAgentId
+    ? ledgerUnreadByAgentId[activeAgentId]
+    : undefined;
   const sidePanelAgentId = selectedAgent?.id ?? selectedAgentId;
-  const markSelectedAgentConversationRead = useCallback(() => {
-    if (activeAgentId) markAgentConversationRead(activeAgentId);
-  }, [activeAgentId, markAgentConversationRead]);
   const selectedAgentSession = useRuntimeStore((state) =>
     sidePanelAgentId ? state.sessionsByAgentId[sidePanelAgentId] : undefined,
   );
+  const markSelectedAgentConversationRead = useCallback(() => {
+    if (activeAgentId) markAgentConversationRead(activeAgentId);
+  }, [
+    activeAgentId,
+    activeAgentLedgerUnread,
+    discoveryFreshness,
+    activeAgentId ? ledgerReadinessRevisionByAgentId[activeAgentId] : undefined,
+    markAgentConversationRead,
+    selectedAgentSession?.briefHydrationById,
+    selectedAgentSession?.gaps.length,
+    selectedAgentSession?.liveStatus,
+    selectedAgentSession?.loading,
+    selectedAgentSession?.syncStatus,
+  ]);
   const selectedAgentTimelineEvents = useRuntimeStore((state) =>
     sidePanelAgentId ? state.timelineEventsByAgentId[sidePanelAgentId] : undefined,
   );

--- a/web-gui/app/src/e2e/diagnostics-bridge.ts
+++ b/web-gui/app/src/e2e/diagnostics-bridge.ts
@@ -1,4 +1,19 @@
-import { useRuntimeStore } from "../runtime/runtime-store";
+import {
+  ledgerReadMarkerDecision,
+  useRuntimeStore,
+} from "../runtime/runtime-store";
+import {
+  AGENT_SESSIONS_STORE,
+  LEDGER_DB_NAME,
+  LEDGER_DB_VERSION,
+  PENDING_HYDRATION_STORE,
+  READ_STATES_STORE,
+} from "../runtime/event-ledger/db";
+import type {
+  LedgerAgentSessionRecord,
+  LedgerHydrationJobRecord,
+  LedgerReadStateRecord,
+} from "../runtime/event-ledger/ledger";
 
 export interface HolonE2eSnapshot {
   route: string;
@@ -19,7 +34,36 @@ export interface HolonE2eSnapshot {
 
 export interface HolonE2eDiagnostics {
   snapshot(): HolonE2eSnapshot;
+  ledger(agentId: string): Promise<HolonE2eLedgerSnapshot | null>;
   subscribe(listener: (snapshot: HolonE2eSnapshot) => void): () => void;
+}
+
+export interface HolonE2eLedgerSnapshot {
+  agentId: string;
+  ingestedThroughSeq: number;
+  projectionReadyThroughSeq: number;
+  pendingHydrationJobs: number;
+  failedHydrationJobs: number;
+  blockedByEventSeq?: number;
+  blockedReason?: "pending_hydration";
+  readThroughEventSeq?: number;
+  unreadCount?: number;
+  readGateDecision: {
+    mayAdvance: boolean;
+    candidateSeq?: number;
+    reason?: string;
+  };
+  readGateContext: {
+    route: string;
+    selectedAgentId: string;
+    documentVisible: boolean;
+    discoveryFreshness: string;
+    sessionLoading?: boolean;
+    sessionSyncStatus?: string;
+    sessionLiveStatus?: string;
+    sessionGapCount?: number;
+    pendingProjectionHydrationCount?: number;
+  };
 }
 
 declare global {
@@ -48,8 +92,80 @@ function snapshot(): HolonE2eSnapshot {
   };
 }
 
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function ledgerSnapshot(agentId: string): Promise<HolonE2eLedgerSnapshot | null> {
+  const db = await requestResult(indexedDB.open(LEDGER_DB_NAME, LEDGER_DB_VERSION));
+  try {
+    const transaction = db.transaction(
+      [AGENT_SESSIONS_STORE, PENDING_HYDRATION_STORE, READ_STATES_STORE],
+      "readonly",
+    );
+    const sessions = await requestResult(
+      transaction.objectStore(AGENT_SESSIONS_STORE).getAll(),
+    ) as LedgerAgentSessionRecord[];
+    const session = sessions
+      .filter((candidate) => candidate.agentId === agentId)
+      .sort((left, right) => right.updatedAt - left.updatedAt)[0];
+    if (!session) return null;
+    const scope = [
+      session.remoteKey,
+      session.runtimeId,
+      session.visibilityScopeId,
+      session.eventLogEpoch,
+      session.agentId,
+    ];
+    const jobs = await requestResult(
+      transaction.objectStore(PENDING_HYDRATION_STORE).index("byScope").getAll(scope),
+    ) as LedgerHydrationJobRecord[];
+    const readState = await requestResult(
+      transaction.objectStore(READ_STATES_STORE).get(scope),
+    ) as LedgerReadStateRecord | undefined;
+    const pending = jobs.filter((job) => job.state !== "failed");
+    const storeState = useRuntimeStore.getState();
+    const runtimeSession = storeState.sessionsByAgentId[agentId];
+    return {
+      agentId,
+      ingestedThroughSeq: session.ingestedThroughSeq ?? 0,
+      projectionReadyThroughSeq: session.projectionReadyThroughSeq ?? 0,
+      pendingHydrationJobs: pending.length,
+      failedHydrationJobs: jobs.length - pending.length,
+      blockedByEventSeq: pending.length
+        ? Math.min(...pending.map((job) => job.createdByEventSeq))
+        : undefined,
+      blockedReason: pending.length ? "pending_hydration" : undefined,
+      readThroughEventSeq: readState?.readThroughEventSeq,
+      unreadCount: storeState.ledgerUnreadByAgentId[agentId]?.count,
+      readGateDecision: ledgerReadMarkerDecision(agentId),
+      readGateContext: {
+        route: storeState.route,
+        selectedAgentId: storeState.selectedAgentId,
+        documentVisible: document.visibilityState === "visible",
+        discoveryFreshness: storeState.discovery.freshness,
+        sessionLoading: runtimeSession?.loading,
+        sessionSyncStatus: runtimeSession?.syncStatus,
+        sessionLiveStatus: runtimeSession?.liveStatus,
+        sessionGapCount: runtimeSession?.gaps.length,
+        pendingProjectionHydrationCount: runtimeSession
+          ? Object.values(runtimeSession.briefHydrationById).filter(
+            (hydration) => hydration.status === "loading",
+          ).length
+          : undefined,
+      },
+    };
+  } finally {
+    db.close();
+  }
+}
+
 window.__HOLON_E2E__ = Object.freeze({
   snapshot,
+  ledger: ledgerSnapshot,
   subscribe(listener: (value: HolonE2eSnapshot) => void) {
     return useRuntimeStore.subscribe(() => listener(snapshot()));
   },

--- a/web-gui/app/src/runtime/agent-session-repository.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.ts
@@ -563,6 +563,7 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
   sessionLedgerReadiness(agentId: string): {
     readyThroughSeq: number;
     ingestedThroughSeq: number;
+    observedHeadSeq?: number;
     blockedByEventSeq?: number;
     blockedReason?: "pending_hydration" | "unknown_envelope_version";
   } | null {

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
@@ -111,6 +111,35 @@ describe("ledger ingestion pipeline", () => {
     ledger.close();
   });
 
+  it("never reloads an observed head behind the persisted contiguous cursor", async () => {
+    const scope = makeScope();
+    const ledger = await openLedgerHandle();
+    await ledger
+      .beginWrite()
+      .advanceIngestionCursor(scope, 2)
+      .applyProjectionChange(scope, { projectionReadyThroughSeq: 2 })
+      .putRuntimeScope(
+        {
+          remoteKey: scope.remoteKey,
+          runtimeId: scope.runtimeId,
+          visibilityScopeId: scope.visibilityScopeId,
+          eventLogEpoch: scope.eventLogEpoch,
+        },
+        { eventHeadSeq: 0 },
+      )
+      .commit();
+    ledger.close();
+
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+
+    expect(await pipeline.resume(scope)).toMatchObject({
+      ingestedThroughSeq: 2,
+      projectionReadyThroughSeq: 2,
+      observedEventHeadSeq: 2,
+    });
+  });
+
   it("keeps the contiguous cursor behind out-of-order gaps", async () => {
     const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
     await pipeline.open();

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
@@ -943,6 +943,7 @@ export class LedgerIngestionPipeline {
   ): {
     readyThroughSeq: number;
     ingestedThroughSeq: number;
+    observedHeadSeq?: number;
     blockedByEventSeq?: number;
     blockedReason?: "pending_hydration" | "unknown_envelope_version";
   } {
@@ -954,6 +955,7 @@ export class LedgerIngestionPipeline {
     return {
       readyThroughSeq: tracker.readyThrough,
       ingestedThroughSeq: tracker.contiguousThrough,
+      observedHeadSeq: Math.max(tracker.observedHead, tracker.contiguousThrough) || undefined,
       blockedByEventSeq: Number.isFinite(blockedSeq) ? blockedSeq : undefined,
       blockedReason: blocker?.kind,
     };
@@ -985,7 +987,13 @@ export class LedgerIngestionPipeline {
       session?.projectionReadyThroughSeq ?? 0,
       tracker.contiguousThrough,
     );
-    tracker.observedHead = runtimeScope?.eventHeadSeq ?? tracker.contiguousThrough;
+    // These records are read independently, so another tab may commit between
+    // the two reads. A persisted contiguous cursor is itself proof that the
+    // observed head reached at least that sequence.
+    tracker.observedHead = Math.max(
+      runtimeScope?.eventHeadSeq ?? 0,
+      tracker.contiguousThrough,
+    );
     for (const job of jobs) {
       const view = this.jobViewFromRecord(job);
       tracker.jobs.set(view.jobId, view);
@@ -1162,13 +1170,17 @@ export class LedgerIngestionPipeline {
     const durability: LedgerDurability = this.ledger?.durability ?? "memory_only";
     const state: LedgerIngestionState =
       durability !== "exact" ? "memory_only" : tracker.state;
+    const observedHead = Math.max(
+      tracker.observedHead,
+      tracker.contiguousThrough,
+    );
     return {
       scope,
       durability,
       state,
       ingestedThroughSeq: tracker.contiguousThrough || undefined,
       projectionReadyThroughSeq: tracker.readyThrough || undefined,
-      observedEventHeadSeq: tracker.observedHead || undefined,
+      observedEventHeadSeq: observedHead || undefined,
       pendingHydrationJobs: pendingJobs,
       failedHydrationJobs: failedJobs,
       blockedByEventSeq: Number.isFinite(blockedSeq) ? blockedSeq : undefined,

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -369,6 +369,8 @@ export interface RuntimeStoreState {
   rosterActivityByAgentId: Record<string, AgentRosterActivity>;
   /** Ledger-backed unread views (W5); absent entries use the legacy path. */
   ledgerUnreadByAgentId: Record<string, LedgerUnreadView>;
+  /** Monotonic signal for durable ledger readiness transitions. */
+  ledgerReadinessRevisionByAgentId: Record<string, number>;
   sessionsByAgentId: Record<string, AgentSessionState>;
   skillInstallJobs: SkillInstallJob[];
   resumeRevision: number;
@@ -1210,6 +1212,23 @@ async function refreshLedgerUnreadInView(agentId: string): Promise<void> {
   }
 }
 
+export function ledgerReadMarkerDecision(agentId: string) {
+  const state = useRuntimeStore.getState();
+  const readiness = agentSessionRepository.sessionLedgerReadiness(agentId);
+  return evaluateLedgerReadMarkerGate(
+    {
+      route: state.route,
+      selectedAgentId: state.selectedAgentId,
+      documentVisible:
+        typeof document !== "undefined" && document.visibilityState === "visible",
+      session: state.sessionsByAgentId[agentId],
+      discoveryFresh: state.discovery.freshness === "fresh",
+      readiness,
+    },
+    agentId,
+  );
+}
+
 export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
   agentSessionRepository = new AgentSessionRepository<RuntimeStoreState>({
     get,
@@ -1376,6 +1395,13 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
       },
       onStatus: (status) => {
         // W5: unread counts refresh from durable readiness transitions.
+        set((state) => ({
+          ledgerReadinessRevisionByAgentId: {
+            ...state.ledgerReadinessRevisionByAgentId,
+            [status.scope.agentId]:
+              (state.ledgerReadinessRevisionByAgentId[status.scope.agentId] ?? 0) + 1,
+          },
+        }));
         void refreshLedgerUnreadInView(status.scope.agentId);
       },
     },
@@ -1436,6 +1462,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
   codexDeviceLogin: { status: "idle" as const },
   rosterActivityByAgentId: readStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig)),
   ledgerUnreadByAgentId: {},
+  ledgerReadinessRevisionByAgentId: {},
   sessionsByAgentId: {},
   skillInstallJobs: loadSkillInstallJobs(),
   resumeRevision: 0,
@@ -1471,28 +1498,10 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
     }),
   markAgentConversationRead: (agentId) => {
     const state = get();
-    const context = {
-      route: state.route,
-      selectedAgentId: state.selectedAgentId,
-      documentVisible:
-        typeof document !== "undefined" && document.visibilityState === "visible",
-    };
     if (agentSessionRepository.knownLedgerScope(agentId)) {
       // Ledger-backed path (W5): the durable marker is the only read state;
       // the legacy roster activity no longer tracks this agent.
-      const status = agentSessionRepository.sessionLedgerStatus(agentId);
-      const readiness = agentSessionRepository.sessionLedgerReadiness(agentId);
-      const decision = evaluateLedgerReadMarkerGate(
-        {
-          ...context,
-          session: state.sessionsByAgentId[agentId],
-          discoveryFresh: state.discovery.freshness === "fresh",
-          readiness: readiness
-            ? { ...readiness, observedHeadSeq: status?.observedEventHeadSeq }
-            : null,
-        },
-        agentId,
-      );
+      const decision = ledgerReadMarkerDecision(agentId);
       if (decision.mayAdvance && decision.candidateSeq != null) {
         const candidateSeq = decision.candidateSeq;
         void agentSessionRepository
@@ -1511,7 +1520,10 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
     // Legacy in-memory path: remotes without the ledger capability.
     const session = state.sessionsByAgentId[agentId];
     if (!session || !canMarkConversationRead({
-      ...context,
+      route: state.route,
+      selectedAgentId: state.selectedAgentId,
+      documentVisible:
+        typeof document !== "undefined" && document.visibilityState === "visible",
       session,
     }, agentId)) {
       return;


### PR DESCRIPTION
## Summary

- add deterministic Chromium coverage for offline/reconnect authoritative roster ordering and cached catch-up
- verify read-marker monotonic convergence through real IndexedDB/BroadcastChannel across two tabs, with browser-context isolation
- verify pending hydration recovery across reload/page close, UI deduplication, projection readiness, and hydration read gating
- extend the session-scoped fixture and read-only E2E diagnostics only as needed for these lifecycle scenarios

## Verification

- `npm test` — 39 files, 443 tests passed
- `npm run test:e2e:production-bundle` — typecheck, production build, and bridge exclusion passed
- `npm run test:e2e` — complete Chromium suite passed
- `npx playwright test e2e/browser-lifecycle.spec.ts --repeat-each=20 --workers=1` — 60/60 passed
