### PR TITLE
fix: show full skill list in agent overview panel

### DIFF
--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -403,7 +403,7 @@ export function AgentOverviewPanel({
         {skillCatalogError ? <p className="inspector-error">{skillCatalogError}</p> : null}
         {skillCatalog?.catalog.length ? (
           <ul className="inspector-list agent-skill-list">
-            {skillCatalog.catalog.slice(0, 8).map((skill) => (
+            {skillCatalog.catalog.map((skill) => (
               <AgentSkillItem
                 key={`${skill.scope}:${skill.skillId}:${skill.path}`}
                 skill={skill}


### PR DESCRIPTION
## Summary

- Remove the hardcoded `.slice(0, 8)` on the skill catalog in `AgentOverviewPanel`, so the agent overview Skills card renders the full list returned by `GET /agents/{agent_id}/skills`.
- Previously the card title showed the full count (e.g. "Skills (12)") but only 8 items were listed, making the panel appear truncated/incomplete. The backend already returns the full catalog, so this is purely a frontend display limit.
- The Skill Manager panel was already untruncated and is unchanged.

## Testing

- `npm run typecheck` ✅
- `npm test` ✅ (39 files, 456 tests)

Web-only change; no Rust code touched.