### PR TITLE
feat: add first-class Ollama provider support

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -62,6 +62,7 @@ implementation and tests.
 - [Execution Policy and Virtual Execution Boundary](./execution-policy-and-virtual-execution-boundary.md)
 - [Runtime Configuration Surface](./runtime-configuration-surface.md)
 - [Extensible Model And Provider Configuration](./extensible-model-provider-configuration.md)
+- [First-Class Ollama Provider](./first-class-ollama-provider.md)
 - [Model Capability Resolution](./model-capability-resolution.md)
 - [Model Metadata Precedence](./model-metadata-precedence.md)
 

--- a/docs/rfcs/first-class-ollama-provider.md
+++ b/docs/rfcs/first-class-ollama-provider.md
@@ -1,0 +1,68 @@
+# First-Class Ollama Provider
+
+## Status
+
+Accepted for phased implementation in GitHub issue #2676.
+
+## Decision
+
+Holon will expose Ollama as a built-in `ollama@default` provider without
+coupling agent turns to Ollama's native `/api/chat` protocol.
+
+Phase 1 uses the existing Anthropic Messages transport:
+
+- inference base URL: `http://127.0.0.1:11434`
+- messages endpoint: `/v1/messages`
+- authentication: none
+- catalog policy: discovery only
+
+A same-model bake-off on August 26, 2026 covered non-streaming, streaming,
+thinking, a tool-call round trip, and three-turn full history. Anthropic
+Messages, OpenAI Responses, and OpenAI Chat Completions each passed all five
+cases. Anthropic Messages remains the default because its standard thinking
+and tool-result content blocks match Holon's existing full-history agent loop.
+
+The Anthropic transport must therefore honor the endpoint authentication
+contract: configured credentials produce an authorization header, while an
+explicit `CredentialKind::None` endpoint sends no authorization header.
+
+## Discovery Contract
+
+Ollama discovery is provider-specific control-plane behavior:
+
+1. `GET /api/tags` lists installed models.
+2. `POST /api/show` with `{"model":"<name>"}` enriches each model.
+3. Results enter the normal remote-discovery cache as
+   `BuiltInModelMetadata`.
+
+Phase 1 maps only fields already represented by Holon's catalog:
+
+- advertised context length to `context_window_tokens`
+- `vision` to `image_input`
+- `thinking` to `supports_reasoning`
+- `tools` to the existing tool-call capability projection
+
+Unknown or absent metadata remains conservative. Holon does not infer
+capability from model names and does not automatically pull, run, stop, or
+delete models.
+
+The default endpoint is loopback-only. A user may explicitly configure a
+remote endpoint; doctor should warn for a non-loopback, cleartext,
+unauthenticated endpoint rather than silently elevating trust or rejecting an
+intentional self-hosted configuration.
+
+## Preserved Boundaries
+
+- Ollama is not inserted into the default or fallback model chain.
+- Existing custom OpenAI-compatible Ollama configurations remain valid.
+- Provider discovery may be specialized without introducing a general
+  arbitrary request-graph framework.
+- Transport selection is explicit in endpoint configuration; runtime code does
+  not switch transports implicitly per request or capability.
+
+## Deferred
+
+Later phases may add capability evidence improvements, Chat Completions
+reasoning compatibility, structured-output capability, embeddings and rerank
+classification, lifecycle management, warmup diagnostics, or a native Ollama
+transport. Those changes are not part of the Phase 1 provider contract.

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -6,8 +6,8 @@ generated: auto-generated from holon source — do not edit directly
 
 # Supported Models
 
