### PR TITLE
feat: add native macOS menu app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,11 +157,128 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+  macos-app:
+    name: Build macOS menu app
+    runs-on: macos-latest
+    needs: e2e-gate
+    env:
+      MACOS_DEVELOPER_ID_APPLICATION: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}
+      MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      MACOS_NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+      MACOS_NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
+      MACOS_NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+      HOLON_SPARKLE_FEED_URL: ${{ vars.HOLON_SPARKLE_FEED_URL }}
+      HOLON_SPARKLE_PUBLIC_KEY: ${{ secrets.HOLON_SPARKLE_PUBLIC_KEY }}
+      HOLON_SPARKLE_PRIVATE_KEY: ${{ secrets.HOLON_SPARKLE_PRIVATE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Build web GUI
+        run: make web
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Select matching macOS target
+        id: macos-target
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            arm64) target="aarch64-apple-darwin" ;;
+            x86_64) target="x86_64-apple-darwin" ;;
+            *) echo "Unsupported macOS runner architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+          rustup target add "$target"
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+
+      - name: Validate macOS release credentials
+        run: |
+          set -euo pipefail
+          required=(
+            MACOS_DEVELOPER_ID_APPLICATION
+            MACOS_CERTIFICATE_P12
+            MACOS_CERTIFICATE_PASSWORD
+            MACOS_NOTARY_APPLE_ID
+            MACOS_NOTARY_PASSWORD
+            MACOS_NOTARY_TEAM_ID
+            HOLON_SPARKLE_FEED_URL
+            HOLON_SPARKLE_PUBLIC_KEY
+            HOLON_SPARKLE_PRIVATE_KEY
+          )
+          for name in "${required[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              echo "Required macOS release credential is not configured: ${name}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Import Developer ID certificate
+        run: |
+          set -euo pipefail
+          keychain="$RUNNER_TEMP/holon-signing.keychain-db"
+          keychain_password="$(openssl rand -hex 24)"
+          certificate="$RUNNER_TEMP/holon-developer-id.p12"
+          printf '%s' "$MACOS_CERTIFICATE_P12" | base64 --decode > "$certificate"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$certificate" \
+            -P "$MACOS_CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$keychain"
+          security list-keychain -d user -s "$keychain" login.keychain-db
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$keychain_password" \
+            "$keychain"
+
+      - name: Build bundled Holon runtime
+        run: cargo build --release --locked --target "${{ steps.macos-target.outputs.target }}"
+
+      - name: Test macOS menu app
+        run: swift test --package-path apps/macos/HolonMenu
+
+      - name: Package macOS app and DMG
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          scripts/package-macos-menu-app.sh \
+            "target/${{ steps.macos-target.outputs.target }}/release/holon" \
+            dist \
+            "$version"
+
+      - name: Generate signed Sparkle appcast
+        run: |
+          set -euo pipefail
+          scripts/generate-macos-appcast.sh \
+            dist \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/"
+
+      - name: Upload macOS app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-holon-macos-app
+          path: |
+            dist/Holon-*.dmg
+            dist/Holon-*.dmg.sha256
+            dist/appcast.xml
+          if-no-files-found: error
+
   release:
     name: Publish GitHub release
     runs-on: ubuntu-latest
     needs:
       - build
+      - macos-app
       - e2e-gate
     permissions:
       contents: write
