### PR TITLE
fix(web): support UUID generation over HTTP

### DIFF
--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -90,6 +90,36 @@ function sessionState(overrides: Partial<AgentSessionState> = {}): AgentSessionS
   };
 }
 
+describe("sendOperatorPrompt", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reports UUID generation failures instead of silently ignoring the send", async () => {
+    const previous = useRuntimeStore.getState();
+    useRuntimeStore.setState({
+      ...previous,
+      sessionsByAgentId: {
+        "agent-a": sessionState(),
+      },
+    }, true);
+    vi.stubGlobal("crypto", {});
+
+    try {
+      await expect(
+        useRuntimeStore.getState().sendOperatorPrompt("agent-a", "hello", "info"),
+      ).rejects.toThrow("Secure random number generation is unavailable");
+
+      expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toMatchObject({
+        sendingPrompt: false,
+        promptError: "Secure random number generation is unavailable",
+      });
+    } finally {
+      useRuntimeStore.setState(previous, true);
+    }
+  });
+});
+
 describe("skillDetailCacheKey", () => {
   it("keeps global and agent-scoped versions separate", () => {
     expect(skillDetailCacheKey("workspace:root:demo")).toBe("workspace:root:demo");

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -65,6 +65,7 @@ import type { AgentSessionState as AgentSessionStateBase } from "./runtime-store
 import {
   briefIdForPayload,
 } from "./session-reducer";
+import { generateUuid } from "./uuid";
 import {
   briefIdsForProjectionHydration,
   deriveSessionTimeline,
@@ -3381,34 +3382,34 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
     }
 
     const request = captureClientRequest();
-    const clientId = crypto.randomUUID();
-    set((state) => {
-      const rosterActivityByAgentId = touchRosterActivity(state.rosterActivityByAgentId, agentId, "operator", new Date().toISOString());
-      if (rosterActivityByAgentId !== state.rosterActivityByAgentId) {
-        writeStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig), rosterActivityByAgentId);
-      }
-      return {
-        bootstrap: sortBootstrapAgents(state.bootstrap, rosterActivityByAgentId),
-        rosterActivityByAgentId,
-        sessionsByAgentId: {
-          ...state.sessionsByAgentId,
-          [agentId]: {
-            ...emptyAgentSession(),
-            ...state.sessionsByAgentId[agentId],
-            sendingPrompt: true,
-            promptError: undefined,
-            detail: appendOptimisticOperatorPrompt(
-              state.sessionsByAgentId[agentId]?.detail ?? null,
-              state.bootstrap.agents.find((agent) => agent.id === agentId),
-              prompt,
-              clientId,
-            ),
-          },
-        },
-      };
-    });
-
     try {
+      const clientId = generateUuid();
+      set((state) => {
+        const rosterActivityByAgentId = touchRosterActivity(state.rosterActivityByAgentId, agentId, "operator", new Date().toISOString());
+        if (rosterActivityByAgentId !== state.rosterActivityByAgentId) {
+          writeStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig), rosterActivityByAgentId);
+        }
+        return {
+          bootstrap: sortBootstrapAgents(state.bootstrap, rosterActivityByAgentId),
+          rosterActivityByAgentId,
+          sessionsByAgentId: {
+            ...state.sessionsByAgentId,
+            [agentId]: {
+              ...emptyAgentSession(),
+              ...state.sessionsByAgentId[agentId],
+              sendingPrompt: true,
+              promptError: undefined,
+              detail: appendOptimisticOperatorPrompt(
+                state.sessionsByAgentId[agentId]?.detail ?? null,
+                state.bootstrap.agents.find((agent) => agent.id === agentId),
+                prompt,
+                clientId,
+              ),
+            },
+          },
+        };
+      });
+
       const { messageId } = await request.client.sendOperatorPrompt(agentId, prompt, attachments);
       if (!isCurrentClientRequest(request)) return;
       scheduleBootstrapRefresh(get, 250);

--- a/web-gui/app/src/runtime/uuid.test.ts
+++ b/web-gui/app/src/runtime/uuid.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { generateUuid } from "./uuid";
+
+describe("generateUuid", () => {
+  it("uses crypto.randomUUID when available", () => {
+    const randomUUID = vi.fn(() => "123e4567-e89b-42d3-a456-426614174000");
+
+    expect(generateUuid({ randomUUID } as unknown as Crypto)).toBe(
+      "123e4567-e89b-42d3-a456-426614174000",
+    );
+    expect(randomUUID).toHaveBeenCalledOnce();
+  });
+
+  it("generates a UUID v4 with getRandomValues when randomUUID is unavailable", () => {
+    const getRandomValues = vi.fn((bytes: Uint8Array) => {
+      bytes.set([
+        0x00, 0x11, 0x22, 0x33,
+        0x44, 0x55,
+        0x66, 0x77,
+        0x08, 0x99,
+        0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+      ]);
+      return bytes;
+    });
+
+    expect(generateUuid({ getRandomValues } as unknown as Crypto)).toBe(
+      "00112233-4455-4677-8899-aabbccddeeff",
+    );
+    expect(getRandomValues).toHaveBeenCalledOnce();
+  });
+
+  it("fails clearly when no cryptographically secure generator is available", () => {
+    expect(() => generateUuid({} as Crypto)).toThrow(
+      "Secure random number generation is unavailable",
+    );
+  });
+});

--- a/web-gui/app/src/runtime/uuid.ts
+++ b/web-gui/app/src/runtime/uuid.ts
@@ -1,0 +1,21 @@
+export function generateUuid(cryptoApi: Crypto | undefined = globalThis.crypto): string {
+  if (typeof cryptoApi?.randomUUID === "function") {
+    return cryptoApi.randomUUID();
+  }
+  if (typeof cryptoApi?.getRandomValues !== "function") {
+    throw new Error("Secure random number generation is unavailable");
+  }
+
+  const bytes = cryptoApi.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10).join(""),
+  ].join("-");
+}


### PR DESCRIPTION
## 问题

远程通过普通 HTTP 打开 Web GUI 时，`crypto.randomUUID()` 在非 Secure Context 中不可用。发送流程在发起请求前抛错，而该错误此前未进入 store 的发送错误状态，因此表现为点击发送无响应且没有网络请求。

## 修改

- 新增集中式 UUID v4 helper：优先使用 `crypto.randomUUID()`，不可用时回退到 `crypto.getRandomValues()`
- 将 UUID 生成纳入 `sendOperatorPrompt` 的既有错误处理范围
- 补充 fallback、UUID version/variant 和发送错误状态回归测试

## 验证

- `npm test`（40 个测试文件，463 项测试）
- `npm run typecheck`
- `npm run build`
- `git diff --check`