-Holon includes built-in configuration for **33 provider accounts**
-across **42 endpoints** and **256 models**.
+Holon includes built-in configuration for **34 provider accounts**
+across **43 endpoints** and **264 models**.
 
 This page is auto-generated from the Holon source code
 ([`src/model_catalog.rs`](../../../src/model_catalog.rs) and
@@ -46,6 +46,7 @@ used in existing `provider/model` refs and config shortcuts.
 | `moonshot` | `default` | `moonshot` | OpenAI Chat Completions | `https://api.moonshot.ai/v1` | `MOONSHOT_API_KEY` |
 | `nearai` | `default` | `nearai` | OpenAI Chat Completions | `https://cloud-api.near.ai/v1` | `NEARAI_API_KEY` |
 | `nvidia` | `default` | `nvidia` | OpenAI Chat Completions | `https://integrate.api.nvidia.com/v1` | `NVIDIA_API_KEY` |
+| `ollama` | `default` | `ollama` | Anthropic Messages | `http://127.0.0.1:11434` | `—` |
 | `openai` | `default` | `openai` | OpenAI Responses | `https://api.openai.com/v1` | `OPENAI_API_KEY` |
 | `openai-codex` | `default` | `openai-codex` | OpenAI Codex | `https://chatgpt.com/backend-api/codex` | `—` |
 | `opencode-go` | `default` | `opencode-go` | OpenAI Chat Completions | `https://opencode.ai/zen/go/v1` | `OPENCODE_GO_API_KEY` |
@@ -101,6 +102,7 @@ and capabilities.
 | `bigmodel` | `glm-5-turbo` | `bigmodel/glm-5-turbo` | 204800 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5.1` | `bigmodel/glm-5.1` | 204800 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5.2` | `bigmodel/glm-5.2` | 1000000 | 131072 | ✅ | — |
+| `bigmodel` | `glm-5.3` | `bigmodel/glm-5.3` | 1000000 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5v-turbo` | `bigmodel/glm-5v-turbo` | 204800 | 131072 | ✅ | ✅ |
 | `chutes` | `MiniMaxAI/MiniMax-M2.5-TEE` | `chutes/MiniMaxAI/MiniMax-M2.5-TEE` | 196608 | 65536 | ✅ | — |
 | `chutes` | `Qwen/Qwen3-235B-A22B-Thinking-2507-TEE` | `chutes/Qwen/Qwen3-235B-A22B-Thinking-2507-TEE` | 262144 | 262144 | ✅ | — |
@@ -118,16 +120,18 @@ and capabilities.
 | `dashscope` | `MiniMax-M2.5` | `dashscope/MiniMax-M2.5` | 196608 | 32768 | ✅ | — |
 | `dashscope` | `MiniMax/MiniMax-M3` | `dashscope/MiniMax/MiniMax-M3` | 196608 | 32768 | ✅ | — |
 | `dashscope` | `ZHIPU/GLM-5.2` | `dashscope/ZHIPU/GLM-5.2` | 1000000 | 131072 | ✅ | — |
+| `dashscope` | `ZHIPU/GLM-5.3` | `dashscope/ZHIPU/GLM-5.3` | 1000000 | 131072 | ✅ | — |
 | `dashscope` | `deepseek-v3.2` | `dashscope/deepseek-v3.2` | 128000 | 32768 | ✅ | — |
-| `dashscope` | `deepseek-v4-flash` | `dashscope/deepseek-v4-flash` | 1000000 | 65536 | ✅ | — |
-| `dashscope` | `deepseek-v4-pro` | `dashscope/deepseek-v4-pro` | 1000000 | 65536 | ✅ | — |
+| `dashscope` | `deepseek-v4-flash` | `dashscope/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
+| `dashscope` | `deepseek-v4-flash-0731` | `dashscope/deepseek-v4-flash-0731` | 1000000 | 384000 | ✅ | — |
+| `dashscope` | `deepseek-v4-pro` | `dashscope/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
 | `dashscope` | `glm-4.7` | `dashscope/glm-4.7` | 202752 | 16384 | ✅ | — |
 | `dashscope` | `glm-5` | `dashscope/glm-5` | 202752 | 16384 | ✅ | — |
-| `dashscope` | `glm-5.1` | `dashscope/glm-5.1` | 202752 | 65536 | ✅ | — |
-| `dashscope` | `glm-5.2` | `dashscope/glm-5.2` | 1000000 | 65536 | ✅ | — |
+| `dashscope` | `glm-5.1` | `dashscope/glm-5.1` | 202752 | 131072 | ✅ | — |
+| `dashscope` | `glm-5.2` | `dashscope/glm-5.2` | 204800 | 128000 | ✅ | — |
 | `dashscope` | `kimi-k2.5` | `dashscope/kimi-k2.5` | 262144 | 32768 | ✅ | ✅ |
-| `dashscope` | `kimi-k2.6` | `dashscope/kimi-k2.6` | 262144 | 65536 | ✅ | ✅ |
-| `dashscope` | `kimi-k2.7-code` | `dashscope/kimi-k2.7-code` | 262144 | 65536 | ✅ | ✅ |
+| `dashscope` | `kimi-k2.6` | `dashscope/kimi-k2.6` | 262144 | 98304 | ✅ | ✅ |
+| `dashscope` | `kimi-k2.7-code` | `dashscope/kimi-k2.7-code` | 262144 | 98304 | ✅ | ✅ |
 | `dashscope` | `mimo-v2.5-pro` | `dashscope/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
 | `dashscope` | `qwen3-coder-flash` | `dashscope/qwen3-coder-flash` | 1000000 | 65536 | ✅ | — |
 | `dashscope` | `qwen3-coder-next` | `dashscope/qwen3-coder-next` | 262144 | 65536 | ✅ | — |
@@ -142,6 +146,8 @@ and capabilities.
 | `dashscope` | `qwen3.7-max-2026-06-08` | `dashscope/qwen3.7-max-2026-06-08` | 1000000 | 65536 | ✅ | — |
 | `dashscope` | `qwen3.7-plus` | `dashscope/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope` | `qwen3.7-plus-2026-05-26` | `dashscope/qwen3.7-plus-2026-05-26` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope` | `qwen3.8-max` | `dashscope/qwen3.8-max` | 1000000 | 131072 | ✅ | ✅ |
+| `dashscope` | `qwen3.8-max-preview` | `dashscope/qwen3.8-max-preview` | 1000000 | 65536 | ✅ | ✅ |
 | `deepseek` | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
 | `deepseek` | `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
 | `fireworks` | `accounts/fireworks/models/deepseek-v4-flash` | `fireworks/accounts/fireworks/models/deepseek-v4-flash` | 1048576 | — | ✅ | — |
@@ -183,6 +189,7 @@ and capabilities.
 | `moonshot` | `kimi-k2.6` | `moonshot/kimi-k2.6` | 262144 | 262144 | ✅ | ✅ |
 | `moonshot` | `kimi-k2.7-code` | `moonshot/kimi-k2.7-code` | 262144 | 262144 | ✅ | ✅ |
 | `moonshot` | `kimi-k2.7-code-highspeed` | `moonshot/kimi-k2.7-code-highspeed` | 262144 | 262144 | ✅ | ✅ |
+| `moonshot` | `kimi-k3` | `moonshot/kimi-k3` | 1000000 | 262144 | ✅ | ✅ |
 | `moonshot` | `moonshot-v1-128k` | `moonshot/moonshot-v1-128k` | 131072 | 131072 | — | — |
 | `moonshot` | `moonshot-v1-128k-vision-preview` | `moonshot/moonshot-v1-128k-vision-preview` | 131072 | 131072 | — | ✅ |
 | `moonshot` | `moonshot-v1-32k` | `moonshot/moonshot-v1-32k` | 32768 | 32768 | — | — |
@@ -307,6 +314,7 @@ and capabilities.
 | `volcengine` | `doubao-seed-2-0-pro-260215` | `volcengine/doubao-seed-2-0-pro-260215` | 256000 | 4096 | ✅ | ✅ |
 | `volcengine` | `doubao-seedream-5.0-lite` | `volcengine/doubao-seedream-5.0-lite` | — | — | — | — |
 | `volcengine` | `glm-5.2` | `volcengine/glm-5.2` | 204800 | 128000 | ✅ | — |
+| `volcengine` | `glm-5.3` | `volcengine/glm-5.3` | 204800 | 128000 | ✅ | — |
 | `volcengine` | `kimi-k2.6` | `volcengine/kimi-k2.6` | 262144 | 32768 | ✅ | — |
 | `volcengine` | `kimi-k2.7-code` | `volcengine/kimi-k2.7-code` | 262144 | 32768 | ✅ | — |
 | `xai` | `grok-4.3` | `xai/grok-4.3` | 1000000 | — | ✅ | ✅ |
@@ -331,4 +339,5 @@ and capabilities.
 | `zai` | `glm-5-turbo` | `zai/glm-5-turbo` | 202800 | 131072 | ✅ | — |
 | `zai` | `glm-5.1` | `zai/glm-5.1` | 202800 | 131072 | ✅ | — |
 | `zai` | `glm-5.2` | `zai/glm-5.2` | 1000000 | 131072 | ✅ | — |
+| `zai` | `glm-5.3` | `zai/glm-5.3` | 1000000 | 131072 | ✅ | — |
 | `zai` | `glm-5v-turbo` | `zai/glm-5v-turbo` | 202800 | 131072 | ✅ | ✅ |

--- a/src/config/providers.rs
+++ b/src/config/providers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use url::{Host, Url};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlAuthMode {
@@ -95,6 +96,24 @@ impl ProviderRuntimeConfig {
             .as_ref()
             .map(|credential| !credential.trim().is_empty())
             .unwrap_or(false)
+    }
+
+    pub fn unauthenticated_cleartext_remote_warning(&self) -> Option<&'static str> {
+        if self.auth.kind != CredentialKind::None {
+            return None;
+        }
+        let url = Url::parse(&self.base_url).ok()?;
+        if url.scheme() != "http" {
+            return None;
+        }
+        let loopback = match url.host()? {
+            Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+            Host::Ipv4(address) => address.is_loopback(),
+            Host::Ipv6(address) => address.is_loopback(),
+        };
+        (!loopback).then_some(
+            "Provider endpoint is remote, cleartext HTTP, and unauthenticated; network peers may observe or modify model traffic.",
+        )
     }
 }
 

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -24,6 +24,8 @@ use crate::{
 };
 
 const OPENAI_COMPATIBLE_MODELS_PATH: &str = "/models";
