### PR TITLE
fix: address observer sync review follow-ups

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -45,7 +45,6 @@ import { selectSelectedAgent } from "../runtime/runtime-selectors";
 import { unreadBadgeView, type LedgerUnreadView } from "../runtime/read-state";
 import {
   canUseRemoteRuntimeConnections,
-  observerSyncDiagnostics,
   readStoredRemoteConnectionProfiles,
   skillDetailCacheKey,
   useRuntimeStore,
@@ -68,8 +67,6 @@ const APP_WINDOW_TITLE = "Holon";
 export function App() {
   const { bootstrap, loading, refresh } = useRuntimeDashboard();
   const discovery = useRuntimeStore((state) => state.discovery);
-  useRuntimeStore((state) => state.ledgerReadinessRevisionByAgentId);
-  useRuntimeStore((state) => state.ledgerUnreadByAgentId);
   const { t } = useTranslation();
   useSyncExternalStore(subscribeRuntimeTrace, getRuntimeTraceRevision, getRuntimeTraceRevision);
   const developerDiagnosticsEnabled = isRuntimeTraceEnabled();
@@ -818,7 +815,6 @@ export function App() {
         {route === "settings" ? (
           <SettingsPage
             connection={bootstrap.connection}
-            observerSyncDiagnostics={observerSyncDiagnostics()}
             modelCatalog={modelCatalog}
             modelCatalogLoading={modelCatalogLoading}
             modelCatalogError={modelCatalogError}
@@ -1236,7 +1232,7 @@ function unreadTitle(
   t: (key: string, options?: { count?: number }) => string,
 ): string {
   if (view.mode === "truncated") return t("app.unreadTruncated", { count: view.count });
-  if (view.mode === "stale_sync_error") return t("app.unreadStale");
+  if (view.mode === "stale_sync_error") return t("app.unreadSyncError");
   return t("app.unreadUpdates", { count: view.count });
 }
 function formatUnreadCount(count: number): string {

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -16,7 +16,10 @@ import {
   setRuntimeTraceEnabled,
   subscribeRuntimeTrace,
 } from "../../runtime/runtime-trace";
-import type { ObserverSyncDiagnostics } from "../../runtime/runtime-store";
+import {
+  observerSyncDiagnostics,
+  useRuntimeStore,
+} from "../../runtime/runtime-store";
 import type {
   CodexDeviceLoginState,
   CredentialStoreState,
@@ -31,7 +34,6 @@ import type {
 
 interface SettingsPageProps {
   connection: RuntimeConnection;
-  observerSyncDiagnostics: ObserverSyncDiagnostics;
   modelCatalog: RuntimeModelCatalog;
   modelCatalogLoading: boolean;
   modelCatalogError?: string;
@@ -146,7 +148,6 @@ export function buildSearchProviderConfigUpdates(
 
 export function SettingsPage({
   connection,
-  observerSyncDiagnostics,
   modelCatalog,
   modelCatalogLoading,
   modelCatalogError,
@@ -1603,65 +1604,7 @@ export function SettingsPage({
           </div>
         </Card>
 
-        <Card className="settings-card" hidden={activeTab !== "advanced"}>
-          <div className="settings-card-head">
-            <div>
-              <span className="eyebrow">{t("settings.observerSync")}</span>
-              <h2>{t("settings.observerSyncDiagnostics")}</h2>
-            </div>
-            <StatusChip
-              tone={observerSyncDiagnostics.discovery.freshness === "fresh" ? "success" : "warning"}
-              title={observerSyncDiagnostics.discovery.freshness}
-            />
-          </div>
-          <p className="settings-muted">{t("settings.observerSyncDiagnosticsDesc")}</p>
-          <dl className="settings-list compact">
-            <div>
-              <dt>{t("settings.discovery")}</dt>
-              <dd>
-                {observerSyncDiagnostics.discovery.mode} · {observerSyncDiagnostics.discovery.freshness}
-              </dd>
-            </div>
-            <div>
-              <dt>{t("settings.runtimeScopeEpoch")}</dt>
-              <dd>
-                {[
-                  observerSyncDiagnostics.discovery.runtimeId,
-                  observerSyncDiagnostics.discovery.visibilityScopeId,
-                  observerSyncDiagnostics.discovery.eventLogEpoch,
-                ].filter(Boolean).join(" · ") || t("settings.notReported")}
-              </dd>
-            </div>
-          </dl>
-          <div className="provider-list">
-            {observerSyncDiagnostics.agents.map((agent) => (
-              <Card className="provider-card" key={agent.agentId}>
-                <header>
-                  <div>
-                    <h3>{agent.agentId}</h3>
-                    <span>{agent.durability} · {agent.state} · {agent.readCertainty}</span>
-                  </div>
-                </header>
-                <dl className="settings-list compact">
-                  <div>
-                    <dt>{t("settings.syncCursors")}</dt>
-                    <dd>
-                      {agent.ingestedThroughSeq ?? "—"} / {agent.projectionReadyThroughSeq ?? "—"} / {agent.observedEventHeadSeq ?? "—"}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt>{t("settings.hydrationJobs")}</dt>
-                    <dd>{agent.pendingHydrationJobs} pending · {agent.failedHydrationJobs} failed</dd>
-                  </div>
-                  <div>
-                    <dt>{t("settings.resetReason")}</dt>
-                    <dd>{agent.resetReason ?? "—"}</dd>
-                  </div>
-                </dl>
-              </Card>
-            ))}
-          </div>
-        </Card>
+        {activeTab === "advanced" ? <ObserverSyncDiagnosticsCard /> : null}
 
         <Card className="settings-card" hidden={activeTab !== "advanced"}>
           <div className="settings-card-head">
@@ -1755,6 +1698,75 @@ export function SettingsPage({
         </Card>
       </div>
     </section>
+  );
+}
+
+function ObserverSyncDiagnosticsCard() {
+  useRuntimeStore((state) => state.ledgerReadinessRevisionByAgentId);
+  useRuntimeStore((state) => state.ledgerUnreadByAgentId);
+  const diagnostics = observerSyncDiagnostics();
+  const { t } = useTranslation();
+
+  return (
+    <Card className="settings-card">
+      <div className="settings-card-head">
+        <div>
+          <span className="eyebrow">{t("settings.observerSync")}</span>
+          <h2>{t("settings.observerSyncDiagnostics")}</h2>
+        </div>
+        <StatusChip
+          tone={diagnostics.discovery.freshness === "fresh" ? "success" : "warning"}
+          title={diagnostics.discovery.freshness}
+        />
+      </div>
+      <p className="settings-muted">{t("settings.observerSyncDiagnosticsDesc")}</p>
+      <dl className="settings-list compact">
+        <div>
+          <dt>{t("settings.discovery")}</dt>
+          <dd>
+            {diagnostics.discovery.mode} · {diagnostics.discovery.freshness}
+          </dd>
+        </div>
+        <div>
+          <dt>{t("settings.runtimeScopeEpoch")}</dt>
+          <dd>
+            {[
+              diagnostics.discovery.runtimeId,
+              diagnostics.discovery.visibilityScopeId,
+              diagnostics.discovery.eventLogEpoch,
+            ].filter(Boolean).join(" · ") || t("settings.notReported")}
+          </dd>
+        </div>
+      </dl>
+      <div className="provider-list">
+        {diagnostics.agents.map((agent) => (
+          <Card className="provider-card" key={agent.agentId}>
+            <header>
+              <div>
+                <h3>{agent.agentId}</h3>
+                <span>{agent.durability} · {agent.state} · {agent.readCertainty}</span>
+              </div>
+            </header>
+            <dl className="settings-list compact">
+              <div>
+                <dt>{t("settings.syncCursors")}</dt>
+                <dd>
+                  {agent.ingestedThroughSeq ?? "—"} / {agent.projectionReadyThroughSeq ?? "—"} / {agent.observedEventHeadSeq ?? "—"}
+                </dd>
+              </div>
+              <div>
+                <dt>{t("settings.hydrationJobs")}</dt>
+                <dd>{agent.pendingHydrationJobs} pending · {agent.failedHydrationJobs} failed</dd>
+              </div>
+              <div>
+                <dt>{t("settings.resetReason")}</dt>
+                <dd>{agent.resetReason ?? "—"}</dd>
+              </div>
+            </dl>
+          </Card>
+        ))}
+      </div>
+    </Card>
   );
 }
 

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -89,7 +89,6 @@ const en = {
     agentNotFound: "Agent not found",
     unreadUpdates: "{{count}} unread update(s)",
     unreadTruncated: "At least {{count}} unread update(s); older history is no longer retained",
-    unreadLegacy: "Approximately {{count}} unread update(s)",
     unreadSyncError: "Unread count unavailable while synchronization is failing",
     truncationNotice: "Some earlier history is no longer retained by the server, so the unread count is a lower bound.",
     truncationAcknowledge: "Acknowledge earlier history",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -91,7 +91,6 @@ const zh: Record<string, any> = {
     agentNotFound: "未找到智能体",
     unreadUpdates: "{{count}} 条未读更新",
     unreadTruncated: "至少 {{count}} 条未读更新（更早历史已不可恢复）",
-    unreadLegacy: "约 {{count}} 条未读更新",
     unreadSyncError: "同步异常，未读数暂不可用",
     truncationNotice: "部分更早历史已不再保留，未读数仅为下限。",
     truncationAcknowledge: "确认更早历史",

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -2545,15 +2545,6 @@ export function isProjectionBusyError(error: unknown): boolean {
   return error instanceof RuntimeHttpError && error.status === 429 && error.code === "projection_busy";
 }
 
-/** True when the remote does not serve the projection snapshot contract. */
-export function isSnapshotCapabilityUnavailableError(error: unknown): boolean {
-  return (
-    error instanceof RuntimeHttpError &&
-    error.status === 503 &&
-    error.code === "capability_unavailable"
-  );
-}
-
 /** True when the snapshot target agent is unknown or not a member. */
 export function isSnapshotAgentMissingError(error: unknown): boolean {
   return error instanceof RuntimeHttpError && error.status === 404;


### PR DESCRIPTION
## Summary
- move observer-sync diagnostics store subscription from the app root into the Settings diagnostics boundary so updates do not re-render the entire application
- replace the missing `app.unreadStale` reference and remove deprecated `app.unreadLegacy` translations
- remove the unused `isSnapshotCapabilityUnavailableError` export

## Verification
- `npm test` — 39 files / 446 tests passed
- `npm run build` — typecheck and production build passed
- `node e2e/assert-production-bundle.mjs` — production bundle excludes the E2E diagnostics bridge
- `git diff --check`
