### PR TITLE
fix(web-gui): scope observed event heads per agent

### DIFF
--- a/web-gui/app/e2e/reset-scope.spec.ts
+++ b/web-gui/app/e2e/reset-scope.spec.ts
@@ -300,6 +300,7 @@ test("event log epoch replacement clears the old projection and read partition",
     visibilityScopeId: "e2e-scope",
     eventLogEpoch: "epoch-after",
     eventSeqs: [1, 2, 3],
+    observedHeadSeq: 3,
     readThroughEventSeq: 3,
     certainty: "exact",
   }]);
@@ -351,6 +352,7 @@ test("visibility scope rotation clears the old auth-scoped partition", async ({
     visibilityScopeId: "scope-after",
     eventLogEpoch: "e2e-epoch",
     eventSeqs: [1, 2, 3],
+    observedHeadSeq: 3,
     readThroughEventSeq: 3,
     certainty: "exact",
   }]);
@@ -532,6 +534,8 @@ test("divergence repair, sync error, and degraded handle recovery preserve exact
     visibilityScopeId: "e2e-scope",
     eventLogEpoch: "e2e-epoch",
     eventSeqs: [1, 2],
+    observedHeadSeq: 2,
+    readThroughEventSeq: 2,
     certainty: "exact",
   }]);
   const recoveredWrite = await request.post(controlPath(session, "/__e2e__/append-event"), {
@@ -551,6 +555,7 @@ test("divergence repair, sync error, and degraded handle recovery preserve exact
     visibilityScopeId: "e2e-scope",
     eventLogEpoch: "e2e-epoch",
     eventSeqs: [1, 2, 3],
+    observedHeadSeq: 3,
     readThroughEventSeq: 3,
     certainty: "exact",
   }]);

--- a/web-gui/app/src/e2e/diagnostics-bridge.ts
+++ b/web-gui/app/src/e2e/diagnostics-bridge.ts
@@ -54,6 +54,7 @@ export interface HolonE2eLedgerPartition {
   visibilityScopeId: string;
   eventLogEpoch: string;
   eventSeqs: number[];
+  observedHeadSeq?: number;
   readThroughEventSeq?: number;
   certainty?: "exact" | "truncated";
 }
@@ -67,6 +68,7 @@ export interface HolonE2eLedgerSnapshot {
   ingestionState: string;
   ingestionError?: string;
   ingestedThroughSeq: number;
+  observedHeadSeq: number;
   projectionReadyThroughSeq: number;
   pendingHydrationJobs: number;
   failedHydrationJobs: number;
@@ -178,6 +180,7 @@ async function ledgerSnapshot(agentId: string): Promise<HolonE2eLedgerSnapshot |
       ingestionState: status?.state ?? "unknown",
       ingestionError: status?.lastError,
       ingestedThroughSeq: session.ingestedThroughSeq ?? 0,
+      observedHeadSeq: session.observedHeadSeq ?? session.ingestedThroughSeq ?? 0,
       projectionReadyThroughSeq: session.projectionReadyThroughSeq ?? 0,
       pendingHydrationJobs: pending.length,
       failedHydrationJobs: jobs.length - pending.length,
@@ -247,6 +250,7 @@ async function ledgerPartitions(agentId: string): Promise<HolonE2eLedgerPartitio
         visibilityScopeId: session.visibilityScopeId,
         eventLogEpoch: session.eventLogEpoch,
         eventSeqs: rawEvents.filter(sameScope).map((event) => event.eventSeq).sort((a, b) => a - b),
+        observedHeadSeq: session.observedHeadSeq ?? session.ingestedThroughSeq,
         readThroughEventSeq: readState?.readThroughEventSeq,
         certainty: readState?.certainty,
       };