+const OLLAMA_TAGS_PATH: &str = "/api/tags";
+const OLLAMA_SHOW_PATH: &str = "/api/show";
 pub const DEFAULT_DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Transport-level default discovery used for `openai_chat_completions`
@@ -227,6 +229,9 @@ pub async fn refresh_provider_models(
     })?;
 
     let source_url = provider_models_url(provider)?;
+    if discovery.decoder == ModelDiscoveryDecoder::Ollama {
+        return refresh_ollama_models(provider, cache_path, source_url).await;
+    }
     let request = reqwest::Client::builder()
         .user_agent("holon-model-discovery")
         .build()
@@ -273,6 +278,7 @@ pub async fn refresh_provider_models(
                 .context("failed to parse OpenAI-compatible model discovery response")?
                 .into_model_metadata(&provider.id)
         }
+        ModelDiscoveryDecoder::Ollama => unreachable!("Ollama discovery is handled above"),
         ModelDiscoveryDecoder::NearAi => serde_json::from_slice::<NearAiModelsResponse>(&raw)
             .context("failed to parse NEAR AI model discovery response")?
             .into_model_metadata(&provider.id),
@@ -335,9 +341,190 @@ fn provider_models_url(provider: &ProviderRuntimeConfig) -> Result<String> {
     match discovery.route {
         ModelDiscoveryRoute::Fixed(url) => Ok(url.to_string()),
         ModelDiscoveryRoute::OpenAiCompatible => openai_compatible_models_url(&provider.base_url),
+        ModelDiscoveryRoute::Ollama => ollama_tags_url(&provider.base_url),
         ModelDiscoveryRoute::OpenAiV1 => openai_v1_models_url(&provider.base_url),
         ModelDiscoveryRoute::Venice => venice_models_url(&provider.base_url),
         ModelDiscoveryRoute::VercelAiGateway => vercel_models_url(&provider.base_url),
+    }
+}
+
+fn ollama_tags_url(base_url: &str) -> Result<String> {
+    ollama_api_url(base_url, OLLAMA_TAGS_PATH)
+}
+
+fn ollama_show_url(base_url: &str) -> Result<String> {
+    ollama_api_url(base_url, OLLAMA_SHOW_PATH)
+}
+
+fn ollama_api_url(base_url: &str, api_path: &str) -> Result<String> {
+    let mut url = reqwest::Url::parse(base_url)
+        .with_context(|| format!("invalid Ollama base_url {base_url:?}"))?;
+    let path = url.path().trim_end_matches('/');
+    let path = path
+        .strip_suffix("/v1")
+        .unwrap_or(path)
+        .trim_end_matches('/');
+    url.set_path(&format!("{path}{api_path}"));
+    Ok(url.to_string())
+}
+
+async fn refresh_ollama_models(
+    provider: &ProviderRuntimeConfig,
+    cache_path: &Path,
+    source_url: String,
+) -> Result<ModelDiscoveryRefreshReport> {
+    let client = reqwest::Client::builder()
+        .user_agent("holon-model-discovery")
+        .build()
+        .context("failed to build model discovery HTTP client")?;
+    let request = client.get(&source_url);
+    let request = if let Some(credential) = provider.credential.as_deref() {
+        request.bearer_auth(credential)
+    } else {
+        request
+    };
+    let raw = request
+        .send()
+        .await
+        .with_context(|| format!("{} model discovery request failed", provider.id.as_str()))?
+        .error_for_status()
+        .with_context(|| {
+            format!(
+                "{} model discovery returned an error status",
+                provider.id.as_str()
+            )
+        })?
+        .bytes()
+        .await
+        .context("failed to read Ollama tags response")?;
+    let mut tags = serde_json::from_slice::<OllamaTagsResponse>(&raw)
+        .context("failed to parse Ollama tags response")?;
+    tags.models
+        .sort_by(|left, right| left.name.cmp(&right.name));
+    tags.models.dedup_by(|left, right| left.name == right.name);
+
+    let show_url = ollama_show_url(&provider.base_url)?;
+    let mut models = Vec::new();
+    for tagged in tags.models {
+        let name = tagged.name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        let request = client
+            .post(&show_url)
+            .json(&OllamaShowRequest { model: name });
+        let request = if let Some(credential) = provider.credential.as_deref() {
+            request.bearer_auth(credential)
+        } else {
+            request
+        };
+        let raw = request
+            .send()
+            .await
+            .with_context(|| format!("Ollama show request failed for model {name:?}"))?
+            .error_for_status()
+            .with_context(|| format!("Ollama show returned an error status for model {name:?}"))?
+            .bytes()
+            .await
+            .with_context(|| format!("failed to read Ollama show response for model {name:?}"))?;
+        let show = serde_json::from_slice::<OllamaShowResponse>(&raw)
+            .with_context(|| format!("failed to parse Ollama show response for model {name:?}"))?;
+        models.push(show.into_model_metadata(&provider.id, name));
+    }
+    models.sort_by(|left, right| left.model_ref.model.cmp(&right.model_ref.model));
+
+    let response_hash = format!(
+        "sha256:{}",
+        sha256_hex(
+            &serde_json::to_vec(&models)
+                .context("failed to serialize Ollama discovery result for hashing")?
+        )
+    );
+    let fetched_at = Utc::now();
+    let mut cache = load_discovery_cache_at(cache_path)?;
+    cache.providers.insert(
+        provider.id.clone(),
+        ProviderModelDiscoveryCache {
+            provider: provider.id.clone(),
+            fetched_at,
+            source_url: Some(source_url),
+            response_hash: Some(response_hash),
+            models: models.clone(),
+        },
+    );
+    save_discovery_cache_at(cache_path, &cache)?;
+
+    Ok(ModelDiscoveryRefreshReport {
+        provider: provider.id.clone(),
+        fetched_at,
+        model_count: models.len(),
+        cache_path: cache_path.to_path_buf(),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaTagsResponse {
+    #[serde(default)]
+    models: Vec<OllamaTaggedModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaTaggedModel {
+    name: String,
+}
+
+#[derive(Serialize)]
+struct OllamaShowRequest<'a> {
+    model: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaShowResponse {
+    #[serde(default)]
+    capabilities: Vec<String>,
+    #[serde(default)]
+    model_info: BTreeMap<String, serde_json::Value>,
+}
+
+impl OllamaShowResponse {
+    fn into_model_metadata(self, provider: &ProviderId, model: &str) -> BuiltInModelMetadata {
+        let has_capability = |expected: &str| {
+            self.capabilities
+                .iter()
+                .any(|capability| capability.eq_ignore_ascii_case(expected))
+        };
+        let context_window_tokens = self
+            .model_info
+            .iter()
+            .filter(|(key, _)| key.ends_with(".context_length"))
+            .filter_map(|(_, value)| {
+                value
+                    .as_u64()
+                    .and_then(|value| usize::try_from(value).ok())
+                    .or_else(|| value.as_str().and_then(|value| value.parse::<usize>().ok()))
+            })
+            .max();
+        BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider.clone(), model.to_string()),
+            display_name: model.to_string(),
+            description: "Remote discovered Ollama model.".to_string(),
+            context_window_tokens,
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: None,
+            capabilities: ModelCapabilityFlags {
+                image_input: has_capability("vision"),
+                supports_reasoning: has_capability("thinking"),
+                // Ollama's `tools` capability does not imply parallel tool calls.
+                ..ModelCapabilityFlags::default()
+            },
+            reasoning_effort_options: Vec::new(),
+            source: ModelMetadataSource::RemoteDiscovered,
+            endpoint: None,
+        }
     }
 }
 
@@ -1647,6 +1834,13 @@ mod tests {
         }
     }
 
+    fn ollama_provider(base_url: String) -> ProviderRuntimeConfig {
+        let mut provider = custom_openai_provider(base_url);
+        provider.id = ProviderId::parse("ollama").unwrap();
+        provider.route_provider = provider.id.clone();
+        provider
+    }
+
     #[test]
     fn maps_arcee_models_without_inventing_capabilities_or_output_limits() {
         let payload: ArceeModelsResponse = serde_json::from_str(
@@ -2473,5 +2667,106 @@ mod tests {
         let fresh = discovery_cache_status_for_provider(&provider, &cache, ttl, false);
         assert_eq!(fresh.state, ModelDiscoveryCacheState::Fresh);
         assert!(!discovery_cache_needs_refresh(&provider, &cache, ttl));
+    }
+
+    #[test]
+    fn ollama_discovery_urls_replace_openai_v1_suffix_and_preserve_prefix() {
+        assert_eq!(
+            ollama_tags_url("http://127.0.0.1:11434/v1").unwrap(),
+            "http://127.0.0.1:11434/api/tags"
+        );
+        assert_eq!(
+            ollama_show_url("https://example.test/ollama/v1/").unwrap(),
+            "https://example.test/ollama/api/show"
+        );
+    }
+
+    #[test]
+    fn ollama_show_maps_context_vision_and_thinking_without_parallel_tools() {
+        let show: OllamaShowResponse = serde_json::from_str(
+            r#"{
+                "capabilities":["completion","vision","tools","thinking"],
+                "model_info":{
+                    "general.architecture":"qwen3",
+                    "qwen3.context_length":131072,
+                    "other.context_length":"65536"
+                }
+            }"#,
+        )
+        .unwrap();
+        let model =
+            show.into_model_metadata(&ProviderId::parse("ollama").unwrap(), "qwen3-vl:latest");
+
+        assert_eq!(model.context_window_tokens, Some(131_072));
+        assert!(model.capabilities.image_input);
+        assert!(model.capabilities.supports_reasoning);
+        assert!(!model.capabilities.parallel_tool_calls);
+        assert_eq!(model.source, ModelMetadataSource::RemoteDiscovered);
+    }
+
+    #[tokio::test]
+    async fn ollama_discovery_uses_tags_then_show_without_authentication() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_url = format!("http://{}/v1", listener.local_addr().unwrap());
+        let server = thread::spawn(move || {
+            let (mut tags_stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 2048];
+            let read = tags_stream.read(&mut request).unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("GET /api/tags HTTP/1.1"));
+            assert!(!request.to_ascii_lowercase().contains("authorization:"));
+            let body = r#"{"models":[{"name":"qwen3-vl:latest"}]}"#;
+            write!(
+                tags_stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+
+            let (mut show_stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let read = show_stream.read(&mut request).unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("POST /api/show HTTP/1.1"));
+            assert!(!request.to_ascii_lowercase().contains("authorization:"));
+            assert!(request.contains(r#""model":"qwen3-vl:latest""#));
+            let body = r#"{
+                "capabilities":["vision","tools","thinking"],
+                "model_info":{"qwen3.context_length":131072}
+            }"#;
+            write!(
+                show_stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+
+        let provider = ollama_provider(base_url);
+        let cache_dir = tempfile::tempdir().unwrap();
+        let cache_path = cache_dir.path().join("model-discovery-cache.json");
+        let report = refresh_provider_models(&provider, &cache_path)
+            .await
+            .unwrap();
+        server.join().unwrap();
+
+        assert_eq!(report.model_count, 1);
+        let cache = load_discovery_cache_at(&cache_path).unwrap();
+        let entry = cache.providers.get(&provider.id).unwrap();
+        assert_eq!(
+            entry.source_url.as_deref(),
+            Some(provider_models_url(&provider).unwrap().as_str())
+        );
+        assert!(entry
+            .response_hash
+            .as_deref()
+            .is_some_and(|hash| hash.starts_with("sha256:")));
+        let model = &entry.models[0];
+        assert_eq!(model.context_window_tokens, Some(131_072));
+        assert!(model.capabilities.image_input);
+        assert!(model.capabilities.supports_reasoning);
+        assert!(!model.capabilities.parallel_tool_calls);
     }
 }

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -718,7 +718,10 @@ fn model_provider_section(config: &AppConfig) -> OnboardingSection {
 
     let credential_configured =
         provider.has_configured_credential() || provider.auth.source == CredentialSource::None;
-    let status = if credential_configured {
+    let security_warning = provider.unauthenticated_cleartext_remote_warning();
+    let status = if security_warning.is_some() {
+        OnboardingStatus::Restricted
+    } else if credential_configured {
         OnboardingStatus::Configured
     } else {
         OnboardingStatus::Missing
@@ -743,7 +746,9 @@ fn model_provider_section(config: &AppConfig) -> OnboardingSection {
         "model_provider",
         "Model provider",
         status,
-        if credential_configured {
+        if security_warning.is_some() {
+            "The default model provider uses remote, cleartext, unauthenticated transport."
+        } else if credential_configured {
             "The default model provider has a configured credential path."
         } else {
             "The default model provider is missing a configured credential path."
@@ -755,6 +760,7 @@ fn model_provider_section(config: &AppConfig) -> OnboardingSection {
             ("credential_source", json!(provider.auth.source.as_str())),
             ("credential_kind", json!(provider.auth.kind.as_str())),
             ("credential_configured", json!(credential_configured)),
+            ("security_warning", json!(security_warning)),
         ],
         actions,
     )
@@ -1072,6 +1078,50 @@ mod tests {
         assert_eq!(report.status, OnboardingStatus::Missing);
         assert_eq!(model.status, OnboardingStatus::Missing);
         assert_eq!(report.next_actions.len(), 1);
+    }
+
+    #[test]
+    fn onboarding_report_warns_for_remote_cleartext_unauthenticated_provider() {
+        let mut config = test_config(Some("openai-key"));
+        let ollama = ProviderId::parse("ollama").unwrap();
+        config.providers.insert(
+            ollama.clone(),
+            ProviderRuntimeConfig {
+                id: ollama.clone(),
+                route_provider: ollama,
+                route_endpoint: ProviderEndpointId::default_endpoint(),
+                transport: ProviderTransportKind::AnthropicMessages,
+                base_url: "http://192.0.2.10:11434".into(),
+                auth: ProviderAuthConfig {
+                    source: CredentialSource::None,
+                    kind: CredentialKind::None,
+                    env: None,
+                    profile: None,
+                    external: None,
+                },
+                credential: None,
+                credential_store_path: None,
+                codex_home: None,
+                originator: None,
+                reasoning_effort: None,
+                context_management: Default::default(),
+                builtin_web_search: None,
+            },
+        );
+        config.default_model = ModelRouteRef::parse_compatible("ollama/qwen3.8:latest").unwrap();
+
+        let report = onboarding_report(&config);
+        let provider = report
+            .sections
+            .iter()
+            .find(|section| section.id == "model_provider")
+            .expect("model provider section");
+        assert_eq!(provider.status, OnboardingStatus::Restricted);
+        assert!(
+            provider.details["security_warning"].as_str().is_some_and(
+                |warning| warning.contains("remote, cleartext HTTP, and unauthenticated")
+            )
+        );
     }
 
     #[test]

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -26,6 +26,10 @@ pub fn provider_doctor(config: &AppConfig) -> Value {
             .providers
             .get(&model_ref.provider)
             .map(|provider| {
+                let security_warnings = provider
+                    .unauthenticated_cleartext_remote_warning()
+                    .into_iter()
+                    .collect::<Vec<_>>();
                 json!({
                     "base_url": provider.base_url,
                     "transport": provider.transport.as_str(),
@@ -37,6 +41,7 @@ pub fn provider_doctor(config: &AppConfig) -> Value {
                         "external": provider.auth.external,
                         "credential_configured": provider.has_configured_credential(),
                     },
+                    "security_warnings": security_warnings,
                 })
             })
             .unwrap_or_else(|| json!({"error": "provider_not_configured"}));
@@ -528,7 +533,10 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::{
-        config::{provider_registry_for_tests, AppConfig, ControlAuthMode, ModelRef, ProviderId},
+        config::{
+            built_in_provider_registry_with_settings, provider_registry_for_tests, AppConfig,
+            ControlAuthMode, ModelRef, ModelRouteRef, ProviderId,
+        },
         model_catalog::{ModelMetadataSource, ModelRuntimeOverride},
     };
 
@@ -946,5 +954,30 @@ mod tests {
             .expect("onboarding sections")
             .iter()
             .any(|section| section["id"].as_str() == Some("model_provider")));
+    }
+
+    #[test]
+    fn provider_doctor_warns_for_remote_cleartext_unauthenticated_endpoint() {
+        let mut fixture = test_config(Some("openai-key"));
+        let ollama_id = ProviderId::parse("ollama").unwrap();
+        let mut built_ins = built_in_provider_registry_with_settings(&HashMap::new()).unwrap();
+        fixture
+            .config
+            .providers
+            .insert(ollama_id.clone(), built_ins.remove(&ollama_id).unwrap());
+        fixture.config.default_model =
+            ModelRouteRef::parse_compatible("ollama/qwen3.8:latest").unwrap();
+        let ollama = fixture
+            .config
+            .providers
+            .get_mut(&ollama_id)
+            .expect("ollama provider");
+        ollama.base_url = "http://192.0.2.10:11434".into();
+
+        let doctor = provider_doctor(&fixture.config);
+        let warning = doctor["providers"][0]["settings"]["security_warnings"][0]
+            .as_str()
+            .expect("security warning");
+        assert!(warning.contains("remote, cleartext HTTP, and unauthenticated"));
     }
 }

--- a/src/provider/registry.rs
+++ b/src/provider/registry.rs
@@ -258,5 +258,13 @@ mod tests {
             );
             assert_eq!(runtime.transport, definition.transport);
         }
+
+        let ollama = registry
+            .get(&ProviderId::parse("ollama").unwrap())
+            .expect("ollama provider");
+        assert_eq!(ollama.base_url, "http://127.0.0.1:11434");
+        assert_eq!(ollama.transport, ProviderTransportKind::AnthropicMessages);
+        assert_eq!(ollama.auth.kind, crate::config::CredentialKind::None);
+        assert!(ollama.credential.is_none());
     }
 }

--- a/src/provider/registry/providers.rs
+++ b/src/provider/registry/providers.rs
@@ -38,6 +38,7 @@ pub(crate) enum ModelDiscoveryAuth {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ModelDiscoveryRoute {
     Fixed(&'static str),
+    Ollama,
     OpenAiCompatible,
     OpenAiV1,
     Venice,
@@ -49,6 +50,7 @@ pub(crate) enum ModelDiscoveryDecoder {
     Arcee,
     HuggingFace,
     Kilo,
+    Ollama,
     OpenAiCompatible,
     NearAi,
     OpenCodeGo,
@@ -172,6 +174,13 @@ const PROVIDER_DEFINITIONS: &[ProviderDefinition] = &[
         "openai" => "openai" @ "default",
         OpenAiResponses, "https://api.openai.com/v1", ["OPENAI_API_KEY"],
         OpenAi, Default, OpenAi, None, None, StaticOnly, HostedEarly
+    ),
+    provider!(
+        "ollama" => "ollama" @ "default",
+        AnthropicMessages, "http://127.0.0.1:11434", [],
+        Generic, AnthropicCompatible, None, None,
+        discovery!(Optional, ModelDiscoveryRoute::Ollama, Ollama),
+        DiscoveryOnly
     ),
     provider!(
         "anthropic" => "anthropic" @ "default",

--- a/src/provider/tests/anthropic_messages.rs
+++ b/src/provider/tests/anthropic_messages.rs
@@ -4,11 +4,68 @@ use std::sync::{Arc, Mutex};
 
 use super::support::*;
 use super::*;
-use crate::config::{AnthropicCacheStrategy, ProviderId};
+use crate::config::{
+    AnthropicCacheStrategy, ProviderEndpointId, ProviderId, ProviderRuntimeConfig,
+    ProviderTransportKind,
+};
 use crate::provider::{http_trace::ProviderHttpTrace, provider_transport_diagnostics};
 use axum::{http::HeaderMap, routing::post, Json, Router};
 use serde_json::{json, Value};
 use std::path::Path;
+
+#[tokio::test]
+async fn anthropic_compatible_endpoint_can_send_without_authentication() {
+    let captured_headers = Arc::new(Mutex::new(None::<HeaderMap>));
+    let captured_headers_for_server = captured_headers.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/v1/messages",
+        post(move |headers: HeaderMap| {
+            let captured_headers = captured_headers_for_server.clone();
+            async move {
+                *captured_headers.lock().unwrap() = Some(headers);
+                Json(json!({
+                    "content": [{ "type": "text", "text": "ok" }],
+                    "stop_reason": "end_turn",
+                    "usage": { "input_tokens": 4, "output_tokens": 2 }
+                }))
+            }
+        }),
+    ))
+    .await;
+    let provider_config = ProviderRuntimeConfig {
+        id: ProviderId::parse("ollama").unwrap(),
+        route_provider: ProviderId::parse("ollama").unwrap(),
+        route_endpoint: ProviderEndpointId::default_endpoint(),
+        transport: ProviderTransportKind::AnthropicMessages,
+        base_url,
+        auth: Default::default(),
+        credential: None,
+        credential_store_path: None,
+        codex_home: None,
+        originator: None,
+        reasoning_effort: None,
+        context_management: Default::default(),
+        builtin_web_search: None,
+    };
+    let provider = AnthropicProvider::from_runtime_config(
+        &provider_config,
+        "qwen3.8:latest",
+        1024,
+        Path::new("."),
+        true,
+    )
+    .unwrap();
+
+    provider
+        .complete_turn(ProviderTurnRequest::plain("hello", Vec::new(), Vec::new()))
+        .await
+        .unwrap();
+
+    let headers = captured_headers.lock().unwrap();
+    let headers = headers.as_ref().expect("server should capture headers");
+    assert!(headers.get("authorization").is_none());
+    assert_eq!(headers["anthropic-version"], "2023-06-01");
+}
 
 #[tokio::test]
 async fn anthropic_request_lowers_prompt_frame_blocks_to_cache_control() {

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -12,7 +12,7 @@ use twox_hash::XxHash64;
 
 use crate::{
     config::{
-        AnthropicCacheStrategy, AnthropicContextManagementConfig, AppConfig,
+        AnthropicCacheStrategy, AnthropicContextManagementConfig, AppConfig, CredentialKind,
         ProviderBuiltinWebSearchConfig, ProviderId, ProviderRuntimeConfig,
     },
     prompt::PromptStability,
@@ -42,7 +42,7 @@ pub struct AnthropicProvider {
     route_provider: String,
     route_endpoint: String,
     base_url: String,
-    auth_token: String,
+    auth_token: Option<String>,
     model: String,
     max_output_tokens: u32,
     reasoning_effort: Option<String>,
@@ -181,17 +181,17 @@ impl AnthropicProvider {
         let auth_token = provider_config
             .credential
             .clone()
-            .filter(|value| !value.trim().is_empty())
-            .ok_or_else(|| {
-                let credential_name = provider_config
-                    .auth
-                    .env
-                    .as_deref()
-                    .or(provider_config.auth.profile.as_deref())
-                    .or(provider_config.auth.external.as_deref())
-                    .unwrap_or("configured credential");
-                anyhow!("missing {credential_name}")
-            })?;
+            .filter(|value| !value.trim().is_empty());
+        if auth_token.is_none() && provider_config.auth.kind != CredentialKind::None {
+            let credential_name = provider_config
+                .auth
+                .env
+                .as_deref()
+                .or(provider_config.auth.profile.as_deref())
+                .or(provider_config.auth.external.as_deref())
+                .unwrap_or("configured credential");
+            return Err(anyhow!("missing {credential_name}"));
+        }
         Ok(Self {
             client,
             route_provider: provider_config.route_provider.as_str().to_string(),
@@ -309,9 +309,11 @@ impl AgentProvider for AnthropicProvider {
         );
         let mut headers = vec![
             ("content-type", "application/json".to_string()),
-            ("authorization", format!("Bearer {}", self.auth_token)),
             ("anthropic-version", "2023-06-01".to_string()),
         ];
+        if let Some(auth_token) = self.auth_token.as_deref() {
+            headers.push(("authorization", format!("Bearer {auth_token}")));
+        }
         if self.context_management.enabled {
             headers.push((
                 "anthropic-beta",


### PR DESCRIPTION
## Summary

- add a built-in `ollama` provider using Ollama's Anthropic-compatible Messages endpoint without requiring credentials
- discover local models and capabilities from Ollama's native API while preserving Holon's provider/model routing and fallback contracts
- surface explicit doctor and onboarding warnings for remote cleartext unauthenticated endpoints
- document the Phase 1 transport decision, capability boundary, and follow-up work in a focused RFC

## Runtime concept

This makes local Ollama a first-class provider without coupling the runtime to Ollama's private generation protocol. The provider uses the existing Anthropic transport for turns and a provider-specific discovery adapter for model metadata and capabilities. Loopback is the safe default; custom remote endpoints remain configurable but are diagnosed when they are cleartext and unauthenticated.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- provider registry, Anthropic no-auth endpoint, Ollama discovery, remote cleartext warning, and model discovery unit tests
- real Ollama 0.33.0 smoke tests with `qwen3.8:latest`: text, tool use, JSON Schema lowering, vision request, and model fallback

Closes #2676
