### PR TITLE
fix: preserve provider server-tool results without exposing raw JSON as assistant text

### DIFF
--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -473,6 +473,32 @@ pub enum ModelBlock {
         #[serde(default)]
         kind: ModelToolCallKind,
     },
+    /// A tool call executed by the model provider rather than by Holon.
+    ///
+    /// Provider-owned tool blocks are retained for audit and compatible
+    /// conversation replay, but must never be dispatched as managed tools or
+    /// rendered as assistant prose.
+    ProviderToolUse {
+        id: String,
+        name: String,
+        input: Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        provider_data: Option<ProviderBlockData>,
+    },
+    /// A result produced by a provider-owned tool.
+    ProviderToolResult {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_use_id: Option<String>,
+        content: Value,
+        #[serde(default)]
+        is_error: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        provider_data: Option<ProviderBlockData>,
+    },
     Thinking {
         text: String,
         /// Opaque signature returned by the provider (e.g. DeepSeek V4 Pro).
@@ -489,6 +515,12 @@ pub enum ModelBlock {
         /// Must be passed back verbatim in subsequent requests.
         data: String,
     },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProviderBlockData {
+    pub format: String,
+    pub payload: Value,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -20,9 +20,10 @@ use crate::{
         builtin_web_search_probe_turn_request,
         http_trace::{ProviderHttpTrace, ProviderHttpTraceRequest},
         AgentProvider, AnthropicPromptCacheDiagnostics, CacheBreakpointInfo, ConversationMessage,
-        ModelBlock, ModelToolCallKind, PromptContentBlock, ProviderBuiltinWebSearchCapability,
-        ProviderCacheUsage, ProviderContextManagementPolicy, ProviderNativeWebSearchDiagnostics,
-        ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest, ProviderPromptCapability,
+        ModelBlock, ModelToolCallKind, PromptContentBlock, ProviderBlockData,
+        ProviderBuiltinWebSearchCapability, ProviderCacheUsage, ProviderContextManagementPolicy,
+        ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind,
+        ProviderNativeWebSearchRequest, ProviderPromptCapability,
         ProviderResponseFormatDiagnostics, ProviderResponseFormatRequest, ProviderTurnRequest,
         ProviderTurnResponse,
     },
@@ -35,6 +36,8 @@ use crate::provider::retry::{
     timeout_transport_error_with_trace, ProviderFailureClassification, ProviderFailureKind,
     RetryDisposition,
 };
+
+const ANTHROPIC_PROVIDER_BLOCK_FORMAT: &str = "anthropic_messages/v1";
 
 #[derive(Clone)]
 pub struct AnthropicProvider {
@@ -132,15 +135,30 @@ struct MessagesResponse {
 struct ApiResponseBlock {
     #[serde(rename = "type")]
     kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     signature: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     data: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     input: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     tool_use_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    is_error: Option<bool>,
+    #[serde(flatten)]
+    extra: std::collections::BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -631,7 +649,7 @@ async fn read_anthropic_streaming_response(
 }
 
 fn anthropic_messages_response_to_turn_response(
-    parsed: MessagesResponse,
+    mut parsed: MessagesResponse,
     provider_request_id: Option<String>,
     request: &ProviderTurnRequest,
     wire_conversation: &[ConversationMessage],
@@ -704,6 +722,7 @@ fn anthropic_messages_response_to_turn_response(
             trace,
         ));
     }
+    strip_zai_redundant_provider_tool_text(&mut parsed.content);
     let response_format_tool_name = anthropic_response_format_tool_name(request);
     let blocks = parsed
         .content
@@ -1582,6 +1601,48 @@ fn conversation_message_to_api(
                                     "name": name,
                                     "input": input,
                                 }),
+                                ModelBlock::ProviderToolUse {
+                                    id,
+                                    name,
+                                    input,
+                                    status,
+                                    provider_data,
+                                } => anthropic_provider_block_payload(provider_data)
+                                    .unwrap_or_else(|| {
+                                        let mut value = json!({
+                                            "type": "server_tool_use",
+                                            "id": id,
+                                            "name": name,
+                                            "input": input,
+                                        });
+                                        if let Some(status) = status {
+                                            value["status"] = json!(status);
+                                        }
+                                        value
+                                    }),
+                                ModelBlock::ProviderToolResult {
+                                    tool_use_id,
+                                    content,
+                                    is_error,
+                                    status,
+                                    provider_data,
+                                } => anthropic_provider_block_payload(provider_data)
+                                    .unwrap_or_else(|| {
+                                        let mut value = json!({
+                                            "type": "tool_result",
+                                            "content": content,
+                                        });
+                                        if let Some(tool_use_id) = tool_use_id {
+                                            value["tool_use_id"] = json!(tool_use_id);
+                                        }
+                                        if *is_error {
+                                            value["is_error"] = json!(true);
+                                        }
+                                        if let Some(status) = status {
+                                            value["status"] = json!(status);
+                                        }
+                                        value
+                                    }),
                                 ModelBlock::Thinking { text, signature } => {
                                     let mut v = json!({
                                         "type": "thinking",
@@ -1632,6 +1693,13 @@ fn conversation_message_to_api(
             ),
         },
     }
+}
+
+fn anthropic_provider_block_payload(provider_data: &Option<ProviderBlockData>) -> Option<Value> {
+    provider_data
+        .as_ref()
+        .filter(|data| data.format == ANTHROPIC_PROVIDER_BLOCK_FORMAT)
+        .map(|data| data.payload.clone())
 }
 
 fn maybe_mark_cache_control(mut content: Value, should_mark: bool) -> Value {
@@ -1703,8 +1771,9 @@ fn warn_unsupported_anthropic_response_block(
 ) {
     if matches!(
         block.kind.as_str(),
-        "text" | "tool_use" | "thinking" | "redacted_thinking" | "server_tool_use" | "tool_result"
-    ) {
+        "text" | "tool_use" | "thinking" | "redacted_thinking" | "server_tool_use"
+    ) || is_provider_tool_result_kind(&block.kind)
+    {
         return;
     }
 
@@ -1760,6 +1829,12 @@ fn api_response_block_to_model(
     block: ApiResponseBlock,
     response_format_tool_name: Option<&str>,
 ) -> Option<ModelBlock> {
+    let provider_data = serde_json::to_value(&block)
+        .ok()
+        .map(|payload| ProviderBlockData {
+            format: ANTHROPIC_PROVIDER_BLOCK_FORMAT.to_string(),
+            payload,
+        });
     match block.kind.as_str() {
         "text" => Some(ModelBlock::Text {
             text: block.text.unwrap_or_default(),
@@ -1786,39 +1861,94 @@ fn api_response_block_to_model(
         "redacted_thinking" => Some(ModelBlock::RedactedThinking {
             data: block.data.unwrap_or_default(),
         }),
-        // Anthropic server-side tool use (e.g. web search). This is a server-
-        // internal block that doesn't need to be stored or replayed.
-        "server_tool_use" => None,
-        // Anthropic server-side tool result (e.g. web search results) returned
-        // in the assistant response `content` array. This is distinct from
-        // client-side tool_result blocks in user messages, handled separately.
-        // Convert to Text so the content is preserved in subsequent turns.
-        "tool_result" => {
-            let text = match block.content {
-                Some(Value::String(s)) => s,
-                Some(Value::Array(arr)) => {
-                    // Anthropic tool_result content is an array of content blocks.
-                    // Extract text blocks and concatenate.
-                    arr.iter()
-                        .filter_map(|v| {
-                            v.get("text")
-                                .and_then(|t| t.as_str())
-                                .map(|s| s.to_string())
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                }
-                Some(other) => other.to_string(),
-                None => String::new(),
-            };
-            if text.is_empty() {
-                None
-            } else {
-                Some(ModelBlock::Text { text })
-            }
-        }
+        "server_tool_use" => Some(ModelBlock::ProviderToolUse {
+            id: block.id?,
+            name: block.name?,
+            input: block.input.unwrap_or_else(|| json!({})),
+            status: block.status,
+            provider_data,
+        }),
+        kind if is_provider_tool_result_kind(kind) => Some(ModelBlock::ProviderToolResult {
+            tool_use_id: block.tool_use_id,
+            content: block.content.unwrap_or(Value::Null),
+            is_error: block.is_error.unwrap_or(false),
+            status: block.status,
+            provider_data,
+        }),
         _ => None,
     }
+}
+
+fn is_provider_tool_result_kind(kind: &str) -> bool {
+    kind == "tool_result" || kind.ends_with("_tool_result")
+}
+
+fn strip_zai_redundant_provider_tool_text(blocks: &mut Vec<ApiResponseBlock>) {
+    let mut remove = vec![false; blocks.len()];
+    for (index, window) in blocks.windows(4).enumerate() {
+        let [input_text, tool_use, output_text, tool_result] = window else {
+            continue;
+        };
+        if is_zai_provider_tool_display_sequence(input_text, tool_use, output_text, tool_result) {
+            remove[index] = true;
+            remove[index + 2] = true;
+        }
+    }
+
+    let mut index = 0;
+    blocks.retain(|_| {
+        let keep = !remove[index];
+        index += 1;
+        keep
+    });
+}
+
+fn is_zai_provider_tool_display_sequence(
+    input_text: &ApiResponseBlock,
+    tool_use: &ApiResponseBlock,
+    output_text: &ApiResponseBlock,
+    tool_result: &ApiResponseBlock,
+) -> bool {
+    if input_text.kind != "text"
+        || tool_use.kind != "server_tool_use"
+        || output_text.kind != "text"
+        || !is_provider_tool_result_kind(&tool_result.kind)
+        || tool_use.id.as_deref() != tool_result.tool_use_id.as_deref()
+    {
+        return false;
+    }
+
+    let Some(name) = tool_use.name.as_deref() else {
+        return false;
+    };
+    let Some(input) = tool_use.input.as_ref() else {
+        return false;
+    };
+    let Some(displayed_input) =
+        parse_zai_provider_tool_input_display(input_text.text.as_deref().unwrap_or_default(), name)
+    else {
+        return false;
+    };
+    if &displayed_input != input {
+        return false;
+    }
+
+    let output_prefix = format!("**Output:**\n**{name}_result_summary:** ");
+    output_text
+        .text
+        .as_deref()
+        .is_some_and(|text| text.starts_with(&output_prefix))
+}
+
+fn parse_zai_provider_tool_input_display(text: &str, expected_name: &str) -> Option<Value> {
+    let name = text
+        .strip_prefix("**🌐 Z.ai Built-in Tool: ")?
+        .split_once("**\n\n**Input:**\n```json\n")?;
+    if name.0 != expected_name {
+        return None;
+    }
+    let json = name.1.strip_suffix("\n```\n*Executing on server...*\n")?;
+    serde_json::from_str(json).ok()
 }
 
 fn collect_anthropic_cache_diagnostics(
@@ -2269,6 +2399,8 @@ fn model_block_kind(block: &ModelBlock) -> &'static str {
     match block {
         ModelBlock::Text { .. } => "assistant_text",
         ModelBlock::ToolUse { .. } => "tool_use",
+        ModelBlock::ProviderToolUse { .. } => "provider_tool_use",
+        ModelBlock::ProviderToolResult { .. } => "provider_tool_result",
         ModelBlock::Thinking { .. } => "thinking",
         ModelBlock::ReasoningText { .. } => "reasoning_text",
         ModelBlock::RedactedThinking { .. } => "redacted_thinking",
@@ -2306,6 +2438,40 @@ fn hash_model_block(block: &ModelBlock) -> String {
             });
             sha256_hex(canonical_json(&value).as_bytes())
         }
+        ModelBlock::ProviderToolUse {
+            id,
+            name,
+            input,
+            status,
+            provider_data,
+        } => {
+            let value = json!({
+                "type": "provider_tool_use",
+                "id": id,
+                "name": name,
+                "input": input,
+                "status": status,
+                "provider_data": provider_data,
+            });
+            sha256_hex(canonical_json(&value).as_bytes())
+        }
+        ModelBlock::ProviderToolResult {
+            tool_use_id,
+            content,
+            is_error,
+            status,
+            provider_data,
+        } => {
+            let value = json!({
+                "type": "provider_tool_result",
+                "tool_use_id": tool_use_id,
+                "content": content,
+                "is_error": is_error,
+                "status": status,
+                "provider_data": provider_data,
+            });
+            sha256_hex(canonical_json(&value).as_bytes())
+        }
         ModelBlock::Citations { citations } => {
             let value = json!({ "type": "citations", "citations": citations });
             sha256_hex(canonical_json(&value).as_bytes())
@@ -2327,6 +2493,28 @@ fn estimate_model_block_tokens(block: &ModelBlock) -> u64 {
     match block {
         ModelBlock::Text { text } => estimate_tokens_from_chars(text.len()),
         ModelBlock::ToolUse { .. } => 50,
+        ModelBlock::ProviderToolUse {
+            input,
+            provider_data,
+            ..
+        } => provider_data
+            .as_ref()
+            .and_then(|data| serde_json::to_string(&data.payload).ok())
+            .map_or_else(
+                || estimate_tokens_from_chars(input.to_string().len()),
+                |payload| estimate_tokens_from_chars(payload.len()),
+            ),
+        ModelBlock::ProviderToolResult {
+            content,
+            provider_data,
+            ..
+        } => provider_data
+            .as_ref()
+            .and_then(|data| serde_json::to_string(&data.payload).ok())
+            .map_or_else(
+                || estimate_tokens_from_chars(content.to_string().len()),
+                |payload| estimate_tokens_from_chars(payload.len()),
+            ),
         ModelBlock::Thinking { text, .. } => estimate_tokens_from_chars(text.len()),
         ModelBlock::ReasoningText { text } => estimate_tokens_from_chars(text.len()),
         ModelBlock::RedactedThinking { data } => estimate_tokens_from_chars(data.len()),
@@ -3581,37 +3769,211 @@ mod tests {
     }
 
     #[test]
-    fn api_response_block_tool_result_converts_to_text() {
+    fn api_response_block_provider_tool_result_preserves_structured_content() {
         let block = ApiResponseBlock {
-            kind: "tool_result".to_string(),
+            kind: "web_search_tool_result".to_string(),
             tool_use_id: Some("srv_001".to_string()),
             content: Some(json!([{
-                "type": "text",
-                "text": "Search results: Rust is awesome."
+                "type": "web_search_result",
+                "url": "https://example.com/rust",
+                "title": "Rust"
             }])),
+            extra: [("provider_extension".to_string(), json!("kept"))]
+                .into_iter()
+                .collect(),
             ..Default::default()
         };
         let model = api_response_block_to_model(block, None);
-        assert!(
-            matches!(&model, Some(ModelBlock::Text { text }) if text.contains("Search results: Rust is awesome.")),
-            "tool_result should convert to Text preserving content, got: {model:?}"
-        );
+        match model {
+            Some(ModelBlock::ProviderToolResult {
+                tool_use_id,
+                content,
+                provider_data,
+                ..
+            }) => {
+                assert_eq!(tool_use_id.as_deref(), Some("srv_001"));
+                assert_eq!(content[0]["type"], json!("web_search_result"));
+                let provider_data = provider_data.expect("raw provider block should be preserved");
+                assert_eq!(provider_data.format, ANTHROPIC_PROVIDER_BLOCK_FORMAT);
+                assert_eq!(
+                    provider_data.payload["type"],
+                    json!("web_search_tool_result")
+                );
+                assert_eq!(provider_data.payload["provider_extension"], json!("kept"));
+            }
+            other => panic!("unexpected block: {other:?}"),
+        }
     }
 
     #[test]
-    fn api_response_block_server_tool_use_returns_none() {
+    fn api_response_block_server_tool_use_preserves_structured_input() {
         let block = ApiResponseBlock {
             kind: "server_tool_use".to_string(),
             id: Some("srv_search_1".to_string()),
             name: Some("web_search".to_string()),
             input: Some(json!({"query": "rust async"})),
+            extra: [("provider_extension".to_string(), json!({"version": 2}))]
+                .into_iter()
+                .collect(),
             ..Default::default()
         };
         let model = api_response_block_to_model(block, None);
-        assert!(
-            model.is_none(),
-            "server_tool_use should return None (server-side only), got: {model:?}"
-        );
+        match model {
+            Some(ModelBlock::ProviderToolUse {
+                id,
+                name,
+                input,
+                provider_data,
+                ..
+            }) => {
+                assert_eq!(id, "srv_search_1");
+                assert_eq!(name, "web_search");
+                assert_eq!(input, json!({"query": "rust async"}));
+                assert_eq!(
+                    provider_data
+                        .expect("raw provider block should be preserved")
+                        .payload["provider_extension"]["version"],
+                    json!(2)
+                );
+            }
+            other => panic!("unexpected block: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn provider_tool_blocks_round_trip_through_anthropic_assistant_history() {
+        let raw_use = json!({
+            "type": "server_tool_use",
+            "id": "srv_search_1",
+            "name": "web_search",
+            "input": {"query": "rust async"},
+            "provider_extension": {"version": 2}
+        });
+        let raw_result = json!({
+            "type": "web_search_tool_result",
+            "tool_use_id": "srv_search_1",
+            "content": [{
+                "type": "web_search_result",
+                "url": "https://example.com/rust",
+                "title": "Rust"
+            }]
+        });
+        let message = ConversationMessage::AssistantBlocks(vec![
+            ModelBlock::ProviderToolUse {
+                id: "srv_search_1".to_string(),
+                name: "web_search".to_string(),
+                input: json!({"query": "rust async"}),
+                status: None,
+                provider_data: Some(ProviderBlockData {
+                    format: ANTHROPIC_PROVIDER_BLOCK_FORMAT.to_string(),
+                    payload: raw_use.clone(),
+                }),
+            },
+            ModelBlock::ProviderToolResult {
+                tool_use_id: Some("srv_search_1".to_string()),
+                content: raw_result["content"].clone(),
+                is_error: false,
+                status: None,
+                provider_data: Some(ProviderBlockData {
+                    format: ANTHROPIC_PROVIDER_BLOCK_FORMAT.to_string(),
+                    payload: raw_result.clone(),
+                }),
+            },
+        ]);
+
+        let encoded = conversation_message_to_api(&message, None);
+        assert_eq!(encoded.content, json!([raw_use, raw_result]));
+    }
+
+    #[test]
+    fn strips_zai_redundant_provider_tool_display_text() {
+        let mut blocks = vec![
+            ApiResponseBlock {
+                kind: "text".to_string(),
+                text: Some(
+                    "**🌐 Z.ai Built-in Tool: web_search_prime**\n\n\
+                     **Input:**\n```json\n\
+                     {\"content_size\":\"medium\",\"search_query\":\"rust async\"}\n\
+                     ```\n*Executing on server...*\n"
+                        .to_string(),
+                ),
+                ..Default::default()
+            },
+            ApiResponseBlock {
+                kind: "server_tool_use".to_string(),
+                id: Some("call_1".to_string()),
+                name: Some("web_search_prime".to_string()),
+                input: Some(json!({
+                    "content_size": "medium",
+                    "search_query": "rust async"
+                })),
+                ..Default::default()
+            },
+            ApiResponseBlock {
+                kind: "text".to_string(),
+                text: Some(
+                    "**Output:**\n**web_search_prime_result_summary:** [{\"title\":\"Rust\"}]"
+                        .to_string(),
+                ),
+                ..Default::default()
+            },
+            ApiResponseBlock {
+                kind: "tool_result".to_string(),
+                tool_use_id: Some("call_1".to_string()),
+                content: Some(json!([[{"title": "Rust"}]])),
+                ..Default::default()
+            },
+            ApiResponseBlock {
+                kind: "text".to_string(),
+                text: Some("Rust uses async/await.".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        strip_zai_redundant_provider_tool_text(&mut blocks);
+
+        assert_eq!(blocks.len(), 3);
+        assert_eq!(blocks[0].kind, "server_tool_use");
+        assert_eq!(blocks[1].kind, "tool_result");
+        assert_eq!(blocks[2].text.as_deref(), Some("Rust uses async/await."));
+    }
+
+    #[test]
+    fn preserves_zai_like_text_without_matching_structured_sequence() {
+        let mut blocks = vec![
+            ApiResponseBlock {
+                kind: "text".to_string(),
+                text: Some(
+                    "**🌐 Z.ai Built-in Tool: web_search_prime**\n\n\
+                     **Input:**\n```json\n{\"search_query\":\"displayed\"}\n```\n\
+                     *Executing on server...*\n"
+                        .to_string(),
+                ),
+                ..Default::default()
+            },
+            ApiResponseBlock {
+                kind: "server_tool_use".to_string(),
+                id: Some("call_1".to_string()),
+                name: Some("web_search_prime".to_string()),
+                input: Some(json!({"search_query": "actual"})),
+                ..Default::default()
+            },
+            ApiResponseBlock {
+                kind: "text".to_string(),
+                text: Some("**Output:**\n**web_search_prime_result_summary:** []".to_string()),
+                ..Default::default()
+            },
+            ApiResponseBlock {
+                kind: "tool_result".to_string(),
+                tool_use_id: Some("call_1".to_string()),
+                content: Some(json!([])),
+                ..Default::default()
+            },
+        ];
+
+        strip_zai_redundant_provider_tool_text(&mut blocks);
+
+        assert_eq!(blocks.len(), 4);
     }
 
     #[test]

--- a/src/provider/transports/gemini.rs
+++ b/src/provider/transports/gemini.rs
@@ -349,7 +349,9 @@ fn conversation_message_to_gemini_content(message: &ConversationMessage) -> Opti
                     },
                     ModelBlock::Thinking { .. }
                     | ModelBlock::ReasoningText { .. }
-                    | ModelBlock::RedactedThinking { .. } => {
+                    | ModelBlock::RedactedThinking { .. }
+                    | ModelBlock::ProviderToolUse { .. }
+                    | ModelBlock::ProviderToolResult { .. } => {
                         GeminiPart {
                             text: None,
                             function_call: None,

--- a/src/provider/transports/openai/chat/plan.rs
+++ b/src/provider/transports/openai/chat/plan.rs
@@ -313,7 +313,9 @@ pub(crate) fn build_chat_completion_messages(
                         ModelBlock::Thinking { .. }
                         | ModelBlock::ReasoningText { .. }
                         | ModelBlock::RedactedThinking { .. }
-                        | ModelBlock::Citations { .. } => {}
+                        | ModelBlock::Citations { .. }
+                        | ModelBlock::ProviderToolUse { .. }
+                        | ModelBlock::ProviderToolResult { .. } => {}
                     }
                 }
 

--- a/src/provider/transports/openai/responses/plan.rs
+++ b/src/provider/transports/openai/responses/plan.rs
@@ -480,7 +480,9 @@ fn build_openai_input_for_contract(
                         }
                         ModelBlock::Thinking { .. }
                         | ModelBlock::RedactedThinking { .. }
-                        | ModelBlock::Citations { .. } => {}
+                        | ModelBlock::Citations { .. }
+                        | ModelBlock::ProviderToolUse { .. }
+                        | ModelBlock::ProviderToolResult { .. } => {}
                     }
                 }
                 flush_assistant_text(&mut items, &mut pending_text);

--- a/src/runtime/subagent.rs
+++ b/src/runtime/subagent.rs
@@ -331,7 +331,9 @@ impl RuntimeHandle {
                     ModelBlock::Thinking { .. }
                     | ModelBlock::ReasoningText { .. }
                     | ModelBlock::RedactedThinking { .. }
-                    | ModelBlock::Citations { .. } => None,
+                    | ModelBlock::Citations { .. }
+                    | ModelBlock::ProviderToolUse { .. }
+                    | ModelBlock::ProviderToolResult { .. } => None,
                 })
                 .collect::<Vec<_>>()
                 .join("\n\n"),

--- a/src/runtime/turn/completion.rs
+++ b/src/runtime/turn/completion.rs
@@ -174,7 +174,9 @@ pub(super) fn completion_report_texts_by_tool_id(
             }
             ModelBlock::Thinking { .. }
             | ModelBlock::ReasoningText { .. }
-            | ModelBlock::RedactedThinking { .. } => {}
+            | ModelBlock::RedactedThinking { .. }
+            | ModelBlock::ProviderToolUse { .. }
+            | ModelBlock::ProviderToolResult { .. } => {}
         }
     }
     reports

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -1763,6 +1763,7 @@ impl TurnExecution<'_> {
                     | ModelBlock::RedactedThinking { .. } => {
                         thinking_block_count += 1;
                     }
+                    ModelBlock::ProviderToolUse { .. } | ModelBlock::ProviderToolResult { .. } => {}
                 }
             }
 

--- a/src/runtime/turn/projection.rs
+++ b/src/runtime/turn/projection.rs
@@ -88,6 +88,41 @@ pub(super) fn estimate_model_block_tokens(block: &ModelBlock) -> usize {
         ModelBlock::ToolUse {
             id, name, input, ..
         } => estimate_text_tokens(id) + estimate_text_tokens(name) + estimate_json_tokens(input),
+        ModelBlock::ProviderToolUse {
+            id,
+            name,
+            input,
+            provider_data,
+            ..
+        } => {
+            estimate_text_tokens(id)
+                + estimate_text_tokens(name)
+                + estimate_json_tokens(input)
+                + provider_data
+                    .as_ref()
+                    .map(|data| {
+                        estimate_text_tokens(&data.format) + estimate_json_tokens(&data.payload)
+                    })
+                    .unwrap_or(0)
+        }
+        ModelBlock::ProviderToolResult {
+            tool_use_id,
+            content,
+            provider_data,
+            ..
+        } => {
+            tool_use_id
+                .as_deref()
+                .map(estimate_text_tokens)
+                .unwrap_or(0)
+                + estimate_json_tokens(content)
+                + provider_data
+                    .as_ref()
+                    .map(|data| {
+                        estimate_text_tokens(&data.format) + estimate_json_tokens(&data.payload)
+                    })
+                    .unwrap_or(0)
+        }
         ModelBlock::Thinking { text, .. } => estimate_text_tokens(text),
         ModelBlock::ReasoningText { text } => estimate_text_tokens(text),
         ModelBlock::RedactedThinking { data } => estimate_text_tokens(data),

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -160,7 +160,9 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
             ModelBlock::Thinking { .. }
             | ModelBlock::ReasoningText { .. }
             | ModelBlock::RedactedThinking { .. }
-            | ModelBlock::Citations { .. } => None,
+            | ModelBlock::Citations { .. }
+            | ModelBlock::ProviderToolUse { .. }
+            | ModelBlock::ProviderToolResult { .. } => None,
         })
         .collect::<Vec<_>>()
         .join("\n");

--- a/tests/live_llm_baseline.rs
+++ b/tests/live_llm_baseline.rs
@@ -42,7 +42,9 @@ fn response_text(blocks: &[ModelBlock]) -> String {
             | ModelBlock::Thinking { .. }
             | ModelBlock::ReasoningText { .. }
             | ModelBlock::RedactedThinking { .. }
-            | ModelBlock::Citations { .. } => None,
+            | ModelBlock::Citations { .. }
+            | ModelBlock::ProviderToolUse { .. }
+            | ModelBlock::ProviderToolResult { .. } => None,
         })
         .collect::<Vec<_>>()
         .join("\n")

--- a/tests/support/runtime_helpers.rs
+++ b/tests/support/runtime_helpers.rs
@@ -254,7 +254,9 @@ pub fn compact_request_snapshot(
                         ModelBlock::Thinking { .. }
                         | ModelBlock::ReasoningText { .. }
                         | ModelBlock::RedactedThinking { .. }
-                        | ModelBlock::Citations { .. } => None,
+                        | ModelBlock::Citations { .. }
+                        | ModelBlock::ProviderToolUse { .. }
+                        | ModelBlock::ProviderToolResult { .. } => None,
                     })
                     .collect::<Vec<_>>()
                     .join("\n"),


### PR DESCRIPTION
## Summary

- add provider-neutral `ProviderToolUse` and `ProviderToolResult` model blocks so provider-executed tools retain structured use/result semantics
- preserve Anthropic `server_tool_use` and assistant-side `tool_result` blocks through response decoding, transcript evidence, and assistant-history replay
- keep provider-tool payloads out of operator-visible assistant prose while retaining ordinary text, final answers, and citations
- remove Z.AI's redundant tool display text only when it forms the exact adjacent text/use/text/result sequence observed in its Anthropic-compatible SSE response
- update other transports and runtime projections to explicitly ignore provider-tool blocks where they are unsupported or non-visible

Closes #2694.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib provider_tool -- --nocapture`
- `cargo test --lib provider::transports::anthropic -- --nocapture` — 47 passed
- rebuilt `target/debug/holon` and verified the configured GLM/Z.AI provider end to end:
  - raw trace retained structured `server_tool_use` and matching `tool_result`
  - operator-visible output contained only the final answer, without tool JSON or protocol decoration

`cargo test --all-targets` was also run. It is not fully green because existing workspace-control path/worktree failures and `turn_local_continuation_recovers_by_reprojecting_recent_turns` fail independently of this patch; the turn-local assertion was reproduced from an `origin/main` source archive with the same `left: 1, right: 2` result.
