### PR TITLE
fix: scope reasoning effort overrides to model routes

### DIFF
--- a/docs/implementation-decisions/114-reasoning-effort-scope-in-model-chains.md
+++ b/docs/implementation-decisions/114-reasoning-effort-scope-in-model-chains.md
@@ -1,0 +1,14 @@
+# Reasoning effort preserves its configuration scope
+
+Agent model override `reasoning_effort` belongs to the exact model route named
+by that override. Provider construction applies it only to that resolved
+candidate, so later candidates in the model fallback chain do not inherit a
+value selected for another model.
+
+An explicit `reasoning_effort` in provider endpoint configuration retains its
+endpoint-wide scope. Every candidate using that endpoint validates the value
+against its own model policy; incompatible candidates are excluded, and
+provider construction fails if no candidate remains.
+
+Holon does not translate effort values between models. Fallback changes the
+active model route, not the meaning or ownership of a model-specific override.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -111,3 +111,4 @@ Current decision notes:
 - [098 Scheduler Protocol Transition Wraps Legacy Boundaries Atomically](./098-scheduler-protocol-transition-wraps-legacy-boundaries-atomically.md)
 - [101 Scheduler Authority Convergence](./101-scheduler-authority-convergence.md)
 - [103 DeepSeek Responses Endpoint Dialect](./103-deepseek-responses-endpoint-dialect.md)
