### PR TITLE
feat: forward chat reasoning effort

### DIFF
--- a/docs/implementation-decisions/094-openai-codex-reasoning-effort.md
+++ b/docs/implementation-decisions/094-openai-codex-reasoning-effort.md
@@ -2,7 +2,7 @@
 
 Holon uses each Codex model's catalog policy as the source of accepted
 `reasoning_effort` values. Configuration parsing accepts the shared Codex
-vocabulary through `max`, while provider construction and runtime model
+vocabulary from `none` through `max`, while provider construction and runtime model
 overrides validate the value against the selected model.
 
 `max` is exposed only for Codex models whose metadata declares it. `ultra` is

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -1346,14 +1346,14 @@ pub(crate) fn materialize_provider_config(
 
 pub(crate) fn validate_openai_reasoning_effort(value: &str) -> Result<()> {
     match value {
-        "low" | "medium" | "high" | "xhigh" | "max" => Ok(()),
+        "none" | "low" | "medium" | "high" | "xhigh" | "max" => Ok(()),
         "ultra" => Err(anyhow!(
             "OpenAI Codex reasoning_effort 'ultra' is unavailable; \
              Holon does not yet implement the required orchestration semantics"
         )),
         _ => Err(anyhow!(
             "invalid OpenAI Codex reasoning_effort '{value}'; \
-             must be one of low, medium, high, xhigh, max"
+             must be one of none, low, medium, high, xhigh, max"
         )),
     }
 }
@@ -1365,6 +1365,7 @@ mod reasoning_effort_tests {
     #[test]
     fn codex_reasoning_effort_vocabulary_allows_max_but_not_ultra() {
         validate_openai_reasoning_effort("max").unwrap();
+        validate_openai_reasoning_effort("none").unwrap();
         let error = validate_openai_reasoning_effort("ultra").unwrap_err();
         assert!(error.to_string().contains("orchestration semantics"));
     }

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -363,9 +363,9 @@ impl ResolvedModelRoute {
         }
 
         match value {
-            "low" | "medium" | "high" | "xhigh" | "max" => Ok(()),
+            "none" | "low" | "medium" | "high" | "xhigh" | "max" => Ok(()),
             _ => Err(ReasoningEffortValidationError::new(format!(
-                "invalid reasoning_effort '{value}'; must be one of low, medium, high, xhigh, max"
+                "invalid reasoning_effort '{value}'; must be one of none, low, medium, high, xhigh, max"
             ))),
         }
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2157,6 +2157,7 @@ fn resolves_compatible_reasoning_effort_for_non_codex_route() {
         .unwrap();
 
     assert!(route.validate_reasoning_effort("xhigh").is_ok());
+    assert!(route.validate_reasoning_effort("none").is_ok());
     assert!(route.validate_reasoning_effort("arbitrary").is_err());
 }
 

--- a/src/provider/tests/openai_chat_completions.rs
+++ b/src/provider/tests/openai_chat_completions.rs
@@ -149,6 +149,7 @@ fn chat_completion_request_builds_openai_function_tools() {
         &request,
         ToolSchemaContract::Relaxed,
         false,
+        None,
     )
     .expect("should build chat completion request");
 
@@ -192,6 +193,7 @@ fn chat_completion_request_includes_tool_choice_auto() {
         &request,
         ToolSchemaContract::Relaxed,
         false,
+        None,
     )
     .expect("should build chat completion request");
 
@@ -721,18 +723,48 @@ fn chat_completion_request_includes_stream_flag() {
     let request = provider_turn_request();
 
     // Test with stream = true
-    let streaming_request =
-        build_chat_completion_request("gpt-4", 1000, &request, ToolSchemaContract::Relaxed, true)
-            .expect("should build streaming request");
+    let streaming_request = build_chat_completion_request(
+        "gpt-4",
+        1000,
+        &request,
+        ToolSchemaContract::Relaxed,
+        true,
+        None,
+    )
+    .expect("should build streaming request");
 
     assert_eq!(streaming_request["stream"], true);
 
     // Test with stream = false
-    let non_streaming_request =
-        build_chat_completion_request("gpt-4", 1000, &request, ToolSchemaContract::Relaxed, false)
-            .expect("should build non-streaming request");
+    let non_streaming_request = build_chat_completion_request(
+        "gpt-4",
+        1000,
+        &request,
+        ToolSchemaContract::Relaxed,
+        false,
+        None,
+    )
+    .expect("should build non-streaming request");
 
     assert_eq!(non_streaming_request["stream"], false);
+}
+
+#[test]
+fn chat_completion_request_forwards_reasoning_effort_when_configured() {
+    use crate::provider::transports::build_chat_completion_request;
+
+    let request = provider_turn_request();
+    let body = build_chat_completion_request(
+        "qwen3.8:27b-mlx",
+        1000,
+        &request,
+        ToolSchemaContract::Relaxed,
+        false,
+        Some("none"),
+    )
+    .expect("should build chat completion request");
+
+    assert_eq!(body["reasoning_effort"], "none");
 }
 
 #[test]
@@ -1107,6 +1139,7 @@ fn chat_completion_request_handles_empty_tools_list() {
         &request,
         ToolSchemaContract::Relaxed,
         false,
+        None,
     );
 
     assert!(chat_request.is_ok());

--- a/src/provider/transports/openai/chat/plan.rs
+++ b/src/provider/transports/openai/chat/plan.rs
@@ -10,6 +10,7 @@ pub(crate) fn build_chat_completion_request(
     request: &ProviderTurnRequest,
     tool_schema_contract: ToolSchemaContract,
     stream: bool,
+    reasoning_effort: Option<&str>,
 ) -> Result<Value> {
     // Build messages array for Chat Completions API
     let messages =
@@ -57,6 +58,12 @@ pub(crate) fn build_chat_completion_request(
         body["prompt_cache_key"] = Value::String(cache.prompt_cache_key.clone());
     }
 
+    // Forward configured reasoning_effort; e.g. "none" disables thinking on
+    // local OpenAI-compatible servers such as Ollama.
+    if let Some(reasoning_effort) = reasoning_effort {
+        body["reasoning_effort"] = Value::String(reasoning_effort.to_string());
+    }
+
     Ok(body)
 }
 
@@ -66,6 +73,7 @@ pub(crate) fn plan_chat_completion_request(
     request: &ProviderTurnRequest,
     tool_schema_contract: ToolSchemaContract,
     stream: bool,
+    reasoning_effort: Option<&str>,
     continuation: &Arc<Mutex<OpenAiContinuationState>>,
 ) -> Result<(Value, OpenAiRequestPlan)> {
     let full_body = build_chat_completion_request(
@@ -74,6 +82,7 @@ pub(crate) fn plan_chat_completion_request(
         request,
         tool_schema_contract,
         stream,
+        reasoning_effort,
     )?;
 
     let body_messages = full_body

--- a/src/provider/transports/openai/mod.rs
+++ b/src/provider/transports/openai/mod.rs
@@ -168,6 +168,7 @@ pub struct OpenAiChatCompletionsProvider {
     api_key: Option<String>,
     model: String,
     max_output_tokens: u32,
+    reasoning_effort: Option<String>,
     trace_home_dir: PathBuf,
     continuation: Arc<Mutex<OpenAiContinuationState>>,
 }
@@ -456,6 +457,7 @@ impl OpenAiChatCompletionsProvider {
             api_key,
             model: model.to_string(),
             max_output_tokens: resolved_max_output_tokens,
+            reasoning_effort: provider_config.reasoning_effort.clone(),
             trace_home_dir: trace_home_dir.to_path_buf(),
             continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
         })
@@ -1103,9 +1105,11 @@ impl AgentProvider for OpenAiChatCompletionsProvider {
             &request,
             ToolSchemaContract::Relaxed,
             false, // Streaming infrastructure exists but is not currently enabled; requests are non-streaming
+            self.reasoning_effort.as_deref(),
             &self.continuation,
         )?;
-        let sent_diagnostics = plan.diagnostics.clone();
+        let mut sent_diagnostics = plan.diagnostics.clone();
+        sent_diagnostics.reasoning_effort = self.reasoning_effort.clone();
         let headers = self
             .api_key
             .as_ref()

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1607,7 +1607,7 @@ pub async fn control_agent_model_override_validates_codex_reasoning_effort() -> 
     assert!(invalid_non_codex
         .text()
         .await?
-        .contains("must be one of low, medium, high, xhigh, max"));
+        .contains("must be one of none, low, medium, high, xhigh, max"));
 
     server.abort();
     Ok(())


### PR DESCRIPTION
## Summary
- forward configured `reasoning_effort` through the `openai_chat_completions` request body
- accept `reasoning_effort = "none"` in shared and route-specific validation so OpenAI-compatible backends can disable thinking
- add request-body and validation coverage, and align the reasoning-effort RFC wording

## Verification
- `cargo fmt --all -- --check`
- `cargo test chat_completion_request_forwards_reasoning_effort_when_configured`
- `cargo test openai_chat_route_accepts_none_reasoning_effort`
- `cargo test validate_openai_reasoning_effort_accepts_none`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
