### PR TITLE
test: cover web sync reset boundaries

### DIFF
--- a/web-gui/app/e2e/browser-lifecycle.spec.ts
+++ b/web-gui/app/e2e/browser-lifecycle.spec.ts
@@ -36,7 +36,8 @@ interface LedgerSnapshot {
 }
 
 function sessionFor(testInfo: TestInfo): string {
-  return `${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${testInfo.retry}`;
+  const testCase = testInfo.testId.replace(/[^a-zA-Z0-9_-]/g, "-");
+  return `${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${testInfo.retry}-${testCase}`;
 }
 
 function controlPath(session: string, path: string): string {

--- a/web-gui/app/e2e/fixture-server.mjs
+++ b/web-gui/app/e2e/fixture-server.mjs
@@ -44,6 +44,12 @@ function sessionFor(req, url) {
       briefsById: new Map(),
       blockedBriefIds: new Set(),
       streamGeneration: 0,
+      runtimeId: "e2e-runtime",
+      eventLogEpoch: "e2e-epoch",
+      visibilityScopeId: "e2e-scope",
+      oldestRetainedSeqByAgentId: new Map(),
+      snapshotThroughSeqByAgentId: new Map(),
+      projectionLatestBriefByAgentId: new Map(),
     };
     sessions.set(id, session);
   }
