### PR TITLE
test: add real daemon web e2e gate

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,0 +1,121 @@
+name: Web E2E
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/web-e2e.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "build.rs"
+      - "src/**"
+      - "web-gui/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/web-e2e.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "build.rs"
+      - "src/**"
+      - "web-gui/**"
+  schedule:
+    - cron: "37 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  chromium-p0:
+    name: Chromium P0
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: web-gui/app
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: web-gui/app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Build diagnostics assets
+        run: npm run build:e2e
+
+      - name: Run Chromium P0
+        run: npm run test:e2e -- --project=chromium
+
+      - name: Verify production bundle
+        run: npm run test:e2e:production-bundle
+
+      - name: Upload Chromium P0 artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-e2e-chromium-p0
+          if-no-files-found: ignore
+          path: |
+            web-gui/app/playwright-report
+            web-gui/app/test-results
+          retention-days: 7
+
+  real-daemon:
+    name: Real daemon (${{ github.event_name == 'schedule' && 'nightly repeat' || 'main repeat' }})
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: web-gui/app
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: web-gui/app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Build daemon
+        working-directory: .
+        run: cargo build --bin holon
+
+      - name: Build production and diagnostics assets
+        run: |
+          npm run build
+          npm run build:e2e:real-daemon
+
+      - name: Run real daemon repeat suite
+        env:
+          HOLON_E2E_REPEAT: ${{ github.event_name == 'schedule' && '20' || '3' }}
+        run: npm run test:e2e:real-daemon -- --workers=1 --repeat-each="${HOLON_E2E_REPEAT}"
+
+      - name: Upload real daemon artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-e2e-real-daemon-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          path: |
+            web-gui/app/playwright-report
+            web-gui/app/test-results
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Generated
 dist/
+web-gui/app/dist-e2e/
 build/
 coverage/
 .DS_Store

