### PR TITLE
fix: retry pending web read markers

### DIFF
--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -16,6 +16,7 @@ import {
   missingBriefIdsForHydration,
   observerSyncDiagnostics,
   readStoredRemoteConnectionProfiles,
+  retryPendingReadMarker,
   resetSessionsForResume,
   resetTransientRuntimeStateForResume,
   readStoredRuntimeConnectionConfig,
@@ -27,6 +28,10 @@ import {
 } from "./runtime-store";
 import type { StreamEventEnvelopeDto } from "./client";
 import { AgentSessionRepository } from "./agent-session-repository";
+import {
+  getRuntimeTraceRecords,
+  setRuntimeTraceEnabled,
+} from "./runtime-trace";
 import type { AgentSessionState } from "./runtime-store";
 import { createSessionProjectionState, reduceSessionProjection } from "./session-projection";
 import type { AgentSummary } from "./types";
@@ -680,7 +685,131 @@ describe("agent deletion cache cleanup", () => {
 
 describe("roster activity unread state", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    setRuntimeTraceEnabled(false, { clear: true });
+    useRuntimeStore.setState({
+      route: "dashboard",
+      selectedAgentId: "",
+      sessionsByAgentId: {},
+      ledgerUnreadByAgentId: {},
+    });
+  });
+
+  it("retries a pending read marker after ledger readiness becomes available", async () => {
+    vi.stubGlobal("document", { visibilityState: "visible" });
+    let ready = false;
+    vi.spyOn(AgentSessionRepository.prototype, "sessionLedgerReadiness")
+      .mockImplementation(() => ready
+        ? { readyThroughSeq: 12, ingestedThroughSeq: 12, observedHeadSeq: 12 }
+        : null);
+    const advanceReadMarker = vi
+      .spyOn(AgentSessionRepository.prototype, "advanceReadMarker")
+      .mockResolvedValue({
+        advanced: true,
+        record: {
+          remoteKey: "local",
+          runtimeId: "runtime-1",
+          visibilityScopeId: "scope-1",
+          eventLogEpoch: "epoch-1",
+          agentId: "agent-retry",
+          readThroughEventSeq: 12,
+          updatedAt: 1,
+        },
+      });
+    vi.spyOn(AgentSessionRepository.prototype, "unreadSnapshot").mockResolvedValue({
+      scopeAgentId: "agent-retry",
+      boundarySeq: 12,
+      countedThroughSeq: 12,
+      certainty: "exact",
+      count: 0,
+      historyTruncatedBeforeSeq: null,
+      acknowledgedTruncationBeforeSeq: null,
+    });
+    useRuntimeStore.setState({
+      route: "agent",
+      selectedAgentId: "agent-retry",
+      discovery: {
+        mode: "authoritative",
+        freshness: "fresh",
+        retryAttempt: 0,
+      },
+      sessionsByAgentId: {
+        "agent-retry": sessionState(),
+      },
+      ledgerUnreadByAgentId: {
+        "agent-retry": { mode: "exact", count: 2 },
+      },
+    });
+
+    useRuntimeStore.getState().markAgentConversationRead("agent-retry");
+    await Promise.resolve();
+    expect(advanceReadMarker).not.toHaveBeenCalled();
+
+    ready = true;
+    await retryPendingReadMarker("agent-retry");
+
+    expect(advanceReadMarker).toHaveBeenCalledWith("agent-retry", 12);
+    expect(useRuntimeStore.getState().ledgerUnreadByAgentId["agent-retry"]).toEqual({
+      mode: "exact",
+      count: 0,
+    });
+  });
+
+  it("refreshes a stale unread view after a monotonic read-marker no-op", async () => {
+    vi.stubGlobal("document", { visibilityState: "visible" });
+    setRuntimeTraceEnabled(true, { clear: true });
+    vi.spyOn(AgentSessionRepository.prototype, "sessionLedgerReadiness").mockReturnValue({
+      readyThroughSeq: 12,
+      ingestedThroughSeq: 12,
+      observedHeadSeq: 12,
+    });
+    vi.spyOn(AgentSessionRepository.prototype, "advanceReadMarker").mockResolvedValue({
+      advanced: false,
+      record: {
+        remoteKey: "local",
+        runtimeId: "runtime-1",
+        visibilityScopeId: "scope-1",
+        eventLogEpoch: "epoch-1",
+        agentId: "agent-noop",
+        readThroughEventSeq: 12,
+        updatedAt: 1,
+      },
+    });
+    vi.spyOn(AgentSessionRepository.prototype, "unreadSnapshot").mockResolvedValue({
+      scopeAgentId: "agent-noop",
+      boundarySeq: 12,
+      countedThroughSeq: 12,
+      certainty: "exact",
+      count: 0,
+      historyTruncatedBeforeSeq: null,
+      acknowledgedTruncationBeforeSeq: null,
+    });
+    useRuntimeStore.setState({
+      route: "agent",
+      selectedAgentId: "agent-noop",
+      discovery: {
+        mode: "authoritative",
+        freshness: "fresh",
+        retryAttempt: 0,
+      },
+      sessionsByAgentId: {
+        "agent-noop": sessionState(),
+      },
+      ledgerUnreadByAgentId: {
+        "agent-noop": { mode: "exact", count: 2 },
+      },
+    });
+
+    useRuntimeStore.getState().markAgentConversationRead("agent-noop");
+    await vi.waitFor(() => {
+      expect(useRuntimeStore.getState().ledgerUnreadByAgentId["agent-noop"]?.count).toBe(0);
+    });
+    expect(getRuntimeTraceRecords({ agentId: "agent-noop" }).at(-1)).toMatchObject({
+      name: "read_marker.advance",
+      outcome: "ok",
+      attributes: { advanced: false, candidateSeq: 12 },
+    });
   });
 
   it("does not mutate legacy roster activity when marking a conversation read", async () => {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -1210,6 +1210,9 @@ function publishReadStateInvalidation(agentId: string): void {
 
 const unreadRefreshInFlight = new Set<string>();
 const unreadRefreshQueued = new Set<string>();
+const pendingReadMarkerAgentIds = new Set<string>();
+const readMarkerAdvanceInFlight = new Set<string>();
+const readMarkerAdvanceQueued = new Set<string>();
 
 /**
  * Recompute one agent's ledger-backed unread view from durable state.
@@ -1279,6 +1282,61 @@ export function ledgerReadMarkerDecision(agentId: string) {
     },
     agentId,
   );
+}
+
+export async function retryPendingReadMarker(agentId: string): Promise<void> {
+  if (!pendingReadMarkerAgentIds.has(agentId)) return;
+  if (readMarkerAdvanceInFlight.has(agentId)) {
+    readMarkerAdvanceQueued.add(agentId);
+    return;
+  }
+  const trace = createRuntimeTrace("read_marker.advance", {
+    agentId,
+    trigger: "conversation.read",
+  });
+  const span = startRuntimeSpan(trace, "read_marker.advance");
+  const decision = ledgerReadMarkerDecision(agentId);
+  if (!decision.mayAdvance || decision.candidateSeq == null) {
+    if (decision.reason === "not_selected") {
+      pendingReadMarkerAgentIds.delete(agentId);
+    }
+    span.end("skipped", { reason: decision.reason ?? "candidate_unavailable" });
+    return;
+  }
+
+  readMarkerAdvanceInFlight.add(agentId);
+  try {
+    const result = await agentSessionRepository.advanceReadMarker(
+      agentId,
+      decision.candidateSeq,
+    );
+    if (!result) {
+      span.end("skipped", {
+        candidateSeq: decision.candidateSeq,
+        reason: "ledger_unavailable",
+      });
+      return;
+    }
+    pendingReadMarkerAgentIds.delete(agentId);
+    if (result.advanced) publishReadStateInvalidation(agentId);
+    await refreshLedgerUnreadInView(agentId);
+    span.end("ok", {
+      advanced: result.advanced,
+      candidateSeq: decision.candidateSeq,
+    });
+  } catch (error) {
+    span.end("error", {
+      candidateSeq: decision.candidateSeq,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    console.warn(`Failed to advance read marker for ${agentId}.`, error);
+  } finally {
+    readMarkerAdvanceInFlight.delete(agentId);
+    if (readMarkerAdvanceQueued.delete(agentId)) {
+      pendingReadMarkerAgentIds.add(agentId);
+      void retryPendingReadMarker(agentId);
+    }
+  }
 }
 
 export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
@@ -1455,6 +1513,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
           },
         }));
         void refreshLedgerUnreadInView(status.scope.agentId);
+        void retryPendingReadMarker(status.scope.agentId);
       },
     },
   });
@@ -1549,19 +1608,8 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
       };
     }),
   markAgentConversationRead: (agentId) => {
-    const decision = ledgerReadMarkerDecision(agentId);
-    if (!decision.mayAdvance || decision.candidateSeq == null) return;
-    const candidateSeq = decision.candidateSeq;
-    void agentSessionRepository
-      .advanceReadMarker(agentId, candidateSeq)
-      .then((result) => {
-        if (!result?.advanced) return;
-        publishReadStateInvalidation(agentId);
-        void refreshLedgerUnreadInView(agentId);
-      })
-      .catch((error) =>
-        console.warn(`Failed to advance read marker for ${agentId}.`, error),
-      );
+    pendingReadMarkerAgentIds.add(agentId);
+    void retryPendingReadMarker(agentId);
   },
   refreshLedgerUnread: async (agentId) => {
     await refreshLedgerUnreadInView(agentId);


### PR DESCRIPTION
## Summary
- retain pending conversation read requests while ledger readiness is unavailable
- retry read-marker advancement when ledger sync status becomes ready
- refresh the unread snapshot even when the durable marker is already advanced
- record `read_marker.advance` Web runtime trace outcomes and reasons

## Root cause
Opening an agent could request a read-marker advance before ledger readiness was available. The request was discarded, so the unread count remained until a later action such as sending a message changed sync state. A monotonic `advanced: false` result also skipped refreshing a stale UI snapshot.

## Verification
- `PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" npm test` (448/448)
- `PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" npm run typecheck`
- `git diff --check`
