### PR TITLE
fix: discover Ollama vision models for ViewImage

### DIFF
--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -738,6 +738,17 @@ impl RuntimeModelCatalog {
                 candidates.push(model_ref);
             }
         }
+        let mut discovered = self
+            .discovered_models
+            .keys()
+            .map(ModelRouteRef::from_legacy_model_ref)
+            .collect::<Vec<_>>();
+        discovered.sort_by_key(ModelRouteRef::as_string);
+        for model_ref in discovered {
+            if !candidates.iter().any(|existing| existing == &model_ref) {
+                candidates.push(model_ref);
+            }
+        }
 
         self.select_view_image_vision_model_from_candidates(
             base_context_config,

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -109,6 +109,11 @@ pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bo
     provider_discovery_definition(provider).is_some()
 }
 
+pub fn provider_discovers_model_capabilities(provider: &ProviderRuntimeConfig) -> bool {
+    provider_discovery_definition(provider)
+        .is_some_and(|definition| definition.decoder == ModelDiscoveryDecoder::Ollama)
+}
+
 fn provider_model_discovery_requires_credential(provider: &ProviderRuntimeConfig) -> bool {
     provider_discovery_definition(provider)
         .is_some_and(|definition| definition.auth == ModelDiscoveryAuth::Required)
@@ -2636,6 +2641,16 @@ mod tests {
         assert!(models
             .iter()
             .all(|model| model.capabilities == ModelCapabilityFlags::default()));
+    }
+
+    #[test]
+    fn only_ollama_discovery_currently_supplies_model_capabilities() {
+        assert!(provider_discovers_model_capabilities(&ollama_provider(
+            "http://127.0.0.1:11434".into()
+        )));
+        assert!(!provider_discovers_model_capabilities(
+            &custom_openai_provider("http://127.0.0.1:8000".into())
+        ));
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -338,6 +338,7 @@ struct RuntimeInner {
     view_image_observation_cache:
         Mutex<HashMap<ViewImageObservationCacheKey, ViewImageObservation>>,
     model_discovery_refreshes: Mutex<HashSet<crate::config::ProviderId>>,
+    model_discovery_refresh_notify: Notify,
     callback_base_url: String,
     tools: ToolRegistry,
     system: Arc<LocalSystem>,

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -17,8 +17,8 @@ use crate::{
     host::RuntimeHostBridge,
     model_discovery::{
         discovery_cache_needs_refresh, discovery_cache_path, discovery_cache_status_for_provider,
-        load_discovery_cache_at, refresh_provider_models, ModelDiscoveryCacheFile,
-        ModelDiscoveryCacheStatus, DEFAULT_DISCOVERY_CACHE_TTL,
+        load_discovery_cache_at, provider_discovers_model_capabilities, refresh_provider_models,
+        ModelDiscoveryCacheFile, ModelDiscoveryCacheStatus, DEFAULT_DISCOVERY_CACHE_TTL,
     },
     provider::{
         build_candidate_from_model_route, build_provider_from_model_chain,
@@ -396,6 +396,7 @@ impl RuntimeHandle {
                 builtin_web_search_probe_cache: Mutex::new(HashMap::new()),
                 view_image_observation_cache: Mutex::new(HashMap::new()),
                 model_discovery_refreshes: Mutex::new(HashSet::new()),
+                model_discovery_refresh_notify: Notify::new(),
                 callback_base_url,
                 tools: ToolRegistry::new(PathBuf::new()),
                 system: Arc::new(LocalSystem::new()),
@@ -613,6 +614,31 @@ impl RuntimeHandle {
     pub(crate) async fn current_view_image_vision_selection(
         &self,
     ) -> Result<crate::types::ViewImageVisionSelection> {
+        let selection = self.view_image_vision_selection().await?;
+        if selection.selected_mode
+            == crate::types::ViewImageSelectedMode::NativeImageWithObservation
+        {
+            return Ok(selection);
+        }
+        let failures = self
+            .refresh_view_image_discovery_candidates(&selection)
+            .await?;
+        let mut selection = self.view_image_vision_selection().await?;
+        for (provider, error) in failures {
+            selection
+                .candidates
+                .push(crate::types::ViewImageVisionCandidate {
+                    provider: provider.as_str().to_string(),
+                    model: "*".to_string(),
+                    model_ref: format!("{}/*", provider.as_str()),
+                    image_input: false,
+                    reason: format!("provider_model_discovery_failed: {error}"),
+                });
+        }
+        Ok(selection)
+    }
+
+    async fn view_image_vision_selection(&self) -> Result<crate::types::ViewImageVisionSelection> {
         let state = self.agent_state().await?;
         let fallback_model = self.inner.turn_fallback_model.read().await.clone();
         let snap = self.inner.config_snapshot.load();
@@ -621,6 +647,110 @@ impl RuntimeHandle {
             state.model_override.as_ref(),
             fallback_model.as_ref(),
         ))
+    }
+
+    async fn refresh_view_image_discovery_candidates(
+        &self,
+        selection: &crate::types::ViewImageVisionSelection,
+    ) -> Result<Vec<(crate::config::ProviderId, String)>> {
+        let snap = self.inner.config_snapshot.load();
+        let Some(reconfig) = snap.provider_reconfig.as_ref() else {
+            return Ok(Vec::new());
+        };
+        let config = reconfig.config.clone();
+        let cache_path = discovery_cache_path(&config.home_dir);
+        let cache_path_for_load = cache_path.clone();
+        let cache =
+            tokio::task::spawn_blocking(move || load_discovery_cache_at(&cache_path_for_load))
+                .await??;
+        let candidate_providers = selection
+            .candidates
+            .iter()
+            .filter_map(|candidate| crate::config::ProviderId::parse(&candidate.provider).ok())
+            .collect::<HashSet<_>>();
+        let providers = config
+            .providers
+            .values()
+            .filter(|provider| {
+                provider_discovers_model_capabilities(provider)
+                    && (candidate_providers.contains(&provider.id)
+                        || crate::provider::provider_definition(provider.id.as_str()).is_some_and(
+                            |definition| {
+                                definition.catalog_policy
+                                    == crate::provider::ProviderCatalogPolicy::DiscoveryOnly
+                            },
+                        ))
+                    && (provider.auth.kind == crate::config::CredentialKind::None
+                        || provider.has_configured_credential())
+                    && discovery_cache_needs_refresh(provider, &cache, DEFAULT_DISCOVERY_CACHE_TTL)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut failures = Vec::new();
+        for provider in providers {
+            if let Err(error) = self
+                .refresh_model_discovery_provider(provider.clone(), &cache_path)
+                .await
+            {
+                tracing::warn!(
+                    provider = %provider.id.as_str(),
+                    error = %error,
+                    "ViewImage model discovery refresh failed"
+                );
+                failures.push((provider.id, error.to_string()));
+            }
+        }
+        self.reload_model_discovery_cache_snapshot().await?;
+        Ok(failures)
+    }
+
+    async fn refresh_model_discovery_provider(
+        &self,
+        provider: crate::config::ProviderRuntimeConfig,
+        cache_path: &std::path::Path,
+    ) -> Result<()> {
+        loop {
+            let notified = self.inner.model_discovery_refresh_notify.notified();
+            let should_refresh = {
+                let mut in_flight = self.inner.model_discovery_refreshes.lock().await;
+                if in_flight.contains(&provider.id) {
+                    false
+                } else {
+                    in_flight.insert(provider.id.clone());
+                    true
+                }
+            };
+            if should_refresh {
+                let result = refresh_provider_models(&provider, cache_path).await;
+                self.inner
+                    .model_discovery_refreshes
+                    .lock()
+                    .await
+                    .remove(&provider.id);
+                self.inner.model_discovery_refresh_notify.notify_waiters();
+                result?;
+                return Ok(());
+            }
+            notified.await;
+            if self
+                .inner
+                .model_discovery_refreshes
+                .lock()
+                .await
+                .contains(&provider.id)
+            {
+                continue;
+            }
+            let cache_path = cache_path.to_path_buf();
+            let cache =
+                tokio::task::spawn_blocking(move || load_discovery_cache_at(&cache_path)).await??;
+            if !discovery_cache_needs_refresh(&provider, &cache, DEFAULT_DISCOVERY_CACHE_TTL) {
+                return Ok(());
+            }
+            return Err(anyhow!(
+                "concurrent provider model discovery did not produce a fresh cache entry"
+            ));
+        }
     }
 
     pub(crate) async fn cached_view_image_observation(
@@ -820,6 +950,10 @@ impl RuntimeHandle {
                     .lock()
                     .await
                     .remove(&provider_id);
+                runtime
+                    .inner
+                    .model_discovery_refresh_notify
+                    .notify_waiters();
             });
         }
     }

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -106,6 +106,58 @@ impl ConfigSnapshot {
     }
 }
 
+pub(super) struct ModelDiscoveryRefreshGuard {
+    runtime: RuntimeHandle,
+    provider_id: crate::config::ProviderId,
+    released: bool,
+}
+
+impl ModelDiscoveryRefreshGuard {
+    pub(super) fn new(runtime: RuntimeHandle, provider_id: crate::config::ProviderId) -> Self {
+        Self {
+            runtime,
+            provider_id,
+            released: false,
+        }
+    }
+
+    async fn release(mut self) {
+        self.runtime
+            .inner
+            .model_discovery_refreshes
+            .lock()
+            .await
+            .remove(&self.provider_id);
+        self.runtime
+            .inner
+            .model_discovery_refresh_notify
+            .notify_waiters();
+        self.released = true;
+    }
+}
+
+impl Drop for ModelDiscoveryRefreshGuard {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        let runtime = self.runtime.clone();
+        let provider_id = self.provider_id.clone();
+        tokio::spawn(async move {
+            runtime
+                .inner
+                .model_discovery_refreshes
+                .lock()
+                .await
+                .remove(&provider_id);
+            runtime
+                .inner
+                .model_discovery_refresh_notify
+                .notify_waiters();
+        });
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct ProviderReconfigurator {
     pub(super) config: AppConfig,
@@ -721,13 +773,10 @@ impl RuntimeHandle {
                 }
             };
             if should_refresh {
+                let refresh_guard =
+                    ModelDiscoveryRefreshGuard::new(self.clone(), provider.id.clone());
                 let result = refresh_provider_models(&provider, cache_path).await;
-                self.inner
-                    .model_discovery_refreshes
-                    .lock()
-                    .await
-                    .remove(&provider.id);
-                self.inner.model_discovery_refresh_notify.notify_waiters();
+                refresh_guard.release().await;
                 result?;
                 return Ok(());
             }
@@ -920,6 +969,8 @@ impl RuntimeHandle {
 
             let runtime = self.clone();
             let cache_path = discovery_cache_path(&config.home_dir);
+            let refresh_guard =
+                ModelDiscoveryRefreshGuard::new(runtime.clone(), provider_id.clone());
             tokio::spawn(async move {
                 let result = refresh_provider_models(&provider, &cache_path).await;
                 match result {
@@ -944,16 +995,7 @@ impl RuntimeHandle {
                         );
                     }
                 }
-                runtime
-                    .inner
-                    .model_discovery_refreshes
-                    .lock()
-                    .await
-                    .remove(&provider_id);
-                runtime
-                    .inner
-                    .model_discovery_refresh_notify
-                    .notify_waiters();
+                refresh_guard.release().await;
             });
         }
     }

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -2113,12 +2113,15 @@ async fn concurrent_view_image_selection_discovers_ollama_vision_once_from_cold_
     };
 
     let home = tempdir().unwrap();
+    std::fs::write(
+        home.path().join("config.json"),
+        r#"{"model":{"default":"ollama/qwen3-vl:latest"}}"#,
+    )
+    .unwrap();
     let mut config = {
         let _env_lock = crate::test_env::lock_env();
         AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap()
     };
-    config.default_model =
-        crate::config::ModelRouteRef::parse_compatible("ollama/qwen3-vl:latest").unwrap();
     config
         .providers
         .get_mut(&crate::config::ProviderId::parse("ollama").unwrap())

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -2062,6 +2062,88 @@ async fn view_image_selection_uses_current_turn_fallback_model() {
 }
 
 #[tokio::test]
+async fn concurrent_view_image_selection_discovers_ollama_vision_once_from_cold_cache() {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let base_url = format!("http://{}/v1", listener.local_addr().unwrap());
+    let stopped = Arc::new(AtomicBool::new(false));
+    let tags_requests = Arc::new(AtomicUsize::new(0));
+    let show_requests = Arc::new(AtomicUsize::new(0));
+    let server = {
+        let stopped = Arc::clone(&stopped);
+        let tags_requests = Arc::clone(&tags_requests);
+        let show_requests = Arc::clone(&show_requests);
+        std::thread::spawn(move || {
+            while !stopped.load(Ordering::SeqCst) {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(connection) => connection,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                        continue;
+                    }
+                    Err(error) => panic!("Ollama test server accept failed: {error}"),
+                };
+                let mut request = [0_u8; 4096];
+                let read = stream.read(&mut request).unwrap();
+                let request = String::from_utf8_lossy(&request[..read]);
+                let body = if request.starts_with("GET /api/tags HTTP/1.1") {
+                    tags_requests.fetch_add(1, Ordering::SeqCst);
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    r#"{"models":[{"name":"qwen3-vl:latest"}]}"#
+                } else if request.starts_with("POST /api/show HTTP/1.1") {
+                    show_requests.fetch_add(1, Ordering::SeqCst);
+                    assert!(request.contains(r#""model":"qwen3-vl:latest""#));
+                    r#"{"capabilities":["vision"],"model_info":{"qwen3.context_length":131072}}"#
+                } else {
+                    panic!("unexpected Ollama test request: {request}");
+                };
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+                .unwrap();
+            }
+        })
+    };
+
+    let home = tempdir().unwrap();
+    let mut config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+    config.default_model =
+        crate::config::ModelRouteRef::parse_compatible("ollama/qwen3-vl:latest").unwrap();
+    config
+        .providers
+        .get_mut(&crate::config::ProviderId::parse("ollama").unwrap())
+        .unwrap()
+        .base_url = base_url;
+    let host = RuntimeHost::new(config).unwrap();
+    let runtime = host.default_runtime().await.unwrap();
+
+    let (first, second) = tokio::join!(
+        runtime.current_view_image_vision_selection(),
+        runtime.current_view_image_vision_selection()
+    );
+    stopped.store(true, Ordering::SeqCst);
+    server.join().unwrap();
+
+    for selection in [first.unwrap(), second.unwrap()] {
+        assert_eq!(
+            selection.selected_mode,
+            crate::types::ViewImageSelectedMode::NativeImageWithObservation
+        );
+        assert_eq!(selection.primary_provider.as_deref(), Some("ollama"));
+        assert_eq!(selection.primary_model.as_deref(), Some("qwen3-vl:latest"));
+    }
+    assert_eq!(tags_requests.load(Ordering::SeqCst), 1);
+    assert_eq!(show_requests.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
 async fn fallback_turn_model_state_uses_fallback_model_policy() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -2113,7 +2113,10 @@ async fn concurrent_view_image_selection_discovers_ollama_vision_once_from_cold_
     };
 
     let home = tempdir().unwrap();
-    let mut config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+    let mut config = {
+        let _env_lock = crate::test_env::lock_env();
+        AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap()
+    };
     config.default_model =
         crate::config::ModelRouteRef::parse_compatible("ollama/qwen3-vl:latest").unwrap();
     config
@@ -2141,6 +2144,52 @@ async fn concurrent_view_image_selection_discovers_ollama_vision_once_from_cold_
     }
     assert_eq!(tags_requests.load(Ordering::SeqCst), 1);
     assert_eq!(show_requests.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn panicking_model_discovery_refresh_releases_waiters_and_in_flight_state() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let provider_id = crate::config::ProviderId::parse("ollama").unwrap();
+    runtime
+        .inner
+        .model_discovery_refreshes
+        .lock()
+        .await
+        .insert(provider_id.clone());
+
+    let notified = runtime.inner.model_discovery_refresh_notify.notified();
+    tokio::pin!(notified);
+    notified.as_mut().enable();
+    let refresh_guard = crate::runtime::bootstrap::ModelDiscoveryRefreshGuard::new(
+        runtime.clone(),
+        provider_id.clone(),
+    );
+    let refresh = tokio::spawn(async move {
+        let _refresh_guard = refresh_guard;
+        panic!("simulated provider discovery panic");
+    });
+
+    assert!(refresh.await.unwrap_err().is_panic());
+    tokio::time::timeout(std::time::Duration::from_secs(1), notified)
+        .await
+        .expect("panic cleanup should notify discovery waiters");
+    assert!(!runtime
+        .inner
+        .model_discovery_refreshes
+        .lock()
+        .await
+        .contains(&provider_id));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add registry-derived endpoints for credential-free discovery-only providers without overriding explicit user endpoints
- lazily refresh Ollama discovery before capability-sensitive `ViewImage` selection, with shared cache/in-flight deduplication and structured failure diagnostics
- preserve image-input-only semantics and add cold-cache concurrent discovery coverage

## Verification
- `cargo fmt --all -- --check`
- `cargo test concurrent_view_image_selection_discovers_ollama_vision_once_from_cold_cache --lib`
- `cargo test model_discovery::tests --lib`
- `cargo test --all-targets -- --test-threads=1`
- `RUSTFLAGS=\"-D warnings\" cargo check --all-targets`

Closes #2681