--- a/web-gui/app/e2e/fixture-server.mjs
+++ b/web-gui/app/e2e/fixture-server.mjs
@@ -11,7 +11,7 @@ const sessions = new Map();
 const vite = await createViteServer({
   appType: "spa",
   mode: "e2e",
-  server: { middlewareMode: true },
+  server: { hmr: false, middlewareMode: true },
 });
 
 function record(req, url) {

--- a/web-gui/app/e2e/real-daemon/daemon-fixture.ts
+++ b/web-gui/app/e2e/real-daemon/daemon-fixture.ts
@@ -1,0 +1,291 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { expect, test as base } from "@playwright/test";
+
+const DEFAULT_AGENT_ID = "default";
+const START_TIMEOUT_MS = 30_000;
+const STOP_TIMEOUT_MS = 10_000;
+
+interface DaemonController {
+  readonly agentId: string;
+  readonly baseUrl: string;
+  readonly token: string;
+  api(pathname: string, init?: RequestInit): Promise<Response>;
+  enqueue(text: string): Promise<string>;
+  restart(): Promise<void>;
+  stop(): Promise<void>;
+  start(): Promise<void>;
+}
+
+interface DaemonOptions {
+  webDist: string;
+}
+
+type Fixtures = {
+  artifacts: void;
+  daemonFactory: (options: DaemonOptions) => Promise<DaemonController>;
+};
+
+async function reservePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to allocate a daemon port"));
+        return;
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+function waitForExit(child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`daemon did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("exit", onExit);
+    };
+    const onExit = () => {
+      cleanup();
+      resolve();
+    };
+    child.once("exit", onExit);
+  });
+}
+
+async function waitForReady(
+  baseUrl: string,
+  token: string,
+  child: ChildProcessWithoutNullStreams,
+): Promise<void> {
+  const deadline = Date.now() + START_TIMEOUT_MS;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`daemon exited before readiness with code ${child.exitCode}`);
+    }
+    try {
+      const response = await fetch(`${baseUrl}/api/handshake`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(1_000),
+      });
+      if (response.ok) return;
+      lastError = new Error(`handshake returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`daemon readiness timed out: ${String(lastError)}`);
+}
+
+async function createDaemon(
+  options: DaemonOptions,
+  workerIndex: number,
+): Promise<{ controller: DaemonController; cleanup: () => Promise<void> }> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "holon-web-e2e-"));
+  const home = path.join(root, "home");
+  const tokenFile = path.join(root, "control-token");
+  const controlToken = randomBytes(24).toString("hex");
+  const artifactDir = path.resolve("test-results", "real-daemon", `worker-${workerIndex}`);
+  const stdoutPath = path.join(artifactDir, "daemon.stdout.log");
+  const stderrPath = path.join(artifactDir, "daemon.stderr.log");
+  const port = await reservePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const binary = path.resolve(
+    process.env.HOLON_E2E_DAEMON_BIN ?? "../../target/debug/holon",
+  );
+  let child: ChildProcessWithoutNullStreams | undefined;
+  let agentCreated = false;
+
+  await mkdir(home, { recursive: true });
+  await mkdir(artifactDir, { recursive: true });
+  await writeFile(tokenFile, `${controlToken}\n`, { mode: 0o600 });
+
+  const start = async () => {
+    if (child && child.exitCode === null && child.signalCode === null) {
+      throw new Error("daemon is already running");
+    }
+    child = spawn(binary, [
+      "serve",
+      "--listen",
+      `127.0.0.1:${port}`,
+      "--token-file",
+      tokenFile,
+      "--web-dist",
+      path.resolve(options.webDist),
+    ], {
+      env: {
+        ...process.env,
+        HOLON_HOME: home,
+        HOLON_CONTROL_AUTH_MODE: "required",
+        HOLON_CALLBACK_BASE_URL: baseUrl,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.pipe(createWriteStream(stdoutPath, { flags: "a" }));
+    child.stderr.pipe(createWriteStream(stderrPath, { flags: "a" }));
+    await waitForReady(baseUrl, controlToken, child);
+    if (!agentCreated) {
+      const response = await fetch(
+        `${baseUrl}/api/control/agents/${DEFAULT_AGENT_ID}/create`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${controlToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            authority_class: "operator_instruction",
+            template: null,
+          }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(
+          `agent bootstrap failed with ${response.status}: ${await response.text()}`,
+        );
+      }
+      agentCreated = true;
+    }
+  };
+
+  const stop = async () => {
+    if (!child || child.exitCode !== null || child.signalCode !== null) return;
+    const running = child;
+    running.kill("SIGTERM");
+    try {
+      await waitForExit(running, STOP_TIMEOUT_MS);
+    } catch {
+      running.kill("SIGKILL");
+      await waitForExit(running, STOP_TIMEOUT_MS);
+    }
+  };
+
+  const api = async (pathname: string, init: RequestInit = {}) => {
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${controlToken}`);
+    if (init.body && !headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+    return await fetch(`${baseUrl}/api${pathname}`, { ...init, headers });
+  };
+
+  const controller: DaemonController = {
+    agentId: DEFAULT_AGENT_ID,
+    baseUrl,
+    token: controlToken,
+    api,
+    async enqueue(text: string) {
+      const response = await api(`/agents/${DEFAULT_AGENT_ID}/enqueue`, {
+        method: "POST",
+        body: JSON.stringify({
+          text,
+          origin: { kind: "webhook", source: "web-e2e", event_type: "marker" },
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`enqueue failed with ${response.status}: ${await response.text()}`);
+      }
+      const body = await response.json() as { message_id: string };
+      return body.message_id;
+    },
+    restart: async () => {
+      await stop();
+      await start();
+    },
+    start,
+    stop,
+  };
+
+  try {
+    await start();
+  } catch (error) {
+    await stop();
+    await rm(root, { recursive: true, force: true });
+    throw error;
+  }
+  return {
+    controller,
+    cleanup: async () => {
+      await stop();
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+export const test = base.extend<Fixtures>({
+  artifacts: [async ({ page }, use, testInfo) => {
+    const consoleMessages: string[] = [];
+    const requestFailures: string[] = [];
+    const errorResponses: string[] = [];
+    page.on("console", (message) => {
+      consoleMessages.push(`[${message.type()}] ${message.text()}`);
+    });
+    page.on("requestfailed", (request) => {
+      requestFailures.push(
+        `${request.method()} ${request.url()} ${request.failure()?.errorText ?? "unknown failure"}`,
+      );
+    });
+    page.on("response", (response) => {
+      if (response.status() >= 400) {
+        errorResponses.push(
+          `${response.status()} ${response.request().method()} ${response.url()}`,
+        );
+      }
+    });
+
+    await use();
+
+    if (testInfo.status === testInfo.expectedStatus) return;
+    await testInfo.attach("browser-console", {
+      body: Buffer.from(consoleMessages.join("\n")),
+      contentType: "text/plain",
+    });
+    await testInfo.attach("request-failures", {
+      body: Buffer.from([...requestFailures, ...errorResponses].join("\n")),
+      contentType: "text/plain",
+    });
+    const diagnostics = await page.evaluate(async () => {
+      const bridge = window.__HOLON_E2E__;
+      if (!bridge) return null;
+      const snapshot = bridge.snapshot();
+      const ledgers = await Promise.all(snapshot.agentIds.map(async (agentId) => ({
+        agentId,
+        ledger: await bridge.ledger(agentId),
+        partitions: await bridge.ledgerPartitions(agentId),
+      })));
+      return { snapshot, ledgers };
+    }).catch((error: unknown) => ({ error: String(error) }));
+    await testInfo.attach("diagnostics", {
+      body: Buffer.from(JSON.stringify(diagnostics, null, 2)),
+      contentType: "application/json",
+    });
+  }, { auto: true }],
+  daemonFactory: async ({}, use, workerInfo) => {
+    const daemons: Array<() => Promise<void>> = [];
+    await use(async (options) => {
+      const daemon = await createDaemon(options, workerInfo.workerIndex);
+      daemons.push(daemon.cleanup);
+      return daemon.controller;
+    });
+    for (const cleanup of daemons.reverse()) await cleanup();
+  },
+});
+
+export { expect };

--- a/web-gui/app/e2e/real-daemon/production-smoke.spec.ts
+++ b/web-gui/app/e2e/real-daemon/production-smoke.spec.ts
@@ -1,0 +1,47 @@
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "./daemon-fixture";
+
+async function installLocalToken(page: Page, token: string): Promise<void> {
+  await page.addInitScript((value) => {
+    sessionStorage.setItem("holon.webGui.activeRuntimeConnection.v1", JSON.stringify({
+      mode: "local",
+      token: value,
+    }));
+  }, token);
+}
+
+test("production assets authenticate and use real snapshot, SSE, and route refresh", async ({
+  daemonFactory,
+  page,
+}) => {
+  const daemon = await daemonFactory({ webDist: "dist" });
+  const requests: string[] = [];
+  page.on("request", (request) => {
+    if (request.url().startsWith(`${daemon.baseUrl}/api/`)) {
+      requests.push(`${request.method()} ${new URL(request.url()).pathname}`);
+    }
+  });
+
+  const unauthorized = await page.request.get(`${daemon.baseUrl}/api/handshake`);
+  expect(unauthorized.status()).toBe(403);
+
+  await installLocalToken(page, daemon.token);
+  await page.goto(daemon.baseUrl);
+  await expect(page.locator('aside[aria-label="Holon navigation"]')).toBeVisible();
+  await expect(page.getByText(/\d+ agents ·/)).toBeVisible();
+  await expect.poll(() => requests).toEqual(expect.arrayContaining([
+    "GET /api/handshake",
+    "GET /api/agents/snapshot",
+    "GET /api/events/stream",
+  ]));
+  expect(await page.evaluate(() => window.__HOLON_E2E__)).toBeUndefined();
+
+  await daemon.enqueue("production SSE marker");
+  await page.goto(`${daemon.baseUrl}/agents/${daemon.agentId}`);
+  await expect(page).toHaveURL(new RegExp(`/agents/${daemon.agentId}$`));
+  await expect(page.locator("main")).toBeVisible();
+  await page.reload();
+  await expect(page).toHaveURL(new RegExp(`/agents/${daemon.agentId}$`));
+  await expect(page.locator('aside[aria-label="Holon navigation"]')).toBeVisible();
+});

--- a/web-gui/app/e2e/real-daemon/restart-catch-up.spec.ts
+++ b/web-gui/app/e2e/real-daemon/restart-catch-up.spec.ts
@@ -1,0 +1,111 @@
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "./daemon-fixture";
+
+interface LedgerSnapshot {
+  eventLogEpoch: string;
+  eventSeqs: number[];
+  ingestedThroughSeq: number;
+}
+
+async function installLocalToken(page: Page, token: string): Promise<void> {
+  await page.addInitScript((value) => {
+    sessionStorage.setItem("holon.webGui.activeRuntimeConnection.v1", JSON.stringify({
+      mode: "local",
+      token: value,
+    }));
+  }, token);
+}
+
+async function ledger(page: Page, agentId: string): Promise<LedgerSnapshot | null> {
+  return await page.evaluate(
+    async (id) => {
+      const diagnostics = window.__HOLON_E2E__;
+      if (!diagnostics) return null;
+      const [value, partitions] = await Promise.all([
+        diagnostics.ledger(id),
+        diagnostics.ledgerPartitions(id),
+      ]);
+      if (!value) return null;
+      const partition = partitions.find((candidate) =>
+        candidate.runtimeId === value.runtimeId
+        && candidate.visibilityScopeId === value.visibilityScopeId
+        && candidate.eventLogEpoch === value.eventLogEpoch
+      );
+      return {
+        eventLogEpoch: value.eventLogEpoch,
+        eventSeqs: partition?.eventSeqs ?? [],
+        ingestedThroughSeq: value.ingestedThroughSeq,
+      };
+    },
+    agentId,
+  );
+}
+
+test("same database restart reconnects, catches up, preserves epoch, and deduplicates events", async ({
+  daemonFactory,
+  page,
+}) => {
+  const daemon = await daemonFactory({ webDist: "dist-e2e" });
+  await installLocalToken(page, daemon.token);
+  await page.goto(daemon.baseUrl);
+
+  await expect.poll(async () => page.evaluate(() => window.__HOLON_E2E__?.snapshot()))
+    .toMatchObject({
+      bootstrapLoading: false,
+      globalStreamStatus: "streaming",
+      discovery: { mode: "authoritative", freshness: "fresh" },
+    });
+
+  await daemon.enqueue("before restart");
+  await expect.poll(async () => ledger(page, daemon.agentId))
+    .toMatchObject({ eventLogEpoch: expect.any(String), ingestedThroughSeq: expect.any(Number) });
+  const before = await ledger(page, daemon.agentId);
+  expect(before?.eventLogEpoch).toBeTruthy();
+
+  await daemon.stop();
+  await expect.poll(async () => page.evaluate(() => window.__HOLON_E2E__?.snapshot().globalStreamStatus))
+    .toBe("reconnecting");
+
+  let releaseReconnect!: () => void;
+  const reconnectBlocked = new Promise<void>((resolve) => {
+    releaseReconnect = resolve;
+  });
+  let observeReconnect!: () => void;
+  const reconnectObserved = new Promise<void>((resolve) => {
+    observeReconnect = resolve;
+  });
+  let finishReconnect!: () => void;
+  const reconnectFinished = new Promise<void>((resolve) => {
+    finishReconnect = resolve;
+  });
+  let blockNextReconnect = true;
+  await page.route("**/api/events/stream**", async (route) => {
+    if (blockNextReconnect) {
+      blockNextReconnect = false;
+      observeReconnect();
+      await reconnectBlocked;
+    }
+    await route.continue();
+    finishReconnect();
+  });
+
+  await daemon.start();
+  await reconnectObserved;
+  await daemon.enqueue("during restart");
+  releaseReconnect();
+  await reconnectFinished;
+  await page.unroute("**/api/events/stream**");
+
+  await expect.poll(async () => page.evaluate(() => window.__HOLON_E2E__?.snapshot().globalStreamStatus))
+    .toBe("streaming");
+  await expect.poll(async () => {
+    const value = await ledger(page, daemon.agentId);
+    return value?.ingestedThroughSeq ?? 0;
+  }).toBeGreaterThan(before?.ingestedThroughSeq ?? 0);
+
+  const after = await ledger(page, daemon.agentId);
+  expect(after).not.toBeNull();
+  expect(after?.eventLogEpoch).toBe(before?.eventLogEpoch);
+  expect(new Set(after!.eventSeqs).size).toBe(after!.eventSeqs.length);
+});

--- a/web-gui/app/package.json
+++ b/web-gui/app/package.json
@@ -7,9 +7,11 @@
     "dev": "vite --host 127.0.0.1",
     "build": "npm run typecheck && vite build",
     "build:e2e": "npm run typecheck && vite build --mode e2e",
+    "build:e2e:real-daemon": "npm run typecheck && vite build --mode e2e --outDir dist-e2e",
     "preview": "vite preview --host 127.0.0.1",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:e2e:real-daemon": "playwright test --config playwright.real-daemon.config.ts",
     "test:e2e:production-bundle": "npm run build && node e2e/assert-production-bundle.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json --pretty false && tsc --noEmit -p tsconfig.node.json --pretty false"
   },

--- a/web-gui/app/playwright.config.ts
+++ b/web-gui/app/playwright.config.ts
@@ -28,6 +28,7 @@ const baseURL = `http://127.0.0.1:${port}`;
 
 export default defineConfig({
   testDir: "./e2e",
+  testIgnore: ["real-daemon/**"],
   outputDir: "test-results",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
@@ -41,6 +42,7 @@ export default defineConfig({
   },
   webServer: {
     command: `node e2e/fixture-server.mjs --port ${port}`,
+    gracefulShutdown: { signal: "SIGTERM", timeout: 5_000 },
     url: `${baseURL}/__e2e__/health`,
     reuseExistingServer: false,
     stdout: "pipe",

--- a/web-gui/app/playwright.real-daemon.config.ts
+++ b/web-gui/app/playwright.real-daemon.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e/real-daemon",
+  outputDir: "test-results/real-daemon",
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["line"], ["html", { open: "never" }]] : "line",
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium-real-daemon",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- add an isolated real `holon serve` Playwright fixture with temporary `HOLON_HOME`, database/token state, dynamic ports, deterministic readiness, restart support, and reliable process cleanup
- cover daemon restart/reconnect/catch-up without epoch changes or duplicate events, plus production-assets authentication, snapshot, SSE, and route-refresh smoke against a real daemon
- add a Chromium Layer A PR gate and Layer B real-daemon/repeat jobs for `main`, nightly, and manual runs, with failure artifacts

## Verification
- `npm test` (445 tests)
- `npm run test:e2e -- --project=chromium` (8 tests)
- `npm run typecheck`
- `npm run test:e2e:production-bundle`
- `npm run test:e2e:real-daemon -- --workers=1 --repeat-each=20` (40/40)
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
