### PR TITLE
fix: restore reliable web unread state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ on:
       - "web-gui/**"
       - "Makefile"
       - "build.rs"
+      - "build_support/**"
       - "scripts/docker-smoke.sh"
       - "scripts/docker-e2e.py"
       - "scripts/docker-live-acceptance.py"
@@ -42,6 +43,7 @@ on:
       - "web-gui/**"
       - "Makefile"
       - "build.rs"
+      - "build_support/**"
       - "scripts/docker-smoke.sh"
       - "scripts/docker-e2e.py"
       - "scripts/docker-live-acceptance.py"
@@ -79,6 +81,7 @@ jobs:
               - 'Cargo.lock'
               - 'Makefile'
               - 'build.rs'
+              - 'build_support/**'
               - 'scripts/docker-smoke.sh'
               - 'scripts/docker-e2e.py'
               - 'scripts/docker-live-acceptance.py'
@@ -92,6 +95,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'build.rs'
+              - 'build_support/**'
               - 'Makefile'
               - 'agent_templates/**'
               - 'builtin_templates/**'
@@ -164,9 +168,13 @@ jobs:
             web-gui/app/package-lock.json
             web-gui/openapi-tools/package-lock.json
 
-      - name: Test and build web GUI
+      - name: Test web GUI
         if: needs.changes.outputs.web == 'true'
         run: make web-ci
+
+      - name: Build web GUI for embedding
+        if: needs.changes.outputs.web != 'true'
+        run: make web
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -203,6 +211,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: web-gui/app/package-lock.json
+
+      - name: Build web GUI for embedding
+        run: make web
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -229,7 +247,6 @@ jobs:
           cache-dependency-path: web-gui/app/package-lock.json
 
       - name: Build web GUI
-        if: needs.changes.outputs.web == 'true'
         run: make web
 
       - name: Set up Rust

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -95,14 +95,14 @@ jobs:
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Build daemon
-        working-directory: .
-        run: cargo build --bin holon
-
       - name: Build production and diagnostics assets
         run: |
           npm run build
           npm run build:e2e:real-daemon
+
+      - name: Build daemon
+        working-directory: .
+        run: cargo build --bin holon
 
       - name: Run real daemon repeat suite
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ tempfile = "3.14"
 proptest = "1.6"
 tokio = { version = "1.43", features = ["test-util"] }
 
+[build-dependencies]
+serde_json = "1.0"
+sha2 = "0.10"
+
 [lib]
 name = "holon"
 path = "src/lib.rs"

--- a/build.rs
+++ b/build.rs
@@ -1,21 +1,16 @@
-use std::path::Path;
 use std::process::Command;
+
+#[path = "build_support/web_dist.rs"]
+mod web_dist;
 
 fn main() {
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs/");
+    web_dist::emit_rerun_directives();
 
     let pkg_version = std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".into());
-
-    // Ensure the embedded web assets directory exists at compile time.
-    // rust-embed requires the folder to be present even when empty; a fresh
-    // clone or `cargo clean` without `npm run build` would otherwise fail.
-    // The directory is git-ignored (it holds build output), so we create it
-    // here as a self-healing step. An empty directory simply embeds zero files.
-    let dist_dir = Path::new("web-gui/app/dist");
-    if !dist_dir.exists() {
-        std::fs::create_dir_all(dist_dir).expect("failed to create web-gui/app/dist");
-    }
+    let web_identity = web_dist::validate_embedded_web_dist()
+        .unwrap_or_else(|error| panic!("{error}\nRun `make web` and retry the Rust build."));
 
     let sha = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
@@ -43,4 +38,8 @@ fn main() {
     };
 
     println!("cargo:rustc-env=HOLON_VERSION={}", version);
+    println!(
+        "cargo:rustc-env=HOLON_WEB_SOURCE_HASH={}",
+        web_identity.source_hash
+    );
 }