@@ -190,8 +307,8 @@ jobs:
           set -euo pipefail
           (
             cd dist-artifacts
-            rm -f ./*.sha256
-            shasum -a 256 ./*.tar.gz | sort -k2 > checksums.txt
+            rm -f ./*.tar.gz.sha256
+            shasum -a 256 ./*.tar.gz ./*.dmg | sort -k2 > checksums.txt
           )
           bash scripts/generate-homebrew-formula.sh \
             "$GITHUB_REF_NAME" \
@@ -259,6 +376,9 @@ jobs:
           body_path: release-notes.md
           files: |
             dist-artifacts/*.tar.gz
+            dist-artifacts/*.dmg
+            dist-artifacts/*.dmg.sha256
+            dist-artifacts/appcast.xml
             dist-artifacts/checksums.txt
 
       - name: Push Homebrew formula

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help web web-ci transport-types transport-types-check snapshots-check snapshots-refresh build all test test-resource-lint test-concurrent test-concurrent-repeat test-live test-live-openai test-live-anthropic test-live-codex test-live-xai test-live-images test-live-runtime docker-build docker-smoke docker-e2e docker-e2e-scheduler-required docker-e2e-scheduler-live-canary docker-e2e-validate docker-live-acceptance fmt fmt-check lint check ci run clean
+.PHONY: help web web-ci macos-menu-test macos-menu-package transport-types transport-types-check snapshots-check snapshots-refresh build all test test-resource-lint test-concurrent test-concurrent-repeat test-live test-live-openai test-live-anthropic test-live-codex test-live-xai test-live-images test-live-runtime docker-build docker-smoke docker-e2e docker-e2e-scheduler-required docker-e2e-scheduler-live-canary docker-e2e-validate docker-live-acceptance fmt fmt-check lint check ci run clean
 
 WEB_DIR := web-gui/app
 OPENAPI_TOOLS_DIR := web-gui/openapi-tools
@@ -34,6 +34,12 @@ web-ci: ## Test and build the web GUI with one clean dependency install
 	@if [ -s "$$HOME/.nvm/nvm.sh" ]; then . "$$HOME/.nvm/nvm.sh" && nvm use; fi; \
 	cd $(OPENAPI_TOOLS_DIR) && npm ci && npm run check && \
 	cd ../../$(WEB_DIR) && npm ci && npm test && npm run build
+
+macos-menu-test: ## Build and test the native macOS menu app
+	swift test --package-path apps/macos/HolonMenu
+
+macos-menu-package: ## Package Holon.app and a DMG from target/release/holon
+	scripts/package-macos-menu-app.sh target/release/holon dist
 
 transport-types: ## Refresh OpenAPI and generated TypeScript transport types
 	cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ You can also download prebuilt binaries for Linux amd64, macOS amd64, and macOS
 arm64 from [GitHub Releases](https://github.com/holon-run/holon/releases/latest).
 The Linux amd64 binary supports Ubuntu 22.04 or newer (glibc 2.35 or newer).
 
+macOS 13 or later users can install `Holon-<version>.dmg` from the same release
+page. The native menu bar app controls the same daemon as the CLI, supports
+launch at login, and can install its bundled CLI into `~/.local/bin` without
+overwriting another installation.
+
 The examples below assume `holon` is installed on `PATH`.
 
 ### Docker

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,6 +76,10 @@ holon --help
 下载 Linux amd64、macOS amd64 和 macOS arm64 预编译二进制。
 Linux amd64 二进制支持 Ubuntu 22.04 或更新版本（glibc 2.35 或更新版本）。
 
+macOS 13 或更新版本的用户也可以从同一发布页面安装
+`Holon-<version>.dmg`。原生菜单栏应用与 CLI 控制同一个 daemon，支持登录时
+启动，并可将内置 CLI 安装到 `~/.local/bin`，不会覆盖其他安装来源。
+
 下文示例假设 `holon` 已在 `PATH` 中。
 
 ### Docker

--- a/apps/macos/HolonMenu/.gitignore
+++ b/apps/macos/HolonMenu/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/apps/macos/HolonMenu/Package.resolved
+++ b/apps/macos/HolonMenu/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "20acc24749fa8a696724cead5aba21a3c7c799df86d903f31600bba1ee6d041b",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/apps/macos/HolonMenu/Package.swift
+++ b/apps/macos/HolonMenu/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "HolonMenu",
+    platforms: [
+        .macOS(.v13),
+    ],
+    products: [
+        .executable(
+            name: "HolonMenu",
+            targets: ["HolonMenu"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.4"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "HolonMenu",
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle"),
+            ],
+            path: "Sources/HolonMenu"
+        ),
+        .testTarget(
+            name: "HolonMenuTests",
+            dependencies: ["HolonMenu"],
+            path: "Tests/HolonMenuTests"
+        ),
+    ]
+)

--- a/apps/macos/HolonMenu/README.md
+++ b/apps/macos/HolonMenu/README.md
@@ -1,0 +1,16 @@
+# HolonMenu
+
+Phase 2 macOS menu bar skeleton for Holon.
+
+## Build and test
+
+- `xcodebuild -scheme HolonMenu -destination 'platform=macOS' test`
+
+## Runtime shape
+
+- macOS 13+
+- SwiftUI `MenuBarExtra`
+- accessory app lifecycle
+- bundled `holon` CLI lookup via `HOLON_BINARY_PATH` or app bundle lookup
+- `SMAppService.mainApp` login item toggle
+- fake client for Swift tests

--- a/apps/macos/HolonMenu/Resources/HolonMenu.entitlements
+++ b/apps/macos/HolonMenu/Resources/HolonMenu.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+</dict>
+</plist>

--- a/apps/macos/HolonMenu/Resources/Info.plist
+++ b/apps/macos/HolonMenu/Resources/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Holon</string>
+    <key>CFBundleExecutable</key>
+    <string>HolonMenu</string>
+    <key>CFBundleIdentifier</key>
+    <string>run.holon.menu</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Holon</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(HOLON_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(HOLON_BUILD_NUMBER)</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
+    <key>SUFeedURL</key>
+    <string>$(HOLON_SPARKLE_FEED_URL)</string>
+    <key>SUPublicEDKey</key>
+    <string>$(HOLON_SPARKLE_PUBLIC_KEY)</string>
+</dict>
+</plist>

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuApp.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuApp.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+@main
+struct HolonMenuApp: App {
+    @NSApplicationDelegateAdaptor(HolonMenuAppDelegate.self) private var appDelegate
+    @StateObject private var viewModel = HolonMenuViewModel(client: HolonCLIClient())
+    private let updater = HolonUpdater()
+
+    var body: some Scene {
+        MenuBarExtra("Holon", systemImage: "bolt.horizontal.circle") {
+            HolonMenuView(viewModel: viewModel, updater: updater)
+                .task {
+                    await viewModel.bootstrap()
+                }
+        }
+        .menuBarExtraStyle(.window)
+    }
+}

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuAppDelegate.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuAppDelegate.swift
@@ -1,0 +1,7 @@
+import AppKit
+
+final class HolonMenuAppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+    }
+}

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuClient.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuClient.swift
@@ -1,0 +1,211 @@
+import Foundation
+import ServiceManagement
+
+enum HolonCLIError: LocalizedError {
+    case missingHolonBinary
+    case processFailed(command: [String], terminationStatus: Int32, stderr: String)
+    case invalidJSON(String)
+    case invalidWebAddress(String)
+    case loginItem(Error)
+    case commandLineToolConflict(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingHolonBinary:
+            return "Unable to locate the bundled holon CLI."
+        case let .processFailed(command, terminationStatus, stderr):
+            let renderedCommand = command.joined(separator: " ")
+            if stderr.isEmpty {
+                return "holon command failed with exit status \(terminationStatus): \(renderedCommand)"
+            }
+            return "holon command failed with exit status \(terminationStatus): \(renderedCommand)\n\(stderr)"
+        case let .invalidJSON(output):
+            return "holon returned invalid JSON: \(output)"
+        case let .invalidWebAddress(address):
+            return "holon returned an invalid web address: \(address)"
+        case let .loginItem(error):
+            return "Failed to update the login item: \(error.localizedDescription)"
+        case let .commandLineToolConflict(path):
+            return "A different holon command already exists at \(path). It was not replaced."
+        }
+    }
+}
+
+struct HolonProcessResult: Sendable {
+    var terminationStatus: Int32
+    var stdout: Data
+    var stderr: Data
+}
+
+protocol HolonProcessLaunching: Sendable {
+    func run(executableURL: URL, arguments: [String]) async throws -> HolonProcessResult
+}
+
+struct SystemHolonProcessLauncher: HolonProcessLaunching {
+    func run(executableURL: URL, arguments: [String]) async throws -> HolonProcessResult {
+        try await Task.detached(priority: .utility) {
+            let process = Process()
+            process.executableURL = executableURL
+            process.arguments = arguments
+
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+
+            try process.run()
+            process.waitUntilExit()
+
+            let stdout = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            let stderr = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            return HolonProcessResult(
+                terminationStatus: process.terminationStatus,
+                stdout: stdout,
+                stderr: stderr
+            )
+        }.value
+    }
+}
+
+enum HolonBinaryLocator {
+    static func resolve() throws -> URL {
+        if let path = ProcessInfo.processInfo.environment["HOLON_BINARY_PATH"], !path.isEmpty {
+            return URL(fileURLWithPath: path)
+        }
+
+        let bundle = Bundle.main
+        if let url = bundle.url(forAuxiliaryExecutable: "holon") {
+            return url
+        }
+        if let url = bundle.url(forResource: "holon", withExtension: nil) {
+            return url
+        }
+        if let resourceURL = bundle.resourceURL {
+            let candidate = resourceURL.appendingPathComponent("bin/holon")
+            if FileManager.default.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        if let executable = bundle.executableURL {
+            let candidate = executable.deletingLastPathComponent().appendingPathComponent("holon")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+
+        throw HolonCLIError.missingHolonBinary
+    }
+}
+
+final class HolonCLIClient: HolonDesiredStateClient {
+    private let executableURL: URL?
+    private let launcher: HolonProcessLaunching
+    private let launchOptions: HolonDaemonLaunchOptions
+    private let decoder: JSONDecoder
+
+    init(
+        executableURL: URL? = nil,
+        launcher: HolonProcessLaunching = SystemHolonProcessLauncher(),
+        launchOptions: HolonDaemonLaunchOptions = .default
+    ) {
+        self.executableURL = executableURL
+        self.launcher = launcher
+        self.launchOptions = launchOptions
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        self.decoder = decoder
+    }
+
+    func status() async throws -> HolonDaemonStatus {
+        try await run(["daemon", "status"], as: HolonDaemonStatus.self)
+    }
+
+    func start() async throws -> HolonDaemonStatus {
+        try await run(["daemon", "start"] + launchOptions.arguments(), as: HolonDaemonStatus.self)
+    }
+
+    func stop() async throws -> HolonDaemonStatus {
+        try await run(["daemon", "stop"], as: HolonDaemonStatus.self)
+    }
+
+    func restart() async throws -> HolonDaemonStatus {
+        try await run(["daemon", "restart"] + launchOptions.arguments(), as: HolonDaemonStatus.self)
+    }
+
+    func webURL() async throws -> URL {
+        let status = try await status()
+        guard let url = status.webURL else {
+            throw HolonCLIError.invalidWebAddress(status.httpAddr)
+        }
+        return url
+    }
+
+    func logsURL() async throws -> URL {
+        let logs = try await run(["daemon", "logs", "--tail", "1"], as: HolonDaemonLogs.self)
+        return logs.fileURL
+    }
+
+    func launchAtLoginEnabled() async throws -> Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    func setLaunchAtLoginEnabled(_ enabled: Bool) async throws {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+            } else {
+                try await SMAppService.mainApp.unregister()
+            }
+        } catch {
+            throw HolonCLIError.loginItem(error)
+        }
+    }
+
+    func installCommandLineTool() async throws -> URL {
+        let executable = try executableURL ?? HolonBinaryLocator.resolve()
+        let destination = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/bin/holon")
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        if FileManager.default.fileExists(atPath: destination.path) {
+            let existing = try? FileManager.default.destinationOfSymbolicLink(
+                atPath: destination.path
+            )
+            if existing == executable.path {
+                return destination
+            }
+            throw HolonCLIError.commandLineToolConflict(destination.path)
+        }
+
+        try FileManager.default.createSymbolicLink(
+            at: destination,
+            withDestinationURL: executable
+        )
+        return destination
+    }
+
+    private func run<T: Decodable>(_ arguments: [String], as type: T.Type) async throws -> T {
+        let executable = try executableURL ?? HolonBinaryLocator.resolve()
+        let result = try await launcher.run(executableURL: executable, arguments: arguments)
+
+        guard result.terminationStatus == 0 else {
+            throw HolonCLIError.processFailed(
+                command: [executable.path] + arguments,
+                terminationStatus: result.terminationStatus,
+                stderr: String(data: result.stderr, encoding: .utf8) ?? ""
+            )
+        }
+
+        do {
+            return try decoder.decode(T.self, from: result.stdout)
+        } catch {
+            throw HolonCLIError.invalidJSON(
+                String(data: result.stdout, encoding: .utf8) ?? "<non-utf8 output>"
+            )
+        }
+    }
+}

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuFakeClient.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuFakeClient.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+actor FakeHolonClient: HolonDesiredStateClient {
+    enum Command: Equatable, Sendable {
+        case status
+        case start
+        case stop
+        case restart
+        case webURL
+        case logsURL
+        case launchAtLoginEnabled
+        case setLaunchAtLoginEnabled(Bool)
+        case installCommandLineTool
+    }
+
+    private(set) var commands: [Command] = []
+    private var currentStatus: HolonDaemonStatus
+    private var launchAtLoginEnabledValue: Bool
+
+    init(
+        currentStatus: HolonDaemonStatus = HolonDaemonStatus(
+            ok: true,
+            state: .stopped,
+            healthy: false,
+            homeDir: "/Users/holon/.holon",
+            socketPath: "/tmp/holon.sock",
+            httpAddr: "127.0.0.1:7878",
+            webURLString: "http://127.0.0.1:7878",
+            productVersion: "test",
+            controlProtocolVersion: 1,
+            lifecycleOwner: "standalone",
+            executablePath: "/Applications/Holon.app/Contents/Resources/bin/holon",
+            desiredRunning: false,
+            pid: nil,
+            controlConnectivity: false,
+            runtimeConfigFingerprint: nil,
+            configFingerprintMatch: nil,
+            message: "Holon runtime is stopped."
+        ),
+        launchAtLoginEnabled: Bool = false
+    ) {
+        self.currentStatus = currentStatus
+        self.launchAtLoginEnabledValue = launchAtLoginEnabled
+    }
+
+    func status() async throws -> HolonDaemonStatus {
+        commands.append(.status)
+        return currentStatus
+    }
+
+    func start() async throws -> HolonDaemonStatus {
+        commands.append(.start)
+        currentStatus.state = .running
+        currentStatus.healthy = true
+        currentStatus.ok = true
+        currentStatus.desiredRunning = true
+        currentStatus.message = "Holon runtime is running."
+        return currentStatus
+    }
+
+    func stop() async throws -> HolonDaemonStatus {
+        commands.append(.stop)
+        currentStatus.state = .stopped
+        currentStatus.healthy = false
+        currentStatus.ok = true
+        currentStatus.desiredRunning = false
+        currentStatus.message = "Holon runtime is stopped."
+        return currentStatus
+    }
+
+    func restart() async throws -> HolonDaemonStatus {
+        commands.append(.restart)
+        currentStatus.state = .running
+        currentStatus.healthy = true
+        currentStatus.ok = true
+        currentStatus.desiredRunning = true
+        currentStatus.message = "Holon runtime restarted."
+        return currentStatus
+    }
+
+    func webURL() async throws -> URL {
+        commands.append(.webURL)
+        guard let url = currentStatus.webURL else {
+            throw HolonCLIError.invalidWebAddress(currentStatus.httpAddr)
+        }
+        return url
+    }
+
+    func logsURL() async throws -> URL {
+        commands.append(.logsURL)
+        return currentStatus.logURL
+    }
+
+    func launchAtLoginEnabled() async throws -> Bool {
+        commands.append(.launchAtLoginEnabled)
+        return launchAtLoginEnabledValue
+    }
+
+    func setLaunchAtLoginEnabled(_ enabled: Bool) async throws {
+        commands.append(.setLaunchAtLoginEnabled(enabled))
+        launchAtLoginEnabledValue = enabled
+    }
+
+    func installCommandLineTool() async throws -> URL {
+        commands.append(.installCommandLineTool)
+        return URL(fileURLWithPath: "/Users/holon/.local/bin/holon")
+    }
+
+    func recordedCommands() -> [Command] {
+        commands
+    }
+}

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuFakeClient.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuFakeClient.swift
@@ -25,7 +25,7 @@ actor FakeHolonClient: HolonDesiredStateClient {
             homeDir: "/Users/holon/.holon",
             socketPath: "/tmp/holon.sock",
             httpAddr: "127.0.0.1:7878",
-            webURLString: "http://127.0.0.1:7878",
+            webUrl: "http://127.0.0.1:7878",
             productVersion: "test",
             controlProtocolVersion: 1,
             lifecycleOwner: "standalone",

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuModels.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuModels.swift
@@ -19,7 +19,7 @@ struct HolonDaemonStatus: Codable, Equatable, Sendable {
     var homeDir: String
     var socketPath: String
     var httpAddr: String
-    var webURLString: String?
+    var webUrl: String?
     var productVersion: String?
     var controlProtocolVersion: UInt32?
     var lifecycleOwner: String?
@@ -32,7 +32,7 @@ struct HolonDaemonStatus: Codable, Equatable, Sendable {
     var message: String
 
     var webURL: URL? {
-        HolonURLBuilder.webURL(from: webURLString ?? httpAddr)
+        HolonURLBuilder.webURL(from: webUrl ?? httpAddr)
     }
 
     var logURL: URL {

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuModels.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuModels.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+enum HolonDaemonLifecycleState: String, Codable, Sendable {
+    case running
+    case degraded
+    case stopped
+    case stale
+    case versionMismatch = "version_mismatch"
+
+    var title: String {
+        rawValue.capitalized
+    }
+}
+
+struct HolonDaemonStatus: Codable, Equatable, Sendable {
+    var ok: Bool
+    var state: HolonDaemonLifecycleState
+    var healthy: Bool
+    var homeDir: String
+    var socketPath: String
+    var httpAddr: String
+    var webURLString: String?
+    var productVersion: String?
+    var controlProtocolVersion: UInt32?
+    var lifecycleOwner: String?
+    var executablePath: String?
+    var desiredRunning: Bool
+    var pid: UInt32?
+    var controlConnectivity: Bool
+    var runtimeConfigFingerprint: String?
+    var configFingerprintMatch: Bool?
+    var message: String
+
+    var webURL: URL? {
+        HolonURLBuilder.webURL(from: webURLString ?? httpAddr)
+    }
+
+    var logURL: URL {
+        URL(fileURLWithPath: homeDir, isDirectory: true)
+            .appendingPathComponent("run")
+            .appendingPathComponent("daemon.log")
+    }
+}
+
+struct HolonDaemonLogs: Codable, Equatable, Sendable {
+    var ok: Bool
+    var logPath: String
+    var tail: [String]
+    var message: String
+
+    var fileURL: URL {
+        URL(fileURLWithPath: logPath)
+    }
+}
+
+struct HolonDaemonLaunchOptions: Equatable, Sendable {
+    var access: String?
+    var host: String?
+    var listen: String?
+    var port: UInt16?
+    var advertise: String?
+    var token: String?
+    var tokenFilePath: String?
+    var webDistPath: String?
+
+    static let `default` = HolonDaemonLaunchOptions()
+
+    func arguments() -> [String] {
+        var arguments: [String] = []
+
+        if let access {
+            arguments += ["--access", access]
+        }
+        if let host {
+            arguments += ["--host", host]
+        }
+        if let listen {
+            arguments += ["--listen", listen]
+        }
+        if let port {
+            arguments += ["--port", String(port)]
+        }
+        if let advertise {
+            arguments += ["--advertise", advertise]
+        }
+        if let token {
+            arguments += ["--token", token]
+        }
+        if let tokenFilePath {
+            arguments += ["--token-file", tokenFilePath]
+        }
+        if let webDistPath {
+            arguments += ["--web-dist", webDistPath]
+        }
+
+        return arguments
+    }
+}
+
+enum HolonURLBuilder {
+    static func webURL(from address: String) -> URL? {
+        let string = address.hasPrefix("http://") || address.hasPrefix("https://")
+            ? address
+            : "http://\(address)"
+        return URL(string: string)
+    }
+}
+
+protocol HolonDesiredStateClient: Sendable {
+    func status() async throws -> HolonDaemonStatus
+    func start() async throws -> HolonDaemonStatus
+    func stop() async throws -> HolonDaemonStatus
+    func restart() async throws -> HolonDaemonStatus
+    func webURL() async throws -> URL
+    func logsURL() async throws -> URL
+    func launchAtLoginEnabled() async throws -> Bool
+    func setLaunchAtLoginEnabled(_ enabled: Bool) async throws
+    func installCommandLineTool() async throws -> URL
+}

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuView.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuView.swift
@@ -1,0 +1,98 @@
+import AppKit
+import SwiftUI
+
+struct HolonMenuView: View {
+    @ObservedObject var viewModel: HolonMenuViewModel
+    let updater: HolonUpdater
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Holon")
+                    .font(.headline)
+                Text(viewModel.stateTitle)
+                    .font(.title3.weight(.semibold))
+                Text(viewModel.statusMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let activeOperation = viewModel.activeOperation {
+                    ProgressView(activeOperation)
+                        .controlSize(.small)
+                }
+            }
+
+            GroupBox {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Web: \(viewModel.webAddressText)")
+                    Text("Polling: \(viewModel.isPolling ? "On" : "Off")")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .font(.caption)
+            }
+
+            HStack(spacing: 8) {
+                Button("Start") {
+                    Task { await viewModel.start() }
+                }
+                .disabled(viewModel.isOperating || viewModel.isRunning)
+                Button("Stop") {
+                    Task { await viewModel.stop() }
+                }
+                .disabled(viewModel.isOperating || !viewModel.isRunning)
+                Button("Restart") {
+                    Task { await viewModel.restart() }
+                }
+                .disabled(viewModel.isOperating || !viewModel.isRunning)
+            }
+
+            HStack(spacing: 8) {
+                Button("Open Web") {
+                    Task { await viewModel.openWeb() }
+                }
+                Button("Open Logs") {
+                    Task { await viewModel.openLogs() }
+                }
+            }
+
+            Toggle(
+                "Launch Holon Menu App at Login",
+                isOn: Binding(
+                    get: { viewModel.launchAtLoginEnabled },
+                    set: { newValue in
+                        viewModel.launchAtLoginEnabled = newValue
+                        Task { await viewModel.setLaunchAtLogin(newValue) }
+                    }
+                )
+            )
+
+            Button("Check for Updates…") {
+                updater.checkForUpdates()
+            }
+
+            Button("Install Command Line Tool…") {
+                Task { await viewModel.installCommandLineTool() }
+            }
+
+            if let message = viewModel.commandLineToolMessage {
+                Text(message)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let error = viewModel.lastError {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Divider()
+
+            Button("Quit Holon Menu App") {
+                NSApplication.shared.terminate(nil)
+            }
+        }
+        .padding(12)
+        .frame(width: 320)
+    }
+}

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuViewModel.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuViewModel.swift
@@ -130,7 +130,7 @@ final class HolonMenuViewModel: ObservableObject {
     }
 
     var webAddressText: String {
-        status?.webURLString ?? status?.httpAddr ?? "No web endpoint yet."
+        status?.webUrl ?? status?.httpAddr ?? "No web endpoint yet."
     }
 
     var isRunning: Bool {

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuViewModel.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonMenuViewModel.swift
@@ -1,0 +1,155 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+protocol MenuURLOpening {
+    func open(_ url: URL)
+}
+
+struct SystemMenuURLOpener: MenuURLOpening {
+    func open(_ url: URL) {
+        NSWorkspace.shared.open(url)
+    }
+}
+
+@MainActor
+final class HolonMenuViewModel: ObservableObject {
+    @Published private(set) var status: HolonDaemonStatus?
+    @Published private(set) var isPolling = false
+    @Published private(set) var activeOperation: String?
+    @Published var launchAtLoginEnabled = false
+    @Published var lastError: String?
+    @Published var commandLineToolMessage: String?
+
+    private let client: any HolonDesiredStateClient
+    private let opener: MenuURLOpening
+    private var pollingTask: Task<Void, Never>?
+
+    init(client: some HolonDesiredStateClient, opener: some MenuURLOpening = SystemMenuURLOpener()) {
+        self.client = client
+        self.opener = opener
+    }
+
+    deinit {
+        pollingTask?.cancel()
+    }
+
+    func bootstrap() async {
+        await refresh()
+        if status?.desiredRunning == true, status?.state == .stopped {
+            await start()
+        }
+        startPolling()
+    }
+
+    func refresh() async {
+        do {
+            status = try await client.status()
+            launchAtLoginEnabled = try await client.launchAtLoginEnabled()
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func start() async {
+        await runOperation { try await self.client.start() }
+    }
+
+    func stop() async {
+        await runOperation { try await self.client.stop() }
+    }
+
+    func restart() async {
+        await runOperation { try await self.client.restart() }
+    }
+
+    func openWeb() async {
+        do {
+            let url = try await client.webURL()
+            opener.open(url)
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func openLogs() async {
+        do {
+            let url = try await client.logsURL()
+            opener.open(url)
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func setLaunchAtLogin(_ enabled: Bool) async {
+        do {
+            try await client.setLaunchAtLoginEnabled(enabled)
+            launchAtLoginEnabled = try await client.launchAtLoginEnabled()
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func installCommandLineTool() async {
+        do {
+            let destination = try await client.installCommandLineTool()
+            commandLineToolMessage =
+                "Installed at \(destination.path). Add ~/.local/bin to PATH if needed."
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func startPolling(intervalNanoseconds: UInt64 = 3_000_000_000) {
+        pollingTask?.cancel()
+        isPolling = true
+        pollingTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                await self.refresh()
+                try? await Task.sleep(nanoseconds: intervalNanoseconds)
+            }
+        }
+    }
+
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+        isPolling = false
+    }
+
+    var stateTitle: String {
+        status?.state.title ?? "Unknown"
+    }
+
+    var statusMessage: String {
+        status?.message ?? "Waiting for Holon status."
+    }
+
+    var webAddressText: String {
+        status?.webURLString ?? status?.httpAddr ?? "No web endpoint yet."
+    }
+
+    var isRunning: Bool {
+        status?.state == .running || status?.state == .degraded
+    }
+
+    var isOperating: Bool {
+        activeOperation != nil
+    }
+
+    private func runOperation(_ operation: @escaping () async throws -> HolonDaemonStatus) async {
+        activeOperation = "Updating Holon…"
+        defer { activeOperation = nil }
+        do {
+            let updated = try await operation()
+            status = updated
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+}

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonUpdater.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonUpdater.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Sparkle
+
+@MainActor
+final class HolonUpdater: NSObject, SPUUpdaterDelegate {
+    private lazy var controller = SPUStandardUpdaterController(
+        startingUpdater: true,
+        updaterDelegate: self,
+        userDriverDelegate: nil
+    )
+
+    func checkForUpdates() {
+        controller.checkForUpdates(nil)
+    }
+
+    nonisolated func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+        guard let executable = try? HolonBinaryLocator.resolve() else {
+            return
+        }
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = ["daemon", "prepare-update"]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try? process.run()
+        process.waitUntilExit()
+    }
+}

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonUpdater.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonUpdater.swift
@@ -1,6 +1,18 @@
 import Foundation
 import Sparkle
 
+private final class InstallHandler: @unchecked Sendable {
+    private let handler: () -> Void
+
+    init(_ handler: @escaping () -> Void) {
+        self.handler = handler
+    }
+
+    func invoke() {
+        handler()
+    }
+}
+
 @MainActor
 final class HolonUpdater: NSObject, SPUUpdaterDelegate {
     private lazy var controller = SPUStandardUpdaterController(
@@ -13,18 +25,24 @@ final class HolonUpdater: NSObject, SPUUpdaterDelegate {
         controller.checkForUpdates(nil)
     }
 
-    nonisolated func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+    nonisolated func updater(
+        _ updater: SPUUpdater,
+        shouldPostponeRelaunchForUpdate item: SUAppcastItem,
+        untilInvokingBlock installHandler: @escaping () -> Void
+    ) -> Bool {
+        let continuation = InstallHandler(installHandler)
         DispatchQueue.global(qos: .userInitiated).async {
-            guard let executable = try? HolonBinaryLocator.resolve() else {
-                return
+            if let executable = try? HolonBinaryLocator.resolve() {
+                let process = Process()
+                process.executableURL = executable
+                process.arguments = ["daemon", "prepare-update"]
+                process.standardOutput = FileHandle.nullDevice
+                process.standardError = FileHandle.nullDevice
+                try? process.run()
+                process.waitUntilExit()
             }
-            let process = Process()
-            process.executableURL = executable
-            process.arguments = ["daemon", "prepare-update"]
-            process.standardOutput = FileHandle.nullDevice
-            process.standardError = FileHandle.nullDevice
-            try? process.run()
-            process.waitUntilExit()
+            continuation.invoke()
         }
+        return true
     }
 }

--- a/apps/macos/HolonMenu/Sources/HolonMenu/HolonUpdater.swift
+++ b/apps/macos/HolonMenu/Sources/HolonMenu/HolonUpdater.swift
@@ -14,15 +14,17 @@ final class HolonUpdater: NSObject, SPUUpdaterDelegate {
     }
 
     nonisolated func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
-        guard let executable = try? HolonBinaryLocator.resolve() else {
-            return
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let executable = try? HolonBinaryLocator.resolve() else {
+                return
+            }
+            let process = Process()
+            process.executableURL = executable
+            process.arguments = ["daemon", "prepare-update"]
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            try? process.run()
+            process.waitUntilExit()
         }
-        let process = Process()
-        process.executableURL = executable
-        process.arguments = ["daemon", "prepare-update"]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        try? process.run()
-        process.waitUntilExit()
     }
 }

--- a/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
+++ b/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
@@ -68,6 +68,8 @@ final class HolonMenuClientTests: XCTestCase {
         let status = try await client.status()
         XCTAssertEqual(status.state, .running)
         XCTAssertEqual(status.httpAddr, "127.0.0.1:7878")
+        XCTAssertEqual(status.webUrl, "http://127.0.0.1:7878")
+        XCTAssertEqual(status.webURL?.absoluteString, "http://127.0.0.1:7878")
         let statusInvocations = await launcher.invocations()
         XCTAssertEqual(statusInvocations.first?.arguments, ["daemon", "status"])
 

--- a/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
+++ b/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import XCTest
+@testable import HolonMenu
+
+actor RecordingProcessLauncher: HolonProcessLaunching {
+    struct Invocation: Equatable, Sendable {
+        let executableURL: URL
+        let arguments: [String]
+    }
+
+    private var recordedInvocations: [Invocation] = []
+    private let result: Result<HolonProcessResult, Error>
+
+    init(result: Result<HolonProcessResult, Error>) {
+        self.result = result
+    }
+
+    func run(executableURL: URL, arguments: [String]) async throws -> HolonProcessResult {
+        recordedInvocations.append(Invocation(executableURL: executableURL, arguments: arguments))
+        return try result.get()
+    }
+
+    func invocations() -> [Invocation] {
+        recordedInvocations
+    }
+}
+
+final class HolonMenuClientTests: XCTestCase {
+    func testClientBuildsDaemonArgumentsAndDecodesJSON() async throws {
+        let statusJSON = """
+        {
+          "ok": true,
+          "state": "running",
+          "healthy": true,
+          "home_dir": "/Users/jane/.holon",
+          "socket_path": "/tmp/holon.sock",
+          "http_addr": "127.0.0.1:7878",
+          "web_url": "http://127.0.0.1:7878",
+          "product_version": "0.33.0 (abcdef0)",
+          "control_protocol_version": 1,
+          "lifecycle_owner": "standalone",
+          "executable_path": "/Applications/Holon.app/Contents/Resources/bin/holon",
+          "desired_running": true,
+          "pid": 123,
+          "control_connectivity": true,
+          "runtime_config_fingerprint": "abc123",
+          "config_fingerprint_match": true,
+          "message": "Holon runtime is running."
+        }
+        """
+
+        let launcher = RecordingProcessLauncher(
+            result: .success(
+                HolonProcessResult(
+                    terminationStatus: 0,
+                    stdout: Data(statusJSON.utf8),
+                    stderr: Data()
+                )
+            )
+        )
+
+        let client = HolonCLIClient(
+            executableURL: URL(fileURLWithPath: "/opt/holon"),
+            launcher: launcher,
+            launchOptions: HolonDaemonLaunchOptions(access: "local", port: 7878)
+        )
+
+        let status = try await client.status()
+        XCTAssertEqual(status.state, .running)
+        XCTAssertEqual(status.httpAddr, "127.0.0.1:7878")
+        let statusInvocations = await launcher.invocations()
+        XCTAssertEqual(statusInvocations.first?.arguments, ["daemon", "status"])
+
+        _ = try await client.start()
+        let startInvocations = await launcher.invocations()
+        XCTAssertEqual(
+            startInvocations.last?.arguments,
+            ["daemon", "start", "--access", "local", "--port", "7878"]
+        )
+    }
+}

--- a/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuFakeClientTests.swift
+++ b/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuFakeClientTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import HolonMenu
+
+final class HolonMenuFakeClientTests: XCTestCase {
+    func testFakeClientTracksStateTransitionsAndLoginItemState() async throws {
+        let client = FakeHolonClient()
+
+        let initial = try await client.status()
+        XCTAssertEqual(initial.state, .stopped)
+        XCTAssertEqual(initial.state.title, "Stopped")
+
+        let running = try await client.start()
+        XCTAssertEqual(running.state, .running)
+
+        let webURL = try await client.webURL()
+        XCTAssertEqual(webURL.absoluteString, "http://127.0.0.1:7878")
+
+        let logsURL = try await client.logsURL()
+        XCTAssertTrue(logsURL.path.hasSuffix("/run/daemon.log"))
+
+        try await client.setLaunchAtLoginEnabled(true)
+        let launchAtLoginEnabled = try await client.launchAtLoginEnabled()
+        XCTAssertTrue(launchAtLoginEnabled)
+
+        let commands = await client.recordedCommands()
+        XCTAssertEqual(
+            commands,
+            [
+                .status,
+                .start,
+                .webURL,
+                .logsURL,
+                .setLaunchAtLoginEnabled(true),
+                .launchAtLoginEnabled,
+            ]
+        )
+    }
+}

--- a/docs/implementation-decisions/115-macos-menu-app-keeps-standalone-daemon.md
+++ b/docs/implementation-decisions/115-macos-menu-app-keeps-standalone-daemon.md
@@ -1,0 +1,26 @@
+# macOS menu app keeps the standalone daemon
+
+## Decision
+
+The first Holon macOS menu bar application uses SwiftUI `MenuBarExtra` on
+macOS 13 or later and invokes the bundled Rust CLI as its lifecycle adapter.
+The existing standalone daemon remains the single runtime. The app registers
+only itself with `SMAppService.mainApp`; it does not install a LaunchAgent.
+
+The app and CLI share an explicit daemon desired state. Quitting the menu app
+does not stop the daemon, and login launch restores the last explicit Start or
+Stop choice.
+
+## Reason
+
+This keeps process identity, stale-state handling, graceful shutdown, and
+configuration ownership in the existing Rust lifecycle implementation. Adding
+launchd supervision in the same change would make Stop semantics, installation
+ownership, helper registration, and update recovery interdependent before the
+GUI contract is proven.
+
+## Preserved boundary
+
+Swift is a native presentation and macOS integration layer, not a second
+runtime supervisor. A future LaunchAgent requires an explicit ownership
+protocol and a separate decision.

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,6 +2,35 @@
 
 Holon releases are published from version tags.
 
+## macOS menu app
+
+The macOS release also builds `Holon.app` for macOS 13 or later. The app is a
+native SwiftUI menu bar control plane and bundles the matching Rust runtime at
+`Contents/Resources/bin/holon`.
+
+Local packaging:
+
+```bash
+cargo build --release
+scripts/package-macos-menu-app.sh target/release/holon dist
+```
+
+The script always verifies the bundle and emits `Holon-<version>.dmg` plus a
+SHA-256 file. Local notarization may use `MACOS_NOTARY_PROFILE`. GitHub Actions
+imports the Developer ID certificate and uses Apple ID notarization with:
+
+- `MACOS_DEVELOPER_ID_APPLICATION`
+- `MACOS_CERTIFICATE_P12` and `MACOS_CERTIFICATE_PASSWORD`
+- `MACOS_NOTARY_APPLE_ID`, `MACOS_NOTARY_PASSWORD`, and
+  `MACOS_NOTARY_TEAM_ID`
+- `HOLON_SPARKLE_PUBLIC_KEY`
+- `HOLON_SPARKLE_PRIVATE_KEY`, used only to sign update archives and appcast
+  entries
+- `HOLON_SPARKLE_FEED_URL`
+
+These values are required for production tag releases. An unsigned local bundle
+remains supported for development and smoke verification.
+
 Every release tag is blocked until the protected **Release E2E** workflow has
 passed for the exact tag commit and intended release tag. That workflow builds
 one candidate image after protected-environment approval, records its immutable

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -80,6 +80,7 @@ implementation and tests.
 ## Eventing And Client Surface
 
 - [Event Stream Interface Design](./event-stream-interface.md)
+- [macOS Menu App And Daemon Lifecycle](./macos-menu-app-and-daemon-lifecycle.md)
 - [Event-Ledger Web Synchronization and Browser-Local Read State](./observer-sync-agent-summary-and-read-markers.md)
 - [Debug Prompt JSON Envelope](./debug-prompt-json-envelope.md)
 - [Operator Display Levels and Event Presentation](./operator-display-levels-and-event-presentation.md)

--- a/docs/rfcs/macos-menu-app-and-daemon-lifecycle.md
+++ b/docs/rfcs/macos-menu-app-and-daemon-lifecycle.md
@@ -1,0 +1,139 @@
+# macOS Menu App And Daemon Lifecycle
+
+## Status
+
+Accepted for implementation on August 28, 2026.
+
+## Goal
+
+Holon provides a native macOS menu bar control plane for users who should not
+need a terminal to start, stop, inspect, or update the runtime. The existing
+Rust daemon remains the single runtime. The menu app and command-line clients
+must never create separate daemon identities or competing configuration and
+lifecycle implementations.
+
+The first supported system is macOS 13.
+
+## Product Shape
+
+`Holon.app` contains:
+
+- a SwiftUI `MenuBarExtra` application;
+- the matching Rust `holon` executable under `Contents/Resources/bin`;
+- update metadata and, when release signing is configured, Sparkle;
+- no launch agent or privileged helper.
+
+The menu app is an accessory application without a default Dock icon. It may
+open ordinary settings and diagnostics windows.
+
+## Runtime Ownership
+
+The MVP lifecycle owner is `standalone`. Both the bundled executable and an
+external compatible CLI address the same daemon home, control socket, metadata,
+and local control API.
+
+The menu app does not:
+
+- inspect PID or socket files to make lifecycle decisions;
+- implement process cleanup or signal escalation in Swift;
+- supervise the daemon as a child whose lifetime is tied to the app;
+- register a `LaunchAgent`.
+
+Instead it invokes the bundled `holon daemon` commands with structured
+arguments and consumes their JSON results. Rust remains the only implementation
+of daemon identity checks, stale-state cleanup, graceful shutdown, and process
+fallback behavior.
+
+## Lifecycle Contract
+
+Every status or mutation result identifies:
+
+- the lifecycle state;
+- daemon product version and control protocol version when known;
+- lifecycle owner;
+- executable path when known;
+- the canonical Web UI URL;
+- runtime health and the most recent failure summary.
+
+The public state model is:
+
+- `starting`
+- `running`
+- `stopping`
+- `stopped`
+- `stale`
+- `degraded`
+- `version_mismatch`
+
+Rust may complete a short transition before returning a mutation response, but
+clients must not infer success optimistically. A mutation returns a final
+snapshot or a structured error.
+
+Cross-process lifecycle mutations are serialized. `start` remains idempotent.
+Conflicting `stop`, `restart`, and update operations cannot interleave.
+
+## Compatibility
+
+Control protocol versions are independent from product versions. A client may
+control a daemon when their protocol versions are compatible even when product
+versions differ.
+
+An incompatible client:
+
+- may display status and diagnostics that can be read safely;
+- must not blindly kill or replace the daemon;
+- must show the actual daemon executable and product version;
+- directs the user to update or explicitly restart with a compatible version.
+
+Additive JSON fields remain backward compatible. Readers must tolerate unknown
+fields, and new optional fields must deserialize from older responses.
+
+## Login And Desired State
+
+`SMAppService.mainApp` controls only **Launch Holon Menu App at Login**.
+
+Daemon desired state records the user's last explicit lifecycle decision:
+
+- explicit Start sets `desired_running = true`;
+- explicit Stop sets `desired_running = false`;
+- Restart preserves `true`;
+- logout, shutdown, app exit, or an unexpected daemon failure does not rewrite
+  the desired state.
+
+When the menu app starts, it reads this shared desired state. It starts a
+stopped daemon only when `desired_running` is true. The CLI and menu app update
+the same state through the Rust lifecycle contract.
+
+Quitting the menu app does not stop Holon.
+
+## Updates
+
+The supported release transaction replaces the complete app bundle:
+
+1. record whether the daemon should be running after the update;
+2. request graceful daemon shutdown;
+3. install the signed and notarized app update;
+4. launch the new app and run compatible migrations;
+5. restore the recorded desired state.
+
+The menu app does not update or overwrite an arbitrary external CLI. The
+initial command-line installation action creates a user-owned link or shim
+under `~/.local/bin` only after checking for an existing command. It never
+silently replaces Homebrew, Cargo, or administrator-owned installations.
+
+## Release Boundary
+
+The initial distribution channel is a Developer ID signed and notarized DMG.
+Mac App Store sandboxing and launch-agent supervision are outside this phase.
+Release automation must verify nested signatures, notarization, stapling, and
+the bundled CLI version before publishing an update feed.
+
+## Preserved Boundaries
+
+- The daemon is the runtime and configuration fact source.
+- Rust owns lifecycle behavior; Swift owns presentation and OS integration.
+- CLI and GUI remain independently usable clients.
+- Login launch, daemon desired state, quitting the app, and uninstalling are
+  distinct user actions.
+- A future launchd owner requires a separate lifecycle ownership decision and
+  is not implied by this contract.

--- a/scripts/generate-macos-appcast.sh
+++ b/scripts/generate-macos-appcast.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "usage: $0 <archives-dir> <download-url-prefix> [output-name]" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+archives_dir="$1"
+download_url_prefix="$2"
+output_name="${3:-appcast.xml}"
+tool="$repo_root/apps/macos/HolonMenu/.build/artifacts/sparkle/Sparkle/bin/generate_appcast"
+
+[[ -x "$tool" ]] || {
+  echo "Sparkle generate_appcast is unavailable; run swift build for apps/macos/HolonMenu first" >&2
+  exit 1
+}
+[[ -n "${HOLON_SPARKLE_PRIVATE_KEY:-}" ]] || {
+  echo "HOLON_SPARKLE_PRIVATE_KEY is required to sign the appcast" >&2
+  exit 1
+}
+
+printf '%s' "$HOLON_SPARKLE_PRIVATE_KEY" |
+  "$tool" \
+    --ed-key-file - \
+    --download-url-prefix "$download_url_prefix" \
+    --maximum-versions 3 \
+    --maximum-deltas 2 \
+    -o "$output_name" \
+    "$archives_dir"
+
+test -s "$archives_dir/$output_name"
+echo "$archives_dir/$output_name"

--- a/scripts/package-macos-menu-app.sh
+++ b/scripts/package-macos-menu-app.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <holon-binary> <output-dir> [version]" >&2
+  exit 2
+}
+
+[[ $# -ge 2 && $# -le 3 ]] || usage
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+holon_binary="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+output_dir="$2"
+version="${3:-$(awk -F '"' '/^version = / { print $2; exit }' "$repo_root/Cargo.toml")}"
+build_number="${HOLON_BUILD_NUMBER:-$(date -u +%Y%m%d%H%M)}"
+app_dir="$output_dir/Holon.app"
+contents_dir="$app_dir/Contents"
+package_dir="$repo_root/apps/macos/HolonMenu"
+
+[[ -x "$holon_binary" ]] || {
+  echo "holon binary is missing or not executable: $holon_binary" >&2
+  exit 1
+}
+
+rm -rf "$app_dir"
+mkdir -p "$contents_dir/MacOS" "$contents_dir/Resources/bin"
+
+swift build \
+  --package-path "$package_dir" \
+  -c release \
+  --product HolonMenu
+
+swift_bin_path="$(swift build \
+  --package-path "$package_dir" \
+  -c release \
+  --show-bin-path)"
+cp "$swift_bin_path/HolonMenu" "$contents_dir/MacOS/HolonMenu"
+cp "$holon_binary" "$contents_dir/Resources/bin/holon"
+chmod 755 "$contents_dir/MacOS/HolonMenu" "$contents_dir/Resources/bin/holon"
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$contents_dir/MacOS/HolonMenu"
+
+cp "$package_dir/Resources/Info.plist" "$contents_dir/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $version" "$contents_dir/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build_number" "$contents_dir/Info.plist"
+/usr/libexec/PlistBuddy -c \
+  "Set :SUFeedURL ${HOLON_SPARKLE_FEED_URL:-https://releases.holon.run/macos/appcast.xml}" \
+  "$contents_dir/Info.plist"
+/usr/libexec/PlistBuddy -c \
+  "Set :SUPublicEDKey ${HOLON_SPARKLE_PUBLIC_KEY:-UNCONFIGURED}" \
+  "$contents_dir/Info.plist"
+
+sparkle_framework="$(find "$package_dir/.build" -path '*/Sparkle.framework' -type d -print -quit)"
+if [[ -n "$sparkle_framework" ]]; then
+  mkdir -p "$contents_dir/Frameworks"
+  ditto "$sparkle_framework" "$contents_dir/Frameworks/Sparkle.framework"
+fi
+
+if [[ -n "${MACOS_DEVELOPER_ID_APPLICATION:-}" ]]; then
+  while IFS= read -r nested; do
+    codesign --force --timestamp --options runtime \
+      --sign "$MACOS_DEVELOPER_ID_APPLICATION" "$nested"
+  done < <(find "$contents_dir/Frameworks" -depth \
+    \( -name '*.framework' -o -name '*.xpc' -o -name '*.app' \) 2>/dev/null)
+  codesign --force --timestamp --options runtime \
+    --sign "$MACOS_DEVELOPER_ID_APPLICATION" "$contents_dir/Resources/bin/holon"
+  codesign --force --timestamp --options runtime \
+    --entitlements "$package_dir/Resources/HolonMenu.entitlements" \
+    --sign "$MACOS_DEVELOPER_ID_APPLICATION" "$app_dir"
+fi
+
+"$repo_root/scripts/verify-macos-menu-app.sh" "$app_dir" "$version"
+
+notary_configured=false
+if [[ -n "${MACOS_NOTARY_PROFILE:-}${MACOS_NOTARY_APPLE_ID:-}" ]]; then
+  notary_configured=true
+  app_archive="$output_dir/Holon-${version}.zip"
+  rm -f "$app_archive"
+  ditto -c -k --keepParent "$app_dir" "$app_archive"
+  if [[ -n "${MACOS_NOTARY_PROFILE:-}" ]]; then
+    xcrun notarytool submit "$app_archive" \
+      --keychain-profile "$MACOS_NOTARY_PROFILE" \
+      --wait
+  else
+    : "${MACOS_NOTARY_PASSWORD:?MACOS_NOTARY_PASSWORD is required}"
+    : "${MACOS_NOTARY_TEAM_ID:?MACOS_NOTARY_TEAM_ID is required}"
+    xcrun notarytool submit "$app_archive" \
+      --apple-id "$MACOS_NOTARY_APPLE_ID" \
+      --password "$MACOS_NOTARY_PASSWORD" \
+      --team-id "$MACOS_NOTARY_TEAM_ID" \
+      --wait
+  fi
+  xcrun stapler staple "$app_dir"
+  rm -f "$app_archive"
+fi
+
+dmg_path="$output_dir/Holon-${version}.dmg"
+rm -f "$dmg_path"
+hdiutil create -quiet -volname Holon -srcfolder "$app_dir" -ov -format UDZO "$dmg_path"
+
+if $notary_configured; then
+  if [[ -n "${MACOS_NOTARY_PROFILE:-}" ]]; then
+    xcrun notarytool submit "$dmg_path" \
+      --keychain-profile "$MACOS_NOTARY_PROFILE" \
+      --wait
+  else
+    xcrun notarytool submit "$dmg_path" \
+      --apple-id "$MACOS_NOTARY_APPLE_ID" \
+      --password "$MACOS_NOTARY_PASSWORD" \
+      --team-id "$MACOS_NOTARY_TEAM_ID" \
+      --wait
+  fi
+  xcrun stapler staple "$dmg_path"
+fi
+
+shasum -a 256 "$dmg_path" > "$dmg_path.sha256"
+echo "$dmg_path"

--- a/scripts/verify-macos-menu-app.sh
+++ b/scripts/verify-macos-menu-app.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <Holon.app> <version>" >&2
+  exit 2
+fi
+
+app_dir="$1"
+expected_version="$2"
+info_plist="$app_dir/Contents/Info.plist"
+menu_binary="$app_dir/Contents/MacOS/HolonMenu"
+holon_binary="$app_dir/Contents/Resources/bin/holon"
+
+[[ -f "$info_plist" && -x "$menu_binary" && -x "$holon_binary" ]] || {
+  echo "incomplete Holon.app bundle: $app_dir" >&2
+  exit 1
+}
+
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$info_plist")" == "run.holon.menu" ]]
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info_plist")" == "$expected_version" ]]
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$info_plist")" == "13.0" ]]
+
+version_output="$("$holon_binary" --version)"
+if [[ "$version_output" == "holon ${expected_version} ("*"-dirty)" ]]; then
+  commit_sha="${version_output#*"("}"
+  commit_sha="${commit_sha%-dirty")"}"
+  [[ "$commit_sha" =~ ^[0-9a-f]{7,40}$ ]] || {
+    echo "unexpected dirty version output: $version_output" >&2
+    exit 1
+  }
+  echo "warning: verified a development bundle built from a dirty worktree" >&2
+else
+  "$(dirname "$0")/verify-release-version.sh" "$expected_version" "$version_output"
+fi
+
+if [[ -d "$app_dir/Contents/_CodeSignature" ]]; then
+  codesign --verify --deep --strict --verbose=2 "$app_dir"
+fi
+
+echo "verified $app_dir"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -307,6 +307,8 @@ pub enum DaemonCommands {
         options: ServeOptions,
     },
     Stop,