--- a/web-gui/app/src/runtime/event-ledger/classification.ts
+++ b/web-gui/app/src/runtime/event-ledger/classification.ts
@@ -29,7 +29,7 @@ import type { RawEventClassification } from "./ledger";
  * Mirrors RUNTIME_EVENT_CONTRACT_VERSION in `runtime/session-events.ts`;
  * duplicated here so the ledger layer stays app-layer-independent.
  */
-export const SUPPORTED_ENVELOPE_CONTRACT_VERSION = 2;
+export const SUPPORTED_ENVELOPE_CONTRACT_VERSION = 3;
 
 export type EnvelopeProjectionEffect = "none" | "display_invalidation";
 

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
@@ -195,6 +195,9 @@ describe("ledger ingestion pipeline", () => {
       projectionReadyThroughSeq: 12,
       observedEventHeadSeq: 12,
     });
+    expect(await reloaded.resume(sibling)).toMatchObject({
+      observedEventHeadSeq: 1_000,
+    });
     reloaded.dispose();
   });
 

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.test.ts
@@ -100,6 +100,7 @@ describe("ledger ingestion pipeline", () => {
     const ledger = await openLedgerHandle();
     const session = await ledger.getAgentSession(scope);
     expect(session?.ingestedThroughSeq).toBe(3);
+    expect(session?.observedHeadSeq).toBe(3);
     expect(session?.projectionReadyThroughSeq).toBe(3);
     const runtimeScope = await ledger.getRuntimeScope({
       remoteKey: scope.remoteKey,
@@ -176,6 +177,27 @@ describe("ledger ingestion pipeline", () => {
     });
   });
 
+  it("reloads the agent-scoped head instead of a sibling agent's runtime head", async () => {
+    const first = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await first.open();
+    const scope = makeScope({ agentId: "agent-low" });
+    const sibling = makeScope({ agentId: "agent-high" });
+
+    await first.ingest(scope, Array.from({ length: 12 }, (_, index) => envelope(index + 1)));
+    await first.ingest(sibling, [envelope(1_000, { agent_id: sibling.agentId })]);
+    first.dispose();
+
+    const reloaded = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await reloaded.open();
+
+    expect(await reloaded.resume(scope)).toMatchObject({
+      ingestedThroughSeq: 12,
+      projectionReadyThroughSeq: 12,
+      observedEventHeadSeq: 12,
+    });
+    reloaded.dispose();
+  });
+
   it("keeps the contiguous cursor behind out-of-order gaps", async () => {
     const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
     await pipeline.open();
@@ -244,6 +266,7 @@ describe("ledger ingestion pipeline", () => {
     // cursor stops at 4, after the gap-filling 1..3 ingest plus the earlier
     // filtered straggler 4 — never at 8.
     expect(session?.ingestedThroughSeq).toBe(4);
+    expect(session?.observedHeadSeq).toBe(8);
     const runtimeScope = await ledger.getRuntimeScope({
       remoteKey: scope.remoteKey,
       runtimeId: scope.runtimeId,
@@ -382,6 +405,20 @@ describe("ledger ingestion pipeline", () => {
     expect(status.blockedReason).toBe("pending_hydration");
   });
 
+  it("accepts the current envelope contract version", async () => {
+    const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await pipeline.open();
+    const scope = makeScope();
+
+    const status = await pipeline.ingest(scope, [
+      envelope(1, { contract_version: 3 }),
+    ]);
+
+    expect(status.ingestedThroughSeq).toBe(1);
+    expect(status.projectionReadyThroughSeq).toBe(1);
+    expect(status.blockedByEventSeq).toBeUndefined();
+  });
+
   it("blocks readiness on unknown envelope contract versions", async () => {
     const pipeline = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
     await pipeline.open();
@@ -460,6 +497,47 @@ describe("ledger ingestion pipeline", () => {
     expect(status.pendingHydrationJobs).toBe(0);
     expect(status.projectionReadyThroughSeq).toBe(2);
     expect(status.ingestedThroughSeq).toBe(2);
+  });
+
+  it("repairs a stale readiness cursor after another tab satisfied hydration", async () => {
+    const scope = makeScope();
+    const first = new LedgerIngestionPipeline({
+      fetchers: {
+        fetchCanonicalRecords: async () => ({
+          recordsById: {},
+          missingIds: ["brief-1"],
+        }),
+      },
+    });
+    await first.open();
+    await first.ingest(scope, [envelope(1), briefEvent(2, "brief-1"), envelope(3)]);
+    await first.drainHydration(scope);
+    expect(first.status(scope)?.projectionReadyThroughSeq).toBe(1);
+    first.dispose();
+
+    // Simulate a sibling tab atomically satisfying the pending job while the
+    // persisted readiness cursor still reflects the old blocker.
+    const ledger = await openLedgerHandle();
+    await ledger
+      .beginWrite()
+      .putCanonicalRecord(scope, "brief", "brief-1", { id: "brief-1" })
+      .deleteHydrationJob(scope, "brief:brief-1")
+      .commit();
+    ledger.close();
+
+    const reloaded = new LedgerIngestionPipeline({ fetchers: emptyFetchers() });
+    await reloaded.open();
+    expect(await reloaded.resume(scope)).toMatchObject({
+      ingestedThroughSeq: 3,
+      projectionReadyThroughSeq: 3,
+      observedEventHeadSeq: 3,
+      pendingHydrationJobs: 0,
+    });
+
+    const verified = await openLedgerHandle();
+    expect((await verified.getAgentSession(scope))?.projectionReadyThroughSeq).toBe(3);
+    verified.close();
+    reloaded.dispose();
   });
 
   it("heals stored out-of-order stragglers across a restart", async () => {

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
@@ -402,6 +402,7 @@ export class LedgerIngestionPipeline {
     }
     const observedHead = Math.max(tracker.observedHead, ...newSeqs);
     if (observedHead > tracker.observedHead) {
+      batch.applyProjectionChange(scope, { observedHeadSeq: observedHead });
       batch.putRuntimeScope(remoteScopeOf(scope), { eventHeadSeq: observedHead });
       tracker.observedHead = observedHead;
     }
@@ -529,7 +530,10 @@ export class LedgerIngestionPipeline {
     // The snapshot is authoritative through its boundary: both cursors sit
     // at the boundary regardless of any prior cache for this scope key.
     batch.advanceIngestionCursor(scope, install.snapshotThroughSeq);
-    batch.applyProjectionChange(scope, { projectionReadyThroughSeq: install.snapshotThroughSeq });
+    batch.applyProjectionChange(scope, {
+      observedHeadSeq: install.eventHeadSeq,
+      projectionReadyThroughSeq: install.snapshotThroughSeq,
+    });
     batch.putRuntimeScope(remoteScopeOf(scope), { eventHeadSeq: install.eventHeadSeq });
     if (options.readState) {
       batch.putReadState(scope, options.readState);
@@ -984,9 +988,8 @@ export class LedgerIngestionPipeline {
       return tracker;
     }
     const ledger = this.ledger!;
-    const [session, runtimeScope, jobs] = await Promise.all([
+    const [session, jobs] = await Promise.all([
       ledger.getAgentSession(scope),
-      ledger.getRuntimeScope(remoteScopeOf(scope)),
       ledger.getPendingHydrationJobs(scope),
     ]);
     tracker.contiguousThrough = session?.ingestedThroughSeq ?? 0;
@@ -994,11 +997,10 @@ export class LedgerIngestionPipeline {
       session?.projectionReadyThroughSeq ?? 0,
       tracker.contiguousThrough,
     );
-    // These records are read independently, so another tab may commit between
-    // the two reads. A persisted contiguous cursor is itself proof that the
-    // observed head reached at least that sequence.
+    // Older databases predate the agent-scoped head. A persisted contiguous
+    // cursor is itself proof that this agent's observed head reached it.
     tracker.observedHead = Math.max(
-      runtimeScope?.eventHeadSeq ?? 0,
+      session?.observedHeadSeq ?? 0,
       tracker.contiguousThrough,
     );
     for (const job of jobs) {
@@ -1028,6 +1030,16 @@ export class LedgerIngestionPipeline {
       if (event.eventSeq > tracker.contiguousThrough) {
         tracker.outOfOrder.add(event.eventSeq);
       }
+    }
+    // A prior tab may have satisfied hydration demand before this tracker
+    // loaded. Reconcile readiness from the remaining durable blockers.
+    const ready = this.computeReady(tracker);
+    if (ready > tracker.readyThrough) {
+      await ledger
+        .beginWrite()
+        .applyProjectionChange(scope, { projectionReadyThroughSeq: ready })
+        .commit();
+      tracker.readyThrough = ready;
     }
     tracker.loaded = true;
     return tracker;

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
@@ -1035,6 +1035,7 @@ export class LedgerIngestionPipeline {
     // loaded. Reconcile readiness from the remaining durable blockers.
     const ready = this.computeReady(tracker);
     if (ready > tracker.readyThrough) {
+      // Initialization has no later ingestion batch that could coalesce this repair.
       await ledger
         .beginWrite()
         .applyProjectionChange(scope, { projectionReadyThroughSeq: ready })

--- a/web-gui/app/src/runtime/event-ledger/ledger.ts
+++ b/web-gui/app/src/runtime/event-ledger/ledger.ts
@@ -126,6 +126,8 @@ export interface LedgerAgentSessionRecord {
   agentId: string;
   /** Contiguous raw ingestion cursor: every event <= this seq is durably stored. */
   ingestedThroughSeq?: number;
+  /** Highest event seq observed for this agent, which may be ahead of ingestion. */
+  observedHeadSeq?: number;
   /**
    * Projection readiness cursor: every display-affecting event <= this seq
    * is durably stored AND satisfied (applied directly, hydrated, or
@@ -222,10 +224,14 @@ type WriteOperation =
  * cursors are validated monotonically against the value observed inside the
  * same transaction, so a coalesced patch can never regress either cursor.
  */
-type AgentSessionCursorField = "ingestedThroughSeq" | "projectionReadyThroughSeq";
+type AgentSessionCursorField =
+  | "ingestedThroughSeq"
+  | "observedHeadSeq"
+  | "projectionReadyThroughSeq";
 
 const CURSOR_FIELDS: readonly AgentSessionCursorField[] = [
   "ingestedThroughSeq",
+  "observedHeadSeq",
   "projectionReadyThroughSeq",
 ];
 


### PR DESCRIPTION
## 问题

localhost Web GUI 连接 remote runtime 时，某个 agent 的 ledger 会把 runtime 级全局 event head 当成自己的 observed head。若 sibling agent 的全局序号远高于当前 agent，当前 agent 会长期停在 `not_caught_up`，导致点击会话或发消息后的 read marker 无法稳定生效，刷新后未读数回弹。

## 修复

- 将 observed event head 持久化到 agent-scoped session，不再用 runtime 共享 head 恢复 agent tracker。
- snapshot/bootstrap 同步写入 agent-scoped observed head。
- tracker 重载时根据剩余 hydration blocker 修复过时的 readiness cursor。
- ledger 分类器同步支持当前 envelope contract v3。
- E2E diagnostics 暴露 agent-scoped observed head。

## 验证

- Web：39 个测试文件、459 项测试全部通过。
- Web production build 与 production bundle E2E 校验通过。
- `cargo fmt --all -- --check` 通过。
- `RUSTFLAGS="-D warnings" cargo check --all-targets` 通过。
- 真实回归：从 localhost 连接 `100.92.113.47:7878`，打开 `holon-ops` 后 `ingested/observed/ready/readThrough` 一致、`certainty=exact`、hydration 为 0；刷新后 read marker 与未读清零状态保持。