--- a/build_support/web_dist.rs
+++ b/build_support/web_dist.rs
@@ -1,0 +1,155 @@
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const WEB_ROOT: &str = "web-gui/app";
+const WEB_DIST: &str = "web-gui/app/dist";
+const MANIFEST_NAME: &str = "holon-web-build.json";
+const SOURCE_FILES: &[&str] = &[
+    "index.html",
+    "package-lock.json",
+    "package.json",
+    "tsconfig.json",
+    "tsconfig.node.json",
+    "vite.config.ts",
+];
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct WebBuildIdentity {
+    pub(crate) source_hash: String,
+}
+
+#[allow(dead_code)]
+pub(crate) fn emit_rerun_directives() {
+    println!("cargo:rerun-if-changed={WEB_ROOT}/src");
+    for path in SOURCE_FILES {
+        println!("cargo:rerun-if-changed={WEB_ROOT}/{path}");
+    }
+    println!("cargo:rerun-if-changed={WEB_DIST}/{MANIFEST_NAME}");
+}
+
+#[allow(dead_code)]
+pub(crate) fn validate_embedded_web_dist() -> Result<WebBuildIdentity, String> {
+    validate_web_dist(Path::new(WEB_ROOT), Path::new(WEB_DIST))
+}
+
+pub(crate) fn validate_web_dist(
+    web_root: &Path,
+    dist_dir: &Path,
+) -> Result<WebBuildIdentity, String> {
+    if !dist_dir.is_dir() {
+        return Err(format!(
+            "embedded Web dist is missing: {}",
+            dist_dir.display()
+        ));
+    }
+    let index_path = dist_dir.join("index.html");
+    if !index_path.is_file() {
+        return Err(format!(
+            "embedded Web dist is incomplete: {} is missing",
+            index_path.display()
+        ));
+    }
+
+    let manifest_path = dist_dir.join(MANIFEST_NAME);
+    let manifest_bytes = fs::read(&manifest_path).map_err(|error| {
+        format!(
+            "embedded Web dist identity is missing or unreadable at {}: {error}",
+            manifest_path.display()
+        )
+    })?;
+    let manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes).map_err(|error| {
+        format!(
+            "embedded Web dist identity is invalid at {}: {error}",
+            manifest_path.display()
+        )
+    })?;
+    if manifest
+        .get("schema_version")
+        .and_then(|value| value.as_u64())
+        != Some(1)
+    {
+        return Err(format!(
+            "embedded Web dist identity at {} has an unsupported schema",
+            manifest_path.display()
+        ));
+    }
+    let built_hash = manifest
+        .get("source_hash")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| {
+            format!(
+                "embedded Web dist identity at {} has no source_hash",
+                manifest_path.display()
+            )
+        })?;
+    let current_hash = compute_web_source_hash(web_root)?;
+    if built_hash != current_hash {
+        return Err(format!(
+            "embedded Web dist is stale: manifest has {built_hash}, current Web sources have {current_hash}"
+        ));
+    }
+
+    Ok(WebBuildIdentity {
+        source_hash: current_hash,
+    })
+}
+
+pub(crate) fn compute_web_source_hash(web_root: &Path) -> Result<String, String> {
+    let mut paths = Vec::new();
+    collect_files(&web_root.join("src"), &mut paths)?;
+    for relative in SOURCE_FILES {
+        let path = web_root.join(relative);
+        if !path.is_file() {
+            return Err(format!("Web source input is missing: {}", path.display()));
+        }
+        paths.push(path);
+    }
+    paths.sort_by(|left, right| relative_path(web_root, left).cmp(&relative_path(web_root, right)));
+
+    let mut hasher = Sha256::new();
+    for path in paths {
+        let relative = relative_path(web_root, &path);
+        let bytes = fs::read(&path)
+            .map_err(|error| format!("failed to read Web source {}: {error}", path.display()))?;
+        hasher.update(relative.as_bytes());
+        hasher.update([0]);
+        hasher.update(bytes);
+        hasher.update([0]);
+    }
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+fn collect_files(directory: &Path, paths: &mut Vec<PathBuf>) -> Result<(), String> {
+    let entries = fs::read_dir(directory).map_err(|error| {
+        format!(
+            "failed to read Web source directory {}: {error}",
+            directory.display()
+        )
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            format!(
+                "failed to read an entry in Web source directory {}: {error}",
+                directory.display()
+            )
+        })?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+        if file_type.is_dir() {
+            collect_files(&path, paths)?;
+        } else if file_type.is_file() {
+            paths.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn relative_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .expect("Web source path must be inside Web root")
+        .to_string_lossy()
+        .replace('\\', "/")
+}

--- a/src/http/web.rs
+++ b/src/http/web.rs
@@ -51,11 +51,14 @@ pub(crate) async fn web_asset_response(
     } else {
         Body::from(bytes)
     };
-    Response::builder()
+    let mut response = Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, content_type.as_ref())
-        .body(body)
-        .ok()
+        .header("x-holon-daemon-version", env!("HOLON_VERSION"));
+    if state.web_dist.is_none() {
+        response = response.header("x-holon-web-source-hash", env!("HOLON_WEB_SOURCE_HASH"));
+    }
+    response.body(body).ok()
 }
 
 pub(crate) fn normalize_web_asset_path(request_path: &str) -> Option<String> {

--- a/tests/web_dist_build.rs
+++ b/tests/web_dist_build.rs
@@ -1,0 +1,78 @@
+#[path = "../build_support/web_dist.rs"]
+mod web_dist;
+
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn rejects_missing_web_dist() {
+    let fixture = WebFixture::new();
+
+    let error = web_dist::validate_web_dist(&fixture.web_root, &fixture.dist_dir).unwrap_err();
+
+    assert!(error.contains("dist is missing"), "{error}");
+}
+
+#[test]
+fn rejects_stale_web_dist() {
+    let fixture = WebFixture::new();
+    fixture.write_dist("sha256:stale");
+
+    let error = web_dist::validate_web_dist(&fixture.web_root, &fixture.dist_dir).unwrap_err();
+
+    assert!(error.contains("dist is stale"), "{error}");
+}
+
+#[test]
+fn accepts_matching_web_dist() {
+    let fixture = WebFixture::new();
+    let source_hash = web_dist::compute_web_source_hash(&fixture.web_root).unwrap();
+    fixture.write_dist(&source_hash);
+
+    let identity = web_dist::validate_web_dist(&fixture.web_root, &fixture.dist_dir).unwrap();
+
+    assert_eq!(identity.source_hash, source_hash);
+}
+
+struct WebFixture {
+    _temp: TempDir,
+    web_root: std::path::PathBuf,
+    dist_dir: std::path::PathBuf,
+}
+
+impl WebFixture {
+    fn new() -> Self {
+        let temp = TempDir::new().unwrap();
+        let web_root = temp.path().join("app");
+        let dist_dir = web_root.join("dist");
+        fs::create_dir_all(web_root.join("src")).unwrap();
+        fs::write(web_root.join("src/main.ts"), "export {};\n").unwrap();
+        for source_file in [
+            "index.html",
+            "package-lock.json",
+            "package.json",
+            "tsconfig.json",
+            "tsconfig.node.json",
+            "vite.config.ts",
+        ] {
+            fs::write(web_root.join(source_file), source_file).unwrap();
+        }
+        Self {
+            _temp: temp,
+            web_root,
+            dist_dir,
+        }
+    }
+
+    fn write_dist(&self, source_hash: &str) {
+        fs::create_dir_all(&self.dist_dir).unwrap();
+        fs::write(self.dist_dir.join("index.html"), "<main>Holon</main>").unwrap();
+        fs::write(
+            self.dist_dir.join("holon-web-build.json"),
+            format!(
+                "{{\"schema_version\":1,\"source_hash\":\"{source_hash}\",\"web_version\":\"test\"}}\n"
+            ),
+        )
+        .unwrap();
+    }
+}

--- a/web-gui/app/e2e/reset-scope.spec.ts
+++ b/web-gui/app/e2e/reset-scope.spec.ts
@@ -532,6 +532,7 @@ test("divergence repair, sync error, and degraded handle recovery preserve exact
     visibilityScopeId: "e2e-scope",
     eventLogEpoch: "e2e-epoch",
     eventSeqs: [1, 2],
+    readThroughEventSeq: 2,
     certainty: "exact",
   }]);
   const recoveredWrite = await request.post(controlPath(session, "/__e2e__/append-event"), {

--- a/web-gui/app/package-lock.json
+++ b/web-gui/app/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@playwright/test": "^1.62.1",
         "@tailwindcss/vite": "^4.3.1",
+        "@types/node": "^24.13.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
@@ -940,6 +941,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -3317,6 +3328,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/web-gui/app/package.json
+++ b/web-gui/app/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@playwright/test": "^1.62.1",
     "@tailwindcss/vite": "^4.3.1",
+    "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",

--- a/web-gui/app/src/e2e/diagnostics-bridge.ts
+++ b/web-gui/app/src/e2e/diagnostics-bridge.ts
@@ -1,4 +1,5 @@
 import {
+  ledgerReadinessForDiagnostics,
   ledgerStatusForDiagnostics,
   ledgerReadMarkerDecision,
   useRuntimeStore,
@@ -68,6 +69,9 @@ export interface HolonE2eLedgerSnapshot {
   ingestionError?: string;
   ingestedThroughSeq: number;
   projectionReadyThroughSeq: number;
+  observedHeadSeq?: number;
+  gateIngestedThroughSeq?: number;
+  gateReadyThroughSeq?: number;
   pendingHydrationJobs: number;
   failedHydrationJobs: number;
   blockedByEventSeq?: number;
@@ -169,6 +173,7 @@ async function ledgerSnapshot(agentId: string): Promise<HolonE2eLedgerSnapshot |
     const storeState = useRuntimeStore.getState();
     const runtimeSession = storeState.sessionsByAgentId[agentId];
     const status = ledgerStatusForDiagnostics(agentId);
+    const readiness = ledgerReadinessForDiagnostics(agentId);
     return {
       agentId,
       runtimeId: session.runtimeId,
@@ -179,6 +184,9 @@ async function ledgerSnapshot(agentId: string): Promise<HolonE2eLedgerSnapshot |
       ingestionError: status?.lastError,
       ingestedThroughSeq: session.ingestedThroughSeq ?? 0,
       projectionReadyThroughSeq: session.projectionReadyThroughSeq ?? 0,
+      observedHeadSeq: readiness?.observedHeadSeq,
+      gateIngestedThroughSeq: readiness?.ingestedThroughSeq,
+      gateReadyThroughSeq: readiness?.readyThroughSeq,
       pendingHydrationJobs: pending.length,
       failedHydrationJobs: jobs.length - pending.length,
       blockedByEventSeq: pending.length

--- a/web-gui/app/src/runtime/event-ledger/classification.ts
+++ b/web-gui/app/src/runtime/event-ledger/classification.ts
@@ -23,13 +23,10 @@
 
 import type { LedgerRecordKind } from "./keys";
 import type { RawEventClassification } from "./ledger";
+import { RUNTIME_EVENT_CONTRACT_VERSION } from "../session-events";
 
-/**
- * Highest StreamEventEnvelope.contract_version this client understands.
- * Mirrors RUNTIME_EVENT_CONTRACT_VERSION in `runtime/session-events.ts`;
- * duplicated here so the ledger layer stays app-layer-independent.
- */
-export const SUPPORTED_ENVELOPE_CONTRACT_VERSION = 2;
+/** Highest StreamEventEnvelope.contract_version this client understands. */
+export const SUPPORTED_ENVELOPE_CONTRACT_VERSION = RUNTIME_EVENT_CONTRACT_VERSION;
 
 export type EnvelopeProjectionEffect = "none" | "display_invalidation";
 

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
@@ -147,7 +147,7 @@ describe("ledger ingestion pipeline", () => {
     ledger.close();
   });
 
-  it("never reloads an observed head behind the persisted contiguous cursor", async () => {
+  it("does not load another agent's runtime head into the session read gate", async () => {
     const scope = makeScope();
     const ledger = await openLedgerHandle();
     await ledger
@@ -161,7 +161,7 @@ describe("ledger ingestion pipeline", () => {
           visibilityScopeId: scope.visibilityScopeId,
           eventLogEpoch: scope.eventLogEpoch,
         },
-        { eventHeadSeq: 0 },
+        { eventHeadSeq: 1_000 },
       )
       .commit();
     ledger.close();
@@ -176,17 +176,18 @@ describe("ledger ingestion pipeline", () => {
     });
   });
 
-  it("keeps the contiguous cursor behind out-of-order gaps", async () => {
+  it("advances across sparse runtime-global sequences in an agent-filtered stream", async () => {
     const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
     await pipeline.open();
     const scope = makeScope();
 
     const afterTail = await pipeline.ingest(scope, [envelope(5), envelope(6), envelope(7)]);
-    expect(afterTail.ingestedThroughSeq).toBeUndefined();
+    expect(afterTail.ingestedThroughSeq).toBe(7);
+    expect(afterTail.projectionReadyThroughSeq).toBe(7);
     expect(afterTail.observedEventHeadSeq).toBe(7);
 
     const afterMid = await pipeline.ingest(scope, [envelope(3), envelope(4)]);
-    expect(afterMid.ingestedThroughSeq).toBeUndefined();
+    expect(afterMid.ingestedThroughSeq).toBe(7);
 
     const afterFill = await pipeline.ingest(scope, [envelope(1), envelope(2)]);
     expect(afterFill.ingestedThroughSeq).toBe(7);
@@ -209,7 +210,7 @@ describe("ledger ingestion pipeline", () => {
     ledger.close();
   });
 
-  it("never advances the raw cursor from filtered subsets or semantic fetches", async () => {
+  it("advances the agent cursor across sparse sequences but not from semantic fetches", async () => {
     const fetches: Array<{ kind: string; ids: string[] }> = [];
     const fetchers: LedgerHydrationFetchers = {
       fetchCanonicalRecords: async (_agentId, kind, ids) => {
@@ -224,9 +225,9 @@ describe("ledger ingestion pipeline", () => {
     await pipeline.open();
     const scope = makeScope();
 
-    // A display-filtered page returns only part of the raw range.
+    // Runtime-global sequence gaps are expected in an agent-filtered page.
     const filtered = await pipeline.ingest(scope, [envelope(4), envelope(6), envelope(8)]);
-    expect(filtered.ingestedThroughSeq).toBeUndefined();
+    expect(filtered.ingestedThroughSeq).toBe(8);
 
     // Hydrating referenced records (semantic timeline demand) fetches
     // canonical bodies but must not move any raw cursor.
@@ -240,10 +241,7 @@ describe("ledger ingestion pipeline", () => {
 
     const ledger = await openLedgerHandle();
     const session = await ledger.getAgentSession(scope);
-    // Events 4 and 6/8 are stored but 5 and 7 never arrived: the contiguous
-    // cursor stops at 4, after the gap-filling 1..3 ingest plus the earlier
-    // filtered straggler 4 — never at 8.
-    expect(session?.ingestedThroughSeq).toBe(4);
+    expect(session?.ingestedThroughSeq).toBe(8);
     const runtimeScope = await ledger.getRuntimeScope({
       remoteKey: scope.remoteKey,
       runtimeId: scope.runtimeId,
@@ -388,7 +386,7 @@ describe("ledger ingestion pipeline", () => {
     const scope = makeScope();
 
     const status = await pipeline.ingest(scope, [
-      envelope(1),
+      envelope(1, { contract_version: 3 }),
       envelope(2, { contract_version: 99 }),
       envelope(3),
     ]);
@@ -462,7 +460,7 @@ describe("ledger ingestion pipeline", () => {
     expect(status.ingestedThroughSeq).toBe(2);
   });
 
-  it("heals stored out-of-order stragglers across a restart", async () => {
+  it("does not regress a sparse agent cursor across a restart", async () => {
     const scope = makeScope();
     const first = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
     await first.open();
@@ -474,7 +472,6 @@ describe("ledger ingestion pipeline", () => {
     await second.resume(scope);
     const status = await second.ingest(scope, [envelope(3)]);
 
-    // The restart scan rediscovered seq 4, so filling seq 3 heals the gap.
     expect(status.ingestedThroughSeq).toBe(4);
     expect(status.projectionReadyThroughSeq).toBe(4);
   });

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
@@ -40,7 +40,6 @@ import { remoteScopeKeyParts, type LedgerRemoteScopeKey } from "./keys";
 import type { LedgerRecordKind, LedgerScopeKey } from "./keys";
 
 /** How far above the contiguous cursor resume() scans for stored stragglers. */
-const RESUME_LOOKAHEAD_SEQ = 1_000;
 const DEFAULT_MAX_HYDRATION_ATTEMPTS = 5;
 const DEFAULT_HYDRATION_BATCH_SIZE = 64;
 
@@ -174,7 +173,6 @@ interface ScopeTracker {
   contiguousThrough: number;
   readyThrough: number;
   observedHead: number;
-  outOfOrder: Set<number>;
   blockers: Map<number, Blocker>;
   jobs: Map<string, HydrationJobView>;
   state: LedgerIngestionState;
@@ -395,7 +393,10 @@ export class LedgerIngestionPipeline {
       batch.putHydrationJob(scope, this.jobRecordFromView(scope, job));
     }
 
-    const contiguous = this.advanceContiguity(tracker, newSeqs);
+    // event_seq is runtime-global while this scope is agent-filtered. The
+    // agent cursor therefore advances to the greatest observed sequence;
+    // gaps represent other agents' events, not missing events in this scope.
+    const contiguous = Math.max(tracker.contiguousThrough, ...newSeqs);
     if (contiguous > tracker.contiguousThrough) {
       batch.advanceIngestionCursor(scope, contiguous);
       tracker.contiguousThrough = contiguous;
@@ -984,9 +985,8 @@ export class LedgerIngestionPipeline {
       return tracker;
     }
     const ledger = this.ledger!;
-    const [session, runtimeScope, jobs] = await Promise.all([
+    const [session, jobs] = await Promise.all([
       ledger.getAgentSession(scope),
-      ledger.getRuntimeScope(remoteScopeOf(scope)),
       ledger.getPendingHydrationJobs(scope),
     ]);
     tracker.contiguousThrough = session?.ingestedThroughSeq ?? 0;
@@ -994,13 +994,10 @@ export class LedgerIngestionPipeline {
       session?.projectionReadyThroughSeq ?? 0,
       tracker.contiguousThrough,
     );
-    // These records are read independently, so another tab may commit between
-    // the two reads. A persisted contiguous cursor is itself proof that the
-    // observed head reached at least that sequence.
-    tracker.observedHead = Math.max(
-      runtimeScope?.eventHeadSeq ?? 0,
-      tracker.contiguousThrough,
-    );
+    // Runtime scope metadata is shared by every agent. It cannot be used as
+    // this agent's observed head because another agent may have a much larger
+    // runtime-global event_seq.
+    tracker.observedHead = tracker.contiguousThrough;
     for (const job of jobs) {
       const view = this.jobViewFromRecord(job);
       tracker.jobs.set(view.jobId, view);
@@ -1015,18 +1012,6 @@ export class LedgerIngestionPipeline {
       );
       for (const event of window) {
         this.registerBlocker(tracker, this.classifyStored(event));
-      }
-    }
-    // Discover stored stragglers above the contiguous cursor so later
-    // gap-filling ingests can count them without re-delivery.
-    const stragglers = await ledger.getRawEventsBetween(
-      scope,
-      tracker.contiguousThrough + 1,
-      tracker.contiguousThrough + RESUME_LOOKAHEAD_SEQ,
-    );
-    for (const event of stragglers) {
-      if (event.eventSeq > tracker.contiguousThrough) {
-        tracker.outOfOrder.add(event.eventSeq);
       }
     }
     tracker.loaded = true;
@@ -1064,24 +1049,13 @@ export class LedgerIngestionPipeline {
     });
   }
 
-  private advanceContiguity(tracker: ScopeTracker, newSeqs: number[]): number {
-    for (const seq of newSeqs) {
-      if (seq > tracker.contiguousThrough) tracker.outOfOrder.add(seq);
-    }
-    let next = tracker.contiguousThrough + 1;
-    while (tracker.outOfOrder.has(next)) {
-      tracker.outOfOrder.delete(next);
-      next += 1;
-    }
-    return next - 1;
-  }
-
   private computeReady(tracker: ScopeTracker): number {
-    let next = tracker.readyThrough + 1;
-    while (next <= tracker.contiguousThrough && !tracker.blockers.has(next)) {
-      next += 1;
-    }
-    return next - 1;
+    const firstBlockedSeq = Math.min(
+      ...(tracker.blockers.size > 0 ? Array.from(tracker.blockers.keys()) : [Infinity]),
+    );
+    return Number.isFinite(firstBlockedSeq)
+      ? Math.min(tracker.contiguousThrough, firstBlockedSeq - 1)
+      : tracker.contiguousThrough;
   }
 
   private removeJobAndBlockers(
@@ -1201,7 +1175,6 @@ export class LedgerIngestionPipeline {
       contiguousThrough: 0,
       readyThrough: 0,
       observedHead: 0,
-      outOfOrder: new Set(),
       blockers: new Map(),
       jobs: new Map(),
       state: "idle",

--- a/web-gui/app/src/runtime/read-state.test.ts
+++ b/web-gui/app/src/runtime/read-state.test.ts
@@ -246,19 +246,12 @@ describe("ledger read-marker gate", () => {
     expect(decision.reason).toBe("document_hidden");
   });
 
-  it("blocks while the session is loading, gapped, or recovering", () => {
+  it("blocks while the session is loading or recovering", () => {
     const loading = evaluateLedgerReadMarkerGate(
       gateInput({ session: { ...emptyAgentSession(), loading: true } }),
       "agent-a",
     );
     expect(loading.reason).toBe("session_not_ready");
-    const gapped = evaluateLedgerReadMarkerGate(
-      gateInput({
-        session: { ...emptyAgentSession(), gaps: [{ afterSeq: 1, beforeSeq: 9 }] },
-      }),
-      "agent-a",
-    );
-    expect(gapped.reason).toBe("session_not_ready");
     const recovering = evaluateLedgerReadMarkerGate(
       gateInput({ session: { ...emptyAgentSession(), syncStatus: "recovering" } }),
       "agent-a",

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -696,6 +696,47 @@ describe("roster activity unread state", () => {
     });
   });
 
+  it("keeps ledger unread exact when only cached session detail is stale", async () => {
+    vi.spyOn(AgentSessionRepository.prototype, "unreadSnapshot").mockResolvedValue({
+      scopeAgentId: "agent-stale-cache",
+      boundarySeq: 12,
+      countedThroughSeq: 12,
+      certainty: "exact",
+      count: 3,
+      historyTruncatedBeforeSeq: null,
+      acknowledgedTruncationBeforeSeq: null,
+    });
+    vi.spyOn(AgentSessionRepository.prototype, "sessionLedgerStatus").mockReturnValue({
+      scope: {
+        remoteKey: "local",
+        runtimeId: "runtime-1",
+        visibilityScopeId: "scope-1",
+        eventLogEpoch: "epoch-1",
+        agentId: "agent-stale-cache",
+      },
+      durability: "exact",
+      state: "idle",
+      ingestedThroughSeq: 12,
+      projectionReadyThroughSeq: 12,
+      observedEventHeadSeq: 12,
+      pendingHydrationJobs: 0,
+      failedHydrationJobs: 0,
+    });
+    useRuntimeStore.setState({
+      sessionsByAgentId: {
+        "agent-stale-cache": sessionState({ syncStatus: "stale" }),
+      },
+      ledgerUnreadByAgentId: {},
+    });
+
+    await useRuntimeStore.getState().refreshLedgerUnread("agent-stale-cache");
+
+    expect(useRuntimeStore.getState().ledgerUnreadByAgentId["agent-stale-cache"]).toEqual({
+      mode: "exact",
+      count: 3,
+    });
+  });
+
   it("retries a pending read marker after ledger readiness becomes available", async () => {
     vi.stubGlobal("document", { visibilityState: "visible" });
     let ready = false;

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -1130,6 +1130,10 @@ export function ledgerStatusForDiagnostics(agentId: string) {
   return agentSessionRepository.sessionLedgerStatus(agentId);
 }
 
+export function ledgerReadinessForDiagnostics(agentId: string) {
+  return agentSessionRepository.sessionLedgerReadiness(agentId);
+}
+
 export interface ObserverSyncAgentDiagnostics {
   agentId: string;
   durability: string;
@@ -1242,13 +1246,8 @@ async function refreshLedgerUnreadInView(agentId: string): Promise<void> {
       return;
     }
     const status = agentSessionRepository.sessionLedgerStatus(agentId);
-    const session = state.sessionsByAgentId[agentId];
-    const stale =
-      status?.state === "sync_error" ||
-      session?.syncStatus === "stale" ||
-      session?.syncStatus === "error";
     const view: LedgerUnreadView = {
-      mode: stale
+      mode: status?.state === "sync_error"
         ? "stale_sync_error"
         : snapshot.certainty === "truncated"
           ? "truncated"

--- a/web-gui/app/src/runtime/session-events.ts
+++ b/web-gui/app/src/runtime/session-events.ts
@@ -2,7 +2,7 @@ import type { components } from "./generated/openapi";
 
 export type SessionEventEnvelope = Partial<components["schemas"]["StreamEventEnvelope"]>;
 
-const RUNTIME_EVENT_CONTRACT_VERSION = 3;
+export const RUNTIME_EVENT_CONTRACT_VERSION = 3;
 const runtimeEventSchemas: Record<string, string> = {
   message_enqueued: "holon.runtime_event.message_lifecycle",
   message_processing_started: "holon.runtime_event.message_lifecycle",

--- a/web-gui/app/src/runtime/session-projection.test.ts
+++ b/web-gui/app/src/runtime/session-projection.test.ts
@@ -234,13 +234,11 @@ describe("SessionProjectionState", () => {
     ]);
   });
 
-  it("records and closes gaps when backfill arrives", () => {
-    const withGap = receive(createSessionProjectionState(), [events[0], events[2]]);
-    expect(withGap.gaps).toEqual([{ afterSeq: 1, beforeSeq: 3 }]);
+  it("does not infer agent gaps from sparse runtime-global event sequences", () => {
+    const projection = receive(createSessionProjectionState(), [events[0], events[2]]);
 
-    const recovered = receive(withGap, [events[1]]);
-    expect(recovered.gaps).toEqual([]);
-    expect(recovered.eventSeqs).toEqual([1, 2, 3]);
+    expect(projection.gaps).toEqual([]);
+    expect(projection.eventSeqs).toEqual([1, 3]);
   });
 
   it("hydrates references without rebuilding normalized domain state", () => {

--- a/web-gui/app/src/runtime/session-projection.ts
+++ b/web-gui/app/src/runtime/session-projection.ts
@@ -369,7 +369,10 @@ function reduceEvents(
     unknownEventIds: events
       .filter((event) => !canApplySessionEvent(event))
       .map((event) => event.id ?? `event-${event.event_seq}`),
-    gaps: eventGaps(events),
+    // event_seq is runtime-global while this projection is agent-filtered.
+    // Sparse sequence numbers therefore represent other agents' events, not
+    // missing events for this session.
+    gaps: [],
     newestSeq: eventSeqs[eventSeqs.length - 1],
     oldestSeq: eventSeqs[0],
     invalidatedReason: undefined,
@@ -405,21 +408,12 @@ function rebuildProjection(projection: SessionProjectionState): SessionProjectio
     referencedMessageIds: references.messageIds,
     referencedTranscriptEntryIds: references.transcriptEntryIds,
     referencedBriefIds: references.briefIds,
-    gaps: eventGaps(events),
+    // Authoritative agent pages clear legacy inferred gaps. A filtered stream
+    // cannot infer missing events from gaps in the runtime-global sequence.
+    gaps: [],
     newestSeq: projection.newestSeq ?? events.at(-1)?.event_seq,
     oldestSeq: projection.oldestSeq ?? events[0]?.event_seq,
   };
-}
-
-function eventGaps(events: ProjectionEvent[]): EventGap[] {
-  const gaps: EventGap[] = [];
-  for (let index = 1; index < events.length; index += 1) {
-    const previous = events[index - 1].event_seq;
-    const current = events[index].event_seq;
-    if (previous == null || current == null) continue;
-    if (current > previous + 1) gaps.push({ afterSeq: previous, beforeSeq: current });
-  }
-  return gaps;
 }
 
 function mergeMissingIds(

--- a/web-gui/app/src/vite-env.d.ts
+++ b/web-gui/app/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
 
 declare const __HOLON_GUI_VERSION__: string;
+declare const __HOLON_GUI_SOURCE_HASH__: string;
 declare const __HOLON_E2E_DIAGNOSTICS__: boolean;

--- a/web-gui/app/tsconfig.node.json
+++ b/web-gui/app/tsconfig.node.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
+    "types": ["node"],
     "strict": true,
     "noEmit": true
   },

--- a/web-gui/app/vite.config.ts
+++ b/web-gui/app/vite.config.ts
@@ -2,21 +2,59 @@
 
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig, loadEnv } from "vite";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { defineConfig, loadEnv, type ResolvedConfig } from "vite";
 import packageJson from "./package.json";
 
 const DEFAULT_HOLON_API_PROXY_TARGET = "http://127.0.0.1:7878";
+const WEB_SOURCE_FILES = [
+  "index.html",
+  "package-lock.json",
+  "package.json",
+  "tsconfig.json",
+  "tsconfig.node.json",
+  "vite.config.ts",
+];
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(async ({ mode }) => {
   const env = loadEnv(mode, ".", "");
   const holonApiProxyTarget = env.HOLON_API_PROXY_TARGET || DEFAULT_HOLON_API_PROXY_TARGET;
+  const sourceHash = await computeWebSourceHash();
+  let outputDirectory = path.resolve("dist");
 
   return {
     define: {
       __HOLON_GUI_VERSION__: JSON.stringify(packageJson.version),
+      __HOLON_GUI_SOURCE_HASH__: JSON.stringify(sourceHash),
       __HOLON_E2E_DIAGNOSTICS__: JSON.stringify(mode === "e2e"),
     },
-    plugins: [tailwindcss(), react()],
+    plugins: [
+      tailwindcss(),
+      react(),
+      {
+        name: "holon-web-build-identity",
+        configResolved(config: ResolvedConfig) {
+          outputDirectory = path.resolve(config.root, config.build.outDir);
+        },
+        async closeBundle() {
+          await mkdir(outputDirectory, { recursive: true });
+          await writeFile(
+            path.join(outputDirectory, "holon-web-build.json"),
+            `${JSON.stringify(
+              {
+                schema_version: 1,
+                source_hash: sourceHash,
+                web_version: packageJson.version,
+              },
+              null,
+              2,
+            )}\n`,
+          );
+        },
+      },
+    ],
     test: {
       exclude: ["e2e/**", "node_modules/**"],
     },
@@ -33,3 +71,29 @@ export default defineConfig(({ mode }) => {
     },
   };
 });
+
+async function computeWebSourceHash(): Promise<string> {
+  const inputs = await collectFiles("src");
+  inputs.push(...WEB_SOURCE_FILES);
+  inputs.sort();
+
+  const hash = createHash("sha256");
+  for (const input of inputs) {
+    hash.update(input);
+    hash.update("\0");
+    hash.update(await readFile(input));
+    hash.update("\0");
+  }
+  return `sha256:${hash.digest("hex")}`;
+}
+
+async function collectFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const paths = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.posix.join(directory, entry.name);
+      return entry.isDirectory() ? collectFiles(entryPath) : [entryPath];
+    }),
+  );
+  return paths.flat();
+}


### PR DESCRIPTION
## 概要

修复 Web GUI 未读状态在本地构建、历史 session cache 与 agent-filtered observer 流下不可靠的问题。

- 为 `web-gui/app/dist` 写入 source/build identity，并在 Rust 构建嵌入前校验，避免新 binary 静默携带旧或空 dist
- stale session cache 错误不再污染 event ledger 的未读分类，恢复精确数字 badge
- 统一 agent-filtered observer 流的 cursor 语义，避免稀疏全局 `event_seq` 被误判为 session gap、从而永久阻塞 read marker
- 扩充定向单测、Rust dist 构建回归与 CI 构建顺序校验

## 根因与行为变化

真实 `localhost:7878` 复核确认了三个相互独立的问题：

1. `RustEmbed` 会直接嵌入 git-ignored 的现有 `dist/`，普通 `cargo build` 无法确认它是否来自当前 Web source。
2. session cache 中的 stale sync error 会被重新摄入 ledger，使本应精确的未读退化为不可信状态。
3. agent-filtered observer 返回的事件序列天然稀疏，但前端按连续全局序号检测 gap，导致 `session_not_ready` 持续阻塞 `read_marker.advance`。

本 PR 分别在构建不变量、ledger classification 与 observer cursor contract 层修复，未通过清空浏览器数据或 UI 后处理掩盖问题。

## 验证

- `npm test`：39 个测试文件、457 个测试通过
- `npm run build`
- `npm run test:e2e:production-bundle`
- `cargo fmt --all -- --check`
- `cargo test --test web_dist_build`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- 真实 daemon + 保留 profile：30 个精确未读点击后清零，刷新后保持
- 全新 profile + 双标签页：未读清零跨标签同步，双页刷新后保持