+    #[command(hide = true)]
+    PrepareUpdate,
     Status,
     Restart {
         #[command(flatten)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6,22 +6,24 @@ mod state;
 mod tests;
 
 pub use lifecycle::{
-    daemon_restart, daemon_start, daemon_status, daemon_stop, ensure_serve_preflight,
-    graceful_runtime_shutdown, prepare_runtime_before_server, DAEMON_SERVE_ARGS_ENV,
-    PRE_SERVER_PREPARED_ENV,
+    daemon_prepare_update, daemon_restart, daemon_start, daemon_status, daemon_stop,
+    ensure_serve_preflight, graceful_runtime_shutdown, prepare_runtime_before_server,
+    DAEMON_SERVE_ARGS_ENV, PRE_SERVER_PREPARED_ENV,
 };
 pub(crate) use service::runtime_activity_message;
 pub use service::{
     runtime_activity_summary, RuntimeActivityState, RuntimeActivitySummary, RuntimeConfigSurface,
     RuntimeControlAuthMode, RuntimeServiceHandle, RuntimeServiceMetadata, RuntimeShutdownResponse,
     RuntimeStartupSurface, RuntimeStatusResponse, RuntimeWebSearchSummary,
+    DAEMON_CONTROL_PROTOCOL_VERSION,
 };
 pub use state::{
     cleanup_daemon_state, config_fingerprint, daemon_logs, daemon_paths, load_daemon_metadata,
-    load_last_runtime_failure, DaemonLifecycleAction, DaemonLifecycleResult, DaemonLifecycleState,
-    DaemonLogsView, DaemonPaths, DaemonStatusView,
+    load_last_runtime_failure, DaemonLifecycleAction, DaemonLifecycleOwner, DaemonLifecycleResult,
+    DaemonLifecycleState, DaemonLogsView, DaemonPaths, DaemonStatusView,
 };
 pub(crate) use state::{
-    clear_persisted_daemon_lifecycle_failures, daemon_log_hint, persist_daemon_lifecycle_failure,
-    read_daemon_log_excerpt, stale_files,
+    clear_persisted_daemon_lifecycle_failures, daemon_log_hint, load_daemon_desired_running,
+    persist_daemon_desired_running, persist_daemon_lifecycle_failure, read_daemon_log_excerpt,
+    stale_files,
 };

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -17,16 +17,18 @@ use crate::{
     client::LocalClient,
     config::AppConfig,
     host::RuntimeHost,
+    runtime_db::RuntimeDbLock,
     types::{RuntimeFailurePhase, RuntimeFailureSummary},
 };
 
 use super::state::latest_known_runtime_failure;
 use super::{
     cleanup_daemon_state, clear_persisted_daemon_lifecycle_failures, config_fingerprint,
-    daemon_log_hint, daemon_paths, load_daemon_metadata, persist_daemon_lifecycle_failure,
-    read_daemon_log_excerpt, runtime_activity_message, stale_files, DaemonLifecycleAction,
+    daemon_log_hint, daemon_paths, load_daemon_desired_running, load_daemon_metadata,
+    persist_daemon_desired_running, persist_daemon_lifecycle_failure, read_daemon_log_excerpt,
+    runtime_activity_message, stale_files, DaemonLifecycleAction, DaemonLifecycleOwner,
     DaemonLifecycleResult, DaemonLifecycleState, DaemonStatusView, RuntimeServiceHandle,
-    RuntimeServiceMetadata, RuntimeStatusResponse,
+    RuntimeServiceMetadata, RuntimeStatusResponse, DAEMON_CONTROL_PROTOCOL_VERSION,
 };
 
 const START_TIMEOUT: Duration = Duration::from_secs(10);
@@ -36,6 +38,40 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 pub const PRE_SERVER_PREPARED_ENV: &str = "HOLON_PRE_SERVER_RUNTIME_PREPARED";
 pub const DAEMON_SERVE_ARGS_ENV: &str = "HOLON_DAEMON_SERVE_ARGS";
 const UNIX_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+
+pub(crate) fn web_url(http_addr: &str) -> String {
+    if http_addr.starts_with("http://") || http_addr.starts_with("https://") {
+        return http_addr.into();
+    }
+    if let Some(port) = http_addr.strip_prefix("0.0.0.0:") {
+        return format!("http://127.0.0.1:{port}");
+    }
+    if let Some(port) = http_addr.strip_prefix("[::]:") {
+        return format!("http://[::1]:{port}");
+    } else {
+        format!("http://{http_addr}")
+    }
+}
+
+fn optional_nonempty(value: String) -> Option<String> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn optional_nonzero(value: u32) -> Option<u32> {
+    (value != 0).then_some(value)
+}
+
+fn optional_path(value: std::path::PathBuf) -> Option<std::path::PathBuf> {
+    (!value.as_os_str().is_empty()).then_some(value)
+}
+
+pub(crate) async fn lifecycle_lock(config: &AppConfig) -> Result<RuntimeDbLock> {
+    let path = daemon_paths(config).lifecycle_lock_path;
+    tokio::task::spawn_blocking(move || RuntimeDbLock::lock(path))
+        .await
+        .context("daemon lifecycle lock task failed")?
+        .context("failed to acquire daemon lifecycle lock")
+}
 
 #[cfg(test)]
 static PREPARE_RUNTIME_BEFORE_SERVER_HOOK: std::sync::Mutex<
@@ -49,11 +85,21 @@ pub async fn daemon_status(config: &AppConfig) -> Result<DaemonStatusView> {
     match probe_runtime(config).await {
         ProbeRuntime::Running(status) => Ok(DaemonStatusView {
             ok: true,
-            state: DaemonLifecycleState::Running,
-            healthy: true,
+            state: if status.healthy {
+                DaemonLifecycleState::Running
+            } else {
+                DaemonLifecycleState::Degraded
+            },
+            healthy: status.healthy,
             home_dir: status.home_dir.clone(),
             socket_path: status.socket_path.clone(),
             http_addr: status.http_addr.clone(),
+            web_url: web_url(&status.http_addr),
+            product_version: optional_nonempty(status.product_version.clone()),
+            control_protocol_version: optional_nonzero(status.control_protocol_version),
+            lifecycle_owner: Some(status.lifecycle_owner),
+            executable_path: optional_path(status.executable_path.clone()),
+            desired_running: load_daemon_desired_running(config)?.unwrap_or(true),
             pid: Some(status.pid),
             control_connectivity: true,
             runtime_config_fingerprint: Some(status.config_fingerprint.clone()),
@@ -61,12 +107,16 @@ pub async fn daemon_status(config: &AppConfig) -> Result<DaemonStatusView> {
             activity: status.activity.clone(),
             last_failure: merge_latest_failure(status.last_failure.clone(), persisted_failure),
             stale_files: Vec::new(),
-            message: status
-                .activity
-                .as_ref()
-                .map(runtime_activity_message)
-                .unwrap_or("runtime is healthy")
-                .into(),
+            message: if status.healthy {
+                status
+                    .activity
+                    .as_ref()
+                    .map(runtime_activity_message)
+                    .unwrap_or("runtime is healthy")
+                    .into()
+            } else {
+                "runtime process is alive, but the control surface is unavailable".into()
+            },
         }),
         ProbeRuntime::Stopped { occupied_socket } => {
             let stale_files = stale_files(config);
@@ -90,6 +140,18 @@ pub async fn daemon_status(config: &AppConfig) -> Result<DaemonStatusView> {
                 home_dir: config.home_dir.clone(),
                 socket_path: config.socket_path.clone(),
                 http_addr: config.http_addr.clone(),
+                web_url: web_url(&config.http_addr),
+                product_version: metadata
+                    .as_ref()
+                    .and_then(|record| optional_nonempty(record.product_version.clone())),
+                control_protocol_version: metadata
+                    .as_ref()
+                    .and_then(|record| optional_nonzero(record.control_protocol_version)),
+                lifecycle_owner: metadata.as_ref().map(|record| record.lifecycle_owner),
+                executable_path: metadata
+                    .as_ref()
+                    .and_then(|record| optional_path(record.executable_path.clone())),
+                desired_running: load_daemon_desired_running(config)?.unwrap_or(false),
                 pid,
                 control_connectivity: false,
                 runtime_config_fingerprint: metadata.map(|record| record.config_fingerprint),
@@ -102,11 +164,23 @@ pub async fn daemon_status(config: &AppConfig) -> Result<DaemonStatusView> {
         }
         ProbeRuntime::Incompatible { details } => Ok(DaemonStatusView {
             ok: true,
-            state: DaemonLifecycleState::Stale,
+            state: DaemonLifecycleState::VersionMismatch,
             healthy: false,
             home_dir: config.home_dir.clone(),
             socket_path: config.socket_path.clone(),
             http_addr: config.http_addr.clone(),
+            web_url: web_url(&config.http_addr),
+            product_version: metadata
+                .as_ref()
+                .and_then(|record| optional_nonempty(record.product_version.clone())),
+            control_protocol_version: metadata
+                .as_ref()
+                .and_then(|record| optional_nonzero(record.control_protocol_version)),
+            lifecycle_owner: metadata.as_ref().map(|record| record.lifecycle_owner),
+            executable_path: metadata
+                .as_ref()
+                .and_then(|record| optional_path(record.executable_path.clone())),
+            desired_running: load_daemon_desired_running(config)?.unwrap_or(false),
             pid: metadata.as_ref().map(|record| record.pid),
             control_connectivity: false,
             runtime_config_fingerprint: metadata.map(|record| record.config_fingerprint),
@@ -122,6 +196,18 @@ pub async fn daemon_status(config: &AppConfig) -> Result<DaemonStatusView> {
 }
 
 pub async fn daemon_start(
+    config: &AppConfig,
+    serve_args: &[OsString],
+    control_token_env: Option<&str>,
+) -> Result<DaemonLifecycleResult> {
+    let _lock = lifecycle_lock(config).await?;
+    persist_daemon_desired_running(config, true)?;
+    let mut result = daemon_start_unlocked(config, serve_args, control_token_env).await?;
+    result.status.desired_running = true;
+    Ok(result)
+}
+
+async fn daemon_start_unlocked(
     config: &AppConfig,
     serve_args: &[OsString],
     control_token_env: Option<&str>,
@@ -355,6 +441,23 @@ pub(crate) fn set_prepare_runtime_before_server_hook(
 }
 
 pub async fn daemon_stop(config: &AppConfig) -> Result<DaemonLifecycleResult> {
+    let _lock = lifecycle_lock(config).await?;
+    persist_daemon_desired_running(config, false)?;
+    let mut result = daemon_stop_unlocked(config).await?;
+    result.status.desired_running = false;
+    Ok(result)
+}
+
+pub async fn daemon_prepare_update(config: &AppConfig) -> Result<DaemonLifecycleResult> {
+    let _lock = lifecycle_lock(config).await?;
+    let desired_running = load_daemon_desired_running(config)?.unwrap_or(false);
+    let mut result = daemon_stop_unlocked(config).await?;
+    result.action = DaemonLifecycleAction::PrepareUpdate;
+    result.status.desired_running = desired_running;
+    Ok(result)
+}
+
+async fn daemon_stop_unlocked(config: &AppConfig) -> Result<DaemonLifecycleResult> {
     let before = daemon_status(config).await?;
     let stop_probe = probe_runtime(config).await;
     match &stop_probe {
@@ -491,6 +594,12 @@ fn stopped_status(config: &AppConfig) -> Result<DaemonStatusView> {
         home_dir: config.home_dir.clone(),
         socket_path: config.socket_path.clone(),
         http_addr: config.http_addr.clone(),
+        web_url: web_url(&config.http_addr),
+        product_version: None,
+        control_protocol_version: None,
+        lifecycle_owner: Some(DaemonLifecycleOwner::Standalone),
+        executable_path: None,
+        desired_running: load_daemon_desired_running(config)?.unwrap_or(false),
         pid: None,
         control_connectivity: false,
         runtime_config_fingerprint: None,
@@ -507,8 +616,11 @@ pub async fn daemon_restart(
     serve_args: &[OsString],
     control_token_env: Option<&str>,
 ) -> Result<DaemonLifecycleResult> {
-    let _ = daemon_stop(config).await?;
-    let started = daemon_start(config, serve_args, control_token_env).await?;
+    let _lock = lifecycle_lock(config).await?;
+    persist_daemon_desired_running(config, true)?;
+    let _ = daemon_stop_unlocked(config).await?;
+    let mut started = daemon_start_unlocked(config, serve_args, control_token_env).await?;
+    started.status.desired_running = true;
     Ok(DaemonLifecycleResult {
         ok: true,
         action: DaemonLifecycleAction::Restart,
@@ -919,13 +1031,13 @@ pub(crate) async fn probe_runtime(config: &AppConfig) -> ProbeRuntime {
             }
         };
         match tokio::time::timeout(UNIX_PROBE_TIMEOUT, client.runtime_readiness_unix_only()).await {
-            Ok(Ok(status)) => return ProbeRuntime::Running(Box::new(status)),
+            Ok(Ok(status)) => return compatible_runtime(status),
             Ok(Err(err)) => {
                 return match unix_probe_stopped_socket_occupancy(err.root_cause()) {
                     Some(occupied_socket) => {
                         if !occupied_socket {
                             if let Some(status) = metadata_status_if_pid_alive(config).await {
-                                return ProbeRuntime::Running(Box::new(status));
+                                return compatible_runtime(status);
                             }
                         }
                         ProbeRuntime::Stopped { occupied_socket }
@@ -947,7 +1059,7 @@ pub(crate) async fn probe_runtime(config: &AppConfig) -> ProbeRuntime {
     // live process, the daemon is still running (the socket may have been
     // removed externally — see https://github.com/holon-run/holon/issues/1448).
     if let Some(status) = metadata_status_if_pid_alive(config).await {
-        return ProbeRuntime::Running(Box::new(status));
+        return compatible_runtime(status);
     }
 
     let client = match LocalClient::new(config.clone()) {
@@ -959,7 +1071,7 @@ pub(crate) async fn probe_runtime(config: &AppConfig) -> ProbeRuntime {
         }
     };
     match client.runtime_readiness().await {
-        Ok(status) => ProbeRuntime::Running(Box::new(status)),
+        Ok(status) => compatible_runtime(status),
         Err(_) => ProbeRuntime::Stopped {
             occupied_socket: false,
         },
@@ -990,6 +1102,18 @@ async fn metadata_status_if_pid_alive(config: &AppConfig) -> Option<RuntimeStatu
     Some(status_from_metadata(metadata))
 }
 
+fn compatible_runtime(status: RuntimeStatusResponse) -> ProbeRuntime {
+    if status.control_protocol_version != DAEMON_CONTROL_PROTOCOL_VERSION {
+        return ProbeRuntime::Incompatible {
+            details: format!(
+                "control protocol version {} is incompatible with client version {}",
+                status.control_protocol_version, DAEMON_CONTROL_PROTOCOL_VERSION
+            ),
+        };
+    }
+    ProbeRuntime::Running(Box::new(status))
+}
+
 pub(crate) fn runtime_status_matches_metadata(
     status: &RuntimeStatusResponse,
     metadata: &RuntimeServiceMetadata,
@@ -1010,6 +1134,10 @@ fn status_from_metadata(metadata: RuntimeServiceMetadata) -> RuntimeStatusRespon
         pid: metadata.pid,
         started_at: metadata.started_at,
         config_fingerprint: metadata.config_fingerprint,
+        product_version: metadata.product_version,
+        control_protocol_version: metadata.control_protocol_version,
+        lifecycle_owner: metadata.lifecycle_owner,
+        executable_path: metadata.executable_path,
         activity: None,
         startup_surface: None,
         runtime_surface: None,

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -13,7 +13,9 @@ use crate::{
     web::{WebProviderCapabilityMetadata, WebProviderKind},
 };
 
-use super::daemon_paths;
+use super::{daemon_paths, DaemonLifecycleOwner};
+
+pub const DAEMON_CONTROL_PROTOCOL_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeServiceMetadata {
@@ -23,6 +25,14 @@ pub struct RuntimeServiceMetadata {
     pub http_addr: String,
     pub started_at: DateTime<Utc>,
     pub config_fingerprint: String,
+    #[serde(default)]
+    pub product_version: String,
+    #[serde(default)]
+    pub control_protocol_version: u32,
+    #[serde(default)]
+    pub lifecycle_owner: DaemonLifecycleOwner,
+    #[serde(default)]
+    pub executable_path: PathBuf,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub serve_args: Vec<String>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
@@ -39,6 +49,14 @@ pub struct RuntimeStatusResponse {
     pub http_addr: String,
     pub started_at: DateTime<Utc>,
     pub config_fingerprint: String,
+    #[serde(default)]
+    pub product_version: String,
+    #[serde(default)]
+    pub control_protocol_version: u32,
+    #[serde(default)]
+    pub lifecycle_owner: DaemonLifecycleOwner,
+    #[serde(default)]
+    pub executable_path: PathBuf,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub activity: Option<RuntimeActivitySummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -278,6 +296,11 @@ impl RuntimeServiceHandle {
                     http_addr: config.http_addr.clone(),
                     started_at: Utc::now(),
                     config_fingerprint: super::config_fingerprint(config)?,
+                    product_version: env!("HOLON_VERSION").into(),
+                    control_protocol_version: DAEMON_CONTROL_PROTOCOL_VERSION,
+                    lifecycle_owner: DaemonLifecycleOwner::Standalone,
+                    executable_path: env::current_exe()
+                        .map_err(|err| anyhow!("failed to resolve current executable: {err}"))?,
                     serve_args: env::var(super::DAEMON_SERVE_ARGS_ENV)
                         .ok()
                         .and_then(|value| serde_json::from_str(&value).ok())
@@ -305,6 +328,10 @@ impl RuntimeServiceHandle {
             http_addr: self.inner.metadata.http_addr.clone(),
             started_at: self.inner.metadata.started_at,
             config_fingerprint: self.inner.metadata.config_fingerprint.clone(),
+            product_version: self.inner.metadata.product_version.clone(),
+            control_protocol_version: self.inner.metadata.control_protocol_version,
+            lifecycle_owner: self.inner.metadata.lifecycle_owner,
+            executable_path: self.inner.metadata.executable_path.clone(),
             startup_surface: Some(startup_surface),
             runtime_surface: Some(runtime_surface),
             activity: Some(activity),
@@ -326,6 +353,10 @@ impl RuntimeServiceHandle {
             http_addr: self.inner.metadata.http_addr.clone(),
             started_at: self.inner.metadata.started_at,
             config_fingerprint: self.inner.metadata.config_fingerprint.clone(),
+            product_version: self.inner.metadata.product_version.clone(),
+            control_protocol_version: self.inner.metadata.control_protocol_version,
+            lifecycle_owner: self.inner.metadata.lifecycle_owner,
+            executable_path: self.inner.metadata.executable_path.clone(),
             startup_surface: Some(startup_surface),
             runtime_surface: Some(runtime_surface),
             activity: None,

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -27,6 +27,7 @@ pub enum DaemonLifecycleAction {
     Start,
     Stop,
     Restart,
+    PrepareUpdate,
     Status,
 }
 
@@ -34,8 +35,17 @@ pub enum DaemonLifecycleAction {
 #[serde(rename_all = "snake_case")]
 pub enum DaemonLifecycleState {
     Running,
+    Degraded,
     Stopped,
     Stale,
+    VersionMismatch,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DaemonLifecycleOwner {
+    #[default]
+    Standalone,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -46,6 +56,16 @@ pub struct DaemonStatusView {
     pub home_dir: PathBuf,
     pub socket_path: PathBuf,
     pub http_addr: String,
+    pub web_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub product_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub control_protocol_version: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lifecycle_owner: Option<DaemonLifecycleOwner>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executable_path: Option<PathBuf>,
+    pub desired_running: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
     pub control_connectivity: bool,
@@ -80,6 +100,8 @@ pub struct DaemonPaths {
     pub last_failure_path: PathBuf,
     pub startup_failure_path: PathBuf,
     pub shutdown_failure_path: PathBuf,
+    pub lifecycle_lock_path: PathBuf,
+    pub desired_state_path: PathBuf,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -114,7 +136,45 @@ pub fn daemon_paths(config: &AppConfig) -> DaemonPaths {
         last_failure_path: run_dir.join("last_failure.json"),
         startup_failure_path: run_dir.join("startup_failure.json"),
         shutdown_failure_path: run_dir.join("shutdown_failure.json"),
+        lifecycle_lock_path: run_dir.join("lifecycle.lock"),
+        desired_state_path: run_dir.join("desired_state.json"),
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct DaemonDesiredState {
+    desired_running: bool,
+}
+
+pub fn load_daemon_desired_running(config: &AppConfig) -> Result<Option<bool>> {
+    let path = daemon_paths(config).desired_state_path;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let state: DaemonDesiredState = serde_json::from_slice(&bytes)
+        .with_context(|| format!("failed to decode {}", path.display()))?;
+    Ok(Some(state.desired_running))
+}
+
+pub fn persist_daemon_desired_running(config: &AppConfig, desired_running: bool) -> Result<()> {
+    let paths = daemon_paths(config);
+    fs::create_dir_all(&paths.run_dir)
+        .with_context(|| format!("failed to create {}", paths.run_dir.display()))?;
+    let temporary_path = paths
+        .run_dir
+        .join(format!("desired_state.{}.tmp", std::process::id()));
+    let encoded = serde_json::to_vec_pretty(&DaemonDesiredState { desired_running })?;
+    fs::write(&temporary_path, encoded)
+        .with_context(|| format!("failed to write {}", temporary_path.display()))?;
+    fs::rename(&temporary_path, &paths.desired_state_path).with_context(|| {
+        format!(
+            "failed to replace {} with {}",
+            paths.desired_state_path.display(),
+            temporary_path.display()
+        )
+    })?;
+    Ok(())
 }
 
 pub(crate) fn daemon_log_hint() -> String {

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -1,23 +1,26 @@
 use super::lifecycle::{
-    effective_config_mismatch_summary, probe_runtime, runtime_status_matches_metadata,
-    set_prepare_runtime_before_server_hook, should_retry_startup_stability_probe,
-    wait_for_startup_stability_with_probe, ProbeRuntime,
+    effective_config_mismatch_summary, lifecycle_lock, probe_runtime,
+    runtime_status_matches_metadata, set_prepare_runtime_before_server_hook,
+    should_retry_startup_stability_probe, wait_for_startup_stability_with_probe, web_url,
+    ProbeRuntime,
 };
 use super::state::{
     persist_last_runtime_failure, DAEMON_LOG_TAIL_LINE_CHAR_LIMIT, DAEMON_LOG_TAIL_READ_BYTE_LIMIT,
 };
 use super::{
     clear_persisted_daemon_lifecycle_failures, config_fingerprint, daemon_log_hint, daemon_logs,
-    daemon_paths, daemon_start, daemon_status, daemon_stop, ensure_serve_preflight,
-    load_last_runtime_failure, persist_daemon_lifecycle_failure, prepare_runtime_before_server,
-    runtime_activity_summary, DaemonLifecycleState, RuntimeActivityState, RuntimeConfigSurface,
-    RuntimeControlAuthMode, RuntimeServiceMetadata, RuntimeStartupSurface, RuntimeStatusResponse,
+    daemon_paths, daemon_prepare_update, daemon_start, daemon_status, daemon_stop,
+    ensure_serve_preflight, load_daemon_desired_running, load_last_runtime_failure,
+    persist_daemon_desired_running, persist_daemon_lifecycle_failure,
+    prepare_runtime_before_server, runtime_activity_summary, DaemonLifecycleAction,
+    DaemonLifecycleState, RuntimeActivityState, RuntimeConfigSurface, RuntimeControlAuthMode,
+    RuntimeServiceMetadata, RuntimeStartupSurface, RuntimeStatusResponse,
 };
 use crate::config::{provider_registry_for_tests, AppConfig, ProviderId};
 use crate::{
     host::RuntimeHost,
     provider::StubProvider,
-    runtime_db::RuntimeDb,
+    runtime_db::{RuntimeDb, RuntimeDbLock},
     storage::AppStorage,
     types::{
         AgentIdentityRecord, AgentKind, AgentOwnership, AgentProfilePreset, AgentState,
@@ -138,6 +141,22 @@ fn daemon_paths_use_run_dir_convention() {
         paths.shutdown_failure_path,
         config.run_dir().join("shutdown_failure.json")
     );
+    assert_eq!(
+        paths.lifecycle_lock_path,
+        config.run_dir().join("lifecycle.lock")
+    );
+    assert_eq!(
+        paths.desired_state_path,
+        config.run_dir().join("desired_state.json")
+    );
+}
+
+#[test]
+fn daemon_web_url_uses_a_connectable_loopback_address() {
+    assert_eq!(web_url("0.0.0.0:7878"), "http://127.0.0.1:7878");
+    assert_eq!(web_url("[::]:7878"), "http://[::1]:7878");
+    assert_eq!(web_url("127.0.0.1:7878"), "http://127.0.0.1:7878");
+    assert_eq!(web_url("https://holon.example"), "https://holon.example");
 }
 
 #[test]
@@ -150,6 +169,10 @@ fn runtime_service_metadata_round_trips() {
         http_addr: config.http_addr.clone(),
         started_at: Utc::now(),
         config_fingerprint: config_fingerprint(&config).unwrap(),
+        product_version: env!("HOLON_VERSION").into(),
+        control_protocol_version: crate::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+        lifecycle_owner: crate::daemon::DaemonLifecycleOwner::Standalone,
+        executable_path: std::env::current_exe().unwrap(),
         serve_args: Vec::new(),
         control_token_env_configured: false,
     };
@@ -157,6 +180,88 @@ fn runtime_service_metadata_round_trips() {
     let decoded: RuntimeServiceMetadata = serde_json::from_slice(&encoded).unwrap();
     assert_eq!(decoded.pid, 42);
     assert_eq!(decoded.home_dir, config.home_dir);
+}
+
+#[test]
+fn runtime_service_metadata_defaults_new_lifecycle_fields_for_old_records() {
+    let decoded: RuntimeServiceMetadata = serde_json::from_value(serde_json::json!({
+        "pid": 42,
+        "home_dir": "/tmp/holon",
+        "socket_path": "/tmp/holon/run/control.sock",
+        "http_addr": "127.0.0.1:7878",
+        "started_at": "2026-08-28T00:00:00Z",
+        "config_fingerprint": "old"
+    }))
+    .unwrap();
+
+    assert_eq!(decoded.product_version, "");
+    assert_eq!(decoded.control_protocol_version, 0);
+    assert_eq!(
+        decoded.lifecycle_owner,
+        crate::daemon::DaemonLifecycleOwner::Standalone
+    );
+    assert!(decoded.executable_path.as_os_str().is_empty());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn daemon_status_reports_old_live_metadata_as_version_mismatch() {
+    let config = test_config();
+    let paths = daemon_paths(&config);
+    fs::create_dir_all(config.run_dir()).unwrap();
+    fs::write(&paths.pid_path, format!("{}\n", std::process::id())).unwrap();
+    fs::write(
+        &paths.metadata_path,
+        serde_json::to_vec(&serde_json::json!({
+            "pid": std::process::id(),
+            "home_dir": config.home_dir,
+            "socket_path": config.socket_path,
+            "http_addr": config.http_addr,
+            "started_at": "2026-08-28T00:00:00Z",
+            "config_fingerprint": config_fingerprint(&config).unwrap()
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let status = daemon_status(&config).await.unwrap();
+    assert_eq!(status.state, DaemonLifecycleState::VersionMismatch);
+    assert_eq!(status.control_protocol_version, None);
+    assert!(status.message.contains("control protocol version 0"));
+}
+
+#[test]
+fn daemon_desired_state_round_trips_without_affecting_runtime_files() {
+    let config = test_config();
+    assert_eq!(load_daemon_desired_running(&config).unwrap(), None);
+
+    persist_daemon_desired_running(&config, true).unwrap();
+    assert_eq!(load_daemon_desired_running(&config).unwrap(), Some(true));
+
+    persist_daemon_desired_running(&config, false).unwrap();
+    assert_eq!(load_daemon_desired_running(&config).unwrap(), Some(false));
+    assert!(!daemon_paths(&config).metadata_path.exists());
+}
+
+#[tokio::test]
+async fn daemon_lifecycle_lock_rejects_a_second_holder() {
+    let config = test_config();
+    let _lock = lifecycle_lock(&config).await.unwrap();
+    let second = RuntimeDbLock::try_lock(daemon_paths(&config).lifecycle_lock_path);
+    assert!(second.is_err());
+}
+
+#[tokio::test]
+async fn daemon_prepare_update_stops_without_changing_desired_state() {
+    let config = test_config();
+    persist_daemon_desired_running(&config, true).unwrap();
+
+    let result = daemon_prepare_update(&config).await.unwrap();
+
+    assert_eq!(result.action, DaemonLifecycleAction::PrepareUpdate);
+    assert_eq!(result.status.state, DaemonLifecycleState::Stopped);
+    assert!(result.status.desired_running);
+    assert_eq!(load_daemon_desired_running(&config).unwrap(), Some(true));
 }
 
 #[test]
@@ -369,6 +474,10 @@ fn effective_config_mismatch_summary_lists_actionable_differences() {
         http_addr: "127.0.0.1:7878".into(),
         started_at: Utc::now(),
         config_fingerprint: "actual".into(),
+        product_version: env!("HOLON_VERSION").into(),
+        control_protocol_version: crate::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+        lifecycle_owner: crate::daemon::DaemonLifecycleOwner::Standalone,
+        executable_path: std::env::current_exe().unwrap(),
         activity: None,
         startup_surface: Some(RuntimeStartupSurface {
             home_dir: expected.home_dir.clone(),
@@ -557,6 +666,10 @@ async fn probe_runtime_reports_running_when_socket_missing_but_pid_alive() {
         http_addr: metadata_http.clone(),
         started_at: Utc::now(),
         config_fingerprint: config_fingerprint(&config).unwrap(),
+        product_version: env!("HOLON_VERSION").into(),
+        control_protocol_version: crate::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+        lifecycle_owner: crate::daemon::DaemonLifecycleOwner::Standalone,
+        executable_path: std::env::current_exe().unwrap(),
         serve_args: Vec::new(),
         control_token_env_configured: false,
     };
@@ -591,6 +704,10 @@ async fn probe_runtime_reports_running_when_socket_refuses_but_pid_alive() {
         http_addr: config.http_addr.clone(),
         started_at: Utc::now(),
         config_fingerprint: config_fingerprint(&config).unwrap(),
+        product_version: env!("HOLON_VERSION").into(),
+        control_protocol_version: crate::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+        lifecycle_owner: crate::daemon::DaemonLifecycleOwner::Standalone,
+        executable_path: std::env::current_exe().unwrap(),
         serve_args: Vec::new(),
         control_token_env_configured: false,
     };
@@ -617,6 +734,10 @@ fn runtime_status_metadata_match_rejects_foreign_runtime() {
         http_addr: config.http_addr.clone(),
         started_at: Utc::now(),
         config_fingerprint: config_fingerprint(&config).unwrap(),
+        product_version: env!("HOLON_VERSION").into(),
+        control_protocol_version: crate::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+        lifecycle_owner: crate::daemon::DaemonLifecycleOwner::Standalone,
+        executable_path: std::env::current_exe().unwrap(),
         serve_args: Vec::new(),
         control_token_env_configured: false,
     };
@@ -629,6 +750,10 @@ fn runtime_status_metadata_match_rejects_foreign_runtime() {
         http_addr: metadata.http_addr.clone(),
         started_at: metadata.started_at,
         config_fingerprint: metadata.config_fingerprint.clone(),
+        product_version: env!("HOLON_VERSION").into(),
+        control_protocol_version: crate::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+        lifecycle_owner: crate::daemon::DaemonLifecycleOwner::Standalone,
+        executable_path: std::env::current_exe().unwrap(),
         activity: None,
         startup_surface: None,
         runtime_surface: None,
@@ -656,6 +781,10 @@ async fn daemon_status_surfaces_dead_pid_and_leftover_socket_as_stale() {
         http_addr: config.http_addr.clone(),
         started_at: Utc::now(),
         config_fingerprint: config_fingerprint(&config).unwrap(),
+        product_version: env!("HOLON_VERSION").into(),
+        control_protocol_version: crate::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+        lifecycle_owner: crate::daemon::DaemonLifecycleOwner::Standalone,
+        executable_path: std::env::current_exe().unwrap(),
         serve_args: Vec::new(),
         control_token_env_configured: false,
     };
@@ -689,6 +818,10 @@ async fn serve_preflight_cleans_dead_pid_and_leftover_socket_state() {
         http_addr: config.http_addr.clone(),
         started_at: Utc::now(),
         config_fingerprint: config_fingerprint(&config).unwrap(),
+        product_version: env!("HOLON_VERSION").into(),
+        control_protocol_version: crate::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+        lifecycle_owner: crate::daemon::DaemonLifecycleOwner::Standalone,
+        executable_path: std::env::current_exe().unwrap(),
         serve_args: Vec::new(),
         control_token_env_configured: false,
     };
@@ -824,6 +957,10 @@ async fn daemon_stop_treats_missing_pid_process_as_stale_state() {
         http_addr: config.http_addr.clone(),
         started_at: Utc::now(),
         config_fingerprint: config_fingerprint(&config).unwrap(),
+        product_version: env!("HOLON_VERSION").into(),
+        control_protocol_version: crate::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+        lifecycle_owner: crate::daemon::DaemonLifecycleOwner::Standalone,
+        executable_path: std::env::current_exe().unwrap(),
         serve_args: Vec::new(),
         control_token_env_configured: false,
     };
@@ -857,6 +994,10 @@ async fn daemon_stop_uses_recorded_runtime_http_addr_when_socket_is_missing() {
         http_addr: metadata_http.clone(),
         started_at: Utc::now(),
         config_fingerprint: config_fingerprint(&config).unwrap(),
+        product_version: env!("HOLON_VERSION").into(),
+        control_protocol_version: crate::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+        lifecycle_owner: crate::daemon::DaemonLifecycleOwner::Standalone,
+        executable_path: std::env::current_exe().unwrap(),
         serve_args: Vec::new(),
         control_token_env_configured: false,
     };
@@ -951,6 +1092,10 @@ async fn daemon_stop_errors_on_permission_denied_signals() {
         http_addr: config.http_addr.clone(),
         started_at: Utc::now(),
         config_fingerprint: config_fingerprint(&config).unwrap(),
+        product_version: env!("HOLON_VERSION").into(),
+        control_protocol_version: crate::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+        lifecycle_owner: crate::daemon::DaemonLifecycleOwner::Standalone,
+        executable_path: std::env::current_exe().unwrap(),
         serve_args: Vec::new(),
         control_token_env_configured: false,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ use holon::{
     },
     config::{AgentTemplateRemoteSourceConfigFile, AgentTemplatesConfigFile},
     daemon::{
-        daemon_logs, daemon_restart, daemon_start, daemon_status, daemon_stop,
-        ensure_serve_preflight, prepare_runtime_before_server, RuntimeServiceHandle,
+        daemon_logs, daemon_prepare_update, daemon_restart, daemon_start, daemon_status,
+        daemon_stop, ensure_serve_preflight, prepare_runtime_before_server, RuntimeServiceHandle,
         DAEMON_SERVE_ARGS_ENV, PRE_SERVER_PREPARED_ENV,
     },
     fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
@@ -1929,6 +1929,10 @@ mod tests {
             http_addr: config.http_addr.clone(),
             started_at: chrono::Utc::now(),
             config_fingerprint: "test-fingerprint".into(),
+            product_version: env!("HOLON_VERSION").into(),
+            control_protocol_version: holon::daemon::DAEMON_CONTROL_PROTOCOL_VERSION,
+            lifecycle_owner: holon::daemon::DaemonLifecycleOwner::Standalone,
+            executable_path: std::env::current_exe().unwrap(),
             serve_args: args.into_iter().map(String::from).collect(),
             control_token_env_configured,
         }
@@ -3722,6 +3726,9 @@ async fn handle_daemon_command(config: AppConfig, command: DaemonCommands) -> Re
             )?
         }
         DaemonCommands::Stop => serde_json::to_value(daemon_stop(&config).await?)?,
+        DaemonCommands::PrepareUpdate => {
+            serde_json::to_value(daemon_prepare_update(&config).await?)?
+        }
         DaemonCommands::Status => serde_json::to_value(daemon_status(&config).await?)?,
         DaemonCommands::Restart { options } => {
             let mut config = config;

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -541,6 +541,12 @@
     "aliases": []
   },
   {
+    "path": "daemon.prepare-update",
+    "positionals": [],
+    "flags": [],
+    "aliases": []
+  },
+  {
     "path": "daemon.restart",
     "positionals": [],
     "flags": [


### PR DESCRIPTION
## Summary

- add a native macOS 13+ SwiftUI `MenuBarExtra` app that controls the existing Holon daemon through the bundled Rust CLI
- extend the shared daemon lifecycle contract with product/protocol/owner/executable metadata, canonical Web URL, desired state, version mismatch/degraded states, cross-process mutation locking, and update preparation
- add login-item integration, desired-state restore, logs/Web actions, user-level CLI installation, and Sparkle update checks
- add DMG packaging, bundle verification, Developer ID signing, App + DMG notarization/stapling, signed Sparkle appcast generation, and release workflow integration
- document the standalone-daemon architecture and macOS release requirements; LaunchAgent supervision remains explicitly out of scope

## Runtime concept

The daemon remains the single runtime and lifecycle fact source. Swift is only a native presentation/macOS integration adapter. CLI and GUI serialize mutations through the same Rust lifecycle lock and share the last explicit desired state.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test daemon::tests --lib` (38 passed)
- `cargo test --test cli_json_contract` (9 passed)
- `cargo test --test cli_snapshot`
- `swift test --package-path apps/macos/HolonMenu` (2 passed)
- `bash -n scripts/package-macos-menu-app.sh scripts/verify-macos-menu-app.sh scripts/generate-macos-appcast.sh`
- release workflow YAML parse
- unsigned local packaging produced and verified `Holon.app` and `Holon-0.33.0.dmg` (19 MB)

## Release configuration required

The new tag-release job intentionally fails until these production credentials are configured:

- `MACOS_DEVELOPER_ID_APPLICATION`
- `MACOS_CERTIFICATE_P12`
- `MACOS_CERTIFICATE_PASSWORD`
- `MACOS_NOTARY_APPLE_ID`
- `MACOS_NOTARY_PASSWORD`
- `MACOS_NOTARY_TEAM_ID`
- `HOLON_SPARKLE_PUBLIC_KEY`
- `HOLON_SPARKLE_PRIVATE_KEY`
- repository variable `HOLON_SPARKLE_FEED_URL`

Local development packaging remains unsigned and does not require these values.