@@ -136,12 +142,15 @@ function agentState(agentId) {
 function rosterSnapshot(session) {
   return {
     contract_version: 1,
-    runtime_id: "e2e-runtime",
-    event_log_epoch: "e2e-epoch",
-    visibility_scope_id: "e2e-scope",
+    runtime_id: session.runtimeId,
+    event_log_epoch: session.eventLogEpoch,
+    visibility_scope_id: session.visibilityScopeId,
     agents: session.visibleAgentIds.map((agentId) => ({
           agent: listEntry(agentId),
-          event_window: { event_head_seq: eventHead(session, agentId), oldest_retained_seq: 0 },
+          event_window: {
+            event_head_seq: eventHead(session, agentId),
+            oldest_retained_seq: session.oldestRetainedSeqByAgentId.get(agentId) ?? 0,
+          },
           latest_brief: null,
         })),
   };
@@ -161,7 +170,7 @@ function eventPage(session, agentId, url) {
   const events = all.slice(0, limit);
   return {
     events,
-    event_log_epoch: "e2e-epoch",
+    event_log_epoch: session.eventLogEpoch,
     has_older: false,
     has_newer: false,
     order,
@@ -169,27 +178,30 @@ function eventPage(session, agentId, url) {
     agent_id: agentId,
     cursor_seq: eventHead(session, agentId),
     newest_seq: eventHead(session, agentId),
-    oldest_seq: all.length ? Math.min(...all.map((event) => event.event_seq)) : null,
+    oldest_seq: session.oldestRetainedSeqByAgentId.get(agentId)
+      ?? (all.length ? Math.min(...all.map((event) => event.event_seq)) : null),
   };
 }
 
 function projectionSnapshot(session, agentId) {
+  const snapshotThroughSeq =
+    session.snapshotThroughSeqByAgentId.get(agentId) ?? 0;
   return {
     contract_version: 1,
-    runtime_id: "e2e-runtime",
-    visibility_scope_id: "e2e-scope",
-    event_log_epoch: "e2e-epoch",
+    runtime_id: session.runtimeId,
+    visibility_scope_id: session.visibilityScopeId,
+    event_log_epoch: session.eventLogEpoch,
     agent_id: agentId,
-    snapshot_through_seq: 0,
+    snapshot_through_seq: snapshotThroughSeq,
     event_head_seq: eventHead(session, agentId),
-    oldest_retained_seq: 0,
+    oldest_retained_seq: session.oldestRetainedSeqByAgentId.get(agentId) ?? 0,
     projection: {
       agent: listEntry(agentId),
       conversation: { latest_message_id: null, latest_transcript_entry_id: null },
       current_work_item: null,
       hydration_references: [],
       hydration_tombstones: [],
-      latest_brief: null,
+      latest_brief: session.projectionLatestBriefByAgentId.get(agentId) ?? null,
     },
   };
 }
@@ -217,6 +229,9 @@ async function handleControl(req, res, url) {
       agentStreamCount: session.agentStreams.size,
       streamGeneration: session.streamGeneration,
       blockedBriefIds: [...session.blockedBriefIds],
+      runtimeId: session.runtimeId,
+      eventLogEpoch: session.eventLogEpoch,
+      visibilityScopeId: session.visibilityScopeId,
     });
     return true;
   }
@@ -252,6 +267,26 @@ async function handleControl(req, res, url) {
     }
     if (Array.isArray(body.blockedBriefIds)) {
       session.blockedBriefIds = new Set(body.blockedBriefIds);
+    }
+    if (typeof body.runtimeId === "string") session.runtimeId = body.runtimeId;
+    if (typeof body.eventLogEpoch === "string") session.eventLogEpoch = body.eventLogEpoch;
+    if (typeof body.visibilityScopeId === "string") {
+      session.visibilityScopeId = body.visibilityScopeId;
+    }
+    if (body.oldestRetainedSeqByAgentId && typeof body.oldestRetainedSeqByAgentId === "object") {
+      session.oldestRetainedSeqByAgentId = new Map(
+        Object.entries(body.oldestRetainedSeqByAgentId),
+      );
+    }
+    if (body.snapshotThroughSeqByAgentId && typeof body.snapshotThroughSeqByAgentId === "object") {
+      session.snapshotThroughSeqByAgentId = new Map(
+        Object.entries(body.snapshotThroughSeqByAgentId),
+      );
+    }
+    if (body.projectionLatestBriefByAgentId && typeof body.projectionLatestBriefByAgentId === "object") {
+      session.projectionLatestBriefByAgentId = new Map(
+        Object.entries(body.projectionLatestBriefByAgentId),
+      );
     }
     json(res, { configured: true });
     return true;

--- a/web-gui/app/e2e/reset-scope.spec.ts
+++ b/web-gui/app/e2e/reset-scope.spec.ts
@@ -1,0 +1,558 @@
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type BrowserContext,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+
+interface LedgerSnapshot {
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  durability: string;
+  ingestionState: string;
+  ingestionError?: string;
+  ingestedThroughSeq: number;
+  projectionReadyThroughSeq: number;
+  pendingHydrationJobs: number;
+  failedHydrationJobs: number;
+  readThroughEventSeq?: number;
+  certainty?: "exact" | "truncated";
+  historyTruncatedBeforeSeq?: number;
+  acknowledgedTruncationBeforeSeq?: number;
+}
+
+interface LedgerPartition {
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  eventSeqs: number[];
+  readThroughEventSeq?: number;
+  certainty?: "exact" | "truncated";
+}
+
+interface LedgerStatus {
+  durability: string;
+  ingestionState: string;
+  ingestionError?: string;
+}
+
+function sessionFor(testInfo: TestInfo): string {
+  const testCase = testInfo.testId.replace(/[^a-zA-Z0-9_-]/g, "-");
+  return `${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${testInfo.retry}-${testCase}`;
+}
+
+function controlPath(session: string, path: string): string {
+  return `${path}?session=${encodeURIComponent(session)}`;
+}
+
+async function attachSession(context: BrowserContext, session: string): Promise<void> {
+  await context.addCookies([{
+    name: "holon_e2e_session",
+    value: session,
+    domain: "127.0.0.1",
+    path: "/",
+  }]);
+}
+
+async function configure(
+  request: APIRequestContext,
+  session: string,
+  body: Record<string, unknown>,
+): Promise<void> {
+  const response = await request.post(controlPath(session, "/__e2e__/configure"), { data: body });
+  expect(response.ok()).toBe(true);
+}
+
+function envelope(
+  agentId: string,
+  eventSeq: number,
+  eventLogEpoch = "e2e-epoch",
+  type = "agent_state_changed",
+  payload: Record<string, unknown> = {},
+) {
+  return {
+    id: `${agentId}-${eventLogEpoch}-event-${eventSeq}`,
+    event_seq: eventSeq,
+    event_log_epoch: eventLogEpoch,
+    contract_version: 2,
+    ts: `2026-08-25T00:00:${String(eventSeq).padStart(2, "0")}Z`,
+    agent_id: agentId,
+    type,
+    payload_schema: `holon.runtime_event.${type}`,
+    payload_schema_version: 1,
+    payload,
+  };
+}
+
+function latestBrief(briefId: string, eventSeq: number) {
+  return {
+    brief_id: briefId,
+    created_at: `2026-08-25T00:00:${String(eventSeq).padStart(2, "0")}Z`,
+    created_event_seq: eventSeq,
+    preview: `Brief ${eventSeq}`,
+  };
+}
+
+async function ledger(page: Page, agentId: string): Promise<LedgerSnapshot | null> {
+  return page.evaluate((id) => window.__HOLON_E2E__?.ledger(id) ?? null, agentId);
+}
+
+async function ledgerStatus(page: Page, agentId: string): Promise<LedgerStatus | null> {
+  return page.evaluate((id) => window.__HOLON_E2E__?.ledgerStatus(id) ?? null, agentId);
+}
+
+async function partitions(page: Page, agentId: string): Promise<LedgerPartition[]> {
+  return page.evaluate(
+    (id) => window.__HOLON_E2E__?.ledgerPartitions(id) ?? [],
+    agentId,
+  );
+}
+
+async function openAgent(page: Page, agentId: string): Promise<void> {
+  const agentButton = page.getByRole("region", { name: "agents" })
+    .getByRole("button")
+    .filter({ hasText: agentId });
+  await expect(agentButton).toBeVisible();
+  await agentButton.click();
+  await expect.poll(async () => (await ledger(page, agentId))?.readGateContext)
+    .toMatchObject({ route: "agent", selectedAgentId: agentId });
+}
+
+async function briefFetchCount(
+  request: APIRequestContext,
+  session: string,
+  agentId: string,
+): Promise<number> {
+  const response = await request.get(controlPath(session, "/__e2e__/requests"));
+  expect(response.ok()).toBe(true);
+  const body = await response.json() as { requests: string[] };
+  return body.requests.filter(
+    (entry) => entry === `POST /api/agents/${agentId}/briefs:batchGet`,
+  ).length;
+}
+
+async function globalStreamCount(
+  request: APIRequestContext,
+  session: string,
+): Promise<number> {
+  const response = await request.get(controlPath(session, "/__e2e__/state"));
+  expect(response.ok()).toBe(true);
+  const body = await response.json() as { globalStreamCount: number };
+  return body.globalStreamCount;
+}
+
+async function hydrationAttemptCount(page: Page, agentId: string): Promise<number | null> {
+  return page.evaluate(async (id) => {
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open("holon.webGui.eventLedger.v1");
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    try {
+      const records = await new Promise<Array<{ agentId?: string; attemptCount?: number }>>(
+        (resolve, reject) => {
+          const request = database
+            .transaction("pending_hydration", "readonly")
+            .objectStore("pending_hydration")
+            .getAll();
+          request.onsuccess = () => resolve(request.result);
+          request.onerror = () => reject(request.error);
+        },
+      );
+      const attempts = records
+        .filter((record) => record.agentId === id)
+        .map((record) => record.attemptCount ?? 0);
+      return attempts.length > 0 ? Math.max(...attempts) : null;
+    } finally {
+      database.close();
+    }
+  }, agentId);
+}
+
+async function driveHydrationUntil(
+  page: Page,
+  request: APIRequestContext,
+  session: string,
+  agentId: string,
+  terminal: (snapshot: LedgerSnapshot | null) => boolean,
+): Promise<void> {
+  for (let attempt = 0; attempt < 16; attempt += 1) {
+    if (terminal(await ledger(page, agentId))) return;
+    const beforeAttemptCount = await hydrationAttemptCount(page, agentId);
+    await page.reload();
+    await expect.poll(async () => {
+      if (terminal(await ledger(page, agentId))) return true;
+      const currentAttemptCount = await hydrationAttemptCount(page, agentId);
+      return currentAttemptCount !== null &&
+        currentAttemptCount > (beforeAttemptCount ?? -1);
+    }).toBe(true);
+  }
+  const finalSnapshot = await ledger(page, agentId);
+  const finalBriefFetchCount = await briefFetchCount(request, session, agentId);
+  expect(
+    terminal(finalSnapshot),
+    JSON.stringify({ finalSnapshot, finalBriefFetchCount }, null, 2),
+  ).toBe(true);
+}
+
+test("retention reset is truncated until acknowledgement opens a new exact generation", async ({
+  context,
+  page,
+  request,
+}, testInfo) => {
+  const session = sessionFor(testInfo);
+  const agentId = "retention-agent";
+  await configure(request, session, {
+    visibleAgentIds: [agentId],
+    ledgerEnabledAgentIds: [agentId],
+    eventsByAgentId: {
+      [agentId]: [1, 2, 3, 4, 5].map((seq) => envelope(agentId, seq)),
+    },
+  });
+  await attachSession(context, session);
+  await page.goto("/");
+  await openAgent(page, agentId);
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    ingestedThroughSeq: 5,
+    projectionReadyThroughSeq: 5,
+    readThroughEventSeq: 5,
+    certainty: "exact",
+  });
+
+  await configure(request, session, {
+    eventsByAgentId: { [agentId]: [envelope(agentId, 8)] },
+    oldestRetainedSeqByAgentId: { [agentId]: 7 },
+    snapshotThroughSeqByAgentId: { [agentId]: 8 },
+  });
+  await request.post(controlPath(session, "/__e2e__/disconnect-streams"));
+
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    ingestedThroughSeq: 8,
+    projectionReadyThroughSeq: 8,
+    certainty: "truncated",
+    historyTruncatedBeforeSeq: 7,
+  });
+  await expect(
+    page.getByRole("region", { name: "Agent conversation" }).getByRole("status"),
+  ).toContainText("Some earlier history");
+  await page.getByRole("button", { name: "Acknowledge earlier history" }).click();
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    certainty: "exact",
+    historyTruncatedBeforeSeq: 7,
+    acknowledgedTruncationBeforeSeq: 8,
+  });
+  await expect(page.getByRole("button", { name: "Acknowledge earlier history" })).toHaveCount(0);
+});
+
+test("event log epoch replacement clears the old projection and read partition", async ({
+  context,
+  page,
+  request,
+}, testInfo) => {
+  const session = sessionFor(testInfo);
+  const agentId = "epoch-agent";
+  await configure(request, session, {
+    eventLogEpoch: "epoch-before",
+    visibleAgentIds: [agentId],
+    ledgerEnabledAgentIds: [agentId],
+    eventsByAgentId: {
+      [agentId]: [
+        envelope(agentId, 1, "epoch-before"),
+        envelope(agentId, 2, "epoch-before"),
+      ],
+    },
+  });
+  await attachSession(context, session);
+  await page.goto("/");
+  await openAgent(page, agentId);
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    eventLogEpoch: "epoch-before",
+    ingestedThroughSeq: 2,
+    projectionReadyThroughSeq: 2,
+    readThroughEventSeq: 2,
+    certainty: "exact",
+  });
+
+  await configure(request, session, {
+    eventLogEpoch: "epoch-after",
+    eventsByAgentId: {
+      [agentId]: [
+        envelope(agentId, 1, "epoch-after"),
+        envelope(agentId, 2, "epoch-after"),
+        envelope(agentId, 3, "epoch-after"),
+      ],
+    },
+  });
+  await request.post(controlPath(session, "/__e2e__/disconnect-streams"));
+
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    eventLogEpoch: "epoch-after",
+    ingestedThroughSeq: 3,
+    projectionReadyThroughSeq: 3,
+    readThroughEventSeq: 3,
+    certainty: "exact",
+  });
+  await expect.poll(() => partitions(page, agentId)).toEqual([{
+    runtimeId: "e2e-runtime",
+    visibilityScopeId: "e2e-scope",
+    eventLogEpoch: "epoch-after",
+    eventSeqs: [1, 2, 3],
+    readThroughEventSeq: 3,
+    certainty: "exact",
+  }]);
+});
+
+test("visibility scope rotation clears the old auth-scoped partition", async ({
+  context,
+  page,
+  request,
+}, testInfo) => {
+  const session = sessionFor(testInfo);
+  const agentId = "scope-agent";
+  await configure(request, session, {
+    visibilityScopeId: "scope-before",
+    visibleAgentIds: [agentId],
+    ledgerEnabledAgentIds: [agentId],
+    eventsByAgentId: {
+      [agentId]: [envelope(agentId, 1), envelope(agentId, 2)],
+    },
+  });
+  await attachSession(context, session);
+  await page.goto("/");
+  await openAgent(page, agentId);
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    visibilityScopeId: "scope-before",
+    ingestedThroughSeq: 2,
+    projectionReadyThroughSeq: 2,
+    readThroughEventSeq: 2,
+    certainty: "exact",
+  });
+
+  await configure(request, session, {
+    visibilityScopeId: "scope-after",
+    eventsByAgentId: {
+      [agentId]: [envelope(agentId, 1), envelope(agentId, 2), envelope(agentId, 3)],
+    },
+  });
+  await request.post(controlPath(session, "/__e2e__/disconnect-streams"));
+
+  await expect.poll(() => ledger(page, agentId)).toMatchObject({
+    visibilityScopeId: "scope-after",
+    ingestedThroughSeq: 3,
+    projectionReadyThroughSeq: 3,
+    readThroughEventSeq: 3,
+    certainty: "exact",
+  });
+  await expect.poll(() => partitions(page, agentId)).toEqual([{
+    runtimeId: "e2e-runtime",
+    visibilityScopeId: "scope-after",
+    eventLogEpoch: "e2e-epoch",
+    eventSeqs: [1, 2, 3],
+    readThroughEventSeq: 3,
+    certainty: "exact",
+  }]);
+});
+
+test("divergence repair, sync error, and degraded handle recovery preserve exactness", async ({
+  context,
+  page,
+  request,
+}, testInfo) => {
+  const session = sessionFor(testInfo);
+  const repairAgentId = "repair-agent";
+  const errorAgentId = "error-agent";
+  const degradedAgentId = "degraded-agent";
+  const repairEvent = envelope(
+    repairAgentId,
+    2,
+    "e2e-epoch",
+    "brief_created",
+    { brief_id: "repair-brief" },
+  );
+  const errorEventA = envelope(
+    errorAgentId,
+    2,
+    "e2e-epoch",
+    "brief_created",
+    { brief_id: "error-brief-a" },
+  );
+  const errorEventB = envelope(
+    errorAgentId,
+    3,
+    "e2e-epoch",
+    "brief_created",
+    { brief_id: "error-brief-b" },
+  );
+  await configure(request, session, {
+    visibleAgentIds: [repairAgentId, errorAgentId, degradedAgentId],
+    ledgerEnabledAgentIds: [repairAgentId, errorAgentId, degradedAgentId],
+    eventsByAgentId: {
+      [repairAgentId]: [envelope(repairAgentId, 1), repairEvent],
+      [errorAgentId]: [envelope(errorAgentId, 1), errorEventA, errorEventB],
+      [degradedAgentId]: [envelope(degradedAgentId, 1), envelope(degradedAgentId, 2)],
+    },
+    snapshotThroughSeqByAgentId: {
+      [repairAgentId]: 0,
+      [errorAgentId]: 0,
+      [degradedAgentId]: 0,
+    },
+  });
+  await attachSession(context, session);
+  await page.goto("/");
+
+  await openAgent(page, repairAgentId);
+  await expect.poll(() => briefFetchCount(request, session, repairAgentId))
+    .toBeGreaterThanOrEqual(1);
+  await configure(request, session, {
+    snapshotThroughSeqByAgentId: {
+      [repairAgentId]: 2,
+      [errorAgentId]: 2,
+      [degradedAgentId]: 0,
+    },
+    projectionLatestBriefByAgentId: {
+      [repairAgentId]: latestBrief("repair-brief", 2),
+    },
+  });
+  await driveHydrationUntil(
+    page,
+    request,
+    session,
+    repairAgentId,
+    (snapshot) => snapshot?.ingestionState === "idle" &&
+      snapshot.projectionReadyThroughSeq === 2,
+  );
+  await expect.poll(() => ledger(page, repairAgentId)).toMatchObject({
+    durability: "exact",
+    ingestionState: "idle",
+    ingestedThroughSeq: 2,
+    projectionReadyThroughSeq: 2,
+    pendingHydrationJobs: 0,
+    failedHydrationJobs: 0,
+  });
+
+  await openAgent(page, errorAgentId);
+  await expect.poll(() => briefFetchCount(request, session, errorAgentId))
+    .toBeGreaterThanOrEqual(1);
+  await driveHydrationUntil(
+    page,
+    request,
+    session,
+    errorAgentId,
+    (snapshot) => snapshot?.ingestionState === "sync_error",
+  );
+  await expect.poll(() => ledger(page, errorAgentId)).toMatchObject({
+    durability: "exact",
+    ingestionState: "sync_error",
+    ingestionError: "hydration_diverged_after_snapshot_repair",
+    ingestedThroughSeq: 3,
+    projectionReadyThroughSeq: 2,
+    pendingHydrationJobs: 0,
+    failedHydrationJobs: 1,
+  });
+
+  await openAgent(page, degradedAgentId);
+  await expect.poll(() => ledger(page, degradedAgentId)).toMatchObject({
+    durability: "exact",
+    ingestedThroughSeq: 2,
+    projectionReadyThroughSeq: 2,
+  });
+  await page.evaluate(() => {
+    const originalPut = IDBObjectStore.prototype.put;
+    const originalOpen = indexedDB.open.bind(indexedDB);
+    const ownOpenDescriptor = Object.getOwnPropertyDescriptor(indexedDB, "open");
+    let armed = true;
+    let abortedWrites = 0;
+    let rejectedReopens = 0;
+    IDBObjectStore.prototype.put = function (...args) {
+      const request = originalPut.apply(this, args);
+      if (armed && this.name === "raw_events") {
+        armed = false;
+        abortedWrites += 1;
+        this.transaction.abort();
+      }
+      return request;
+    };
+    Object.defineProperty(indexedDB, "open", {
+      configurable: true,
+      value: (...args: Parameters<IDBFactory["open"]>) => {
+        if (!armed) {
+          rejectedReopens += 1;
+          throw new DOMException("Injected ledger reopen failure", "AbortError");
+        }
+        return originalOpen(...args);
+      },
+    });
+    Object.defineProperty(window, "__HOLON_E2E_LEDGER_ABORTED_WRITES__", {
+      configurable: true,
+      get: () => abortedWrites,
+    });
+    Object.defineProperty(window, "__HOLON_E2E_LEDGER_REOPEN_REJECTIONS__", {
+      configurable: true,
+      get: () => rejectedReopens,
+    });
+    Object.defineProperty(window, "__HOLON_E2E_RELEASE_LEDGER_REOPEN__", {
+      configurable: true,
+      value: () => {
+        IDBObjectStore.prototype.put = originalPut;
+        if (ownOpenDescriptor) {
+          Object.defineProperty(indexedDB, "open", ownOpenDescriptor);
+        } else {
+          Reflect.deleteProperty(indexedDB, "open");
+        }
+      },
+    });
+  });
+  await expect.poll(() => globalStreamCount(request, session)).toBeGreaterThan(0);
+  const degradedEvent = envelope(degradedAgentId, 3);
+  const failedWrite = await request.post(controlPath(session, "/__e2e__/append-event"), {
+    data: { envelope: degradedEvent },
+  });
+  expect(failedWrite.ok()).toBe(true);
+  await expect.poll(() => page.evaluate(
+    () => Reflect.get(window, "__HOLON_E2E_LEDGER_ABORTED_WRITES__"),
+  )).toBeGreaterThan(0);
+  await expect.poll(async () => (await ledgerStatus(page, degradedAgentId))?.durability)
+    .not.toBe("exact");
+
+  await page.evaluate(() => {
+    const release = Reflect.get(window, "__HOLON_E2E_RELEASE_LEDGER_REOPEN__");
+    if (typeof release === "function") release();
+    Reflect.deleteProperty(window, "__HOLON_E2E_RELEASE_LEDGER_REOPEN__");
+    Reflect.deleteProperty(window, "__HOLON_E2E_LEDGER_REOPEN_REJECTIONS__");
+  });
+  await expect.poll(() => ledger(page, degradedAgentId)).toMatchObject({
+    ingestedThroughSeq: 2,
+    projectionReadyThroughSeq: 2,
+  });
+  await expect.poll(() => partitions(page, degradedAgentId)).toEqual([{
+    runtimeId: "e2e-runtime",
+    visibilityScopeId: "e2e-scope",
+    eventLogEpoch: "e2e-epoch",
+    eventSeqs: [1, 2],
+    certainty: "exact",
+  }]);
+  const recoveredWrite = await request.post(controlPath(session, "/__e2e__/append-event"), {
+    data: { envelope: degradedEvent },
+  });
+  expect(recoveredWrite.ok()).toBe(true);
+  await expect.poll(() => ledger(page, degradedAgentId)).toMatchObject({
+    durability: "exact",
+    ingestionState: "idle",
+    ingestedThroughSeq: 3,
+    projectionReadyThroughSeq: 3,
+    readThroughEventSeq: 3,
+    certainty: "exact",
+  });
+  await expect.poll(() => partitions(page, degradedAgentId)).toEqual([{
+    runtimeId: "e2e-runtime",
+    visibilityScopeId: "e2e-scope",
+    eventLogEpoch: "e2e-epoch",
+    eventSeqs: [1, 2, 3],
+    readThroughEventSeq: 3,
+    certainty: "exact",
+  }]);
+});
+

