### PR TITLE
fix: improve timer tool timeline rendering

### DIFF
--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
@@ -98,6 +98,68 @@ describe("ToolExecutionContent", () => {
     expect(html).toContain("A Holon agent dashboard");
   });
 
+  it("renders Timer details as structured scheduling fields", () => {
+    const html = renderTool({
+      tool_name: "CreateTimer",
+      input: { duration_ms: 60_000, interval_ms: 300_000, summary: "Poll CI" },
+      output: {
+        envelope: {
+          result: {
+            id: "timer_123",
+            status: "active",
+            summary: "Poll CI",
+            duration_ms: 60_000,
+            interval_ms: 300_000,
+            repeat: true,
+            next_fire_at: "2026-08-26T11:15:00Z",
+            last_fired_at: "2026-08-26T11:10:00Z",
+            fire_count: 2,
+            created_at: "2026-08-26T11:00:00Z",
+          },
+        },
+      },
+    });
+
+    expect(html).toContain("Timer ID");
+    expect(html).toContain("timer_123");
+    expect(html).toContain("Poll CI");
+    expect(html).toContain("Every 5m");
+    expect(html).toContain("Repeating");
+    expect(html).toContain("2026-08-26T11:15:00Z");
+    expect(html).toContain("2026-08-26T11:10:00Z");
+    expect(html).toContain("2");
+  });
+
+  it("renders ListTimers as separate structured timer sections", () => {
+    const html = renderTool({
+      tool_name: "ListTimers",
+      input: { limit: 10 },
+      output: {
+        envelope: {
+          result: {
+            returned: 1,
+            limit: 10,
+            timers: [{
+              id: "timer_listed",
+              status: "completed",
+              summary: "One-shot reminder",
+              duration_ms: 30_000,
+              interval_ms: null,
+              repeat: false,
+              fire_count: 1,
+            }],
+          },
+        },
+      },
+    });
+
+    expect(html).toContain("Returned");
+    expect(html).toContain("Timer 1");
+    expect(html).toContain("timer_listed");
+    expect(html).toContain("One-shot reminder");
+    expect(html).toContain("After 30s");
+  });
+
   it("renders WebSearch details as a structured result list", () => {
     const html = renderTool({
       tool_name: "WebSearch",

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
@@ -998,6 +998,89 @@ function WaitForRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
   );
 }
 
+// Timer renderers
+
+function formatTimerDuration(milliseconds: number): string {
+  if (milliseconds < 1000) return `${milliseconds}ms`;
+  const seconds = milliseconds / 1000;
+  if (seconds < 60) return `${formatTimerDurationValue(seconds)}s`;
+  const minutes = seconds / 60;
+  if (minutes < 60) return `${formatTimerDurationValue(minutes)}m`;
+  const hours = minutes / 60;
+  if (hours < 24) return `${formatTimerDurationValue(hours)}h`;
+  return `${formatTimerDurationValue(hours / 24)}d`;
+}
+
+function formatTimerDurationValue(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function TimerFields({ timer }: { timer: Record<string, unknown> }) {
+  const durationMs = nestedValue(timer, ["duration_ms"]);
+  const intervalMs = nestedValue(timer, ["interval_ms"]);
+  const repeat = nestedValue(timer, ["repeat"]) === true;
+  const schedule = typeof intervalMs === "number"
+    ? `Every ${formatTimerDuration(intervalMs)}`
+    : typeof durationMs === "number"
+      ? `After ${formatTimerDuration(durationMs)}`
+      : "";
+
+  return (
+    <>
+      <SimpleField label="Timer ID" value={nestedText(timer, ["id", "timer_id"])} />
+      <SimpleField label="Status" value={nestedText(timer, ["status"])} />
+      <SimpleField label="Summary" value={nestedText(timer, ["summary"])} />
+      <SimpleField label="Schedule" value={schedule} />
+      {repeat ? <SimpleField label="Repeating" value="Yes" /> : null}
+      <SimpleField label="Next fire" value={nestedText(timer, ["next_fire_at"])} />
+      <SimpleField label="Last fired" value={nestedText(timer, ["last_fired_at"])} />
+      <SimpleField label="Fire count" value={nestedValue(timer, ["fire_count"])} />
+      <SimpleField label="Created" value={nestedText(timer, ["created_at"])} />
+    </>
+  );
+}
+
+function TimerRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = isRecord(output) ? output : {};
+  const timers = arrayRecords(result.timers);
+  const timerId = nestedText(input, ["timer_id"]);
+  const durationMs = nestedValue(input, ["duration_ms"]);
+  const intervalMs = nestedValue(input, ["interval_ms"]);
+  const summary = nestedText(input, ["summary"]);
+
+  if (record.tool_name === "ListTimers") {
+    return (
+      <>
+        <SimpleField label="Returned" value={nestedValue(result, ["returned"])} />
+        <SimpleField label="Limit" value={nestedValue(result, ["limit"])} />
+        {timers.map((timer, index) => (
+          <section className="tool-detail-field" key={nestedText(timer, ["id"]) || index}>
+            <h3 className="tool-detail-field-label">Timer {index + 1}</h3>
+            <TimerFields timer={timer} />
+          </section>
+        ))}
+      </>
+    );
+  }
+
+  const hasTimer = Boolean(nestedText(result, ["id", "timer_id"]));
+  return (
+    <>
+      {hasTimer ? <TimerFields timer={result} /> : null}
+      {!hasTimer && timerId ? <SimpleField label="Timer ID" value={timerId} /> : null}
+      {!hasTimer && summary ? <SimpleField label="Summary" value={summary} /> : null}
+      {!hasTimer && typeof durationMs === "number"
+        ? <SimpleField label="Duration" value={formatTimerDuration(durationMs)} />
+        : null}
+      {!hasTimer && typeof intervalMs === "number"
+        ? <SimpleField label="Interval" value={formatTimerDuration(intervalMs)} />
+        : null}
+    </>
+  );
+}
+
 // Enqueue renderer
 
 function EnqueueRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
@@ -1112,6 +1195,11 @@ export function ToolExecutionContent({
       return wrapFailed(<SpawnAgentRenderer record={record} />, record, error, failed, t);
     case "WaitFor":
       return wrapFailed(<WaitForRenderer record={record} />, record, error, failed, t);
+    case "CreateTimer":
+    case "ListTimers":
+    case "GetTimer":
+    case "CancelTimer":
+      return wrapFailed(<TimerRenderer record={record} />, record, error, failed, t);
     case "Enqueue":
       return wrapFailed(<EnqueueRenderer record={record} />, record, error, failed, t);
     case "TaskOutput":

--- a/web-gui/app/src/runtime/session-reducer-core.ts
+++ b/web-gui/app/src/runtime/session-reducer-core.ts
@@ -667,11 +667,16 @@ function projectKnownToolExecution(
   if (toolName === "ListModelProviders") return projectListModelProvidersTool(payload);
   if (toolName === "ListProviderModels") return projectListProviderModelsTool(payload);
   if (toolName === "WaitFor") return projectWaitForTool(payload);
+  if (isTimerTool(toolName)) return projectTimerTool(toolName, payload);
   return undefined;
 }
 
 function isWorkItemMutationTool(toolName: string): boolean {
   return toolName === "CreateWorkItem" || toolName === "UpdateWorkItem" || toolName === "PickWorkItem" || toolName === "CompleteWorkItem";
+}
+
+function isTimerTool(toolName: string): boolean {
+  return toolName === "CreateTimer" || toolName === "ListTimers" || toolName === "GetTimer" || toolName === "CancelTimer";
 }
 
 /**
@@ -736,7 +741,8 @@ function isReadControlTool(toolName: string): boolean {
     toolName === "MemoryGet" ||
     toolName === "AgentGet" ||
     toolName === "ListModelProviders" ||
-    toolName === "ListProviderModels"
+    toolName === "ListProviderModels" ||
+    isTimerTool(toolName)
   );
 }
 
@@ -1310,6 +1316,101 @@ function projectWaitForTool(payload: Record<string, unknown> | undefined): Pick<
   return { body, detail: undefined };
 }
 
+function projectTimerTool(
+  toolName: string,
+  payload: Record<string, unknown> | undefined,
+): Pick<SessionItemDraft, "body" | "detail"> {
+  const result = unwrapToolResult(payload);
+  const input = asRecord(payload?.input);
+  if (toolName === "ListTimers") {
+    const timers = arrayField(result, "timers");
+    const returned = numberField(result, "returned") ?? timers?.length;
+    const summaries = summarizeTimerRecords(timers);
+    const active = (timers ?? []).filter((timer) => stringField(asRecord(timer), "status") === "active").length;
+    return {
+      body: compactJoin([
+        returned == null ? "Listed timers" : `${returned} timer${returned === 1 ? "" : "s"}`,
+        timers?.length ? `${active} active` : undefined,
+        summaries.length ? summaries.slice(0, 3).join("; ") : undefined,
+      ]),
+      detail: summaries.length
+        ? { label: "Timers", text: summaries.join("\n"), tone: "data" }
+        : undefined,
+    };
+  }
+
+  const timer = firstStringField(result, ["id", "timer_id"]) ? result : undefined;
+  const timerId = firstStringField(timer, ["id", "timer_id"])
+    ?? firstStringField(input, ["timer_id"])
+    ?? stringField(payload, "timer_id");
+  const summary = stringField(timer, "summary") ?? stringField(input, "summary");
+  const status = stringField(timer, "status");
+  const durationMs = numberField(timer, "duration_ms") ?? numberField(input, "duration_ms");
+  const intervalMs = numberField(timer, "interval_ms") ?? numberField(input, "interval_ms");
+  const schedule = timerSchedule(durationMs, intervalMs);
+  const fireCount = numberField(timer, "fire_count");
+  const verb = toolName === "CreateTimer"
+    ? intervalMs != null ? "Created repeating timer" : "Created timer"
+    : toolName === "CancelTimer"
+      ? "Cancelled timer"
+      : "Timer";
+  const body = compactJoin([
+    verb,
+    summary,
+    toolName === "GetTimer" ? status : undefined,
+    toolName !== "CancelTimer" ? schedule : undefined,
+    fireCount ? `fired ${fireCount} ${fireCount === 1 ? "time" : "times"}` : undefined,
+    timerId,
+  ]);
+  const detailText = timer ? summarizeTimerRecord(timer) : undefined;
+  return {
+    body,
+    detail: detailText ? { label: "Timer", text: detailText, tone: "data" } : undefined,
+  };
+}
+
+function summarizeTimerRecords(timers: unknown[] | undefined): string[] {
+  return (timers ?? [])
+    .map(asRecord)
+    .filter((timer): timer is Record<string, unknown> => Boolean(timer))
+    .map(summarizeTimerRecord)
+    .filter(Boolean);
+}
+
+function summarizeTimerRecord(timer: Record<string, unknown>): string {
+  const durationMs = numberField(timer, "duration_ms");
+  const intervalMs = numberField(timer, "interval_ms");
+  const fireCount = numberField(timer, "fire_count");
+  return compactJoin([
+    stringField(timer, "summary"),
+    stringField(timer, "status"),
+    timerSchedule(durationMs, intervalMs),
+    fireCount ? `fired ${fireCount} ${fireCount === 1 ? "time" : "times"}` : undefined,
+    firstStringField(timer, ["id", "timer_id"]),
+  ]);
+}
+
+function timerSchedule(durationMs: number | undefined, intervalMs: number | undefined): string | undefined {
+  if (intervalMs != null) return `every ${formatTimerDuration(intervalMs)}`;
+  if (durationMs != null) return `in ${formatTimerDuration(durationMs)}`;
+  return undefined;
+}
+
+function formatTimerDuration(milliseconds: number): string {
+  if (milliseconds < 1000) return `${milliseconds}ms`;
+  const seconds = milliseconds / 1000;
+  if (seconds < 60) return `${formatTimerDurationValue(seconds)}s`;
+  const minutes = seconds / 60;
+  if (minutes < 60) return `${formatTimerDurationValue(minutes)}m`;
+  const hours = minutes / 60;
+  if (hours < 24) return `${formatTimerDurationValue(hours)}h`;
+  return `${formatTimerDurationValue(hours / 24)}d`;
+}
+
+function formatTimerDurationValue(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
 function summarizeWorkItemRecords(items: unknown[] | undefined): string[] {
   return (items ?? [])
     .map(asRecord)
@@ -1507,7 +1608,11 @@ function toolFriendlyLabel(toolName: string, failed: boolean): string {
   if (toolName === "AgentGet") return failed ? "Agent inspection failed" : "Inspected agent";
   if (toolName === "ListModelProviders") return failed ? "Provider list failed" : "Listed model providers";
   if (toolName === "ListProviderModels") return failed ? "Model list failed" : "Listed provider models";
-  return failed ? "Tool failed" : "Tool finished";
+  if (toolName === "CreateTimer") return failed ? "Timer creation failed" : "Created timer";
+  if (toolName === "ListTimers") return failed ? "Timer list failed" : "Listed timers";
+  if (toolName === "GetTimer") return failed ? "Timer lookup failed" : "Timer";
+  if (toolName === "CancelTimer") return failed ? "Timer cancellation failed" : "Cancelled timer";
+  return failed ? `${toolName} failed` : toolName;
 }
 
 function formatDuration(milliseconds: number): string {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -220,7 +220,7 @@ describe("reduceAgentSessionTimeline", () => {
     expect(timeline[0]).toEqual(
       expect.objectContaining({
         kind: "tool",
-        label: "Tool finished",
+        label: "ViewImage",
         body: "Viewed image · Screenshot.png · 1200×800 · A browser screenshot showing the conversation timeline.",
         executionMeta: expect.objectContaining({ outcome: "completed", durationMs: 9700 }),
       }),
@@ -302,6 +302,127 @@ describe("reduceAgentSessionTimeline", () => {
         },
       }),
     );
+  });
+
+  it("projects timer tools as readable scheduling summaries without API duration noise", () => {
+    const timer = {
+      id: "timer_123",
+      agent_id: "agent-1",
+      created_at: "2026-08-26T10:00:00Z",
+      duration_ms: 300_000,
+      interval_ms: null,
+      repeat: false,
+      status: "active",
+      summary: "Check deployment",
+      next_fire_at: "2026-08-26T10:05:00Z",
+      last_fired_at: null,
+      fire_count: 0,
+    };
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("create-timer-1", "CreateTimer", {
+            input: { duration_ms: 300_000, summary: "Check deployment" },
+            output: { envelope: { result: timer } },
+          }),
+          toolEvent("get-timer-2", "GetTimer", {
+            input: { timer_id: "timer_123" },
+            output: { envelope: { result: timer } },
+          }),
+          toolEvent("cancel-timer-3", "CancelTimer", {
+            input: { timer_id: "timer_123" },
+            output: { envelope: { result: { ...timer, status: "cancelled" } } },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline.map((item) => ({
+      label: item.label,
+      body: item.body,
+      durationMs: item.executionMeta?.durationMs,
+    }))).toEqual([
+      {
+        label: "Created timer",
+        body: "Created timer · Check deployment · in 5m · timer_123",
+        durationMs: undefined,
+      },
+      {
+        label: "Timer",
+        body: "Timer · Check deployment · active · in 5m · timer_123",
+        durationMs: undefined,
+      },
+      {
+        label: "Cancelled timer",
+        body: "Cancelled timer · Check deployment · timer_123",
+        durationMs: undefined,
+      },
+    ]);
+  });
+
+  it("projects timer lists with status, schedule, and fire count", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("list-timers-1", "ListTimers", {
+            output: {
+              envelope: {
+                result: {
+                  returned: 2,
+                  limit: 50,
+                  timers: [
+                    {
+                      id: "timer_active",
+                      status: "active",
+                      summary: "Check deployment",
+                      duration_ms: 300_000,
+                      interval_ms: null,
+                      fire_count: 0,
+                    },
+                    {
+                      id: "timer_repeat",
+                      status: "active",
+                      summary: "Poll CI",
+                      duration_ms: 60_000,
+                      interval_ms: 60_000,
+                      fire_count: 3,
+                    },
+                  ],
+                },
+              },
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(expect.objectContaining({
+      label: "Listed timers",
+      body: "2 timers · 2 active · Check deployment · active · in 5m · timer_active; Poll CI · active · every 1m · fired 3 times · timer_repeat",
+      detail: {
+        label: "Timers",
+        text: "Check deployment · active · in 5m · timer_active\nPoll CI · active · every 1m · fired 3 times · timer_repeat",
+        tone: "data",
+      },
+      executionMeta: expect.objectContaining({ durationMs: undefined }),
+    }));
+  });
+
+  it("uses the tool name as the timeline label for generic fallbacks", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("future-tool-1", "FutureRuntimeTool", {
+            summary: "Completed future operation",
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(expect.objectContaining({
+      label: "FutureRuntimeTool",
+      body: "Completed future operation",
+    }));
   });
 
   it("projects TaskOutput with task status and output preview", () => {
@@ -1555,7 +1676,7 @@ describe("debugAgentSessionEvents", () => {
     );
     expect(timeline[1]).toEqual(
       expect.objectContaining({
-        label: "Tool finished",
+        label: "CreateWorkItem",
         body: expect.stringContaining("Track debug visibility"),
         detail: expect.objectContaining({
           label: "Work item change",


### PR DESCRIPTION
## Summary
- add semantic timeline summaries and details for `CreateTimer`, `ListTimers`, `GetTimer`, and `CancelTimer`
- render structured timer fields in the tool execution detail panel
- use the actual tool name for generic timeline fallbacks instead of the opaque `Tool finished` label
- suppress meaningless API round-trip duration metadata for timer control tools

## Verification
- `npx vitest run src/runtime/session-reducer.test.ts src/features/right-panel/ToolExecutionRenderers.test.tsx` (68 passed)
- `npm run typecheck`
- `git diff --check`