+- [114 Reasoning Effort Scope In Model Chains](./114-reasoning-effort-scope-in-model-chains.md)

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -408,6 +408,17 @@ pub struct RuntimeModelCatalog {
 }
 
 impl RuntimeModelCatalog {
+    pub(crate) fn canonicalize_model_route_ref(&self, route_ref: &ModelRouteRef) -> ModelRouteRef {
+        let canonical_model_ref = self
+            .built_in_catalog
+            .canonicalize_model_ref(&route_ref.model_ref());
+        ModelRouteRef::new(
+            route_ref.provider.clone(),
+            route_ref.endpoint.clone(),
+            canonical_model_ref.model,
+        )
+    }
+
     pub fn from_config(config: &AppConfig) -> Self {
         let mut provider_endpoints = config
             .providers

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -87,13 +87,28 @@ fn build_candidate_with_override(
 ) -> Result<ProviderCandidate> {
     let mut route =
         resolve_explicit_model_route_for_candidate(config, route_ref, ModelRouteCapability::Turn)?;
-    if let Some(reasoning_effort_override) = reasoning_effort_override
-        .filter(|reasoning_effort| route.route_ref == *reasoning_effort.route_ref)
+    apply_reasoning_effort_override(config, &mut route, reasoning_effort_override);
+    build_candidate_from_model_route(&config.home_dir, &route)
+}
+
+fn apply_reasoning_effort_override(
+    config: &AppConfig,
+    route: &mut ResolvedModelRoute,
+    reasoning_effort_override: Option<ModelRouteReasoningEffortOverride<'_>>,
+) {
+    let reasoning_effort_override = reasoning_effort_override.map(|reasoning_effort| {
+        (
+            RuntimeModelCatalog::from_config(config)
+                .canonicalize_model_route_ref(reasoning_effort.route_ref),
+            reasoning_effort.reasoning_effort,
+        )
+    });
+    if let Some(reasoning_effort_override) =
+        reasoning_effort_override.filter(|(route_ref, _)| route.route_ref == *route_ref)
     {
         route.endpoint.runtime_config.reasoning_effort =
-            Some(reasoning_effort_override.reasoning_effort.to_string());
+            Some(reasoning_effort_override.1.to_string());
     }
-    build_candidate_from_model_route(&config.home_dir, &route)
 }
 
 pub(crate) fn build_candidate_from_model_route(
@@ -265,5 +280,42 @@ mod tests {
         assert!(error
             .to_string()
             .contains("no available providers for configured model chain"));
+    }
+
+    #[test]
+    fn model_route_effort_override_matches_legacy_model_alias() {
+        let mut config = codex_config("gpt-5.6-luna", "medium");
+        let mistral = crate::config::ProviderId::parse("mistral").unwrap();
+        let mut provider = config
+            .providers
+            .get(&crate::config::ProviderId::openai())
+            .unwrap()
+            .clone();
+        provider.id = mistral.clone();
+        provider.route_provider = mistral.clone();
+        config.providers.insert(mistral.clone(), provider);
+        let alias = ModelRouteRef::new(
+            mistral,
+            crate::config::ProviderEndpointId::default_endpoint(),
+            "devstral-medium-latest",
+        );
+        config.default_model = alias.clone();
+
+        let mut route =
+            resolve_explicit_model_route_for_candidate(&config, &alias, ModelRouteCapability::Turn)
+                .expect("the legacy alias should resolve");
+        apply_reasoning_effort_override(
+            &config,
+            &mut route,
+            Some(ModelRouteReasoningEffortOverride {
+                route_ref: &alias,
+                reasoning_effort: "high",
+            }),
+        );
+
+        assert_eq!(
+            route.endpoint.runtime_config.reasoning_effort.as_deref(),
+            Some("high")
+        );
     }
 }

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -28,6 +28,20 @@ pub fn build_provider_from_model_chain(
     config: &AppConfig,
     provider_chain: &[ModelRouteRef],
 ) -> Result<Arc<dyn AgentProvider>> {
+    build_provider_from_model_chain_with_override(config, provider_chain, None)
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ModelRouteReasoningEffortOverride<'a> {
+    pub(crate) route_ref: &'a ModelRouteRef,
+    pub(crate) reasoning_effort: &'a str,
+}
+
+pub(crate) fn build_provider_from_model_chain_with_override(
+    config: &AppConfig,
+    provider_chain: &[ModelRouteRef],
+    reasoning_effort_override: Option<ModelRouteReasoningEffortOverride<'_>>,
+) -> Result<Arc<dyn AgentProvider>> {
     let mut candidates = Vec::new();
     let mut errors = Vec::new();
     let disable_fallback = config.provider_fallback_disabled();
@@ -37,7 +51,7 @@ pub fn build_provider_from_model_chain(
     } else {
         provider_chain.len()
     }) {
-        match build_candidate(config, model_ref) {
+        match build_candidate_with_override(config, model_ref, reasoning_effort_override) {
             Ok(candidate) => {
                 if !candidates
                     .iter()
@@ -63,8 +77,22 @@ pub(crate) fn build_candidate(
     config: &AppConfig,
     route_ref: &ModelRouteRef,
 ) -> Result<ProviderCandidate> {
-    let route =
+    build_candidate_with_override(config, route_ref, None)
+}
+
+fn build_candidate_with_override(
+    config: &AppConfig,
+    route_ref: &ModelRouteRef,
+    reasoning_effort_override: Option<ModelRouteReasoningEffortOverride<'_>>,
+) -> Result<ProviderCandidate> {
+    let mut route =
         resolve_explicit_model_route_for_candidate(config, route_ref, ModelRouteCapability::Turn)?;
+    if let Some(reasoning_effort_override) = reasoning_effort_override
+        .filter(|reasoning_effort| route.route_ref == *reasoning_effort.route_ref)
+    {
+        route.endpoint.runtime_config.reasoning_effort =
+            Some(reasoning_effort_override.reasoning_effort.to_string());
+    }
     build_candidate_from_model_route(&config.home_dir, &route)
 }
 
@@ -193,5 +221,49 @@ mod tests {
             .expect("unsupported effort should fail provider construction");
         assert!(error.to_string().contains("openai-codex/gpt-5.5"));
         assert!(error.to_string().contains("low, medium, high, xhigh"));
+    }
+
+    #[test]
+    fn model_route_effort_override_does_not_filter_same_provider_fallback() {
+        let mut config = codex_config("gpt-5.6-luna", "medium");
+        let primary = config.default_model.clone();
+        let fallback = ModelRouteRef::parse_compatible("openai-codex/gpt-5.5").unwrap();
+        config.fallback_models.push(fallback.clone());
+
+        let provider = build_provider_from_model_chain_with_override(
+            &config,
+            &config.provider_chain(),
+            Some(ModelRouteReasoningEffortOverride {
+                route_ref: &primary,
+                reasoning_effort: "max",
+            }),
+        )
+        .expect("route-scoped effort should not affect the fallback model");
+
+        assert_eq!(
+            provider.configured_model_refs(),
+            vec![primary.as_string(), fallback.as_string()]
+        );
+    }
+
+    #[test]
+    fn provider_effort_still_filters_each_model_candidate() {
+        let mut config = codex_config("gpt-5.6-luna", "max");
+        let primary = config.default_model.clone();
+        config.fallback_models =
+            vec![ModelRouteRef::parse_compatible("openai-codex/gpt-5.5").unwrap()];
+
+        let provider = build_provider_from_model_chain(&config, &config.provider_chain())
+            .expect("the compatible primary should remain available");
+        assert_eq!(provider.configured_model_refs(), vec![primary.as_string()]);
+
+        config.default_model = ModelRouteRef::parse_compatible("openai-codex/gpt-5.5").unwrap();
+        config.fallback_models.clear();
+        let error = build_provider_from_model_chain(&config, &config.provider_chain())
+            .err()
+            .expect("an incompatible provider effort should reject every candidate");
+        assert!(error
+            .to_string()
+            .contains("no available providers for configured model chain"));
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -23,7 +23,10 @@ mod tool_schema;
 mod transports;
 mod wire_fingerprint;
 
-pub(crate) use catalog::build_candidate_from_model_route;
+pub(crate) use catalog::{
+    build_candidate_from_model_route, build_provider_from_model_chain_with_override,
+    ModelRouteReasoningEffortOverride,
+};
 pub use catalog::{build_provider_from_config, build_provider_from_model_chain};
 pub use diagnostics::{
     provider_doctor, resolved_model_availability, resolved_model_providers,

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -44,6 +44,21 @@ use super::{
     RuntimeAgent, RuntimeHandle, RuntimeInner,
 };
 
+fn model_route_reasoning_effort_override(
+    state: &AgentState,
+) -> Option<ModelRouteReasoningEffortOverride<'_>> {
+    state
+        .model_override
+        .as_ref()
+        .zip(state.model_override_reasoning_effort.as_deref())
+        .map(
+            |(route_ref, reasoning_effort)| ModelRouteReasoningEffortOverride {
+                route_ref,
+                reasoning_effort,
+            },
+        )
+}
+
 /// Snapshot of config-derived runtime fields that can be hot-swapped at runtime.
 /// Stored behind an `ArcSwap` so that config reloads take effect on the next turn
 /// without disturbing an in-progress turn.
@@ -346,16 +361,7 @@ impl RuntimeHandle {
             provider = build_provider_from_model_chain_with_override(
                 &provider_config,
                 &chain,
-                state
-                    .model_override
-                    .as_ref()
-                    .zip(state.model_override_reasoning_effort.as_deref())
-                    .map(
-                        |(route_ref, reasoning_effort)| ModelRouteReasoningEffortOverride {
-                            route_ref,
-                            reasoning_effort,
-                        },
-                    ),
+                model_route_reasoning_effort_override(&state),
             )?;
         }
         let resolved_context_config = if config_snapshot.provider_reconfig.is_some() {
@@ -530,16 +536,7 @@ impl RuntimeHandle {
         let provider = build_provider_from_model_chain_with_override(
             &provider_config,
             &chain,
-            state
-                .model_override
-                .as_ref()
-                .zip(state.model_override_reasoning_effort.as_deref())
-                .map(
-                    |(route_ref, reasoning_effort)| ModelRouteReasoningEffortOverride {
-                        route_ref,
-                        reasoning_effort,
-                    },
-                ),
+            model_route_reasoning_effort_override(state),
         )?;
         *self.inner.provider.write().await = provider;
         *self.inner.context_config.write().await = resolved_context_config;

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -22,7 +22,8 @@ use crate::{
     },
     provider::{
         build_candidate_from_model_route, build_provider_from_model_chain,
-        resolved_model_availability, AgentProvider, ConversationMessage, ModelBlock,
+        build_provider_from_model_chain_with_override, resolved_model_availability, AgentProvider,
+        ConversationMessage, ModelBlock, ModelRouteReasoningEffortOverride,
         ProviderGenerateImageRequest, ProviderGenerateImageResponse,
         ProviderJsonSchemaResponseFormat, ProviderResponseFormatRequest, ProviderTurnRequest,
     },
@@ -342,7 +343,20 @@ impl RuntimeHandle {
                     state.model_override.as_ref(),
                 )
                 .runtime_max_output_tokens;
-            provider = build_provider_from_model_chain(&provider_config, &chain)?;
+            provider = build_provider_from_model_chain_with_override(
+                &provider_config,
+                &chain,
+                state
+                    .model_override
+                    .as_ref()
+                    .zip(state.model_override_reasoning_effort.as_deref())
+                    .map(
+                        |(route_ref, reasoning_effort)| ModelRouteReasoningEffortOverride {
+                            route_ref,
+                            reasoning_effort,
+                        },
+                    ),
+            )?;
         }
         let resolved_context_config = if config_snapshot.provider_reconfig.is_some() {
             config_snapshot.model_catalog.resolved_context_config(
@@ -509,19 +523,24 @@ impl RuntimeHandle {
             fallback_model.or(state.model_override.as_ref()),
         );
         let mut provider_config = reconfig.config.clone();
-        if let (Some(primary), Some(reasoning_effort)) = (
-            chain.first(),
-            state.model_override_reasoning_effort.as_ref(),
-        ) {
-            if let Some(provider) = provider_config.providers.get_mut(&primary.provider) {
-                provider.reasoning_effort = Some(reasoning_effort.clone());
-            }
-        }
         provider_config.runtime_max_output_tokens = snap
             .model_catalog
             .resolved_model_policy(&snap.base_context_config, state.model_override.as_ref())
             .runtime_max_output_tokens;
-        let provider = build_provider_from_model_chain(&provider_config, &chain)?;
+        let provider = build_provider_from_model_chain_with_override(
+            &provider_config,
+            &chain,
+            state
+                .model_override
+                .as_ref()
+                .zip(state.model_override_reasoning_effort.as_deref())
+                .map(
+                    |(route_ref, reasoning_effort)| ModelRouteReasoningEffortOverride {
+                        route_ref,
+                        reasoning_effort,
+                    },
+                ),
+        )?;
         *self.inner.provider.write().await = provider;
         *self.inner.context_config.write().await = resolved_context_config;
         Ok(())

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -816,6 +816,54 @@ impl AgentProvider for OperatorInterjectionProbeProvider {
 }
 
 #[tokio::test]
+async fn model_override_reasoning_effort_does_not_leak_into_deferred_fallback() {
+    let home = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    std::fs::write(
+        home.path().join("config.json"),
+        r#"{"model":{"default":"openai/gpt-5.4"}}"#,
+    )
+    .unwrap();
+    let mut config =
+        crate::config::AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+    config.workspace_dir = workspace.path().to_path_buf();
+    let primary =
+        crate::config::ModelRouteRef::parse_compatible("openai-codex/gpt-5.6-luna").unwrap();
+    let fallback = crate::config::ModelRouteRef::parse_compatible("openai-codex/gpt-5.5").unwrap();
+    config.default_model = primary.clone();
+    config.fallback_models = vec![fallback.clone()];
+    config
+        .providers
+        .get_mut(&crate::config::ProviderId::openai_codex())
+        .unwrap()
+        .credential = Some(
+        r#"{"tokens":{"access_token":"test-token","refresh_token":"test-refresh","account_id":"test-account"}}"#
+            .into(),
+    );
+
+    let host = RuntimeHost::new(config).unwrap();
+    let runtime = host.default_runtime().await.unwrap();
+    runtime
+        .set_model_override(primary.clone(), Some("max".into()))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        runtime.inner.provider.read().await.configured_model_refs(),
+        vec![primary.as_string(), fallback.as_string()]
+    );
+
+    runtime
+        .reconfigure_provider_for_turn(Some(&fallback))
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime.inner.provider.read().await.configured_model_refs(),
+        vec![fallback.as_string()]
+    );
+}
+
+#[tokio::test]
 async fn update_agent_state_rolls_back_memory_when_persist_fails() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();


### PR DESCRIPTION
## 概要

- 将 turn-local `model_override_reasoning_effort` 限定到精确的 `ModelRouteRef`，不再通过 provider 配置影响同 endpoint 的其他模型
- 避免 deferred fallback 和普通模型链 fallback 继承原模型的 reasoning effort override
- 保留显式 provider 级 `reasoning_effort` 的既有 endpoint 范围语义，并补充实现决策说明

## 验证

- `cargo fmt --all -- --check`
- `cargo test --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

Fixes #2672