--- a/web-gui/app/src/e2e/diagnostics-bridge.ts
+++ b/web-gui/app/src/e2e/diagnostics-bridge.ts
@@ -1,4 +1,5 @@
 import {
+  ledgerStatusForDiagnostics,
   ledgerReadMarkerDecision,
   useRuntimeStore,
 } from "../runtime/runtime-store";
@@ -7,11 +8,13 @@ import {
   LEDGER_DB_NAME,
   LEDGER_DB_VERSION,
   PENDING_HYDRATION_STORE,
+  RAW_EVENTS_STORE,
   READ_STATES_STORE,
 } from "../runtime/event-ledger/db";
 import type {
   LedgerAgentSessionRecord,
   LedgerHydrationJobRecord,
+  LedgerRawEventRecord,
   LedgerReadStateRecord,
 } from "../runtime/event-ledger/ledger";
 
@@ -34,12 +37,35 @@ export interface HolonE2eSnapshot {
 
 export interface HolonE2eDiagnostics {
   snapshot(): HolonE2eSnapshot;
+  ledgerStatus(agentId: string): HolonE2eLedgerStatus | null;
   ledger(agentId: string): Promise<HolonE2eLedgerSnapshot | null>;
+  ledgerPartitions(agentId: string): Promise<HolonE2eLedgerPartition[]>;
   subscribe(listener: (snapshot: HolonE2eSnapshot) => void): () => void;
+}
+
+export interface HolonE2eLedgerStatus {
+  durability: string;
+  ingestionState: string;
+  ingestionError?: string;
+}
+
+export interface HolonE2eLedgerPartition {
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  eventSeqs: number[];
+  readThroughEventSeq?: number;
+  certainty?: "exact" | "truncated";
 }
 
 export interface HolonE2eLedgerSnapshot {
   agentId: string;
+  runtimeId: string;
+  visibilityScopeId: string;
+  eventLogEpoch: string;
+  durability: string;
+  ingestionState: string;
+  ingestionError?: string;
   ingestedThroughSeq: number;
   projectionReadyThroughSeq: number;
   pendingHydrationJobs: number;
@@ -47,6 +73,9 @@ export interface HolonE2eLedgerSnapshot {
   blockedByEventSeq?: number;
   blockedReason?: "pending_hydration";
   readThroughEventSeq?: number;
+  certainty?: "exact" | "truncated";
+  historyTruncatedBeforeSeq?: number;
+  acknowledgedTruncationBeforeSeq?: number;
   unreadCount?: number;
   readGateDecision: {
     mayAdvance: boolean;
@@ -92,6 +121,16 @@ function snapshot(): HolonE2eSnapshot {
   };
 }
 
+function ledgerStatus(agentId: string): HolonE2eLedgerStatus | null {
+  const status = ledgerStatusForDiagnostics(agentId);
+  if (!status) return null;
+  return {
+    durability: status.durability,
+    ingestionState: status.state,
+    ingestionError: status.lastError,
+  };
+}
+
 function requestResult<T>(request: IDBRequest<T>): Promise<T> {
   return new Promise((resolve, reject) => {
     request.onsuccess = () => resolve(request.result);
@@ -129,8 +168,15 @@ async function ledgerSnapshot(agentId: string): Promise<HolonE2eLedgerSnapshot |
     const pending = jobs.filter((job) => job.state !== "failed");
     const storeState = useRuntimeStore.getState();
     const runtimeSession = storeState.sessionsByAgentId[agentId];
+    const status = ledgerStatusForDiagnostics(agentId);
     return {
       agentId,
+      runtimeId: session.runtimeId,
+      visibilityScopeId: session.visibilityScopeId,
+      eventLogEpoch: session.eventLogEpoch,
+      durability: status?.durability ?? "unknown",
+      ingestionState: status?.state ?? "unknown",
+      ingestionError: status?.lastError,
       ingestedThroughSeq: session.ingestedThroughSeq ?? 0,
       projectionReadyThroughSeq: session.projectionReadyThroughSeq ?? 0,
       pendingHydrationJobs: pending.length,
@@ -140,6 +186,9 @@ async function ledgerSnapshot(agentId: string): Promise<HolonE2eLedgerSnapshot |
         : undefined,
       blockedReason: pending.length ? "pending_hydration" : undefined,
       readThroughEventSeq: readState?.readThroughEventSeq,
+      certainty: readState?.certainty,
+      historyTruncatedBeforeSeq: readState?.historyTruncatedBeforeSeq,
+      acknowledgedTruncationBeforeSeq: readState?.acknowledgedTruncationBeforeSeq,
       unreadCount: storeState.ledgerUnreadByAgentId[agentId]?.count,
       readGateDecision: ledgerReadMarkerDecision(agentId),
       readGateContext: {
@@ -163,9 +212,55 @@ async function ledgerSnapshot(agentId: string): Promise<HolonE2eLedgerSnapshot |
   }
 }
 
+async function ledgerPartitions(agentId: string): Promise<HolonE2eLedgerPartition[]> {
+  const db = await requestResult(indexedDB.open(LEDGER_DB_NAME, LEDGER_DB_VERSION));
+  try {
+    const transaction = db.transaction(
+      [AGENT_SESSIONS_STORE, RAW_EVENTS_STORE, READ_STATES_STORE],
+      "readonly",
+    );
+    const sessions = (await requestResult(
+      transaction.objectStore(AGENT_SESSIONS_STORE).getAll(),
+    ) as LedgerAgentSessionRecord[]).filter((candidate) => candidate.agentId === agentId);
+    const rawEvents = await requestResult(
+      transaction.objectStore(RAW_EVENTS_STORE).getAll(),
+    ) as LedgerRawEventRecord[];
+    const readStates = await requestResult(
+      transaction.objectStore(READ_STATES_STORE).getAll(),
+    ) as LedgerReadStateRecord[];
+    return sessions.map((session) => {
+      const sameScope = (candidate: {
+        remoteKey: string;
+        runtimeId: string;
+        visibilityScopeId: string;
+        eventLogEpoch: string;
+        agentId: string;
+      }) =>
+        candidate.remoteKey === session.remoteKey
+        && candidate.runtimeId === session.runtimeId
+        && candidate.visibilityScopeId === session.visibilityScopeId
+        && candidate.eventLogEpoch === session.eventLogEpoch
+        && candidate.agentId === session.agentId;
+      const readState = readStates.find(sameScope);
+      return {
+        runtimeId: session.runtimeId,
+        visibilityScopeId: session.visibilityScopeId,
+        eventLogEpoch: session.eventLogEpoch,
+        eventSeqs: rawEvents.filter(sameScope).map((event) => event.eventSeq).sort((a, b) => a - b),
+        readThroughEventSeq: readState?.readThroughEventSeq,
+        certainty: readState?.certainty,
+      };
+    });
+  } finally {
+    db.close();
+  }
+}
+
 window.__HOLON_E2E__ = Object.freeze({
   snapshot,
+  ledgerStatus,
   ledger: ledgerSnapshot,
+  ledgerPartitions,
   subscribe(listener: (value: HolonE2eSnapshot) => void) {
     return useRuntimeStore.subscribe(() => listener(snapshot()));
   },

--- a/web-gui/app/src/runtime/agent-session-repository.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.ts
@@ -488,8 +488,16 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
         visibilityScopeId: scope.visibilityScopeId,
         eventLogEpoch: scope.eventLogEpoch,
       });
-      this.recoveryScopeRegistry.delete(scope.agentId);
-      this.recoveryTriggered.delete(scope.agentId);
+      const registeredScope = this.recoveryScopeRegistry.get(scope.agentId);
+      if (
+        registeredScope?.remoteKey === scope.remoteKey &&
+        registeredScope.runtimeId === scope.runtimeId &&
+        registeredScope.visibilityScopeId === scope.visibilityScopeId &&
+        registeredScope.eventLogEpoch === scope.eventLogEpoch
+      ) {
+        this.recoveryScopeRegistry.delete(scope.agentId);
+        this.recoveryTriggered.delete(scope.agentId);
+      }
     }
   }
 

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
@@ -111,6 +111,42 @@ describe("ledger ingestion pipeline", () => {
     ledger.close();
   });
 
+  it("publishes degraded durability after a failed ingestion transaction", async () => {
+    const statuses: Array<{ durability: string; ingestedThroughSeq?: number }> = [];
+    const pipeline = new LedgerIngestionPipeline({
+      fetchers: emptyFetchers(),
+      onStatus: (status) => statuses.push(status),
+    });
+    expect(await pipeline.open()).toBe(true);
+    const scope = makeScope();
+
+    await pipeline.ingest(scope, [envelope(1)]);
+    const originalPut = IDBObjectStore.prototype.put;
+    const putSpy = vi.spyOn(IDBObjectStore.prototype, "put").mockImplementation(function (
+      this: IDBObjectStore,
+      value: unknown,
+      key?: IDBValidKey,
+    ) {
+      const request = originalPut.call(this, value, key);
+      if (this.name === "raw_events") this.transaction.abort();
+      return request;
+    });
+
+    const failed = await pipeline.ingest(scope, [envelope(2)]);
+    putSpy.mockRestore();
+
+    expect(failed).toMatchObject({
+      durability: "memory_only",
+      ingestedThroughSeq: undefined,
+    });
+    expect(statuses.at(-1)).toMatchObject(failed);
+
+    const ledger = await openLedgerHandle();
+    expect((await ledger.getRawEvents(scope)).map((event) => event.eventSeq)).toEqual([1]);
+    expect((await ledger.getAgentSession(scope))?.ingestedThroughSeq).toBe(1);
+    ledger.close();
+  });
+
   it("never reloads an observed head behind the persisted contiguous cursor", async () => {
     const scope = makeScope();
     const ledger = await openLedgerHandle();

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
@@ -419,7 +419,14 @@ export class LedgerIngestionPipeline {
       // in-memory cursors never run ahead of committed state.
       this.trackers.delete(this.trackerKey(scope));
       if (this.isDurabilityFailure(error)) {
-        return this.statusFor(scope, this.freshTracker());
+        // A storage failure makes the current handle unfit for further
+        // exactness claims. Discard it before publishing status so recovery
+        // must reopen and verify a fresh handle.
+        this.ledger?.close();
+        this.ledger = null;
+        const status = this.statusFor(scope, this.freshTracker());
+        this.dependencies.onStatus?.(status);
+        return status;
       }
       throw error;
     }

--- a/web-gui/app/src/runtime/global-sync-coordinator.ts
+++ b/web-gui/app/src/runtime/global-sync-coordinator.ts
@@ -84,7 +84,7 @@ interface GlobalSyncCoordinatorDependencies<State extends GlobalSyncStoreState> 
     set: GlobalSyncStoreSet<State>,
     snapshot: AgentRosterSnapshotDto,
     context: { previousIdentity?: RosterDiscoveryIdentity; request: ClientRequest },
-  ) => string[];
+  ) => string[] | Promise<string[]>;
   /** Register per-Agent recovery (W3) anchored on the roster event window. */
   registerAgentRecovery: (
     agentId: string,
@@ -336,7 +336,7 @@ export class GlobalSyncCoordinator<State extends GlobalSyncStoreState> {
           visibilityScopeId: snapshot.visibility_scope_id,
           eventLogEpoch: snapshot.event_log_epoch,
         };
-        const omittedAgentIds = this.dependencies.applyRosterSnapshot(
+        const omittedAgentIds = await this.dependencies.applyRosterSnapshot(
           set,
           snapshot,
           { previousIdentity: this.rosterIdentity, request },

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -25,6 +25,7 @@ import {
   writeStoredRuntimeConnectionConfig,
 } from "./runtime-store";
 import type { StreamEventEnvelopeDto } from "./client";
+import { AgentSessionRepository } from "./agent-session-repository";
 import type { AgentSessionState } from "./runtime-store";
 import { createSessionProjectionState, reduceSessionProjection } from "./session-projection";
 import type { AgentSummary } from "./types";
@@ -766,9 +767,13 @@ describe("brief projection and hydration", () => {
       provenance: {},
       payload: { brief_id: "brief-b" },
     };
+    const ingestSessionEvents = vi
+      .spyOn(AgentSessionRepository.prototype, "ingestSessionEvents")
+      .mockResolvedValue(null);
 
     applyStreamEvents(useRuntimeStore.setState, "agent-b", [briefEvent]);
 
+    expect(ingestSessionEvents).toHaveBeenCalledWith("agent-b", [briefEvent]);
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/agents/agent-b/briefs:batchGet");
     await vi.waitFor(() => {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -1019,11 +1019,11 @@ function filterDismissedDiagnostics(
  * cache of agents the authoritative roster omitted. Returns the omitted
  * agent ids so the coordinator can unregister them.
  */
-function applyRosterSnapshotToStore(
+async function applyRosterSnapshotToStore(
   set: StoreSet,
   snapshot: AgentRosterSnapshotDto,
   context: { previousIdentity?: RosterDiscoveryIdentity },
-): string[] {
+): Promise<string[]> {
   const identity: RosterDiscoveryIdentity = {
     runtimeId: snapshot.runtime_id,
     visibilityScopeId: snapshot.visibility_scope_id,
@@ -1043,9 +1043,7 @@ function applyRosterSnapshotToStore(
     });
     const rosterIds = new Set(rosterAgents.map((agent) => agent.id));
     const previousIds = state.bootstrap.agents.map((agent) => agent.id);
-    omittedAgentIds = identityReset
-      ? previousIds
-      : previousIds.filter((id) => !rosterIds.has(id));
+    omittedAgentIds = previousIds.filter((id) => !rosterIds.has(id));
     const dropIds = new Set(identityReset ? previousIds : omittedAgentIds);
     const sessionsByAgentId = dropIds.size
       ? Object.fromEntries(
@@ -1094,9 +1092,11 @@ function applyRosterSnapshotToStore(
   });
   if (identityReset) {
     // Old-identity ledger scopes must never join the new scope's data.
-    void agentSessionRepository
-      .clearLedgerScopesNotMatching(identity)
-      .catch((error) => console.warn("Failed to clear old ledger scopes.", error));
+    try {
+      await agentSessionRepository.clearLedgerScopesNotMatching(identity);
+    } catch (error) {
+      console.warn("Failed to clear old ledger scopes.", error);
+    }
   }
   for (const agentId of omittedAgentIds) {
     stopAgentEventStream(agentId, set);
@@ -1134,6 +1134,11 @@ const globalSyncCoordinator = new GlobalSyncCoordinator<RuntimeStoreState>({
 });
 
 let agentSessionRepository!: AgentSessionRepository<RuntimeStoreState>;
+
+/** Read-only observer-sync status used by the e2e diagnostics bridge. */
+export function ledgerStatusForDiagnostics(agentId: string) {
+  return agentSessionRepository.sessionLedgerStatus(agentId);
+}
 
 /**
  * Cross-tab read-state invalidation (W5). The IndexedDB record is the
@@ -4484,6 +4489,9 @@ export function applyStreamEvents(set: StoreSet, agentId: string, events: Stream
       },
     };
   });
+  void agentSessionRepository
+    .ingestSessionEvents(agentId, incomingEvents)
+    .catch((error) => console.warn(`Agent ledger ingestion failed for ${agentId}.`, error));
   const displayLevel = useRuntimeStore.getState().displayLevel;
   agentSessionRepository.hydrateSelectedContent(agentId, displayLevel);
   agentSessionRepository.hydrateBriefs(agentId, displayLevel);


### PR DESCRIPTION
## 概要

- 新增 Chromium E2E-05 至 E2E-08，覆盖 retention acknowledgement generation、event-log epoch replacement、visibility/auth scope rotation，以及 divergence/degraded IndexedDB handle 恢复
- 扩展确定性 HTTP/SSE fixture 与只读 E2E diagnostics，支持断言 projection、read partition、scope identity、persistence health 和 stream connection
- 在最早持久化失败边界关闭异常 IndexedDB handle，并确保只有重新打开、重建和验证成功后恢复 `exact`

## 验证

- `npm test`（39 files，445 tests）
- `npm run build`
- `npm run test:e2e -- --project=chromium`（8/8）
- `npx playwright test e2e/reset-scope.spec.ts --project=chromium --workers=1 --repeat-each=20`（80/80）

注：Playwright 运行期间仍会输出既有 Vite HMR `24678` 端口占用告警，但测试使用动态 HTTP fixture 端口且全部通过。
