### PR TITLE
fix: configure model for real-daemon web e2e

### DIFF
--- a/web-gui/app/e2e/real-daemon/daemon-fixture.ts
+++ b/web-gui/app/e2e/real-daemon/daemon-fixture.ts
@@ -133,6 +133,7 @@ async function createDaemon(
       env: {
         ...process.env,
         HOLON_HOME: home,
+        HOLON_MODEL: "openai/gpt-5.4",
         HOLON_CONTROL_AUTH_MODE: "required",
         HOLON_CALLBACK_BASE_URL: baseUrl,
       },


### PR DESCRIPTION
## 问题

Web real-daemon E2E 启动测试 daemon 时未配置模型。当前 daemon 启动契约会在 readiness 前解析默认模型；CI 环境没有可用的用户级模型配置，因此进程提前退出，nightly/main 测试只表现为 readiness 超时。

## 修复

- 在 real-daemon fixture 中显式设置 `HOLON_MODEL=openai/gpt-5.4`
- 保持生产启动契约不变，仅让测试夹具提供其运行所需的完整配置

## 验证

- `cargo build --bin holon`
- `npm run build`
- `npm run build:e2e:real-daemon`
- `npm run test:e2e:real-daemon -- --workers=1 --repeat-each=3`（6/6 通过）
- `npm run typecheck`
