### PR TITLE
fix: support completing legacy work items

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -158,6 +158,8 @@ pub(crate) struct PreparedWorkItemCompletion {
     pub(crate) brief: crate::types::BriefRecord,
     pub(crate) expected_execution_protocol_state:
         Option<crate::domain::execution_protocol::ExecutionProtocolState>,
+    pub(crate) legacy_work_item_execution:
+        Option<crate::domain::execution_protocol::WorkItemExecutionRecord>,
     pub(crate) expected_agent_state: crate::types::AgentState,
     pub(crate) committed_agent_state: crate::types::AgentState,
     pub(crate) wait_conditions: Vec<crate::types::WaitConditionRecord>,
@@ -487,8 +489,8 @@ fn execution_protocol_completion_transition_from_prepared(
 ) -> Result<crate::runtime_db::transitions::ExecutionProtocolTransition> {
     use crate::domain::execution_protocol::{
         CompleteWorkItemExecution, ConversationOutcome, ExecutionAttemptState, ExecutionBinding,
-        ExecutionOutcome, ExecutionOutcomeRecord, ExecutionProtocolCommand, SettleExecution,
-        WorkItemExecutionState, WorkItemOutcome,
+        ExecutionOutcome, ExecutionOutcomeRecord, ExecutionProtocolCommand,
+        RegisterWorkItemExecution, SettleExecution, WorkItemExecutionState, WorkItemOutcome,
     };
 
     anyhow::ensure!(
@@ -519,6 +521,7 @@ fn execution_protocol_completion_transition_from_prepared(
     let authoritative = state
         .work_items
         .get(&prepared.record.id)
+        .or(prepared.legacy_work_item_execution.as_ref())
         .ok_or_else(|| anyhow!("completion commit WorkItem execution state is missing"))?;
     anyhow::ensure!(
         intent.work_item_id == prepared.record.id
@@ -578,7 +581,16 @@ fn execution_protocol_completion_transition_from_prepared(
                     ),
                 "completion commit lifecycle WorkItem fence is stale"
             );
-            vec![
+            let mut commands = Vec::with_capacity(3);
+            if !state.work_items.contains_key(&prepared.record.id) {
+                commands.push(ExecutionProtocolCommand::RegisterWorkItem(Box::new(
+                    RegisterWorkItemExecution {
+                        work_item_id: prepared.record.id.clone(),
+                        record: authoritative.clone(),
+                    },
+                )));
+            }
+            commands.extend([
                 ExecutionProtocolCommand::Settle(SettleExecution {
                     outcome: ExecutionOutcomeRecord {
                         outcome_id: format!("outcome:complete:{}", attempt.attempt_id),
@@ -593,7 +605,8 @@ fn execution_protocol_completion_transition_from_prepared(
                     expected: authoritative.clone(),
                     completion: prepared.brief.id.clone(),
                 })),
-            ]
+            ]);
+            commands
         }
         ExecutionBinding::Conversation { .. } | ExecutionBinding::Command => {
             bail!("completion commit requires a WorkItem or agent-lifecycle execution")

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -4028,6 +4028,54 @@ impl RuntimeHandle {
         } else {
             None
         };
+        let legacy_work_item_execution = expected_execution_protocol_state
+            .as_ref()
+            .filter(|state| !state.work_items.contains_key(&existing.id))
+            .map(|_| {
+                use crate::domain::execution_protocol::{
+                    WaitReference, WorkItemExecutionRecord, WorkItemExecutionState,
+                };
+
+                let active_wait_ids = self
+                    .inner
+                    .storage
+                    .raw_active_wait_conditions_for_agent(&agent_id)?
+                    .into_iter()
+                    .filter(|condition| {
+                        condition.work_item_id.as_deref() == Some(existing.id.as_str())
+                    })
+                    .map(|condition| condition.id)
+                    .collect::<Vec<_>>();
+                let generation = existing.revision.max(1);
+                let state = match active_wait_ids.as_slice() {
+                    [wait_id] => WorkItemExecutionState::Waiting {
+                        generation,
+                        wait: WaitReference {
+                            wait_id: wait_id.clone(),
+                        },
+                    },
+                    [] if existing.blocked_by.is_some() => WorkItemExecutionState::Paused {
+                        generation,
+                        reason: existing
+                            .blocked_by
+                            .clone()
+                            .expect("manual blocker checked above"),
+                    },
+                    [] => WorkItemExecutionState::Runnable {
+                        generation,
+                        recovery_ref: None,
+                    },
+                    _ => WorkItemExecutionState::NeedsRepair {
+                        generation,
+                        repair_id: format!("work_item_waits_ambiguous:{}", existing.id),
+                    },
+                };
+                Ok::<_, anyhow::Error>(WorkItemExecutionRecord {
+                    source_revision: existing.revision,
+                    state,
+                })
+            })
+            .transpose()?;
         let expected_agent_state = state.clone();
         let agent_execution_authority = matches!(
             authority,
@@ -4127,17 +4175,17 @@ impl RuntimeHandle {
                                 agent_id: binding_agent_id,
                             } => {
                                 binding_agent_id == &agent_id
-                                    && protocol_state
-                                        .work_items
-                                        .get(&existing.id)
-                                        .is_some_and(|work_item| {
+                                    && protocol_state.work_items.get(&existing.id).map_or_else(
+                                        || legacy_work_item_execution.is_some(),
+                                        |work_item| {
                                             work_item.source_revision == existing.revision
                                                 && !matches!(
                                                     work_item.state,
                                                     crate::domain::execution_protocol::WorkItemExecutionState::InFlight { .. }
                                                         | crate::domain::execution_protocol::WorkItemExecutionState::Terminal { .. }
                                                 )
-                                        })
+                                        },
+                                    )
                             }
                             crate::domain::execution_protocol::ExecutionBinding::Conversation {
                                 ..
@@ -4349,6 +4397,7 @@ impl RuntimeHandle {
             record,
             brief: brief.clone(),
             expected_execution_protocol_state,
+            legacy_work_item_execution,
             expected_agent_state,
             committed_agent_state: state,
             wait_conditions,

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2414,6 +2414,135 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
 }
 
 #[tokio::test]
+async fn lifecycle_completion_registers_missing_legacy_work_item_execution() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let seed_runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = seed_runtime
+        .create_work_item(
+            "complete pre-execution-protocol work".into(),
+            Some(WorkItemPlanStatus::NeedsInput),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(work_item.id.clone())
+        .await
+        .unwrap();
+    seed_runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| {
+            tx.execute(
+                "DELETE FROM execution_protocol_work_items
+                 WHERE agent_id = ?1 AND work_item_id = ?2",
+                ["default", work_item.id.as_str()],
+            )?;
+            tx.execute(
+                "DELETE FROM execution_protocol_command_results
+                 WHERE agent_id = ?1
+                   AND command_kind = 'register_work_item_execution'
+                   AND command_identity = ?2",
+                ["default", work_item.id.as_str()],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    let provider = Arc::new(CompleteWorkItemReportProvider {
+        work_item_id: work_item.id.clone(),
+        report_text: Some("Closed the legacy tracked work.".into()),
+        calls: Mutex::new(0),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider,
+        "default".into(),
+        continuation_context_config(),
+    )
+    .unwrap();
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "close the legacy work item".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::HttpControlPrompt,
+        AdmissionContext::ControlAuthenticated,
+    );
+
+    let mut runtime_task = tokio::spawn(runtime.clone().run());
+    runtime.enqueue(message).await.unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            if runtime
+                .latest_work_item(&work_item.id)
+                .await
+                .unwrap()
+                .is_some_and(|record| record.state == WorkItemState::Completed)
+            {
+                break;
+            }
+            if runtime_task.is_finished() {
+                panic!(
+                    "runtime exited before legacy completion commit: {:#}",
+                    (&mut runtime_task)
+                        .await
+                        .expect("runtime task join")
+                        .expect_err("runtime unexpectedly completed")
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for legacy completion commit");
+    runtime_task.abort();
+
+    let completed = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(completed.state, WorkItemState::Completed);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        execution.work_items.get(&work_item.id).map(|record| &record.state),
+        Some(crate::domain::execution_protocol::WorkItemExecutionState::Terminal {
+            completion,
+            ..
+        }) if Some(completion.as_str()) == completed.result_brief_id.as_deref()
+    ));
+}
+
+#[tokio::test]
 async fn standalone_turn_writer_rejects_prepared_completion() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -7239,6 +7368,7 @@ fn rebase_completion_accepts_diverged_baseline_after_concurrent_persist() {
         record,
         brief,
         expected_execution_protocol_state: None,
+        legacy_work_item_execution: None,
         expected_agent_state: expected,
         committed_agent_state: committed.clone(),
         wait_conditions: Vec::new(),
@@ -7282,6 +7412,7 @@ fn rebase_completion_rejects_mismatched_agent_id() {
         record,
         brief,
         expected_execution_protocol_state: None,
+        legacy_work_item_execution: None,
         expected_agent_state: expected,
         committed_agent_state: committed,
         wait_conditions: Vec::new(),


### PR DESCRIPTION
## 变更说明

- 在生命周期完成准备阶段检测缺少 execution protocol 投影的旧版 WorkItem。
- 仅在旧记录缺失投影时补注册当前 WorkItem，使 CompleteWorkItem 能继续走现有授权与完成提交路径。
- 添加回归测试，覆盖旧 WorkItem 没有 execution_protocol_work_items 记录的场景。

## 验证

- `cargo test lifecycle_completion_registers_missing_legacy_work_item_execution -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
