### PR TITLE
fix: quarantine task results with missing waits

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1106,6 +1106,14 @@ fn exact_task_result_claim_recovery(
             });
         }
     };
+    if let Some(wait) = wait.as_ref() {
+        if wait.status == WaitConditionStatus::Cancelled {
+            return Ok(TaskResultClaimRecovery::Revoked {
+                wait: wait.clone(),
+                reason: "task_result_wait_cancelled",
+            });
+        }
+    }
     let Some(work_item) = runtime_db.work_items().latest(work_item_id)? else {
         return Ok(TaskResultClaimRecovery::Ineligible {
             reason: "task_result_work_item_missing",
@@ -1124,12 +1132,6 @@ fn exact_task_result_claim_recovery(
     let Some(wait) = wait else {
         return Ok(TaskResultClaimRecovery::MissingWait);
     };
-    if wait.status == WaitConditionStatus::Cancelled {
-        return Ok(TaskResultClaimRecovery::Revoked {
-            wait,
-            reason: "task_result_wait_cancelled",
-        });
-    }
     let (command, reason) = match work_item.revision.cmp(&expected_source_revision) {
         std::cmp::Ordering::Greater => (
             crate::domain::execution_protocol::ExecutionProtocolCommand::

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -999,20 +999,6 @@ fn exact_triggered_or_resolved_task_result_wait(
     })
 }
 
-fn exact_task_result_claim_wait(
-    storage: &AppStorage,
-    message: &MessageEnvelope,
-    task_id: &str,
-    work_item_id: &str,
-) -> Result<Option<WaitConditionRecord>> {
-    exact_task_result_wait_with_status(storage, message, task_id, work_item_id, |status| {
-        matches!(
-            status,
-            WaitConditionStatus::Resolved | WaitConditionStatus::Cancelled
-        )
-    })
-}
-
 enum TaskResultClaimRecovery {
     Replayable {
         transition: crate::runtime_db::transitions::ExecutionProtocolTransition,
@@ -1022,6 +1008,7 @@ enum TaskResultClaimRecovery {
         wait: WaitConditionRecord,
         reason: &'static str,
     },
+    MissingWait,
     RequiresInactiveRuntime,
     Ineligible {
         reason: &'static str,
@@ -1089,17 +1076,36 @@ fn exact_task_result_claim_recovery(
             reason: "task_result_rejoin_identity_mismatch",
         });
     }
-    let Some(wait) = exact_task_result_claim_wait(storage, message, task_id, work_item_id)? else {
-        return Ok(TaskResultClaimRecovery::Ineligible {
-            reason: "task_result_wait_missing_or_ambiguous",
-        });
+    let matching_waits = storage
+        .latest_wait_conditions()?
+        .into_iter()
+        .filter(|wait| {
+            wait.agent_id == message.agent_id
+                && wait.work_item_id.as_deref() == Some(work_item_id)
+                && matches!(
+                    wait.status,
+                    WaitConditionStatus::Resolved | WaitConditionStatus::Cancelled
+                )
+                && wait.kind == crate::types::WaitConditionKind::Task
+                && wait.trigger_message_id() == Some(message.id.as_str())
+                && wait.wake_sources.iter().any(|source| {
+                    matches!(
+                        source,
+                        crate::types::WakeSource::TaskResult { task_id: expected }
+                            if expected == task_id
+                    )
+                })
+        })
+        .collect::<Vec<_>>();
+    let wait = match matching_waits.as_slice() {
+        [] => None,
+        [wait] => Some(wait.clone()),
+        _ => {
+            return Ok(TaskResultClaimRecovery::Ineligible {
+                reason: "task_result_wait_ambiguous",
+            });
+        }
     };
-    if wait.status == WaitConditionStatus::Cancelled {
-        return Ok(TaskResultClaimRecovery::Revoked {
-            wait,
-            reason: "task_result_wait_cancelled",
-        });
-    }
     let Some(work_item) = runtime_db.work_items().latest(work_item_id)? else {
         return Ok(TaskResultClaimRecovery::Ineligible {
             reason: "task_result_work_item_missing",
@@ -1113,6 +1119,15 @@ fn exact_task_result_claim_recovery(
     if work_item.state != WorkItemState::Open || work_item.blocked_by.is_some() {
         return Ok(TaskResultClaimRecovery::Ineligible {
             reason: "task_result_work_item_not_runnable",
+        });
+    }
+    let Some(wait) = wait else {
+        return Ok(TaskResultClaimRecovery::MissingWait);
+    };
+    if wait.status == WaitConditionStatus::Cancelled {
+        return Ok(TaskResultClaimRecovery::Revoked {
+            wait,
+            reason: "task_result_wait_cancelled",
         });
     }
     let (command, reason) = match work_item.revision.cmp(&expected_source_revision) {
@@ -1265,6 +1280,13 @@ fn scheduler_task_result_claim_recovery_candidates(
                         .push(format!("cancelled_wait:{}", wait.id));
                     unsettled_claim::ReplayFence::Revoked
                 }
+                TaskResultClaimRecovery::MissingWait => {
+                    candidate.reason = "task_result_wait_missing".into();
+                    candidate
+                        .evidence
+                        .push("task_result_wait:missing".to_string());
+                    unsettled_claim::ReplayFence::Missing
+                }
                 TaskResultClaimRecovery::Ineligible { reason } => {
                     candidate.reason = (*reason).into();
                     unsettled_claim::ReplayFence::Ambiguous
@@ -1330,6 +1352,7 @@ fn scheduler_task_result_claim_recovery_candidates(
                     return Ok(candidate);
                 }
                 TaskResultClaimRecovery::Revoked { .. }
+                | TaskResultClaimRecovery::MissingWait
                 | TaskResultClaimRecovery::Ineligible { .. } => return Ok(candidate),
             };
             let [command] = transition.commands.as_slice() else {
@@ -4900,6 +4923,9 @@ impl RuntimeHandle {
                     ),
                     TaskResultClaimRecovery::Revoked { .. } => {
                         (None, unsettled_claim::ReplayFence::Revoked)
+                    }
+                    TaskResultClaimRecovery::MissingWait => {
+                        (None, unsettled_claim::ReplayFence::Missing)
                     }
                     TaskResultClaimRecovery::RequiresInactiveRuntime => {
                         tracing::error!(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -514,6 +514,59 @@ async fn scheduler_recovery_apply_quarantines_cancelled_task_result_claim_atomic
     );
 }
 
+#[tokio::test]
+async fn scheduler_recovery_quarantines_task_result_claim_with_missing_wait() {
+    use crate::domain::execution_protocol::ExecutionAttemptState;
+
+    let fixture = missing_wait_task_result_claim_fixture("task-missing-wait-debug-apply").await;
+    let report = isolated_task_result_claim_report(&fixture.runtime);
+    let [candidate] = report.task_result_claim_recoveries.as_slice() else {
+        panic!("expected one missing-wait TaskResult claim candidate: {report:#?}");
+    };
+    assert!(candidate.eligible);
+    assert_eq!(candidate.reason, "task_result_wait_missing");
+    assert_eq!(candidate.recovery_decision, "interrupt_and_quarantine");
+
+    assert_eq!(
+        apply_scheduler_recovery_plan_with_backup_policy(
+            &fixture.runtime.inner.storage,
+            &fixture.runtime.inner.runtime_db,
+            "default",
+            &report,
+            SchedulerRecoveryBackupPolicy::SkipApproved,
+        )
+        .unwrap(),
+        (1, None)
+    );
+    let execution = fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        execution.attempts[&fixture.attempt_id].state,
+        ExecutionAttemptState::Interrupted
+    );
+    assert_eq!(
+        fixture
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&fixture.result.id)
+            .unwrap()
+            .expect("quarantined TaskResult")
+            .status,
+        QueueEntryStatus::Quarantined
+    );
+    assert!(isolated_task_result_claim_report(&fixture.runtime)
+        .task_result_claim_recoveries
+        .is_empty());
+}
+
 struct GatedFailingProvider {
     started: Arc<tokio::sync::Notify>,
     release: Arc<tokio::sync::Notify>,
@@ -2361,6 +2414,34 @@ async fn stale_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimF
 
 async fn cancelled_wait_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimFixture {
     task_result_claim_fixture(task_id, true).await
+}
+
+async fn missing_wait_task_result_claim_fixture(task_id: &str) -> StaleTaskResultClaimFixture {
+    let fixture = stale_task_result_claim_fixture(task_id).await;
+    let wait = fixture
+        .runtime
+        .storage()
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| {
+            condition.trigger_message_id() == Some(fixture.result.id.as_str())
+                && condition.work_item_id.as_deref() == Some(fixture.work_item_id.as_str())
+        })
+        .expect("resolved TaskResult wait");
+    fixture
+        .runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| {
+            tx.execute(
+                "DELETE FROM wait_conditions WHERE wait_condition_id = ?1",
+                [&wait.id],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+    fixture
 }
 
 async fn task_result_claim_fixture(

--- a/src/runtime/unsettled_claim.rs
+++ b/src/runtime/unsettled_claim.rs
@@ -13,6 +13,7 @@ pub(crate) struct UnsettledClaimFacts {
 pub(crate) enum ReplayFence {
     ExactReplayable,
     Revoked,
+    Missing,
     Ambiguous,
 }
 
@@ -56,6 +57,11 @@ pub(crate) fn plan_unsettled_claim(facts: &UnsettledClaimFacts) -> UnsettledClai
     if facts.replay_fence == ReplayFence::Revoked {
         return UnsettledClaimDecision::InterruptAndQuarantine {
             reason: "task_result_wait_cancelled",
+        };
+    }
+    if facts.replay_fence == ReplayFence::Missing {
+        return UnsettledClaimDecision::InterruptAndQuarantine {
+            reason: "task_result_wait_missing",
         };
     }
     // Recovery lineage takes precedence over a replayable fence so one replay cannot recurse.


### PR DESCRIPTION
## Summary

- detect recovered `task_result` claims whose referenced wait record is missing
- quarantine those claims instead of leaving scheduler recovery permanently blocked
- cover the missing-wait recovery path with a regression test

## Why

A runtime restart can leave an unsettled `task_result` claim whose wait record is absent. Previously scheduler recovery kept rediscovering the claim but could not settle or quarantine it, leaving the agent stuck. Treating this state as unrecoverable preserves the claim for inspection while allowing scheduler recovery to make progress.

## Verification

- `cargo fmt --all -- --check`
- `cargo test scheduler_recovery_quarantines_task_result_claim_with_missing_wait -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
