### PR TITLE
feat: introduce activation and Turn owner identity

### DIFF
--- a/benchmarks/projection-eval/README.md
+++ b/benchmarks/projection-eval/README.md
@@ -17,6 +17,10 @@ Fixture layout:
 - `corpus/rubric.json`: hard assertions, thresholds, and diagnostic-only metrics
 - `baseline/legacy-phase-0-scorecard.json`: frozen legacy projector observation matrix with per-manifest SHA-256 hashes and invariant results
 - `baseline/manifests/*.json`: 36 frozen legacy baseline manifests (12 cases x 3 budgets)
+- `candidate-phase-1/scorecard.json`: owner-identity-only candidate comparison
+  against the Phase 0 baseline
+- `candidate-phase-1/manifests/*.json`: 36 Phase 1 manifests with typed
+  WorkItem, Conversation, and AgentLifecycle owner metadata
 
 The Rust legacy projector exports the shared manifest through
 `EffectivePrompt::projection_manifest()`. The committed baseline freezes the
@@ -39,3 +43,21 @@ REGEN_BASELINE=1 cargo test --lib projection_eval::baseline::tests::regenerate_s
 
 Normal test runs verify byte-stability, restart equivalence, budget monotonicity,
 and schema/fixture drift against the committed manifests.
+
+## Phase 1 Candidate
+
+Phase 1 changes admission and durable owner metadata without changing rendered
+provider sections. The candidate scorecard compares section order,
+representation, token allocation, rendered character counts, and content hashes
+against the Phase 0 baseline.
+
+The committed scorecard intentionally retains owner-invariant failures where the
+legacy projector selects evidence from another owner at large budgets. Those
+failures are Phase 2 semantic-projection evidence, not a reason to hide or
+rewrite the Phase 1 observation.
+
+To regenerate the Phase 1 candidate manifests and scorecard:
+
+```sh
+REGEN_PHASE1_CANDIDATE=1 cargo test --lib projection_eval::baseline::tests::regenerate_phase_1_candidate -- --nocapture
+```

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-10-turns-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-10-turns-16384.json
@@ -1,0 +1,306 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-10",
+    "turn_id": "turn-10",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-10",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 89,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "f89288ed451890504fadd9c8d20b1e740016d6d38ffe7ede66d7a8ca1ddd9f7c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-decision",
+      "section_name": "brief:turn-2-decision",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "aff90b4dbbb6784547d79f4b2dc45dfb51c2cac5380a18cc40eb2a20861218dc",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-decision",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "4bb1a6a25c3fe86870bcb6cdceb32199c60a91e6cd049c3700a7ddc9cbb5be36",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-response",
+      "section_name": "brief:turn-4-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "4038f06eaeba962626fe33776a4c296613e0bf43ac8166e36f7992a7a3a7071f",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "d58a372ea4d8eb1235d027e38e8a2a1a03cb8d099ccc28567c73283df6ec5f16",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "c2d1e4cb2b1728e9d7e3c72bf6ebbf447be5417047a7fc0757773e4b49ae7aba",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "97bf927becf4cc34092138e41029cd6b9c8835cfff4a45f9aa5ff2ef9e93434a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "64ae50aac51cf421706ef44638ce436814a6469989f4ec89234bd6248114c58e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "7a59c4faf85da6ccc044f7c2b2a2e88e2edbeaa33c1f633ac7c046a8a38b7f2c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "message:turn-10",
+      "section_name": "message:turn-10",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "d0996c332658c913e9bb8ce68b88b99ace809b37c6308a2254adf82552bd47c4",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-10",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-10-turns-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-10-turns-2048.json
@@ -1,0 +1,306 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-10",
+    "turn_id": "turn-10",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-10",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 116,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "f0dca3ec47bf3d8551fbaf481a4356743afc8c886adda5b65bae45ee66718a01",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-decision",
+      "section_name": "brief:turn-2-decision",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "aa1f98d9702307878b626d515e796e1f697ddd52dcdf7db40b2ec61c00728c50",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-decision",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "703b87220b9b2e97a6996977c84d6431ad8c4017097a29d771070b1f97486995",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-response",
+      "section_name": "brief:turn-4-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "ec84744a8efaab827d9311659022aad838655115aaefbf01c768b59290064f0c",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "af0aebce23f990296847eda3ae633db3b0f9af2d8ab42f5b4384b148d45ebdfd",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "9cfdda8d8942c73ea695d76c27bd3de892a45941b4dfa00dd68f898505f05680",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "a06b41d88cb4d61204300bcd1082e80202606f475ea59a2fb1ccdc57c34e3beb",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "6ed1541e17ee0f9c13b30c61ae36ed446d3d3660fe0410456649ab34df77784a",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "d2e79ea7a653066eabc0a97beb9e88e1227afb2b8b094aaace6404a0790a69da",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "message:turn-10",
+      "section_name": "message:turn-10",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "d0996c332658c913e9bb8ce68b88b99ace809b37c6308a2254adf82552bd47c4",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-10",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-10-turns-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-10-turns-4096.json
@@ -1,0 +1,306 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-10",
+    "turn_id": "turn-10",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-10",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 113,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "d5116b380b99adf7fa1835c6bf858b07ac6904730a1929a464ae0d3425416828",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-decision",
+      "section_name": "brief:turn-2-decision",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "aff90b4dbbb6784547d79f4b2dc45dfb51c2cac5380a18cc40eb2a20861218dc",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-decision",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "f3c8b290babf195960e4dd20835ac25ffa3b84f0e86966de320e433f69aa440a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-response",
+      "section_name": "brief:turn-4-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "da2664deddb70752beadbac0b135b17ae56ed10c3dc76700c85351c4ea0d40a3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "70bb140f33cd9a22a1e635bb43cbcadae182e854e04f70bd2648743e59fe93fc",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "d543c3b9c61b121afef90cd3a40b31dcd0572eedf363eceb7d8a8e4be274920d",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "3598aff831c85137eccfa94ba28ba2aaa13a2c51e67d6afdb63a195244b32f98",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "aac044ff3d4ed64aec0a823b1b56caed9102ebc1d975e3be41ef700db00fa47f",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "3052ff2dfcdf46e3070ef45493fbd87eac8f1bde710bc682b12a10c90b2a972c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "message:turn-10",
+      "section_name": "message:turn-10",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "d0996c332658c913e9bb8ce68b88b99ace809b37c6308a2254adf82552bd47c4",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-10",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_4243b09ddc80dc20504e4b8996b54c19"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-20-turns-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-20-turns-16384.json
@@ -1,0 +1,538 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-20",
+    "turn_id": "turn-20",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-20",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 189,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "f89288ed451890504fadd9c8d20b1e740016d6d38ffe7ede66d7a8ca1ddd9f7c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-response",
+      "section_name": "brief:turn-2-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "c4ec0642e10622b9351e42a3a3287d427a1a57df0af9a2388e08956392dfeb05",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "4bb1a6a25c3fe86870bcb6cdceb32199c60a91e6cd049c3700a7ddc9cbb5be36",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-response",
+      "section_name": "brief:turn-4-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "4038f06eaeba962626fe33776a4c296613e0bf43ac8166e36f7992a7a3a7071f",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "d58a372ea4d8eb1235d027e38e8a2a1a03cb8d099ccc28567c73283df6ec5f16",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "c2d1e4cb2b1728e9d7e3c72bf6ebbf447be5417047a7fc0757773e4b49ae7aba",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "97bf927becf4cc34092138e41029cd6b9c8835cfff4a45f9aa5ff2ef9e93434a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "64ae50aac51cf421706ef44638ce436814a6469989f4ec89234bd6248114c58e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "7a59c4faf85da6ccc044f7c2b2a2e88e2edbeaa33c1f633ac7c046a8a38b7f2c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "brief:turn-10-response",
+      "section_name": "brief:turn-10-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "536c1028f444c9ad7e6554c06cc3c17f34346c3589786676e20b1f914a292ab3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-10-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 10,
+      "section_id": "message:turn-11",
+      "section_name": "message:turn-11",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "29e1bd8ae9e4fc18f07b8d8fd6b566cf87022e233d1b7496e20eb429e97e742c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-11",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 11,
+      "section_id": "brief:turn-12-response",
+      "section_name": "brief:turn-12-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "0abb67e23245a221add68b2435491905dfd11f0db263b8d2d540c8f2d81cf937",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-12-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 12,
+      "section_id": "message:turn-13",
+      "section_name": "message:turn-13",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "ccb6c86acc61dc1da0575d45ac938c81d578483aff6fdb5804e4aa3352017635",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-13",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 13,
+      "section_id": "brief:turn-14-response",
+      "section_name": "brief:turn-14-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "7d9dc846f72b4b414fb8a94776b77bd8e2f22812e2e0f9308fb6b69dd77b313e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-14-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 14,
+      "section_id": "message:turn-15",
+      "section_name": "message:turn-15",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "068be12ed8b4895574731c639b67c83a00f4111227e6b3ebc10f24d734cc276a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-15",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 15,
+      "section_id": "brief:turn-16-response",
+      "section_name": "brief:turn-16-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "0f8dcfb8ece716542330fd024545ae6ec65ab5013e8d68ceb11995ac45909140",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-16-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 16,
+      "section_id": "message:turn-17",
+      "section_name": "message:turn-17",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "31110ee4df305b3a652168aa61b3e915f41feea55fc7521f2b3b51059919038c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-17",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 17,
+      "section_id": "brief:turn-18-response",
+      "section_name": "brief:turn-18-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "6b779b5c43f65a6da79d0a463e9062d44c2e4a98ec58df37d7d770252bf712b3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-18-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 18,
+      "section_id": "message:turn-19",
+      "section_name": "message:turn-19",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "bfd7576301636d0998f28f07b3591a21e3de2748bab690e02e4a5cef56106e2e",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-19",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 19,
+      "section_id": "message:turn-20",
+      "section_name": "message:turn-20",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "2a03977de97e635cd978c963e877f0818e84b67815d1b6fd14f609e02334101d",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-20",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-20-turns-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-20-turns-2048.json
@@ -1,0 +1,538 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-20",
+    "turn_id": "turn-20",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-20",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 241,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "f0dca3ec47bf3d8551fbaf481a4356743afc8c886adda5b65bae45ee66718a01",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-response",
+      "section_name": "brief:turn-2-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "bcbd06561e41fb2fe5ac8abc8f98338d97f3b04721abd53890854b20f9ff63ff",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "703b87220b9b2e97a6996977c84d6431ad8c4017097a29d771070b1f97486995",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-response",
+      "section_name": "brief:turn-4-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "ec84744a8efaab827d9311659022aad838655115aaefbf01c768b59290064f0c",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "af0aebce23f990296847eda3ae633db3b0f9af2d8ab42f5b4384b148d45ebdfd",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "9cfdda8d8942c73ea695d76c27bd3de892a45941b4dfa00dd68f898505f05680",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "a06b41d88cb4d61204300bcd1082e80202606f475ea59a2fb1ccdc57c34e3beb",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "6ed1541e17ee0f9c13b30c61ae36ed446d3d3660fe0410456649ab34df77784a",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "d2e79ea7a653066eabc0a97beb9e88e1227afb2b8b094aaace6404a0790a69da",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "brief:turn-10-response",
+      "section_name": "brief:turn-10-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "251479ad0e3ef70fdec067b11efd594eb61a46361b6f3d612e76f025ba23cfbf",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-10-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 10,
+      "section_id": "message:turn-11",
+      "section_name": "message:turn-11",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "1cafd0d240676fb05a0d07477217251b10d661a5505cff31ed00c91b728428e5",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-11",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 11,
+      "section_id": "brief:turn-12-response",
+      "section_name": "brief:turn-12-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "2befcbda34adea6080c041427b129bbf84e7e8d72b2234dc1a6bc8b3effb2f36",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-12-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 12,
+      "section_id": "message:turn-13",
+      "section_name": "message:turn-13",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "c9f8fa3e2824409bbeaddcbd40914bae1dbe746de8196e82a25fa13e11dc3326",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-13",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 13,
+      "section_id": "brief:turn-14-response",
+      "section_name": "brief:turn-14-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "774cfc9fd4d82ba7fb119a48a77737c40b42d3ef18dd2ad09d0792edf911651b",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-14-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 14,
+      "section_id": "message:turn-15",
+      "section_name": "message:turn-15",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "9be82a62da24680e689cc46211b7bac68f045c9b67a7dc88447fe9187745ee0d",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-15",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 15,
+      "section_id": "brief:turn-16-response",
+      "section_name": "brief:turn-16-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "14e4d7ff51c5ec6d265887638bf2002298054798d6f5555d4d2f2b9f78ea2ed8",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-16-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 16,
+      "section_id": "message:turn-17",
+      "section_name": "message:turn-17",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "93e7d9afce919c4cfd98561de682e4126948cee065469a321a98a8241d977989",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-17",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 17,
+      "section_id": "brief:turn-18-response",
+      "section_name": "brief:turn-18-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "c2ee0160eecadf1a42c45d76483ae8c35299e997b194eda6f770fad0dab06079",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-18-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 18,
+      "section_id": "message:turn-19",
+      "section_name": "message:turn-19",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "25558371346cf66e6fb1a9c349896ad4d6ee77d8a7c7a11511a319fbb5da8a4f",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-19",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 19,
+      "section_id": "message:turn-20",
+      "section_name": "message:turn-20",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "2a03977de97e635cd978c963e877f0818e84b67815d1b6fd14f609e02334101d",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-20",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-20-turns-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-20-turns-4096.json
@@ -1,0 +1,538 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-20",
+    "turn_id": "turn-20",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-20",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 236,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "d5116b380b99adf7fa1835c6bf858b07ac6904730a1929a464ae0d3425416828",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-response",
+      "section_name": "brief:turn-2-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "dbf0d46a3a8054a09c8261745a081e95b8b53b51aac55e7e672014546d2713ae",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "f3c8b290babf195960e4dd20835ac25ffa3b84f0e86966de320e433f69aa440a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-response",
+      "section_name": "brief:turn-4-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "da2664deddb70752beadbac0b135b17ae56ed10c3dc76700c85351c4ea0d40a3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "70bb140f33cd9a22a1e635bb43cbcadae182e854e04f70bd2648743e59fe93fc",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "d543c3b9c61b121afef90cd3a40b31dcd0572eedf363eceb7d8a8e4be274920d",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "3598aff831c85137eccfa94ba28ba2aaa13a2c51e67d6afdb63a195244b32f98",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "aac044ff3d4ed64aec0a823b1b56caed9102ebc1d975e3be41ef700db00fa47f",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "3052ff2dfcdf46e3070ef45493fbd87eac8f1bde710bc682b12a10c90b2a972c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "brief:turn-10-response",
+      "section_name": "brief:turn-10-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "7ced6e57e7f6e8cc6524ef1e7c87bb52915cce5054e0afbde42378f93fa8ce32",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-10-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 10,
+      "section_id": "message:turn-11",
+      "section_name": "message:turn-11",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "78ffeda8ed9a261e292075964ca8f53f12da8262751e8e2b8e8c0b0dcc81b13a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-11",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 11,
+      "section_id": "brief:turn-12-response",
+      "section_name": "brief:turn-12-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "ef2e1c1c638b2bdae1a9e3fc5e055e2b654d4919d564f867f9a3ef30334bd169",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-12-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 12,
+      "section_id": "message:turn-13",
+      "section_name": "message:turn-13",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "dd9f01a195053d72a38fe886b4d07b15e21b06af5dc3e0cc70e9189774c13644",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-13",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 13,
+      "section_id": "brief:turn-14-response",
+      "section_name": "brief:turn-14-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "5faa9d85f49c43e7a5a76030be3bd07cd5b372e1841a4c178e80bdaf31206517",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-14-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 14,
+      "section_id": "message:turn-15",
+      "section_name": "message:turn-15",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "b158cce53b3c83bf742c72c9915f99bdabf360804e4d526700480b43bcb84c44",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-15",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 15,
+      "section_id": "brief:turn-16-response",
+      "section_name": "brief:turn-16-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "d383666b7b5574dc177568548f19ee7b1ff724445f457854bc754f4d5298b498",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-16-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 16,
+      "section_id": "message:turn-17",
+      "section_name": "message:turn-17",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "c2ca14fd54f67cbc1e90b6a99f42e78542015b0b122689b2b0cbbaef4908774f",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-17",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 17,
+      "section_id": "brief:turn-18-response",
+      "section_name": "brief:turn-18-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "1e9f41370d56131bb1b08e337480cfb45db8791d3f7460eda8888372022706ba",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-18-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 18,
+      "section_id": "message:turn-19",
+      "section_name": "message:turn-19",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "e0a6c6951e084881dba67e30a71e849da8acb090d533aa5f9a1e06e84a2b3d2b",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-19",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 19,
+      "section_id": "message:turn-20",
+      "section_name": "message:turn-20",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "2a03977de97e635cd978c963e877f0818e84b67815d1b6fd14f609e02334101d",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-20",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_cb39ea8d5ed8eec256cf940d8be98d05"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-40-turns-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-40-turns-16384.json
@@ -1,0 +1,996 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-40",
+    "turn_id": "turn-40",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-40",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 389,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "f89288ed451890504fadd9c8d20b1e740016d6d38ffe7ede66d7a8ca1ddd9f7c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-response",
+      "section_name": "brief:turn-2-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "c4ec0642e10622b9351e42a3a3287d427a1a57df0af9a2388e08956392dfeb05",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "4bb1a6a25c3fe86870bcb6cdceb32199c60a91e6cd049c3700a7ddc9cbb5be36",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-decision",
+      "section_name": "brief:turn-4-decision",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "096af186e2ae0183ae943fe37dd696a2a23c480e62c3deae9c3a5d699f91a54e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-decision",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "d58a372ea4d8eb1235d027e38e8a2a1a03cb8d099ccc28567c73283df6ec5f16",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "c2d1e4cb2b1728e9d7e3c72bf6ebbf447be5417047a7fc0757773e4b49ae7aba",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "97bf927becf4cc34092138e41029cd6b9c8835cfff4a45f9aa5ff2ef9e93434a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "64ae50aac51cf421706ef44638ce436814a6469989f4ec89234bd6248114c58e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "7a59c4faf85da6ccc044f7c2b2a2e88e2edbeaa33c1f633ac7c046a8a38b7f2c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "brief:turn-10-response",
+      "section_name": "brief:turn-10-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "536c1028f444c9ad7e6554c06cc3c17f34346c3589786676e20b1f914a292ab3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-10-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 10,
+      "section_id": "message:turn-11",
+      "section_name": "message:turn-11",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "29e1bd8ae9e4fc18f07b8d8fd6b566cf87022e233d1b7496e20eb429e97e742c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-11",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 11,
+      "section_id": "brief:turn-12-response",
+      "section_name": "brief:turn-12-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "0abb67e23245a221add68b2435491905dfd11f0db263b8d2d540c8f2d81cf937",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-12-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 12,
+      "section_id": "message:turn-13",
+      "section_name": "message:turn-13",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "ccb6c86acc61dc1da0575d45ac938c81d578483aff6fdb5804e4aa3352017635",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-13",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 13,
+      "section_id": "brief:turn-14-response",
+      "section_name": "brief:turn-14-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "7d9dc846f72b4b414fb8a94776b77bd8e2f22812e2e0f9308fb6b69dd77b313e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-14-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 14,
+      "section_id": "message:turn-15",
+      "section_name": "message:turn-15",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "068be12ed8b4895574731c639b67c83a00f4111227e6b3ebc10f24d734cc276a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-15",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 15,
+      "section_id": "brief:turn-16-response",
+      "section_name": "brief:turn-16-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "0f8dcfb8ece716542330fd024545ae6ec65ab5013e8d68ceb11995ac45909140",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-16-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 16,
+      "section_id": "message:turn-17",
+      "section_name": "message:turn-17",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "31110ee4df305b3a652168aa61b3e915f41feea55fc7521f2b3b51059919038c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-17",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 17,
+      "section_id": "brief:turn-18-response",
+      "section_name": "brief:turn-18-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "6b779b5c43f65a6da79d0a463e9062d44c2e4a98ec58df37d7d770252bf712b3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-18-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 18,
+      "section_id": "message:turn-19",
+      "section_name": "message:turn-19",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "bfd7576301636d0998f28f07b3591a21e3de2748bab690e02e4a5cef56106e2e",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-19",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 19,
+      "section_id": "brief:turn-20-response",
+      "section_name": "brief:turn-20-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "cf4f885458a6903c497d1f66df0c87973bc4731a868cc1e52530c0dfea6301fe",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-20-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 20,
+      "section_id": "message:turn-21",
+      "section_name": "message:turn-21",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "3eb7004943dba507090e04dead39704f58f072d7ccdcc99f0ba90ab40eb44cd5",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-21",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 21,
+      "section_id": "brief:turn-22-response",
+      "section_name": "brief:turn-22-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "b7758e11d971cc507586c2b4b36e47bad4f8c60cec0e72f068202326510112be",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-22-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 22,
+      "section_id": "message:turn-23",
+      "section_name": "message:turn-23",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "b91db1f2beab0e48ffb545a28cd86724d5f72ed59a9071a6c24eb98edbcae8e0",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-23",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 23,
+      "section_id": "brief:turn-24-response",
+      "section_name": "brief:turn-24-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "4f426de8fcf8b9a3534286e7d6c838e0d4d33a12e7e7aad85267dfc76d5dcd82",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-24-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 24,
+      "section_id": "message:turn-25",
+      "section_name": "message:turn-25",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "485fca4e603b9aaf1fd1444af89da3eca80f9ae7fdee70bf88259480f76b7031",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-25",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 25,
+      "section_id": "brief:turn-26-response",
+      "section_name": "brief:turn-26-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "1cd32b4b923b3dfd532d2cffb8e6e4a2e4723b06fdb469f5420b1c73b5f2cf9c",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-26-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 26,
+      "section_id": "message:turn-27",
+      "section_name": "message:turn-27",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "9c50cbf4d90eba072bd26fce55ed0c14b875df8205ce62f6ce93dcb741f96d79",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-27",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 27,
+      "section_id": "brief:turn-28-response",
+      "section_name": "brief:turn-28-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "1cd2619b9ae529c95fc7c03c5a619facc81c0d82279ca55228cd7b339f68139c",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-28-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 28,
+      "section_id": "message:turn-29",
+      "section_name": "message:turn-29",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "a9e8e6c885d53bd3f8a368b268b28dfebd8be6c2e9918c5ae9ac714f6f266b17",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-29",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 29,
+      "section_id": "brief:turn-30-response",
+      "section_name": "brief:turn-30-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "77dac42386298bebfe92c13cf523d772ca8bb026e1973e766e496713acb8922f",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-30-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 30,
+      "section_id": "message:turn-31",
+      "section_name": "message:turn-31",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "1fdf322723e859d64bc7d9ed814fa9e90d8c9332f271e24650c23f4951372c87",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-31",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 31,
+      "section_id": "brief:turn-32-response",
+      "section_name": "brief:turn-32-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "dbee3ea4bc6e9a297f8ec88046c015c7e1d726ab6c77fc2534e7080547ad4881",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-32-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 32,
+      "section_id": "message:turn-33",
+      "section_name": "message:turn-33",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "9fd74643c038143ef9bcb07d43adb918b93f4b0348258bbead0df9670739d4ea",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-33",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 33,
+      "section_id": "brief:turn-34-response",
+      "section_name": "brief:turn-34-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "78d7ff32261b8f664b859d7be013597adf961570f0316c8c5940d468b04deff6",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-34-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 34,
+      "section_id": "message:turn-35",
+      "section_name": "message:turn-35",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "4c862d331dcbc4a91bf3ce64f06a1e7507a6a1d11ee5a8b016273818a55897a2",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-35",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 35,
+      "section_id": "brief:turn-36-response",
+      "section_name": "brief:turn-36-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "5d66c17b5f32aa253e732d9b85db8acbd82f00fe1b267ccc9d098971cf962e40",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-36-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 36,
+      "section_id": "message:turn-37",
+      "section_name": "message:turn-37",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "88c3da2ccc332ecd4e795cf552a6d78f4224591f73f48802a5f77824b251f54e",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-37",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 37,
+      "section_id": "brief:turn-38-response",
+      "section_name": "brief:turn-38-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "3e8893e4d6a042385c5150c8d9d3f5346bb613c817c41c68160b80735ac8e07e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-38-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 38,
+      "section_id": "message:turn-39",
+      "section_name": "message:turn-39",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "367c9174fdec556b7ee91c9b3ddd507ab3402e44082ec8e1646892a2590e3830",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-39",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 39,
+      "section_id": "message:turn-40",
+      "section_name": "message:turn-40",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "7157c52a1dc4172460df09a7f15cf961b23f22e0e652a6cafda2fdc9284fbb41",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-40",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-40-turns-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-40-turns-2048.json
@@ -1,0 +1,996 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-40",
+    "turn_id": "turn-40",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-40",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 491,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "f0dca3ec47bf3d8551fbaf481a4356743afc8c886adda5b65bae45ee66718a01",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-response",
+      "section_name": "brief:turn-2-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "bcbd06561e41fb2fe5ac8abc8f98338d97f3b04721abd53890854b20f9ff63ff",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "703b87220b9b2e97a6996977c84d6431ad8c4017097a29d771070b1f97486995",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-decision",
+      "section_name": "brief:turn-4-decision",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "a8e4d1df6b2c1246b1e3ef8f35089a043b44c9110fee9e9c98f1e1002559d6fc",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-decision",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "af0aebce23f990296847eda3ae633db3b0f9af2d8ab42f5b4384b148d45ebdfd",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "9cfdda8d8942c73ea695d76c27bd3de892a45941b4dfa00dd68f898505f05680",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "a06b41d88cb4d61204300bcd1082e80202606f475ea59a2fb1ccdc57c34e3beb",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "6ed1541e17ee0f9c13b30c61ae36ed446d3d3660fe0410456649ab34df77784a",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "d2e79ea7a653066eabc0a97beb9e88e1227afb2b8b094aaace6404a0790a69da",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "brief:turn-10-response",
+      "section_name": "brief:turn-10-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "251479ad0e3ef70fdec067b11efd594eb61a46361b6f3d612e76f025ba23cfbf",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-10-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 10,
+      "section_id": "message:turn-11",
+      "section_name": "message:turn-11",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "1cafd0d240676fb05a0d07477217251b10d661a5505cff31ed00c91b728428e5",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-11",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 11,
+      "section_id": "brief:turn-12-response",
+      "section_name": "brief:turn-12-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "2befcbda34adea6080c041427b129bbf84e7e8d72b2234dc1a6bc8b3effb2f36",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-12-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 12,
+      "section_id": "message:turn-13",
+      "section_name": "message:turn-13",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "c9f8fa3e2824409bbeaddcbd40914bae1dbe746de8196e82a25fa13e11dc3326",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-13",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 13,
+      "section_id": "brief:turn-14-response",
+      "section_name": "brief:turn-14-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "774cfc9fd4d82ba7fb119a48a77737c40b42d3ef18dd2ad09d0792edf911651b",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-14-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 14,
+      "section_id": "message:turn-15",
+      "section_name": "message:turn-15",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "9be82a62da24680e689cc46211b7bac68f045c9b67a7dc88447fe9187745ee0d",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-15",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 15,
+      "section_id": "brief:turn-16-response",
+      "section_name": "brief:turn-16-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "14e4d7ff51c5ec6d265887638bf2002298054798d6f5555d4d2f2b9f78ea2ed8",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-16-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 16,
+      "section_id": "message:turn-17",
+      "section_name": "message:turn-17",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "93e7d9afce919c4cfd98561de682e4126948cee065469a321a98a8241d977989",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-17",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 17,
+      "section_id": "brief:turn-18-response",
+      "section_name": "brief:turn-18-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "c2ee0160eecadf1a42c45d76483ae8c35299e997b194eda6f770fad0dab06079",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-18-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 18,
+      "section_id": "message:turn-19",
+      "section_name": "message:turn-19",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "25558371346cf66e6fb1a9c349896ad4d6ee77d8a7c7a11511a319fbb5da8a4f",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-19",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 19,
+      "section_id": "brief:turn-20-response",
+      "section_name": "brief:turn-20-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "306249f90c2dc1868f6ac4f7c209e391ad68dc6648dd07fa73bfa8473610c552",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-20-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 20,
+      "section_id": "message:turn-21",
+      "section_name": "message:turn-21",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "a00ec07f2b7ccdcf1eb1798e3861ceac186ba8d2afaa9e95b653d6099b425b3d",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-21",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 21,
+      "section_id": "brief:turn-22-response",
+      "section_name": "brief:turn-22-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "2edc8419f3faa57ca5f1c311e93cc9c04a5e368662b900ba554570786a8a0aa2",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-22-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 22,
+      "section_id": "message:turn-23",
+      "section_name": "message:turn-23",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "607e57d1b7e1ef7e20ab4da961bf4778b2494f56ee76c5790b697c60a2daf1f8",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-23",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 23,
+      "section_id": "brief:turn-24-response",
+      "section_name": "brief:turn-24-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "5e280c5648ebb36055b06e9678b9ed48306de0765f8930b44768e9055309c702",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-24-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 24,
+      "section_id": "message:turn-25",
+      "section_name": "message:turn-25",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "8ac4d38b4718323613496df032a7c3c41f460e47a43b759d25a5bc439ecb9f60",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-25",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 25,
+      "section_id": "brief:turn-26-response",
+      "section_name": "brief:turn-26-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "9c814e17a304d5d4c0e514da8aa6c98ad17f99a5be0b0616799314624a879a38",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-26-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 26,
+      "section_id": "message:turn-27",
+      "section_name": "message:turn-27",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "d3d445e564fb14d4f106893cfa3cbd942da82dc3cda32e9326206452b93ce1eb",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-27",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 27,
+      "section_id": "brief:turn-28-response",
+      "section_name": "brief:turn-28-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "e133e0362cece753cf29138e70214296df8d749022c089eef4ca22b2c06f371d",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-28-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 28,
+      "section_id": "message:turn-29",
+      "section_name": "message:turn-29",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "bdf761fa3d000d2a6dd2d846ce4b30ea00363c008fa8d985c633395a33122553",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-29",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 29,
+      "section_id": "brief:turn-30-response",
+      "section_name": "brief:turn-30-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "fab6c68fa488b596365d906d7d8ef347d7c64a2723ad647f3f27d5c0659af9e3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-30-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 30,
+      "section_id": "message:turn-31",
+      "section_name": "message:turn-31",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "9acafc0a1f2d41a978f826e21df92d3e3e8874eea215f6d7422ffb0033027700",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-31",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 31,
+      "section_id": "brief:turn-32-response",
+      "section_name": "brief:turn-32-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "e8175deafab3e559449e119513a8e2aaaf8373e3a3caf354e22e6429c5163df0",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-32-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 32,
+      "section_id": "message:turn-33",
+      "section_name": "message:turn-33",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "5b47302f334e5ebbf6646424f20b73d7a61aefdb19eba0b3dd5368535f1174aa",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-33",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 33,
+      "section_id": "brief:turn-34-response",
+      "section_name": "brief:turn-34-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "8e90961f55bd07d2253e678d0d57d6fee35bcb6570b4163074ee28f3fa15bd89",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-34-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 34,
+      "section_id": "message:turn-35",
+      "section_name": "message:turn-35",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "fe509c8ea0b540e866dfea0ee8ebd0d9d10a2083663410fcb736faa33a79e97a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-35",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 35,
+      "section_id": "brief:turn-36-response",
+      "section_name": "brief:turn-36-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "f87837eca8d1466621b251fdf61f2e45841dc01d83ee6b0af9bb89c188a77e30",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-36-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 36,
+      "section_id": "message:turn-37",
+      "section_name": "message:turn-37",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "c9edcde4179ae8840d5760cb213074aadbcd0d7db51017b4a7767f3562bc1c20",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-37",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 37,
+      "section_id": "brief:turn-38-response",
+      "section_name": "brief:turn-38-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "3df866446d94cc4d9cdbb929a191847d464648dfc39fbafd26625e8859f60fd5",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-38-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 38,
+      "section_id": "message:turn-39",
+      "section_name": "message:turn-39",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "ec44d8e52febb538805c3b28256b8cfb77e22050d32883408de62375ac76d656",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-39",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 39,
+      "section_id": "message:turn-40",
+      "section_name": "message:turn-40",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "7157c52a1dc4172460df09a7f15cf961b23f22e0e652a6cafda2fdc9284fbb41",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-40",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-40-turns-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/continuity-40-turns-4096.json
@@ -1,0 +1,996 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-40",
+    "turn_id": "turn-40",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-40",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 473,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "d5116b380b99adf7fa1835c6bf858b07ac6904730a1929a464ae0d3425416828",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-response",
+      "section_name": "brief:turn-2-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "dbf0d46a3a8054a09c8261745a081e95b8b53b51aac55e7e672014546d2713ae",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "f3c8b290babf195960e4dd20835ac25ffa3b84f0e86966de320e433f69aa440a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-decision",
+      "section_name": "brief:turn-4-decision",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "096af186e2ae0183ae943fe37dd696a2a23c480e62c3deae9c3a5d699f91a54e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-decision",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "70bb140f33cd9a22a1e635bb43cbcadae182e854e04f70bd2648743e59fe93fc",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "d543c3b9c61b121afef90cd3a40b31dcd0572eedf363eceb7d8a8e4be274920d",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "3598aff831c85137eccfa94ba28ba2aaa13a2c51e67d6afdb63a195244b32f98",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "aac044ff3d4ed64aec0a823b1b56caed9102ebc1d975e3be41ef700db00fa47f",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "3052ff2dfcdf46e3070ef45493fbd87eac8f1bde710bc682b12a10c90b2a972c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "brief:turn-10-response",
+      "section_name": "brief:turn-10-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "7ced6e57e7f6e8cc6524ef1e7c87bb52915cce5054e0afbde42378f93fa8ce32",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-10-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 10,
+      "section_id": "message:turn-11",
+      "section_name": "message:turn-11",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "78ffeda8ed9a261e292075964ca8f53f12da8262751e8e2b8e8c0b0dcc81b13a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-11",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 11,
+      "section_id": "brief:turn-12-response",
+      "section_name": "brief:turn-12-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "ef2e1c1c638b2bdae1a9e3fc5e055e2b654d4919d564f867f9a3ef30334bd169",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-12-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 12,
+      "section_id": "message:turn-13",
+      "section_name": "message:turn-13",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "dd9f01a195053d72a38fe886b4d07b15e21b06af5dc3e0cc70e9189774c13644",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-13",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 13,
+      "section_id": "brief:turn-14-response",
+      "section_name": "brief:turn-14-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "5faa9d85f49c43e7a5a76030be3bd07cd5b372e1841a4c178e80bdaf31206517",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-14-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 14,
+      "section_id": "message:turn-15",
+      "section_name": "message:turn-15",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "b158cce53b3c83bf742c72c9915f99bdabf360804e4d526700480b43bcb84c44",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-15",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 15,
+      "section_id": "brief:turn-16-response",
+      "section_name": "brief:turn-16-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "d383666b7b5574dc177568548f19ee7b1ff724445f457854bc754f4d5298b498",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-16-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 16,
+      "section_id": "message:turn-17",
+      "section_name": "message:turn-17",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "c2ca14fd54f67cbc1e90b6a99f42e78542015b0b122689b2b0cbbaef4908774f",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-17",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 17,
+      "section_id": "brief:turn-18-response",
+      "section_name": "brief:turn-18-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "1e9f41370d56131bb1b08e337480cfb45db8791d3f7460eda8888372022706ba",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-18-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 18,
+      "section_id": "message:turn-19",
+      "section_name": "message:turn-19",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "e0a6c6951e084881dba67e30a71e849da8acb090d533aa5f9a1e06e84a2b3d2b",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-19",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 19,
+      "section_id": "brief:turn-20-response",
+      "section_name": "brief:turn-20-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "023fcc584dd7093cf65ef9fb851f2840d5a9a1d6628e33c563b9082626610dc4",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-20-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 20,
+      "section_id": "message:turn-21",
+      "section_name": "message:turn-21",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cbfc20560b146469db548e7a0f3f732a87780fd5d8259a1e765a3e96757d25aa",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-21",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 21,
+      "section_id": "brief:turn-22-response",
+      "section_name": "brief:turn-22-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "1d5c8a1a8019ae8bdefabdce4a5f47bd1a4e9e2dad481f08e47b8bac37e22c54",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-22-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 22,
+      "section_id": "message:turn-23",
+      "section_name": "message:turn-23",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "8b0a94c6e128fae399b30e4d277f682de4a692a00ebc8f2af65abd816d660bfe",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-23",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 23,
+      "section_id": "brief:turn-24-response",
+      "section_name": "brief:turn-24-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "9ea6d26ad5ab386828cb05dbe729e91aade8828c29333f6e15bf2c59513e4a70",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-24-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 24,
+      "section_id": "message:turn-25",
+      "section_name": "message:turn-25",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "fc1a544de3497e58be1ff8bcdcca49c3411f57a58a2e613b724cc4edbc359721",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-25",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 25,
+      "section_id": "brief:turn-26-response",
+      "section_name": "brief:turn-26-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "eb6f4ef22a5d64fbeb0d6f5897e2ceea415949b2fb05467b12252828250cd647",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-26-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 26,
+      "section_id": "message:turn-27",
+      "section_name": "message:turn-27",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "1cbcc15a2846e7535fcbe6bc95b2055c3a7fd2938feb5d11f8c9cd10df119be2",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-27",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 27,
+      "section_id": "brief:turn-28-response",
+      "section_name": "brief:turn-28-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "e52430719c45bd38f73b677d56cd4bb344fa05bbf41fd029e55b60c2ee6407e3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-28-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 28,
+      "section_id": "message:turn-29",
+      "section_name": "message:turn-29",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "b29ddc7a691647788355df2d6c3318e0f845a0bcc6a4e499709a4a4f3deae610",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-29",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 29,
+      "section_id": "brief:turn-30-response",
+      "section_name": "brief:turn-30-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "f99233f40421e971db8f867d66edd93383cdb7d5e3f1156850d93a7b2fd8d106",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-30-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 30,
+      "section_id": "message:turn-31",
+      "section_name": "message:turn-31",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "ea7a4f5f7ff282adb6bf56daf2be2d9883355f4dede855f89ee8042d61b6f975",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-31",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 31,
+      "section_id": "brief:turn-32-response",
+      "section_name": "brief:turn-32-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "88e7b9cce7517b1158573bd67dbdb567bec12680f9bbf610085d2e4d7c7cabc2",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-32-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 32,
+      "section_id": "message:turn-33",
+      "section_name": "message:turn-33",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "2ba7a37694931e3ab55662af2f9335576e0180fa204113a1939db20707c042e4",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-33",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 33,
+      "section_id": "brief:turn-34-response",
+      "section_name": "brief:turn-34-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "830fd7ecec8257ceac58ab1928419b3a3c4bd914b15e3e17f45203ac32b8151d",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-34-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 34,
+      "section_id": "message:turn-35",
+      "section_name": "message:turn-35",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "532fc536192dde5c26c283756844d81114474636debda7728acb0e609a148243",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-35",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 35,
+      "section_id": "brief:turn-36-response",
+      "section_name": "brief:turn-36-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "2cf93c320c064d9cee82c868998b5e6b48087c77d96ec5b0998d45594958be80",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-36-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 36,
+      "section_id": "message:turn-37",
+      "section_name": "message:turn-37",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "8beeb55c11332e49fa7689df816f7c40a11b7a6835ee250a5a40c50560678988",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-37",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 37,
+      "section_id": "brief:turn-38-response",
+      "section_name": "brief:turn-38-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "5f4dcd47387ab28ad41c40f4b73387cd9eb35e4bce1da88def72bc31a9670a83",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-38-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 38,
+      "section_id": "message:turn-39",
+      "section_name": "message:turn-39",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "9dc4b046976a2e6dd8ec1912d1ee8fafda8dd47f9ce64c9eaeb18c7a63a06c81",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-39",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 39,
+      "section_id": "message:turn-40",
+      "section_name": "message:turn-40",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "7157c52a1dc4172460df09a7f15cf961b23f22e0e652a6cafda2fdc9284fbb41",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-40",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ea1f384b666ce07283b3dec7cf1c3817"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/discussion-interleaved-runtime-wakes-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/discussion-interleaved-runtime-wakes-16384.json
@@ -1,0 +1,197 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+  },
+  "activation_binding": {
+    "source_message_id": "message:discussion-followup",
+    "turn_id": "turn-11",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-11",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 31,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:discussion-anchor",
+      "section_name": "message:discussion-anchor",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 26,
+      "content_sha256": "4eda39236344559a24459c00f8d3f4f66dc1eb6c70db5f8bc9caeb26912f103b",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:discussion-anchor",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "message:external-wake",
+      "section_name": "message:external-wake",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 20,
+      "content_sha256": "a1ae349aaecc5d85a80e7c6b6a6016b7af4ef0f1950b636806e1fab1bdb8c8fe",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:external-wake",
+          "role": "supporting",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:timer-wake",
+      "section_name": "message:timer-wake",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 17,
+      "content_sha256": "755e06d0d7079f844a333a0365f1896aae2537b3f6bdadae20985bf3810e1ad5",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:timer-wake",
+          "role": "supporting",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "message:lifecycle-wake",
+      "section_name": "message:lifecycle-wake",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 21,
+      "content_sha256": "59c2c5193ad1dfa8e66ab85e39e00fe594eba3ee2071876fc6bb50e973c9999f",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:lifecycle-wake",
+          "role": "supporting",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:discussion-followup",
+      "section_name": "message:discussion-followup",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 29,
+      "content_sha256": "a807f8adbefa32addde6408785929e07de649c05f304dc0cf195d00b169c31a8",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:discussion-followup",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "fail",
+      "details": [
+        "message:external-wake owner=agent_lifecycle:agent-1 expected=conversation:interaction1_93f816e89241c53003bf347f8322e2bf",
+        "message:timer-wake owner=agent_lifecycle:agent-1 expected=conversation:interaction1_93f816e89241c53003bf347f8322e2bf",
+        "message:lifecycle-wake owner=agent_lifecycle:agent-1 expected=conversation:interaction1_93f816e89241c53003bf347f8322e2bf"
+      ]
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/discussion-interleaved-runtime-wakes-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/discussion-interleaved-runtime-wakes-2048.json
@@ -1,0 +1,193 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+  },
+  "activation_binding": {
+    "source_message_id": "message:discussion-followup",
+    "turn_id": "turn-11",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-11",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 17,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:discussion-anchor",
+      "section_name": "message:discussion-anchor",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 36,
+      "content_sha256": "f8f7d50a8743265da213264001d9e8de57c5501e4175bf6fb4fe95b893114560",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:discussion-anchor",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "message:external-wake",
+      "section_name": "message:external-wake",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:external-wake",
+          "role": "supporting",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ]
+    },
+    {
+      "order": 2,
+      "section_id": "message:timer-wake",
+      "section_name": "message:timer-wake",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:timer-wake",
+          "role": "supporting",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ]
+    },
+    {
+      "order": 3,
+      "section_id": "message:lifecycle-wake",
+      "section_name": "message:lifecycle-wake",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:lifecycle-wake",
+          "role": "supporting",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ]
+    },
+    {
+      "order": 4,
+      "section_id": "message:discussion-followup",
+      "section_name": "message:discussion-followup",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 29,
+      "content_sha256": "a807f8adbefa32addde6408785929e07de649c05f304dc0cf195d00b169c31a8",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:discussion-followup",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/discussion-interleaved-runtime-wakes-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/discussion-interleaved-runtime-wakes-4096.json
@@ -1,0 +1,193 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+  },
+  "activation_binding": {
+    "source_message_id": "message:discussion-followup",
+    "turn_id": "turn-11",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-11",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 15,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:discussion-anchor",
+      "section_name": "message:discussion-anchor",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 26,
+      "content_sha256": "4eda39236344559a24459c00f8d3f4f66dc1eb6c70db5f8bc9caeb26912f103b",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:discussion-anchor",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "message:external-wake",
+      "section_name": "message:external-wake",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:external-wake",
+          "role": "supporting",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ]
+    },
+    {
+      "order": 2,
+      "section_id": "message:timer-wake",
+      "section_name": "message:timer-wake",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:timer-wake",
+          "role": "supporting",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ]
+    },
+    {
+      "order": 3,
+      "section_id": "message:lifecycle-wake",
+      "section_name": "message:lifecycle-wake",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:lifecycle-wake",
+          "role": "supporting",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ]
+    },
+    {
+      "order": 4,
+      "section_id": "message:discussion-followup",
+      "section_name": "message:discussion-followup",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 29,
+      "content_sha256": "a807f8adbefa32addde6408785929e07de649c05f304dc0cf195d00b169c31a8",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:discussion-followup",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_93f816e89241c53003bf347f8322e2bf"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-ordinal-reference-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-ordinal-reference-16384.json
@@ -1,0 +1,191 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+  },
+  "activation_binding": {
+    "source_message_id": "message:previous-plan",
+    "turn_id": "turn-5",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-5",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 27,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:options",
+      "section_name": "message:options",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 7,
+      "content_sha256": "119cc90b815816a87823962c5cbf919c3d69789c1af92bebea962e0882f01fc5",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:options",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:options",
+      "section_name": "brief:options",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 10,
+      "content_sha256": "509505593089304595d192962e364fbd137732bcd9d96d4107b338f1fa92a2da",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:options",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:second",
+      "section_name": "message:second",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 3,
+      "allocated_estimated_tokens": 3,
+      "rendered_chars": 3,
+      "content_sha256": "8ef6b96cd7518a8f125336683d0e7cce576f804d1eae356652d2f8dfb82d89fc",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:second",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:second",
+      "section_name": "brief:second",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 6,
+      "content_sha256": "ccc94125b52012a7cba70eef59b6c69e29e49b3d8749a61c41dc7afbd2bbfb2a",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:second",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:previous-plan",
+      "section_name": "message:previous-plan",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 6,
+      "content_sha256": "9284e94d18e383967a9323937492077e35bd0e438f9a79add19337e32c8133dc",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:previous-plan",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-ordinal-reference-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-ordinal-reference-2048.json
@@ -1,0 +1,191 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+  },
+  "activation_binding": {
+    "source_message_id": "message:previous-plan",
+    "turn_id": "turn-5",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-5",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 38,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:options",
+      "section_name": "message:options",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 19,
+      "content_sha256": "a62aa3a1aaa118f589aa91494d26e0e140f7c12a191b8ed6a9505da13334d7ea",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:options",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:options",
+      "section_name": "brief:options",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 20,
+      "content_sha256": "e6c4f37ad30d47f12bfcf44c1f727764767547accbdd054cec9449e9022068fe",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:options",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:second",
+      "section_name": "message:second",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 3,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 15,
+      "content_sha256": "52463d09d0fe9efbc1895403ede8d41c0cd19da248de3c8be5758f6a482672a2",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:second",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:second",
+      "section_name": "brief:second",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 18,
+      "content_sha256": "a3fc37057808677df4714d9b94e951f1b1a2ab14483046921e3189722eab9e40",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:second",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:previous-plan",
+      "section_name": "message:previous-plan",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 6,
+      "content_sha256": "9284e94d18e383967a9323937492077e35bd0e438f9a79add19337e32c8133dc",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:previous-plan",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-ordinal-reference-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-ordinal-reference-4096.json
@@ -1,0 +1,191 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+  },
+  "activation_binding": {
+    "source_message_id": "message:previous-plan",
+    "turn_id": "turn-5",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-5",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 33,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:options",
+      "section_name": "message:options",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 17,
+      "content_sha256": "64077c868703056271445979e4c39a95a502b8a9713a55962289b949837f8bdc",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:options",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:options",
+      "section_name": "brief:options",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 10,
+      "content_sha256": "509505593089304595d192962e364fbd137732bcd9d96d4107b338f1fa92a2da",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:options",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:second",
+      "section_name": "message:second",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 3,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 13,
+      "content_sha256": "ef63d33bede8a247feff3b7b798034fee1c1c6794f9a5fe3b718e3eb6ada4152",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:second",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:second",
+      "section_name": "brief:second",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 16,
+      "content_sha256": "ed1d1adb92f805e83b1796cfb02e5c685db6e12256d21e42436fdb62bf6ad543",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:second",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:previous-plan",
+      "section_name": "message:previous-plan",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 6,
+      "content_sha256": "9284e94d18e383967a9323937492077e35bd0e438f9a79add19337e32c8133dc",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:previous-plan",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_ecbb9235c0a17c2788459020dbeefe95"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-can-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-can-16384.json
@@ -1,0 +1,170 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+  },
+  "activation_binding": {
+    "source_message_id": "message:2512-can",
+    "turn_id": "turn-4",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-4",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 22,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:2512-plan",
+      "section_name": "message:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 11,
+      "content_sha256": "1acd4bcdedd9919151d7a487b1ea83ec700041295594face1af4719af6c18010",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-plan",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:2512-plan",
+      "section_name": "brief:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 6,
+      "content_sha256": "04284afb2e0f8dbc0f016b983f2fa4377264343bb96e5d836daa7a34462fc48d",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:2512-plan",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:2512-question",
+      "section_name": "message:2512-question",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 7,
+      "content_sha256": "91af2d3bb572aef7d0f102b0ec0df14256bb6b4521f985246435625b9c76dfe6",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-question",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "message:2512-can",
+      "section_name": "message:2512-can",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 2,
+      "allocated_estimated_tokens": 2,
+      "rendered_chars": 2,
+      "content_sha256": "0ef5c86fab94f13a7b7d54aa531ceb5d586cd9ebee98198ad975df3852da824a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-can",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-can-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-can-2048.json
@@ -1,0 +1,170 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+  },
+  "activation_binding": {
+    "source_message_id": "message:2512-can",
+    "turn_id": "turn-4",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-4",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 30,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:2512-plan",
+      "section_name": "message:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 23,
+      "content_sha256": "9022e5e6548340e207d14228370f58e4ea4e976584d3afead4996c369b24b4b1",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-plan",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:2512-plan",
+      "section_name": "brief:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 18,
+      "content_sha256": "0e1fd4763f2dc4f345a665573af4a08f8ab598168c73d97251cdf3cd175f8ef1",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:2512-plan",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:2512-question",
+      "section_name": "message:2512-question",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 17,
+      "content_sha256": "e87aeb9da61cf25865711e5174cdd64c1088804bd038bd7886c9f634796b1016",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-question",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "message:2512-can",
+      "section_name": "message:2512-can",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 2,
+      "allocated_estimated_tokens": 2,
+      "rendered_chars": 2,
+      "content_sha256": "0ef5c86fab94f13a7b7d54aa531ceb5d586cd9ebee98198ad975df3852da824a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-can",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-can-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-can-4096.json
@@ -1,0 +1,170 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+  },
+  "activation_binding": {
+    "source_message_id": "message:2512-can",
+    "turn_id": "turn-4",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-4",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 26,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:2512-plan",
+      "section_name": "message:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 21,
+      "content_sha256": "0d6f38b6b855589c45183e2651b56ac7f186635d28f55203421270b72c445513",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-plan",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:2512-plan",
+      "section_name": "brief:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 16,
+      "content_sha256": "8fd1522f85869e59c10ab0d1e4df50ad8e6d8401b528f40ab0d0d30e77609c4e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:2512-plan",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:2512-question",
+      "section_name": "message:2512-question",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 7,
+      "content_sha256": "91af2d3bb572aef7d0f102b0ec0df14256bb6b4521f985246435625b9c76dfe6",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-question",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "message:2512-can",
+      "section_name": "message:2512-can",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 2,
+      "allocated_estimated_tokens": 2,
+      "rendered_chars": 2,
+      "content_sha256": "0ef5c86fab94f13a7b7d54aa531ceb5d586cd9ebee98198ad975df3852da824a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-can",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_8d2886df4fceb3215edcc4dbec41e825"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-need-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-need-16384.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+  },
+  "activation_binding": {
+    "source_message_id": "message:2512-need",
+    "turn_id": "turn-3",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-3",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 19,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:2512-plan",
+      "section_name": "message:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 11,
+      "content_sha256": "1acd4bcdedd9919151d7a487b1ea83ec700041295594face1af4719af6c18010",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-plan",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:2512-plan",
+      "section_name": "brief:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 21,
+      "content_sha256": "9e32a1ce1c363196114937a577a2ca120b96c3122e3f335790a0e56aef8b00eb",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:2512-plan",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:2512-need",
+      "section_name": "message:2512-need",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 2,
+      "allocated_estimated_tokens": 2,
+      "rendered_chars": 2,
+      "content_sha256": "c9e9a062f5d588f3adb481458f2b719b1a133ffb48b468eb0f61be6004dae9de",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-need",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-need-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-need-2048.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+  },
+  "activation_binding": {
+    "source_message_id": "message:2512-need",
+    "turn_id": "turn-3",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-3",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 24,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:2512-plan",
+      "section_name": "message:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 23,
+      "content_sha256": "9022e5e6548340e207d14228370f58e4ea4e976584d3afead4996c369b24b4b1",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-plan",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:2512-plan",
+      "section_name": "brief:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 31,
+      "content_sha256": "1b4b8829bd64b58aaf595e57bd058c3009ccbe51e26aa941e7b7bd83d8a51eee",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:2512-plan",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:2512-need",
+      "section_name": "message:2512-need",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 2,
+      "allocated_estimated_tokens": 2,
+      "rendered_chars": 2,
+      "content_sha256": "c9e9a062f5d588f3adb481458f2b719b1a133ffb48b468eb0f61be6004dae9de",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-need",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-need-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/issue-2512-short-reference-need-4096.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+  },
+  "activation_binding": {
+    "source_message_id": "message:2512-need",
+    "turn_id": "turn-3",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-3",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 21,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:2512-plan",
+      "section_name": "message:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 21,
+      "content_sha256": "0d6f38b6b855589c45183e2651b56ac7f186635d28f55203421270b72c445513",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-plan",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:2512-plan",
+      "section_name": "brief:2512-plan",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 21,
+      "content_sha256": "9e32a1ce1c363196114937a577a2ca120b96c3122e3f335790a0e56aef8b00eb",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:2512-plan",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:2512-need",
+      "section_name": "message:2512-need",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 2,
+      "allocated_estimated_tokens": 2,
+      "rendered_chars": 2,
+      "content_sha256": "c9e9a062f5d588f3adb481458f2b719b1a133ffb48b468eb0f61be6004dae9de",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:2512-need",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_210fa5fe4088e8163889650babe3db37"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/new-topic-no-false-carry-over-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/new-topic-no-false-carry-over-16384.json
@@ -1,0 +1,262 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+  },
+  "activation_binding": {
+    "source_message_id": "message:topic-b-current",
+    "turn_id": "turn-8",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-8",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 46,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:topic-a-start",
+      "section_name": "message:topic-a-start",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 25,
+      "content_sha256": "c27040d09ca4fcc7968c0319ff59356cf58300d87be9a705672f95c296ff5c39",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-a-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:topic-a-response",
+      "section_name": "brief:topic-a-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 27,
+      "content_sha256": "d4553bba35460a5ace666769f4368ecf9a82ac1b98679fb90897f064bffc237d",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:topic-a-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:topic-a-followup",
+      "section_name": "message:topic-a-followup",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 27,
+      "content_sha256": "72d52e84fd4fb20e87e12781df2e59134ec88c97d2ab9f4cdd65de34891f6b46",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-a-followup",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:topic-a-abandoned-action",
+      "section_name": "brief:topic-a-abandoned-action",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "brief:topic-a-abandoned-action",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ]
+    },
+    {
+      "order": 4,
+      "section_id": "message:topic-b-start",
+      "section_name": "message:topic-b-start",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 25,
+      "content_sha256": "f33e4b71a717f1e1d47a6d8b7f2b3aa17e37f0c536d12351bd7b2499199d50d5",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-b-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:topic-b-response",
+      "section_name": "brief:topic-b-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 27,
+      "content_sha256": "23f2af3cc953c99dc6b127c160ead1619b8d007d648ddf03352dc29958289812",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:topic-b-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:topic-b-followup",
+      "section_name": "message:topic-b-followup",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 18,
+      "content_sha256": "5e870f75866f645be7b46c2ab9e15e697d7307512d0d78895f9042c15308e641",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-b-followup",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "message:topic-b-current",
+      "section_name": "message:topic-b-current",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 24,
+      "content_sha256": "f5570221218a1937b1d5d613f5c35c99d013bbc2f9ae3354f01c26fb92fdd1c9",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-b-current",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/new-topic-no-false-carry-over-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/new-topic-no-false-carry-over-2048.json
@@ -1,0 +1,262 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+  },
+  "activation_binding": {
+    "source_message_id": "message:topic-b-current",
+    "turn_id": "turn-8",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-8",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 63,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:topic-a-start",
+      "section_name": "message:topic-a-start",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 37,
+      "content_sha256": "c81e27361af3a6330a644829877f2c0a9591dbf40e2fd292593790990401abf8",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-a-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:topic-a-response",
+      "section_name": "brief:topic-a-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 39,
+      "content_sha256": "020da4ea1163cc04dbb680955896dcc735f2e76b7bef2cfc66e026655bc252f9",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:topic-a-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:topic-a-followup",
+      "section_name": "message:topic-a-followup",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 39,
+      "content_sha256": "eaf570b04305aa2735570eafa81db8e7b93c5365c0f6d5e0678608910dee156e",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-a-followup",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:topic-a-abandoned-action",
+      "section_name": "brief:topic-a-abandoned-action",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "brief:topic-a-abandoned-action",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ]
+    },
+    {
+      "order": 4,
+      "section_id": "message:topic-b-start",
+      "section_name": "message:topic-b-start",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 37,
+      "content_sha256": "b92d3f016c9de6a7a7f76dc37a6208d03fd5eb7e709fc7271878969d57918976",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-b-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:topic-b-response",
+      "section_name": "brief:topic-b-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 37,
+      "content_sha256": "b10a2832515fb9d87d8ba4c7132843390f2e48cbc619d3bdd0fcee1eac7b2ce5",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:topic-b-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:topic-b-followup",
+      "section_name": "message:topic-b-followup",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 28,
+      "content_sha256": "7332168dcd710f34a1c2d075781e4a77640ea1254b2f9d037abdd33f6336e022",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-b-followup",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "message:topic-b-current",
+      "section_name": "message:topic-b-current",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 24,
+      "content_sha256": "f5570221218a1937b1d5d613f5c35c99d013bbc2f9ae3354f01c26fb92fdd1c9",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-b-current",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/new-topic-no-false-carry-over-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/new-topic-no-false-carry-over-4096.json
@@ -1,0 +1,262 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+  },
+  "activation_binding": {
+    "source_message_id": "message:topic-b-current",
+    "turn_id": "turn-8",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-8",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 56,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:topic-a-start",
+      "section_name": "message:topic-a-start",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 35,
+      "content_sha256": "0c9542ff3c95b9c4b9c769477565c8b256f9b6c4ef445c39bc1cbb2405dafb00",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-a-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:topic-a-response",
+      "section_name": "brief:topic-a-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 37,
+      "content_sha256": "5c6983ce8beaaec1697d32c622565adac3975f3f437cf230c61d6e91c3d61fd3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:topic-a-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:topic-a-followup",
+      "section_name": "message:topic-a-followup",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 37,
+      "content_sha256": "dcc9add262ecae0603d60a5a19190a2bc18045d7332afed4584527e2321a7e78",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-a-followup",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:topic-a-abandoned-action",
+      "section_name": "brief:topic-a-abandoned-action",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "brief:topic-a-abandoned-action",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ]
+    },
+    {
+      "order": 4,
+      "section_id": "message:topic-b-start",
+      "section_name": "message:topic-b-start",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 35,
+      "content_sha256": "0d1407644d29b97272e568bd15edafdfdd81cf46c5679f7419c7aea64f9b4a51",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-b-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:topic-b-response",
+      "section_name": "brief:topic-b-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 27,
+      "content_sha256": "23f2af3cc953c99dc6b127c160ead1619b8d007d648ddf03352dc29958289812",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:topic-b-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:topic-b-followup",
+      "section_name": "message:topic-b-followup",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 18,
+      "content_sha256": "5e870f75866f645be7b46c2ab9e15e697d7307512d0d78895f9042c15308e641",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-b-followup",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "message:topic-b-current",
+      "section_name": "message:topic-b-current",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 24,
+      "content_sha256": "f5570221218a1937b1d5d613f5c35c99d013bbc2f9ae3354f01c26fb92fdd1c9",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-b-current",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_1ac0af3966c468f9b185737a6ae66bad"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/restart-compaction-equivalence-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/restart-compaction-equivalence-16384.json
@@ -1,0 +1,1019 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-40",
+    "turn_id": "turn-40",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-40",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 395,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "f89288ed451890504fadd9c8d20b1e740016d6d38ffe7ede66d7a8ca1ddd9f7c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-response",
+      "section_name": "brief:turn-2-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "c4ec0642e10622b9351e42a3a3287d427a1a57df0af9a2388e08956392dfeb05",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "4bb1a6a25c3fe86870bcb6cdceb32199c60a91e6cd049c3700a7ddc9cbb5be36",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-decision",
+      "section_name": "brief:turn-4-decision",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "096af186e2ae0183ae943fe37dd696a2a23c480e62c3deae9c3a5d699f91a54e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-decision",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "d58a372ea4d8eb1235d027e38e8a2a1a03cb8d099ccc28567c73283df6ec5f16",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "c2d1e4cb2b1728e9d7e3c72bf6ebbf447be5417047a7fc0757773e4b49ae7aba",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "97bf927becf4cc34092138e41029cd6b9c8835cfff4a45f9aa5ff2ef9e93434a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "64ae50aac51cf421706ef44638ce436814a6469989f4ec89234bd6248114c58e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "7a59c4faf85da6ccc044f7c2b2a2e88e2edbeaa33c1f633ac7c046a8a38b7f2c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "brief:turn-10-response",
+      "section_name": "brief:turn-10-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "536c1028f444c9ad7e6554c06cc3c17f34346c3589786676e20b1f914a292ab3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-10-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 10,
+      "section_id": "message:turn-11",
+      "section_name": "message:turn-11",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "29e1bd8ae9e4fc18f07b8d8fd6b566cf87022e233d1b7496e20eb429e97e742c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-11",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 11,
+      "section_id": "brief:turn-12-response",
+      "section_name": "brief:turn-12-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "0abb67e23245a221add68b2435491905dfd11f0db263b8d2d540c8f2d81cf937",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-12-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 12,
+      "section_id": "message:turn-13",
+      "section_name": "message:turn-13",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "ccb6c86acc61dc1da0575d45ac938c81d578483aff6fdb5804e4aa3352017635",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-13",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 13,
+      "section_id": "brief:turn-14-response",
+      "section_name": "brief:turn-14-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "7d9dc846f72b4b414fb8a94776b77bd8e2f22812e2e0f9308fb6b69dd77b313e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-14-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 14,
+      "section_id": "message:turn-15",
+      "section_name": "message:turn-15",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "068be12ed8b4895574731c639b67c83a00f4111227e6b3ebc10f24d734cc276a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-15",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 15,
+      "section_id": "brief:turn-16-response",
+      "section_name": "brief:turn-16-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "0f8dcfb8ece716542330fd024545ae6ec65ab5013e8d68ceb11995ac45909140",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-16-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 16,
+      "section_id": "message:turn-17",
+      "section_name": "message:turn-17",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "31110ee4df305b3a652168aa61b3e915f41feea55fc7521f2b3b51059919038c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-17",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 17,
+      "section_id": "brief:turn-18-response",
+      "section_name": "brief:turn-18-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "6b779b5c43f65a6da79d0a463e9062d44c2e4a98ec58df37d7d770252bf712b3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-18-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 18,
+      "section_id": "message:turn-19",
+      "section_name": "message:turn-19",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "bfd7576301636d0998f28f07b3591a21e3de2748bab690e02e4a5cef56106e2e",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-19",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 19,
+      "section_id": "brief:turn-20-response",
+      "section_name": "brief:turn-20-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "cf4f885458a6903c497d1f66df0c87973bc4731a868cc1e52530c0dfea6301fe",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-20-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 20,
+      "section_id": "message:turn-21",
+      "section_name": "message:turn-21",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "3eb7004943dba507090e04dead39704f58f072d7ccdcc99f0ba90ab40eb44cd5",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-21",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 21,
+      "section_id": "brief:turn-22-response",
+      "section_name": "brief:turn-22-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "b7758e11d971cc507586c2b4b36e47bad4f8c60cec0e72f068202326510112be",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-22-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 22,
+      "section_id": "message:turn-23",
+      "section_name": "message:turn-23",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "b91db1f2beab0e48ffb545a28cd86724d5f72ed59a9071a6c24eb98edbcae8e0",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-23",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 23,
+      "section_id": "brief:turn-24-response",
+      "section_name": "brief:turn-24-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "4f426de8fcf8b9a3534286e7d6c838e0d4d33a12e7e7aad85267dfc76d5dcd82",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-24-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 24,
+      "section_id": "message:turn-25",
+      "section_name": "message:turn-25",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "485fca4e603b9aaf1fd1444af89da3eca80f9ae7fdee70bf88259480f76b7031",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-25",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 25,
+      "section_id": "brief:turn-26-response",
+      "section_name": "brief:turn-26-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "1cd32b4b923b3dfd532d2cffb8e6e4a2e4723b06fdb469f5420b1c73b5f2cf9c",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-26-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 26,
+      "section_id": "message:turn-27",
+      "section_name": "message:turn-27",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "9c50cbf4d90eba072bd26fce55ed0c14b875df8205ce62f6ce93dcb741f96d79",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-27",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 27,
+      "section_id": "brief:turn-28-response",
+      "section_name": "brief:turn-28-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "1cd2619b9ae529c95fc7c03c5a619facc81c0d82279ca55228cd7b339f68139c",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-28-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 28,
+      "section_id": "message:turn-29",
+      "section_name": "message:turn-29",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "a9e8e6c885d53bd3f8a368b268b28dfebd8be6c2e9918c5ae9ac714f6f266b17",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-29",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 29,
+      "section_id": "brief:turn-30-response",
+      "section_name": "brief:turn-30-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "77dac42386298bebfe92c13cf523d772ca8bb026e1973e766e496713acb8922f",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-30-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 30,
+      "section_id": "message:turn-31",
+      "section_name": "message:turn-31",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "1fdf322723e859d64bc7d9ed814fa9e90d8c9332f271e24650c23f4951372c87",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-31",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 31,
+      "section_id": "brief:turn-32-response",
+      "section_name": "brief:turn-32-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "dbee3ea4bc6e9a297f8ec88046c015c7e1d726ab6c77fc2534e7080547ad4881",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-32-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 32,
+      "section_id": "message:turn-33",
+      "section_name": "message:turn-33",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "9fd74643c038143ef9bcb07d43adb918b93f4b0348258bbead0df9670739d4ea",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-33",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 33,
+      "section_id": "brief:turn-34-response",
+      "section_name": "brief:turn-34-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "78d7ff32261b8f664b859d7be013597adf961570f0316c8c5940d468b04deff6",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-34-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 34,
+      "section_id": "message:turn-35",
+      "section_name": "message:turn-35",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "4c862d331dcbc4a91bf3ce64f06a1e7507a6a1d11ee5a8b016273818a55897a2",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-35",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 35,
+      "section_id": "brief:turn-36-response",
+      "section_name": "brief:turn-36-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "5d66c17b5f32aa253e732d9b85db8acbd82f00fe1b267ccc9d098971cf962e40",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-36-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 36,
+      "section_id": "message:turn-37",
+      "section_name": "message:turn-37",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "88c3da2ccc332ecd4e795cf552a6d78f4224591f73f48802a5f77824b251f54e",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-37",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 37,
+      "section_id": "brief:turn-38-response",
+      "section_name": "brief:turn-38-response",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 41,
+      "content_sha256": "3e8893e4d6a042385c5150c8d9d3f5346bb613c817c41c68160b80735ac8e07e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-38-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 38,
+      "section_id": "message:turn-39",
+      "section_name": "message:turn-39",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "367c9174fdec556b7ee91c9b3ddd507ab3402e44082ec8e1646892a2590e3830",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-39",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 39,
+      "section_id": "message:turn-40",
+      "section_name": "message:turn-40",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "7157c52a1dc4172460df09a7f15cf961b23f22e0e652a6cafda2fdc9284fbb41",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-40",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 40,
+      "section_id": "brief:compaction-anchor",
+      "section_name": "brief:compaction-anchor",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 24,
+      "content_sha256": "76be6437230736c876f9e5aa2046be5dc588de700f6d1d2aae85c1c639a5ce71",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:compaction-anchor",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/restart-compaction-equivalence-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/restart-compaction-equivalence-2048.json
@@ -1,0 +1,1019 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-40",
+    "turn_id": "turn-40",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-40",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 500,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "f0dca3ec47bf3d8551fbaf481a4356743afc8c886adda5b65bae45ee66718a01",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-response",
+      "section_name": "brief:turn-2-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "bcbd06561e41fb2fe5ac8abc8f98338d97f3b04721abd53890854b20f9ff63ff",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "703b87220b9b2e97a6996977c84d6431ad8c4017097a29d771070b1f97486995",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-decision",
+      "section_name": "brief:turn-4-decision",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "a8e4d1df6b2c1246b1e3ef8f35089a043b44c9110fee9e9c98f1e1002559d6fc",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-decision",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "af0aebce23f990296847eda3ae633db3b0f9af2d8ab42f5b4384b148d45ebdfd",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "9cfdda8d8942c73ea695d76c27bd3de892a45941b4dfa00dd68f898505f05680",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "a06b41d88cb4d61204300bcd1082e80202606f475ea59a2fb1ccdc57c34e3beb",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "6ed1541e17ee0f9c13b30c61ae36ed446d3d3660fe0410456649ab34df77784a",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 44,
+      "content_sha256": "d2e79ea7a653066eabc0a97beb9e88e1227afb2b8b094aaace6404a0790a69da",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "brief:turn-10-response",
+      "section_name": "brief:turn-10-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "251479ad0e3ef70fdec067b11efd594eb61a46361b6f3d612e76f025ba23cfbf",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-10-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 10,
+      "section_id": "message:turn-11",
+      "section_name": "message:turn-11",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "1cafd0d240676fb05a0d07477217251b10d661a5505cff31ed00c91b728428e5",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-11",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 11,
+      "section_id": "brief:turn-12-response",
+      "section_name": "brief:turn-12-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "2befcbda34adea6080c041427b129bbf84e7e8d72b2234dc1a6bc8b3effb2f36",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-12-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 12,
+      "section_id": "message:turn-13",
+      "section_name": "message:turn-13",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "c9f8fa3e2824409bbeaddcbd40914bae1dbe746de8196e82a25fa13e11dc3326",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-13",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 13,
+      "section_id": "brief:turn-14-response",
+      "section_name": "brief:turn-14-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "774cfc9fd4d82ba7fb119a48a77737c40b42d3ef18dd2ad09d0792edf911651b",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-14-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 14,
+      "section_id": "message:turn-15",
+      "section_name": "message:turn-15",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "9be82a62da24680e689cc46211b7bac68f045c9b67a7dc88447fe9187745ee0d",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-15",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 15,
+      "section_id": "brief:turn-16-response",
+      "section_name": "brief:turn-16-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "14e4d7ff51c5ec6d265887638bf2002298054798d6f5555d4d2f2b9f78ea2ed8",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-16-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 16,
+      "section_id": "message:turn-17",
+      "section_name": "message:turn-17",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "93e7d9afce919c4cfd98561de682e4126948cee065469a321a98a8241d977989",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-17",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 17,
+      "section_id": "brief:turn-18-response",
+      "section_name": "brief:turn-18-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "c2ee0160eecadf1a42c45d76483ae8c35299e997b194eda6f770fad0dab06079",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-18-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 18,
+      "section_id": "message:turn-19",
+      "section_name": "message:turn-19",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "25558371346cf66e6fb1a9c349896ad4d6ee77d8a7c7a11511a319fbb5da8a4f",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-19",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 19,
+      "section_id": "brief:turn-20-response",
+      "section_name": "brief:turn-20-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "306249f90c2dc1868f6ac4f7c209e391ad68dc6648dd07fa73bfa8473610c552",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-20-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 20,
+      "section_id": "message:turn-21",
+      "section_name": "message:turn-21",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "a00ec07f2b7ccdcf1eb1798e3861ceac186ba8d2afaa9e95b653d6099b425b3d",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-21",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 21,
+      "section_id": "brief:turn-22-response",
+      "section_name": "brief:turn-22-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "2edc8419f3faa57ca5f1c311e93cc9c04a5e368662b900ba554570786a8a0aa2",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-22-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 22,
+      "section_id": "message:turn-23",
+      "section_name": "message:turn-23",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "607e57d1b7e1ef7e20ab4da961bf4778b2494f56ee76c5790b697c60a2daf1f8",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-23",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 23,
+      "section_id": "brief:turn-24-response",
+      "section_name": "brief:turn-24-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "5e280c5648ebb36055b06e9678b9ed48306de0765f8930b44768e9055309c702",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-24-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 24,
+      "section_id": "message:turn-25",
+      "section_name": "message:turn-25",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "8ac4d38b4718323613496df032a7c3c41f460e47a43b759d25a5bc439ecb9f60",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-25",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 25,
+      "section_id": "brief:turn-26-response",
+      "section_name": "brief:turn-26-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "9c814e17a304d5d4c0e514da8aa6c98ad17f99a5be0b0616799314624a879a38",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-26-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 26,
+      "section_id": "message:turn-27",
+      "section_name": "message:turn-27",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "d3d445e564fb14d4f106893cfa3cbd942da82dc3cda32e9326206452b93ce1eb",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-27",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 27,
+      "section_id": "brief:turn-28-response",
+      "section_name": "brief:turn-28-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "e133e0362cece753cf29138e70214296df8d749022c089eef4ca22b2c06f371d",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-28-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 28,
+      "section_id": "message:turn-29",
+      "section_name": "message:turn-29",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "bdf761fa3d000d2a6dd2d846ce4b30ea00363c008fa8d985c633395a33122553",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-29",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 29,
+      "section_id": "brief:turn-30-response",
+      "section_name": "brief:turn-30-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "fab6c68fa488b596365d906d7d8ef347d7c64a2723ad647f3f27d5c0659af9e3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-30-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 30,
+      "section_id": "message:turn-31",
+      "section_name": "message:turn-31",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "9acafc0a1f2d41a978f826e21df92d3e3e8874eea215f6d7422ffb0033027700",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-31",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 31,
+      "section_id": "brief:turn-32-response",
+      "section_name": "brief:turn-32-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "e8175deafab3e559449e119513a8e2aaaf8373e3a3caf354e22e6429c5163df0",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-32-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 32,
+      "section_id": "message:turn-33",
+      "section_name": "message:turn-33",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "5b47302f334e5ebbf6646424f20b73d7a61aefdb19eba0b3dd5368535f1174aa",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-33",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 33,
+      "section_id": "brief:turn-34-response",
+      "section_name": "brief:turn-34-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "8e90961f55bd07d2253e678d0d57d6fee35bcb6570b4163074ee28f3fa15bd89",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-34-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 34,
+      "section_id": "message:turn-35",
+      "section_name": "message:turn-35",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "fe509c8ea0b540e866dfea0ee8ebd0d9d10a2083663410fcb736faa33a79e97a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-35",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 35,
+      "section_id": "brief:turn-36-response",
+      "section_name": "brief:turn-36-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "f87837eca8d1466621b251fdf61f2e45841dc01d83ee6b0af9bb89c188a77e30",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-36-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 36,
+      "section_id": "message:turn-37",
+      "section_name": "message:turn-37",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "c9edcde4179ae8840d5760cb213074aadbcd0d7db51017b4a7767f3562bc1c20",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-37",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 37,
+      "section_id": "brief:turn-38-response",
+      "section_name": "brief:turn-38-response",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 52,
+      "content_sha256": "3df866446d94cc4d9cdbb929a191847d464648dfc39fbafd26625e8859f60fd5",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-38-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 38,
+      "section_id": "message:turn-39",
+      "section_name": "message:turn-39",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 12,
+      "rendered_chars": 45,
+      "content_sha256": "ec44d8e52febb538805c3b28256b8cfb77e22050d32883408de62375ac76d656",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-39",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 39,
+      "section_id": "message:turn-40",
+      "section_name": "message:turn-40",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "7157c52a1dc4172460df09a7f15cf961b23f22e0e652a6cafda2fdc9284fbb41",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-40",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 40,
+      "section_id": "brief:compaction-anchor",
+      "section_name": "brief:compaction-anchor",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 34,
+      "content_sha256": "59b1643cc9952e7a2e94a159599065b62178ea980fbdb19f58ef025a58077abc",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:compaction-anchor",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/restart-compaction-equivalence-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/restart-compaction-equivalence-4096.json
@@ -1,0 +1,1019 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+  },
+  "activation_binding": {
+    "source_message_id": "message:turn-40",
+    "turn_id": "turn-40",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-40",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 479,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:turn-1",
+      "section_name": "message:turn-1",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "d5116b380b99adf7fa1835c6bf858b07ac6904730a1929a464ae0d3425416828",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-1",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:turn-2-response",
+      "section_name": "brief:turn-2-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "dbf0d46a3a8054a09c8261745a081e95b8b53b51aac55e7e672014546d2713ae",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-2-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:turn-3",
+      "section_name": "message:turn-3",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "f3c8b290babf195960e4dd20835ac25ffa3b84f0e86966de320e433f69aa440a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-3",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:turn-4-decision",
+      "section_name": "brief:turn-4-decision",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 10,
+      "rendered_chars": 40,
+      "content_sha256": "096af186e2ae0183ae943fe37dd696a2a23c480e62c3deae9c3a5d699f91a54e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-4-decision",
+          "role": "direct_predecessor",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:turn-5",
+      "section_name": "message:turn-5",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "70bb140f33cd9a22a1e635bb43cbcadae182e854e04f70bd2648743e59fe93fc",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-5",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "brief:turn-6-response",
+      "section_name": "brief:turn-6-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "d543c3b9c61b121afef90cd3a40b31dcd0572eedf363eceb7d8a8e4be274920d",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-6-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "message:turn-7",
+      "section_name": "message:turn-7",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "3598aff831c85137eccfa94ba28ba2aaa13a2c51e67d6afdb63a195244b32f98",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-7",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 7,
+      "section_id": "brief:turn-8-response",
+      "section_name": "brief:turn-8-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 10,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 50,
+      "content_sha256": "aac044ff3d4ed64aec0a823b1b56caed9102ebc1d975e3be41ef700db00fa47f",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-8-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 8,
+      "section_id": "message:turn-9",
+      "section_name": "message:turn-9",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 8,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 42,
+      "content_sha256": "3052ff2dfcdf46e3070ef45493fbd87eac8f1bde710bc682b12a10c90b2a972c",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-9",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 9,
+      "section_id": "brief:turn-10-response",
+      "section_name": "brief:turn-10-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "7ced6e57e7f6e8cc6524ef1e7c87bb52915cce5054e0afbde42378f93fa8ce32",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-10-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 10,
+      "section_id": "message:turn-11",
+      "section_name": "message:turn-11",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "78ffeda8ed9a261e292075964ca8f53f12da8262751e8e2b8e8c0b0dcc81b13a",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-11",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 11,
+      "section_id": "brief:turn-12-response",
+      "section_name": "brief:turn-12-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "ef2e1c1c638b2bdae1a9e3fc5e055e2b654d4919d564f867f9a3ef30334bd169",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-12-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 12,
+      "section_id": "message:turn-13",
+      "section_name": "message:turn-13",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "dd9f01a195053d72a38fe886b4d07b15e21b06af5dc3e0cc70e9189774c13644",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-13",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 13,
+      "section_id": "brief:turn-14-response",
+      "section_name": "brief:turn-14-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "5faa9d85f49c43e7a5a76030be3bd07cd5b372e1841a4c178e80bdaf31206517",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-14-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 14,
+      "section_id": "message:turn-15",
+      "section_name": "message:turn-15",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "b158cce53b3c83bf742c72c9915f99bdabf360804e4d526700480b43bcb84c44",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-15",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 15,
+      "section_id": "brief:turn-16-response",
+      "section_name": "brief:turn-16-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "d383666b7b5574dc177568548f19ee7b1ff724445f457854bc754f4d5298b498",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-16-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 16,
+      "section_id": "message:turn-17",
+      "section_name": "message:turn-17",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "c2ca14fd54f67cbc1e90b6a99f42e78542015b0b122689b2b0cbbaef4908774f",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-17",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 17,
+      "section_id": "brief:turn-18-response",
+      "section_name": "brief:turn-18-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "1e9f41370d56131bb1b08e337480cfb45db8791d3f7460eda8888372022706ba",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-18-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 18,
+      "section_id": "message:turn-19",
+      "section_name": "message:turn-19",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "e0a6c6951e084881dba67e30a71e849da8acb090d533aa5f9a1e06e84a2b3d2b",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-19",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 19,
+      "section_id": "brief:turn-20-response",
+      "section_name": "brief:turn-20-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "023fcc584dd7093cf65ef9fb851f2840d5a9a1d6628e33c563b9082626610dc4",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-20-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 20,
+      "section_id": "message:turn-21",
+      "section_name": "message:turn-21",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cbfc20560b146469db548e7a0f3f732a87780fd5d8259a1e765a3e96757d25aa",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-21",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 21,
+      "section_id": "brief:turn-22-response",
+      "section_name": "brief:turn-22-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "1d5c8a1a8019ae8bdefabdce4a5f47bd1a4e9e2dad481f08e47b8bac37e22c54",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-22-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 22,
+      "section_id": "message:turn-23",
+      "section_name": "message:turn-23",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "8b0a94c6e128fae399b30e4d277f682de4a692a00ebc8f2af65abd816d660bfe",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-23",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 23,
+      "section_id": "brief:turn-24-response",
+      "section_name": "brief:turn-24-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "9ea6d26ad5ab386828cb05dbe729e91aade8828c29333f6e15bf2c59513e4a70",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-24-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 24,
+      "section_id": "message:turn-25",
+      "section_name": "message:turn-25",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "fc1a544de3497e58be1ff8bcdcca49c3411f57a58a2e613b724cc4edbc359721",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-25",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 25,
+      "section_id": "brief:turn-26-response",
+      "section_name": "brief:turn-26-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "eb6f4ef22a5d64fbeb0d6f5897e2ceea415949b2fb05467b12252828250cd647",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-26-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 26,
+      "section_id": "message:turn-27",
+      "section_name": "message:turn-27",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "1cbcc15a2846e7535fcbe6bc95b2055c3a7fd2938feb5d11f8c9cd10df119be2",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-27",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 27,
+      "section_id": "brief:turn-28-response",
+      "section_name": "brief:turn-28-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "e52430719c45bd38f73b677d56cd4bb344fa05bbf41fd029e55b60c2ee6407e3",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-28-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 28,
+      "section_id": "message:turn-29",
+      "section_name": "message:turn-29",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "b29ddc7a691647788355df2d6c3318e0f845a0bcc6a4e499709a4a4f3deae610",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-29",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 29,
+      "section_id": "brief:turn-30-response",
+      "section_name": "brief:turn-30-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "f99233f40421e971db8f867d66edd93383cdb7d5e3f1156850d93a7b2fd8d106",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-30-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 30,
+      "section_id": "message:turn-31",
+      "section_name": "message:turn-31",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "ea7a4f5f7ff282adb6bf56daf2be2d9883355f4dede855f89ee8042d61b6f975",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-31",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 31,
+      "section_id": "brief:turn-32-response",
+      "section_name": "brief:turn-32-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "88e7b9cce7517b1158573bd67dbdb567bec12680f9bbf610085d2e4d7c7cabc2",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-32-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 32,
+      "section_id": "message:turn-33",
+      "section_name": "message:turn-33",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "2ba7a37694931e3ab55662af2f9335576e0180fa204113a1939db20707c042e4",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-33",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 33,
+      "section_id": "brief:turn-34-response",
+      "section_name": "brief:turn-34-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "830fd7ecec8257ceac58ab1928419b3a3c4bd914b15e3e17f45203ac32b8151d",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-34-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 34,
+      "section_id": "message:turn-35",
+      "section_name": "message:turn-35",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "532fc536192dde5c26c283756844d81114474636debda7728acb0e609a148243",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-35",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 35,
+      "section_id": "brief:turn-36-response",
+      "section_name": "brief:turn-36-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "2cf93c320c064d9cee82c868998b5e6b48087c77d96ec5b0998d45594958be80",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-36-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 36,
+      "section_id": "message:turn-37",
+      "section_name": "message:turn-37",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "8beeb55c11332e49fa7689df816f7c40a11b7a6835ee250a5a40c50560678988",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-37",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 37,
+      "section_id": "brief:turn-38-response",
+      "section_name": "brief:turn-38-response",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 13,
+      "rendered_chars": 51,
+      "content_sha256": "5f4dcd47387ab28ad41c40f4b73387cd9eb35e4bce1da88def72bc31a9670a83",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:turn-38-response",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 38,
+      "section_id": "message:turn-39",
+      "section_name": "message:turn-39",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "9dc4b046976a2e6dd8ec1912d1ee8fafda8dd47f9ce64c9eaeb18c7a63a06c81",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-39",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 39,
+      "section_id": "message:turn-40",
+      "section_name": "message:turn-40",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 9,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "7157c52a1dc4172460df09a7f15cf961b23f22e0e652a6cafda2fdc9284fbb41",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:turn-40",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 40,
+      "section_id": "brief:compaction-anchor",
+      "section_name": "brief:compaction-anchor",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 24,
+      "content_sha256": "76be6437230736c876f9e5aa2046be5dc588de700f6d1d2aae85c1c639a5ce71",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:compaction-anchor",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_97376cd2e25d7a93c2a98f751629c89b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/return-to-old-topic-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/return-to-old-topic-16384.json
@@ -1,0 +1,216 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+  },
+  "activation_binding": {
+    "source_message_id": "message:return-topic-a",
+    "turn_id": "turn-12",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-12",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 23,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:topic-a-start",
+      "section_name": "message:topic-a-start",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 4,
+      "rendered_chars": 14,
+      "content_sha256": "2af2e7dcedc1ce9211a1e8bb7281bd2ae8886ff21ba7b36f26aef063cb9f1203",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-a-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:topic-a-decision",
+      "section_name": "brief:topic-a-decision",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 23,
+      "content_sha256": "c633bae168cc45b3e885996214f59b52f621a00f723b2a96c7b110a4d5da821c",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:topic-a-decision",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:topic-b-start",
+      "section_name": "message:topic-b-start",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 4,
+      "rendered_chars": 14,
+      "content_sha256": "f9a9361823ee6aa1f2b954eefd77898f15c8bc86f0ed559ff4011cad59474561",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-b-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "brief:topic-b-unrelated-detail",
+      "section_name": "brief:topic-b-unrelated-detail",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "brief:topic-b-unrelated-detail",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ]
+    },
+    {
+      "order": 4,
+      "section_id": "message:topic-b-more",
+      "section_name": "message:topic-b-more",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 4,
+      "rendered_chars": 13,
+      "content_sha256": "f18902053309a5b7e327556ef139caa26143c692af5b3d5fb8c3b7b9a1a27594",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-b-more",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 5,
+      "section_id": "message:return-topic-a",
+      "section_name": "message:return-topic-a",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 18,
+      "content_sha256": "6fa16434c436336c1214c3cafe09727a55504515e3760d5de3ae8ea1dcf97819",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:return-topic-a",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/return-to-old-topic-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/return-to-old-topic-2048.json
@@ -1,0 +1,216 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+  },
+  "activation_binding": {
+    "source_message_id": "message:return-topic-a",
+    "turn_id": "turn-12",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-12",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 21,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:topic-a-start",
+      "section_name": "message:topic-a-start",
+      "stability": "agent_scoped",
+      "representation": "truncated",
+      "reason": "truncated_to_remaining_budget",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 26,
+      "content_sha256": "e23cf8bc4f9f8feed26443317453f882699198e0fe1a12123f89e2fe41c1e4de",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-a-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:topic-a-decision",
+      "section_name": "brief:topic-a-decision",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 33,
+      "content_sha256": "2ec53b21886b9a0562b3fa429b2b5c5bc9cda800a9f20e96c56536a7b1ad129e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:topic-a-decision",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:topic-b-start",
+      "section_name": "message:topic-b-start",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:topic-b-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ]
+    },
+    {
+      "order": 3,
+      "section_id": "brief:topic-b-unrelated-detail",
+      "section_name": "brief:topic-b-unrelated-detail",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "brief:topic-b-unrelated-detail",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ]
+    },
+    {
+      "order": 4,
+      "section_id": "message:topic-b-more",
+      "section_name": "message:topic-b-more",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:topic-b-more",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ]
+    },
+    {
+      "order": 5,
+      "section_id": "message:return-topic-a",
+      "section_name": "message:return-topic-a",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 18,
+      "content_sha256": "6fa16434c436336c1214c3cafe09727a55504515e3760d5de3ae8ea1dcf97819",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:return-topic-a",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/return-to-old-topic-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/return-to-old-topic-4096.json
@@ -1,0 +1,216 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "conversation",
+    "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+  },
+  "activation_binding": {
+    "source_message_id": "message:return-topic-a",
+    "turn_id": "turn-12",
+    "owner": {
+      "kind": "conversation",
+      "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+    },
+    "work_item_id": null,
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-12",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 17,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:topic-a-start",
+      "section_name": "message:topic-a-start",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 24,
+      "content_sha256": "451f13e09c18b63dbb36f8114332f019173b13f60f5a8f5cf16114097a1e104f",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:topic-a-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "brief:topic-a-decision",
+      "section_name": "brief:topic-a-decision",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 23,
+      "content_sha256": "c633bae168cc45b3e885996214f59b52f621a00f723b2a96c7b110a4d5da821c",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:topic-a-decision",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "message:topic-b-start",
+      "section_name": "message:topic-b-start",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:topic-b-start",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ]
+    },
+    {
+      "order": 3,
+      "section_id": "brief:topic-b-unrelated-detail",
+      "section_name": "brief:topic-b-unrelated-detail",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "brief:topic-b-unrelated-detail",
+          "role": "result",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ]
+    },
+    {
+      "order": 4,
+      "section_id": "message:topic-b-more",
+      "section_name": "message:topic-b-more",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:topic-b-more",
+          "role": "input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ]
+    },
+    {
+      "order": 5,
+      "section_id": "message:return-topic-a",
+      "section_name": "message:return-topic-a",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 18,
+      "content_sha256": "6fa16434c436336c1214c3cafe09727a55504515e3760d5de3ae8ea1dcf97819",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:return-topic-a",
+          "role": "current_input",
+          "owner": {
+            "kind": "conversation",
+            "interaction_id": "interaction1_dc17c8027cc7535ad5ee3c72bcc493a9"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-switch-return-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-switch-return-16384.json
@@ -1,0 +1,243 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "work_item",
+    "work_item_id": "a"
+  },
+  "activation_binding": {
+    "source_message_id": "message:a-input",
+    "turn_id": "turn-1",
+    "owner": {
+      "kind": "work_item",
+      "work_item_id": "a"
+    },
+    "work_item_id": "a",
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-return-b-a",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 33,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "work_item:a",
+      "section_name": "work_item:a",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 20,
+      "content_sha256": "d2cb93e8e3289432fca7cd87cddd7eb74047533f263ef341ec79b31f3db415e4",
+      "selected_evidence_refs": [
+        {
+          "reference": "work_item:a",
+          "role": "work_item_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "a"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "message:a-input",
+      "section_name": "message:a-input",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 26,
+      "content_sha256": "a70edfe35449a6b1fe74918cb5be3c866d2b14e8ce89444ece8c13b463c936a4",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:a-input",
+          "role": "current_input",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "a"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "work_item:b",
+      "section_name": "work_item:b",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 20,
+      "content_sha256": "f3f70be9ba527f8967a3a9728388d75ee6874ca605d91a42bc62c67678880017",
+      "selected_evidence_refs": [
+        {
+          "reference": "work_item:b",
+          "role": "work_item_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "turn:switch-a-b",
+      "section_name": "turn:switch-a-b",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 19,
+      "content_sha256": "4d6a114548bb9c3232e98f40a4f19e6baa29da4a1375f93c318be87a29b7c4bd",
+      "selected_evidence_refs": [
+        {
+          "reference": "turn:switch-a-b",
+          "role": "turn",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "message:b-task-result",
+      "section_name": "message:b-task-result",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:b-task-result",
+          "role": "tool_result",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ]
+    },
+    {
+      "order": 5,
+      "section_id": "brief:b-complete",
+      "section_name": "brief:b-complete",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 22,
+      "content_sha256": "0ce0c19a59457153352ca49c26437ab9bb1382ec8ca1378d1c530deb2b21be2e",
+      "selected_evidence_refs": [
+        {
+          "reference": "brief:b-complete",
+          "role": "work_item_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 6,
+      "section_id": "turn:return-b-a",
+      "section_name": "turn:return-b-a",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 5,
+      "rendered_chars": 19,
+      "content_sha256": "23df815f44e1aefb3b706fbd9a947d87312c76c445131daf80644fd11c05620f",
+      "selected_evidence_refs": [
+        {
+          "reference": "turn:return-b-a",
+          "role": "turn",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "a"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "fail",
+      "details": [
+        "work_item:b owner=work_item:b expected=work_item:a",
+        "turn:switch-a-b owner=work_item:b expected=work_item:a",
+        "brief:b-complete owner=work_item:b expected=work_item:a"
+      ]
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-switch-return-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-switch-return-2048.json
@@ -1,0 +1,239 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "work_item",
+    "work_item_id": "a"
+  },
+  "activation_binding": {
+    "source_message_id": "message:a-input",
+    "turn_id": "turn-1",
+    "owner": {
+      "kind": "work_item",
+      "work_item_id": "a"
+    },
+    "work_item_id": "a",
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-return-b-a",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 7,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "work_item:a",
+      "section_name": "work_item:a",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "work_item:a",
+          "role": "work_item_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "a"
+          }
+        }
+      ]
+    },
+    {
+      "order": 1,
+      "section_id": "message:a-input",
+      "section_name": "message:a-input",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 26,
+      "content_sha256": "a70edfe35449a6b1fe74918cb5be3c866d2b14e8ce89444ece8c13b463c936a4",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:a-input",
+          "role": "current_input",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "a"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "work_item:b",
+      "section_name": "work_item:b",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "work_item:b",
+          "role": "work_item_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ]
+    },
+    {
+      "order": 3,
+      "section_id": "turn:switch-a-b",
+      "section_name": "turn:switch-a-b",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "turn:switch-a-b",
+          "role": "turn",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ]
+    },
+    {
+      "order": 4,
+      "section_id": "message:b-task-result",
+      "section_name": "message:b-task-result",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:b-task-result",
+          "role": "tool_result",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ]
+    },
+    {
+      "order": 5,
+      "section_id": "brief:b-complete",
+      "section_name": "brief:b-complete",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "brief:b-complete",
+          "role": "work_item_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ]
+    },
+    {
+      "order": 6,
+      "section_id": "turn:return-b-a",
+      "section_name": "turn:return-b-a",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "turn:return-b-a",
+          "role": "turn",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "a"
+          }
+        }
+      ]
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-switch-return-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-switch-return-4096.json
@@ -1,0 +1,239 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "work_item",
+    "work_item_id": "a"
+  },
+  "activation_binding": {
+    "source_message_id": "message:a-input",
+    "turn_id": "turn-1",
+    "owner": {
+      "kind": "work_item",
+      "work_item_id": "a"
+    },
+    "work_item_id": "a",
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-return-b-a",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 23,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "work_item:a",
+      "section_name": "work_item:a",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 30,
+      "content_sha256": "97faf4f75ad6642db90fad4d1ba4b2efd788b0a6066d5852c57d3aa5d2cb2ea0",
+      "selected_evidence_refs": [
+        {
+          "reference": "work_item:a",
+          "role": "work_item_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "a"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "message:a-input",
+      "section_name": "message:a-input",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 26,
+      "content_sha256": "a70edfe35449a6b1fe74918cb5be3c866d2b14e8ce89444ece8c13b463c936a4",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:a-input",
+          "role": "current_input",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "a"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "work_item:b",
+      "section_name": "work_item:b",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "work_item:b",
+          "role": "work_item_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ]
+    },
+    {
+      "order": 3,
+      "section_id": "turn:switch-a-b",
+      "section_name": "turn:switch-a-b",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "turn:switch-a-b",
+          "role": "turn",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ]
+    },
+    {
+      "order": 4,
+      "section_id": "message:b-task-result",
+      "section_name": "message:b-task-result",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:b-task-result",
+          "role": "tool_result",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ]
+    },
+    {
+      "order": 5,
+      "section_id": "brief:b-complete",
+      "section_name": "brief:b-complete",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "brief:b-complete",
+          "role": "work_item_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "b"
+          }
+        }
+      ]
+    },
+    {
+      "order": 6,
+      "section_id": "turn:return-b-a",
+      "section_name": "turn:return-b-a",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 5,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 29,
+      "content_sha256": "c9281ebe46f1d5e37e7a1542ed3fa7d48d97b4ebfc9990eb36c172766b8dd1bb",
+      "selected_evidence_refs": [
+        {
+          "reference": "turn:return-b-a",
+          "role": "turn",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "a"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-wait-task-result-recovery-16384.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-wait-task-result-recovery-16384.json
@@ -1,0 +1,195 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "work_item",
+    "work_item_id": "recovery"
+  },
+  "activation_binding": {
+    "source_message_id": "message:work-request",
+    "turn_id": "turn-1",
+    "owner": {
+      "kind": "work_item",
+      "work_item_id": "recovery"
+    },
+    "work_item_id": "recovery",
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-recovery",
+  "prompt_budget_estimated_tokens": 16384,
+  "allocated_estimated_tokens": 29,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:work-request",
+      "section_name": "message:work-request",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 21,
+      "content_sha256": "3fec216bb6203e4f0fd49564062faf4a0763b54c7d6849aff26845bda2595af0",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:work-request",
+          "role": "current_input",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "wait:task-1",
+      "section_name": "wait:task-1",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 7,
+      "rendered_chars": 26,
+      "content_sha256": "7623fe4c9ccdc4aaa685bd683d4924e08eed180481d8a8f79e958677ad1bf81f",
+      "selected_evidence_refs": [
+        {
+          "reference": "wait:task-1",
+          "role": "wait_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "turn:daemon-restart",
+      "section_name": "turn:daemon-restart",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 24,
+      "content_sha256": "eb6c43aa90b2a0fff99169be01903e9a69450c54fcb08671d5cdc5002068441c",
+      "selected_evidence_refs": [
+        {
+          "reference": "turn:daemon-restart",
+          "role": "lifecycle",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 3,
+      "section_id": "message:task-1-result",
+      "section_name": "message:task-1-result",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 22,
+      "content_sha256": "b1ae6274ed9d70d29cebe05524d593abe09c20f6ea76754c3eb6614af92eeb07",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:task-1-result",
+          "role": "tool_result",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "turn:recovery",
+      "section_name": "turn:recovery",
+      "stability": "agent_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 4,
+      "rendered_chars": 14,
+      "content_sha256": "5c5b28083a4d18dd3a8873c18c9a1a1f142e73fff222df7e71a2db1c1909107e",
+      "selected_evidence_refs": [
+        {
+          "reference": "turn:recovery",
+          "role": "turn",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "fail",
+      "details": [
+        "turn:daemon-restart owner=agent_lifecycle:agent-1 expected=work_item:recovery"
+      ]
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-wait-task-result-recovery-2048.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-wait-task-result-recovery-2048.json
@@ -1,0 +1,193 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "work_item",
+    "work_item_id": "recovery"
+  },
+  "activation_binding": {
+    "source_message_id": "message:work-request",
+    "turn_id": "turn-1",
+    "owner": {
+      "kind": "work_item",
+      "work_item_id": "recovery"
+    },
+    "work_item_id": "recovery",
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-recovery",
+  "prompt_budget_estimated_tokens": 2048,
+  "allocated_estimated_tokens": 6,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:work-request",
+      "section_name": "message:work-request",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 21,
+      "content_sha256": "3fec216bb6203e4f0fd49564062faf4a0763b54c7d6849aff26845bda2595af0",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:work-request",
+          "role": "current_input",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "wait:task-1",
+      "section_name": "wait:task-1",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "wait:task-1",
+          "role": "wait_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ]
+    },
+    {
+      "order": 2,
+      "section_id": "turn:daemon-restart",
+      "section_name": "turn:daemon-restart",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "turn:daemon-restart",
+          "role": "lifecycle",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ]
+    },
+    {
+      "order": 3,
+      "section_id": "message:task-1-result",
+      "section_name": "message:task-1-result",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "message:task-1-result",
+          "role": "tool_result",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ]
+    },
+    {
+      "order": 4,
+      "section_id": "turn:recovery",
+      "section_name": "turn:recovery",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "turn:recovery",
+          "role": "turn",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ]
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-wait-task-result-recovery-4096.json
+++ b/benchmarks/projection-eval/candidate-phase-1/manifests/work-item-wait-task-result-recovery-4096.json
@@ -1,0 +1,193 @@
+{
+  "schema_version": 1,
+  "projector": "legacy_context_sections_v1",
+  "activation_owner": {
+    "kind": "work_item",
+    "work_item_id": "recovery"
+  },
+  "activation_binding": {
+    "source_message_id": "message:work-request",
+    "turn_id": "turn-1",
+    "owner": {
+      "kind": "work_item",
+      "work_item_id": "recovery"
+    },
+    "work_item_id": "recovery",
+    "claimed_work_revision": null
+  },
+  "turn_id": "turn-recovery",
+  "prompt_budget_estimated_tokens": 4096,
+  "allocated_estimated_tokens": 29,
+  "system_sections": [
+    {
+      "order": 0,
+      "section_id": "identity",
+      "section_name": "identity",
+      "stability": "stable",
+      "representation": "full",
+      "reason": "system_section",
+      "requested_estimated_tokens": 11,
+      "allocated_estimated_tokens": 11,
+      "rendered_chars": 43,
+      "content_sha256": "cc23f147f831d7144b950676211369df343b3d347f4a8067767090b5c77ecbe2",
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "context_sections": [
+    {
+      "order": 0,
+      "section_id": "message:work-request",
+      "section_name": "message:work-request",
+      "stability": "turn_scoped",
+      "representation": "full",
+      "reason": "selected_full",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 21,
+      "content_sha256": "3fec216bb6203e4f0fd49564062faf4a0763b54c7d6849aff26845bda2595af0",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:work-request",
+          "role": "current_input",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 1,
+      "section_id": "wait:task-1",
+      "section_name": "wait:task-1",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 7,
+      "allocated_estimated_tokens": 9,
+      "rendered_chars": 36,
+      "content_sha256": "dd689ecba045b0a76e1939701d5b194fe950af77509da4c30233abcb6190a25d",
+      "selected_evidence_refs": [
+        {
+          "reference": "wait:task-1",
+          "role": "wait_state",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 2,
+      "section_id": "turn:daemon-restart",
+      "section_name": "turn:daemon-restart",
+      "stability": "turn_scoped",
+      "representation": "omitted",
+      "reason": "omitted_lower_priority",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 0,
+      "rendered_chars": 0,
+      "content_sha256": null,
+      "selected_evidence_refs": [],
+      "omitted_evidence_refs": [
+        {
+          "reference": "turn:daemon-restart",
+          "role": "lifecycle",
+          "owner": {
+            "kind": "agent_lifecycle",
+            "agent_id": "agent-1"
+          }
+        }
+      ]
+    },
+    {
+      "order": 3,
+      "section_id": "message:task-1-result",
+      "section_name": "message:task-1-result",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 6,
+      "allocated_estimated_tokens": 8,
+      "rendered_chars": 32,
+      "content_sha256": "dcb2ad73199e10e15a36a89e74a32caa2f687980bca5c18e2c39df4a1ac81edc",
+      "selected_evidence_refs": [
+        {
+          "reference": "message:task-1-result",
+          "role": "tool_result",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    },
+    {
+      "order": 4,
+      "section_id": "turn:recovery",
+      "section_name": "turn:recovery",
+      "stability": "agent_scoped",
+      "representation": "compact",
+      "reason": "selected_compact_for_budget",
+      "requested_estimated_tokens": 4,
+      "allocated_estimated_tokens": 6,
+      "rendered_chars": 24,
+      "content_sha256": "5eff4772500f54e4448ccf61af4428978f982f1c208e0b633eb2cb247584b5a2",
+      "selected_evidence_refs": [
+        {
+          "reference": "turn:recovery",
+          "role": "turn",
+          "owner": {
+            "kind": "work_item",
+            "work_item_id": "recovery"
+          }
+        }
+      ],
+      "omitted_evidence_refs": []
+    }
+  ],
+  "invariant_results": [
+    {
+      "code": "prompt_budget_respected",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "activation_binding_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "current_input_retained",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "direct_predecessor_retained",
+      "status": "not_applicable",
+      "details": [
+        "fixture does not identify a direct predecessor"
+      ]
+    },
+    {
+      "code": "canonical_evidence_unique",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "evidence_owner_consistent",
+      "status": "pass",
+      "details": []
+    },
+    {
+      "code": "section_representation_exclusive",
+      "status": "pass",
+      "details": []
+    }
+  ]
+}

--- a/benchmarks/projection-eval/candidate-phase-1/scorecard.json
+++ b/benchmarks/projection-eval/candidate-phase-1/scorecard.json
@@ -1,0 +1,416 @@
+{
+  "schema_version": 1,
+  "candidate_id": "activation-turn-owner-identity-phase-1",
+  "baseline_id": "legacy-context-sections-v1-phase-0",
+  "projector": "legacy_context_sections_v1",
+  "corpus": "../corpus/cases.json",
+  "rubric": "../corpus/rubric.json",
+  "generated_at": "2026-08-28",
+  "status": "owner_identity_only_observation",
+  "manifest_count": 36,
+  "provider_sections_byte_identical": true,
+  "entries": [
+    {
+      "case_id": "issue-2512-short-reference-need",
+      "budget": 2048,
+      "manifest": "issue-2512-short-reference-need-2048.json",
+      "baseline_sha256": "cbbf09835d27812464039b81f1c20057edba6bdd31da6a8034d8475845d95a32",
+      "candidate_sha256": "cfa1c5b3d28e72672301b609576279dada4ae54a485b25c9c181a6ecfd53bb4e",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "issue-2512-short-reference-need",
+      "budget": 4096,
+      "manifest": "issue-2512-short-reference-need-4096.json",
+      "baseline_sha256": "e4b4184ea388b45571da1368c4629ae4e2d6064906572358c9cd4baa5da49b90",
+      "candidate_sha256": "7404a122d2349d854a61abb1193d70d949fcd4b96fd2611ff7cb1bd08abe26fa",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "issue-2512-short-reference-need",
+      "budget": 16384,
+      "manifest": "issue-2512-short-reference-need-16384.json",
+      "baseline_sha256": "fa9a07db50e6e99378dcacc29fa3c61b0166eb3cff8e1ac7bf29cb7ad96bb874",
+      "candidate_sha256": "e7dfa693bb80c0c739ca1a293da6568cf0d9e20c73f7cbd955cfc19214f26820",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "issue-2512-short-reference-can",
+      "budget": 2048,
+      "manifest": "issue-2512-short-reference-can-2048.json",
+      "baseline_sha256": "fb787f9f53b64bec884000cdad8438faef8b00a7069bb1b96582c7553bf280cd",
+      "candidate_sha256": "94297f5d97b2934b796fddbf5af769996beac5a949ed543283bdc1238485f633",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "issue-2512-short-reference-can",
+      "budget": 4096,
+      "manifest": "issue-2512-short-reference-can-4096.json",
+      "baseline_sha256": "d397c67b7273619dd2e2ef786dd46717283cf709d56d017d3ca3dc16c61393b9",
+      "candidate_sha256": "8637b31a97aa89089362ead7c61ef3437999a5856f8120d04ac50eb3604bdb61",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "issue-2512-short-reference-can",
+      "budget": 16384,
+      "manifest": "issue-2512-short-reference-can-16384.json",
+      "baseline_sha256": "36da985ab72665f9a2edb3813f6b0ae6599e813095d5af82d0daf3326f77eb32",
+      "candidate_sha256": "5e1ae223197db093c6c493cae27d3668ccf252d84816a6e86f234c3c8a8ffbe2",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "issue-2512-ordinal-reference",
+      "budget": 2048,
+      "manifest": "issue-2512-ordinal-reference-2048.json",
+      "baseline_sha256": "f90790f2f27d5a88a99cfaf08670ef6ec0539375b7358c3b6af935cdee049b83",
+      "candidate_sha256": "6d63a62e186194e9f557bf8a36dd3fe4571db93ca47e437ad92066f8c3f464f8",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "issue-2512-ordinal-reference",
+      "budget": 4096,
+      "manifest": "issue-2512-ordinal-reference-4096.json",
+      "baseline_sha256": "b50449c372b21cfb9190dd45e47ec7cf83b9b630f19cc941c8102a485f5a05f6",
+      "candidate_sha256": "8b27428283e7a1d0e06f978d012bbfb84732c166581fd11de542783ba8073759",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "issue-2512-ordinal-reference",
+      "budget": 16384,
+      "manifest": "issue-2512-ordinal-reference-16384.json",
+      "baseline_sha256": "7a1a35ad60ee85a87ce3addd3fcc98412fc91bc27cfcb339b769dc07b41883fc",
+      "candidate_sha256": "090ec1615cf295e2503c971eec0af3f9110a16963f6b308298b97b5dbf0263a4",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "continuity-10-turns",
+      "budget": 2048,
+      "manifest": "continuity-10-turns-2048.json",
+      "baseline_sha256": "34813093f6e225e0518b718729f5d83c8304884e13d5954520cb74db76bd022c",
+      "candidate_sha256": "4a4a746ee11a37351f1401f7045923335579752b7747678dc144021de105f052",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "continuity-10-turns",
+      "budget": 4096,
+      "manifest": "continuity-10-turns-4096.json",
+      "baseline_sha256": "7a2352ddcf0b9e926a2ebfc32c8ca71124705f273a9edccdb1908e953d74a605",
+      "candidate_sha256": "6ed1450aec564270973669c982293dfe7783d9add7f58ff1649ad9a79b221b64",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "continuity-10-turns",
+      "budget": 16384,
+      "manifest": "continuity-10-turns-16384.json",
+      "baseline_sha256": "6494ed83b3deb8a28b0790a272f946f2d9b0bb19145d56700a1e81e2a4fb32f6",
+      "candidate_sha256": "880cec31433d3a637c7ce5036b17850e5650cc08233774a44fa8afbda886e172",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "continuity-20-turns",
+      "budget": 2048,
+      "manifest": "continuity-20-turns-2048.json",
+      "baseline_sha256": "5292707976b2fb4e8042e1c81e07fc56eb68ca762fc445b0b372ff608f775d98",
+      "candidate_sha256": "856282877218306229fd5bfb31ee0944915aef4114d31c84bf925a1831231d30",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "continuity-20-turns",
+      "budget": 4096,
+      "manifest": "continuity-20-turns-4096.json",
+      "baseline_sha256": "dab90b2d3953301192db9b2076f33323c91e35f226c02f67f29f07e18da45bda",
+      "candidate_sha256": "eecfcfe740af71779b2e2524b73c99852079c368e5e19b951e78cf620b59c1aa",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "continuity-20-turns",
+      "budget": 16384,
+      "manifest": "continuity-20-turns-16384.json",
+      "baseline_sha256": "ac5210df61af1ca8b6c2987c486fba1e1cbe3f41bc7574f67595afed52bd1602",
+      "candidate_sha256": "4510cb3cc634a12ea997b7b2b13983e1fadeba0702baa7b0608be8c00022e9f1",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "continuity-40-turns",
+      "budget": 2048,
+      "manifest": "continuity-40-turns-2048.json",
+      "baseline_sha256": "ae0f24a5765181f4717bf95dd590d2655ea344c39e86d5d2c899c238822cf48b",
+      "candidate_sha256": "a4fb4e6299215fc7b8071b59cc18e263a643058ca0151dfa28da7e098f87b511",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "continuity-40-turns",
+      "budget": 4096,
+      "manifest": "continuity-40-turns-4096.json",
+      "baseline_sha256": "0873b77897b4f2e0c97c80ceea804e800db5586da8b43139d2a979d8c272fa14",
+      "candidate_sha256": "de1fcd08c0f79d6be74b0530f764567a63751591ac3ce40294444aa220c636b8",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "continuity-40-turns",
+      "budget": 16384,
+      "manifest": "continuity-40-turns-16384.json",
+      "baseline_sha256": "0375b5b1928d133c68eb2ba8e65d96f92f2974959e569fcea22905b2b949a412",
+      "candidate_sha256": "7ba33f673db9882b0a1c242e69592aba52cd0b964f9f4f88b2987d4f58f3d677",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "new-topic-no-false-carry-over",
+      "budget": 2048,
+      "manifest": "new-topic-no-false-carry-over-2048.json",
+      "baseline_sha256": "515a7dbbce215c331838028757b448e91f81ef03c69f8076791004537152111f",
+      "candidate_sha256": "c255b2d10327873300c71cd6aad9f8b5d51c6f7c0ae1a2f948b0eb3704978bd1",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "new-topic-no-false-carry-over",
+      "budget": 4096,
+      "manifest": "new-topic-no-false-carry-over-4096.json",
+      "baseline_sha256": "994fd5f8400b578246abaf416b43fd69bc4ef94e35b0ff8a4eb74127a33b4f44",
+      "candidate_sha256": "df295eef8992d9ec421872bf4d4c7c9aafdb4819f7405aaf3b6becc6877dc229",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "new-topic-no-false-carry-over",
+      "budget": 16384,
+      "manifest": "new-topic-no-false-carry-over-16384.json",
+      "baseline_sha256": "04b8fb64dfac596e1cf8e4a1077cd788b13046172a038b13b2de4df4ec128452",
+      "candidate_sha256": "b4eb5dd209631055d7818f0c32ba7726f155adcd0c580072497bc0e5bb132080",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "return-to-old-topic",
+      "budget": 2048,
+      "manifest": "return-to-old-topic-2048.json",
+      "baseline_sha256": "06519b4c9bf2b31b4268b3fd80ca3466eacd5233af5983017c4518c70d3d40f6",
+      "candidate_sha256": "6c8e75fb3d97b72bed96a4027fa99a67673324f0626e25fa64a972641a91d210",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "return-to-old-topic",
+      "budget": 4096,
+      "manifest": "return-to-old-topic-4096.json",
+      "baseline_sha256": "6db3fc561bc1be7699d9e5b0c0d1dda0201ee592d016bf120a2bd1d0775f2ccd",
+      "candidate_sha256": "77eebe7e0accd96cf40fe152af9286543a02ee1d64e25b1fe2355238759f34fc",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "return-to-old-topic",
+      "budget": 16384,
+      "manifest": "return-to-old-topic-16384.json",
+      "baseline_sha256": "55ccde1584f44bab400b3d7419845f67a0bd9314ce467f5f630b4d63259fefc8",
+      "candidate_sha256": "28e9e07787939531efbc9d04c0e513c804f7eed634538fb1edb9016db6a5aac3",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "work-item-switch-return",
+      "budget": 2048,
+      "manifest": "work-item-switch-return-2048.json",
+      "baseline_sha256": "1da3c9711765646c3e77b053930b0ae87eeda4bc31c62168b324eb9b8eb13f4d",
+      "candidate_sha256": "7177f750f6ff1f0b8688e6b8e1adf543b09d4920e44d91bc3b3cd0afb505f1cf",
+      "activation_owner_changed": false,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "work-item-switch-return",
+      "budget": 4096,
+      "manifest": "work-item-switch-return-4096.json",
+      "baseline_sha256": "fd88d49299fc6cdb20afab23e5f6b1280adf966fab83907125b6bd13e3192b9c",
+      "candidate_sha256": "d2dfeca30c17f4c1a38047fe5949039c21498da2d85b191d6be152ff980374ec",
+      "activation_owner_changed": false,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "work-item-switch-return",
+      "budget": 16384,
+      "manifest": "work-item-switch-return-16384.json",
+      "baseline_sha256": "15a0a60ecb6befb4242186a21a1da1a36797c4dea607fff3e9f0553648324fe4",
+      "candidate_sha256": "42b68767ab60cbfe297460df7cc997a13dc89d1f3a5b7b37325cda5ae1c73fc2",
+      "activation_owner_changed": false,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": false,
+      "failed_invariants": [
+        "evidence_owner_consistent"
+      ]
+    },
+    {
+      "case_id": "work-item-wait-task-result-recovery",
+      "budget": 2048,
+      "manifest": "work-item-wait-task-result-recovery-2048.json",
+      "baseline_sha256": "ba621c04c59a4d645bcba316aa4efb9725fa1a944d515e1d95a9330bd625bb2d",
+      "candidate_sha256": "1f3d3ccba9030464afb5557432591fc35efa3dc3706fa6c00f0db97e621c05b7",
+      "activation_owner_changed": false,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "work-item-wait-task-result-recovery",
+      "budget": 4096,
+      "manifest": "work-item-wait-task-result-recovery-4096.json",
+      "baseline_sha256": "600c738e9d65a31bbb39bfc493961353952a47783faca8fbdf0affc6dbbd3321",
+      "candidate_sha256": "a962f798f903c4e207d2b5563c38b53e4eac415aecb32a4f663026a5acc09411",
+      "activation_owner_changed": false,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "work-item-wait-task-result-recovery",
+      "budget": 16384,
+      "manifest": "work-item-wait-task-result-recovery-16384.json",
+      "baseline_sha256": "0f68b541b7015200b515f408270f04833c025bc3c08bb4af7384f17379c05fd9",
+      "candidate_sha256": "fe986a5b6243912a1a5bee6999d2072fe4adccfcfd80edd5a1a1c5f1f6a8c610",
+      "activation_owner_changed": false,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": false,
+      "failed_invariants": [
+        "evidence_owner_consistent"
+      ]
+    },
+    {
+      "case_id": "discussion-interleaved-runtime-wakes",
+      "budget": 2048,
+      "manifest": "discussion-interleaved-runtime-wakes-2048.json",
+      "baseline_sha256": "9f060ba978102d32fddb2924a2afd8c164818ed5a7bb12cab40204bfa2706ca6",
+      "candidate_sha256": "979b3686c34b6b97d79124c07ba2101fe902602514ffdec1f8c944a2bf732145",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "discussion-interleaved-runtime-wakes",
+      "budget": 4096,
+      "manifest": "discussion-interleaved-runtime-wakes-4096.json",
+      "baseline_sha256": "023f5194bd2104ea8e11bd063d30d280ca61986efb3335112254d65d5b81e7b0",
+      "candidate_sha256": "7dbac671b625fda5eefdc1fde8056cea311714b8daf444e64c8d3dba76b72288",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "discussion-interleaved-runtime-wakes",
+      "budget": 16384,
+      "manifest": "discussion-interleaved-runtime-wakes-16384.json",
+      "baseline_sha256": "14bf662e46722a38e95d97ea096c3117905beee2aad5042c3e07a40bdacd4624",
+      "candidate_sha256": "f6086d4c92eae8fa74945dd035f98b94119263108713999b8a9f1391d2144178",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": false,
+      "failed_invariants": [
+        "evidence_owner_consistent"
+      ]
+    },
+    {
+      "case_id": "restart-compaction-equivalence",
+      "budget": 2048,
+      "manifest": "restart-compaction-equivalence-2048.json",
+      "baseline_sha256": "23f54bca16b5fbc5ef97f5e129ff0819af47f9e9bffa7572777fed2653678c88",
+      "candidate_sha256": "161bb37a432407668430f51f8e4163b25c999a8ccd821962572285596c88f510",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "restart-compaction-equivalence",
+      "budget": 4096,
+      "manifest": "restart-compaction-equivalence-4096.json",
+      "baseline_sha256": "9b498aa262d7d899380b83cb234c49ec2cb143ec1f9fcbbc652d2fae8a061f29",
+      "candidate_sha256": "bd805d9c8fbe1a668f117657e22aaa1c6257bd70fddb32e6a56c1a70a01fbc82",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    },
+    {
+      "case_id": "restart-compaction-equivalence",
+      "budget": 16384,
+      "manifest": "restart-compaction-equivalence-16384.json",
+      "baseline_sha256": "4785fb4a1e92b008218354541ab85101dee83ab069735b141083586e1706bf1d",
+      "candidate_sha256": "ed28caaf2c1f3a228c63b3ba963e0620affb8b8b1e233f1d0b576199705a5cdd",
+      "activation_owner_changed": true,
+      "provider_sections_byte_identical": true,
+      "invariants_pass": true,
+      "failed_invariants": []
+    }
+  ]
+}

--- a/docs/rfcs/activation-turn-owner-identity.md
+++ b/docs/rfcs/activation-turn-owner-identity.md
@@ -44,8 +44,11 @@ interaction scope. Remote operator transport uses the validated transport
 binding plus its optional `conversation_ref`. Arbitrary message metadata cannot
 choose an interaction.
 
-Conversation expresses continuity only. It owns no WorkItem, task, wait,
-completion, or scheduling authority.
+Conversation expresses continuity only. Its interaction id owns no WorkItem,
+task, wait, completion, or scheduling authority. An agent execution with a
+Conversation owner may still use the existing agent-scoped WorkItem tools, but
+the target must pass the same agent, source-revision, state, and report-binding
+fences; matching an interaction id never satisfies or weakens those fences.
 
 ## Persistence And Compatibility
 

--- a/docs/rfcs/activation-turn-owner-identity.md
+++ b/docs/rfcs/activation-turn-owner-identity.md
@@ -1,0 +1,86 @@
+---
+title: RFC: Activation and Turn Owner Identity
+date: 2026-08-28
+status: accepted
+---
+
+# Activation and Turn Owner Identity
+
+Phase 1 establishes durable owner identity before Holon changes semantic context
+projection. It follows
+[Deterministic Projection Evaluation Phase 0](./projection-evaluation-phase-0.md).
+
+## Scope
+
+Every canonical execution attempt already has one `ExecutionBinding`. Phase 1
+uses that binding as the authority and materializes the same owner on its Turn:
+
+- `WorkItem { work_item_id }`
+- `Conversation { interaction_id }`
+- `AgentLifecycle { agent_id }`
+- `Command`
+
+`TurnRecord.owner` is a query and retention relation. It is not a second
+scheduler authority. `current_work_item_id` remains a compatibility projection
+and must agree with a WorkItem owner.
+
+This phase does not replace prompt sections, select historical Turns by owner,
+or change provider request content. Those are Phase 2 concerns.
+
+## Admission
+
+Owner selection follows trusted admission facts:
+
+1. an exact WorkItem binding always selects `WorkItem`
+2. a trusted operator prompt without a WorkItem or exact wait selects
+   `Conversation`
+3. external, timer, recovery, task, internal lifecycle, and exact wait
+   activations remain `AgentLifecycle` unless exactly bound to a WorkItem
+4. `Command` remains independent
+
+Conversation identity is opaque and derived from authenticated server-side
+facts. Local CLI, run-once, and authenticated control prompts use a stable local
+interaction scope. Remote operator transport uses the validated transport
+binding plus its optional `conversation_ref`. Arbitrary message metadata cannot
+choose an interaction.
+
+Conversation expresses continuity only. It owns no WorkItem, task, wait,
+completion, or scheduling authority.
+
+## Persistence And Compatibility
+
+New Turns persist the canonical owner and indexed `(owner_kind, owner_id)`.
+Restart reconstruction reads the durable owner rather than process-local
+conversation state.
+
+Legacy Turns have no owner field. Their conservative fallback is:
+
+- `current_work_item_id` present: `WorkItem`
+- otherwise: `AgentLifecycle`
+
+Legacy unbound facts are never inferred to be Conversation because doing so
+could join unrelated history or elevate authority.
+
+An existing legacy Turn may be enriched once with a matching canonical owner.
+An existing explicit owner is immutable.
+
+## Authority Invariants
+
+- admission binding, current execution owner, and new Turn owner agree
+- Conversation cannot resume a wait or task solely because interaction ids
+  match
+- exact wait and task-result admission retain their existing authority fences
+- untrusted or external metadata cannot create or merge Conversation identity
+- WorkItem owner semantics and settlement remain unchanged
+- owner reconstruction is deterministic across restart
+
+## Evaluation
+
+`ProjectionManifest.activation_owner` may report the new durable owner, but
+Phase 1 must leave rendered system/context sections and provider lowering
+unchanged. Candidate manifests are compared with the frozen Phase 0 baseline;
+owner-label changes are expected only where admission now records Conversation.
+
+Phase 2 requires separate authorization and must prove owner-thread selection,
+single representation per Turn, direct-predecessor retention, and provider
+behavior before retiring legacy prompt sections.

--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -1615,7 +1615,8 @@ class CaseHarness:
                 "turn_records": sqlite_rows(
                     connection,
                     "SELECT turn_id, turn_index, agent_id, run_id, "
-                    "current_work_item_id, trigger_message_id, terminal_kind, "
+                    "current_work_item_id, owner_kind, owner_id, "
+                    "trigger_message_id, terminal_kind, "
                     "created_at, completed_at, payload_json "
                     "FROM turn_records ORDER BY turn_index, created_at",
                 ),
@@ -1855,14 +1856,14 @@ def require_scheduler_engine_activation_chain(
     *,
     work_item_id: str,
     expected_source_kinds: tuple[str, ...],
-    lifecycle_message_ids: set[str] | None = None,
+    conversation_message_ids: set[str] | None = None,
 ) -> None:
     require_execution_attempt_chain(
         snapshot,
         agent_id=harness.agent_id,
         work_item_id=work_item_id,
         expected_source_kinds=expected_source_kinds,
-        lifecycle_message_ids=lifecycle_message_ids or set(),
+        conversation_message_ids=conversation_message_ids or set(),
     )
 
 
@@ -1976,7 +1977,7 @@ def require_execution_attempt_chain(
     agent_id: str,
     work_item_id: str,
     expected_source_kinds: tuple[str, ...],
-    lifecycle_message_ids: set[str],
+    conversation_message_ids: set[str],
 ) -> list[dict[str, Any]]:
     attempts = [
         (row, execution_attempt(row))
@@ -1988,21 +1989,23 @@ def require_execution_attempt_chain(
         for row, attempt in attempts
         if execution_binding_work_item(attempt) == work_item_id
     ]
-    lifecycle_attempts = [
+    conversation_attempts = [
         (row, attempt)
         for row, attempt in attempts
-        if attempt.get("source_message_id") in lifecycle_message_ids
-        and attempt.get("binding") == {"kind": "agent_lifecycle", "agent_id": agent_id}
+        if attempt.get("source_message_id") in conversation_message_ids
+        and attempt.get("binding", {}).get("kind") == "conversation"
+        and isinstance(attempt.get("binding", {}).get("interaction_id"), str)
+        and attempt["binding"]["interaction_id"]
     ]
     require(
-        len(lifecycle_attempts) == len(lifecycle_message_ids)
+        len(conversation_attempts) == len(conversation_message_ids)
         and all(
             row["lifecycle_state"] == "settled"
             and row["terminal_outcome_id"] is not None
-            for row, _ in lifecycle_attempts
+            for row, _ in conversation_attempts
         ),
-        "canonical lifecycle attempts did not settle without claiming a "
-        f"WorkItem: {[attempt for _, attempt in lifecycle_attempts]}",
+        "canonical Conversation attempts did not settle without claiming a "
+        f"WorkItem: {[attempt for _, attempt in conversation_attempts]}",
     )
     require(
         sorted(
@@ -2019,7 +2022,7 @@ def require_execution_attempt_chain(
         f"source kinds {expected_source_kinds}: "
         f"{[attempt for _, attempt in work_item_attempts]}",
     )
-    terminal_attempts = work_item_attempts + lifecycle_attempts
+    terminal_attempts = work_item_attempts + conversation_attempts
     outcome_by_id = {
         row["outcome_id"]: execution_outcome(row)
         for row in snapshot["execution_protocol_outcomes"]
@@ -2138,7 +2141,19 @@ def require_lifecycle_wait_adoption(
         len(source_turns) == 1,
         f"adopted wait source turn is missing or duplicated: {source_turns}",
     )
-    source_message_id = source_turns[0]["trigger_message_id"]
+    source_turn = source_turns[0]
+    source_message_id = source_turn["trigger_message_id"]
+    owner_kind = source_turn.get("owner_kind")
+    owner_id = source_turn.get("owner_id")
+    if owner_kind == "conversation":
+        expected_binding = {"kind": "conversation", "interaction_id": owner_id}
+    else:
+        require(
+            owner_kind in {None, "agent_lifecycle"}
+            and owner_id in {None, agent_id},
+            f"adopted wait source turn has an invalid owner: {source_turn}",
+        )
+        expected_binding = {"kind": "agent_lifecycle", "agent_id": agent_id}
     attempts = [
         (row, execution_attempt(row))
         for row in snapshot["execution_protocol_attempts"]
@@ -2148,8 +2163,7 @@ def require_lifecycle_wait_adoption(
     require(
         len(attempts) == 1
         and attempts[0][0]["lifecycle_state"] == "settled"
-        and attempts[0][1].get("binding")
-        == {"kind": "agent_lifecycle", "agent_id": agent_id},
+        and attempts[0][1].get("binding") == expected_binding,
         f"lifecycle handoff source attempt is invalid: {attempts}",
     )
     terminal_outcome_id = attempts[0][0]["terminal_outcome_id"]
@@ -3078,7 +3092,7 @@ def run_scheduler_task_wait_resume_case(
             "task_result",
             "triggered_wait",
         ),
-        lifecycle_message_ids={
+        conversation_message_ids={
             harness.prompt_scope("scheduler-task-wait-seed")["message_id"]
         },
     )
@@ -3445,7 +3459,7 @@ def run_scheduler_multi_workitem_case(
             snapshot,
             work_item_id=wid,
             expected_source_kinds=("work_item_continuation",),
-            lifecycle_message_ids={
+            conversation_message_ids={
                 harness.prompt_scope("scheduler-multi-create")["message_id"]
             },
         )
@@ -3562,7 +3576,7 @@ def run_scheduler_external_wait_resume_case(
         snapshot,
         work_item_id=work_item_id,
         expected_source_kinds=("triggered_wait",),
-        lifecycle_message_ids={
+        conversation_message_ids={
             harness.prompt_scope("scheduler-external-wait")["message_id"]
         },
     )
@@ -3676,7 +3690,7 @@ def run_scheduler_operator_wait_resume_case(
         snapshot,
         work_item_id=work_item_id,
         expected_source_kinds=("triggered_wait",),
-        lifecycle_message_ids={
+        conversation_message_ids={
             harness.prompt_scope("scheduler-operator-wait")["message_id"]
         },
     )
@@ -3835,7 +3849,7 @@ def run_scheduler_concurrent_claim_fencing_case(
         snapshot,
         work_item_id=work_item_a_id,
         expected_source_kinds=("work_item_continuation", "triggered_wait"),
-        lifecycle_message_ids={
+        conversation_message_ids={
             harness.prompt_scope("scheduler-concurrent-create")["message_id"]
         },
     )
@@ -3844,7 +3858,7 @@ def run_scheduler_concurrent_claim_fencing_case(
         snapshot,
         work_item_id=work_item_b_id,
         expected_source_kinds=("work_item_continuation",),
-        lifecycle_message_ids=set(),
+        conversation_message_ids=set(),
     )
     waits = require_scheduler_wait_terminal(
         harness,
@@ -4017,7 +4031,7 @@ def run_scheduler_operator_interject_during_wait_case(
         snapshot,
         work_item_id=work_item_a_id,
         expected_source_kinds=("work_item_continuation", "triggered_wait"),
-        lifecycle_message_ids={
+        conversation_message_ids={
             harness.prompt_scope("scheduler-interject-create")["message_id"]
         },
     )
@@ -4026,7 +4040,7 @@ def run_scheduler_operator_interject_during_wait_case(
         snapshot,
         work_item_id=work_item_b_id,
         expected_source_kinds=("work_item_continuation",),
-        lifecycle_message_ids={
+        conversation_message_ids={
             harness.prompt_scope("scheduler-interject-b-create")["message_id"]
         },
     )
@@ -4168,7 +4182,7 @@ def run_scheduler_compaction_continuity_case(
         snapshot,
         work_item_id=work_item_id,
         expected_source_kinds=("triggered_wait",),
-        lifecycle_message_ids={
+        conversation_message_ids={
             harness.prompt_scope("scheduler-compaction-create")["message_id"]
         },
     )
@@ -4281,7 +4295,7 @@ def run_scheduler_worktree_isolation_case(
         snapshot,
         work_item_id=work_item_id,
         expected_source_kinds=(),
-        lifecycle_message_ids={
+        conversation_message_ids={
             harness.prompt_scope("scheduler-worktree-lifecycle")["message_id"]
         },
     )
@@ -4368,7 +4382,7 @@ def run_scheduler_spawn_agent_supervision_case(
         snapshot,
         work_item_id=work_item_id,
         expected_source_kinds=(),
-        lifecycle_message_ids={
+        conversation_message_ids={
             harness.prompt_scope("scheduler-spawn-and-complete")["message_id"]
         },
     )
@@ -4499,7 +4513,7 @@ def run_scheduler_checkpoint_replay_case(
             "work_item_continuation",
             "triggered_wait",
         ),
-        lifecycle_message_ids={
+        conversation_message_ids={
             harness.prompt_scope("scheduler-replay-create")["message_id"]
         },
     )
@@ -4508,7 +4522,7 @@ def run_scheduler_checkpoint_replay_case(
         snapshot,
         work_item_id=work_item_b_id,
         expected_source_kinds=("work_item_continuation",),
-        lifecycle_message_ids={
+        conversation_message_ids={
             harness.prompt_scope("scheduler-replay-create")["message_id"]
         },
     )

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -645,12 +645,22 @@ fn build_projection_evidence(
     tools: &[ToolExecutionRecord],
 ) -> ProjectionEvidenceIndex {
     let mut evidence = ProjectionEvidenceIndex::new();
+    let current_owner = agent
+        .current_execution_binding
+        .as_ref()
+        .and_then(|binding| binding.owner.as_ref())
+        .map(ProjectionOwner::from)
+        .unwrap_or_else(|| projection_owner(current_message.work_item_id.as_deref(), &agent.id));
+    let turn_owners = turn_records
+        .iter()
+        .map(|turn| (turn.turn_id.as_str(), turn.effective_owner()))
+        .collect::<std::collections::BTreeMap<_, _>>();
     evidence.insert(
         "current_input".into(),
         vec![ProjectionEvidenceRef::new(
             format!("message:{}", current_message.id),
             ProjectionEvidenceRole::CurrentInput,
-            projection_owner(current_message.work_item_id.as_deref(), &agent.id),
+            current_owner,
         )],
     );
     if let Some(work_item) = current_work_item {
@@ -684,7 +694,7 @@ fn build_projection_evidence(
         recent_turn_refs.push(ProjectionEvidenceRef::new(
             format!("turn:{}", turn.turn_id),
             ProjectionEvidenceRole::Turn,
-            projection_owner(turn.current_work_item_id.as_deref(), &agent.id),
+            ProjectionOwner::from(&turn.effective_owner()),
         ));
     }
     let direct_predecessor_id = messages
@@ -692,6 +702,12 @@ fn build_projection_evidence(
         .max_by(|left, right| compare_message_recency(left, right))
         .map(|message| message.id.as_str());
     for message in messages {
+        let owner = message
+            .turn_id
+            .as_deref()
+            .and_then(|turn_id| turn_owners.get(turn_id))
+            .map(ProjectionOwner::from)
+            .unwrap_or_else(|| projection_owner(message.work_item_id.as_deref(), &agent.id));
         recent_turn_refs.push(ProjectionEvidenceRef::new(
             format!("message:{}", message.id),
             if direct_predecessor_id == Some(message.id.as_str()) {
@@ -699,21 +715,33 @@ fn build_projection_evidence(
             } else {
                 ProjectionEvidenceRole::Input
             },
-            projection_owner(message.work_item_id.as_deref(), &agent.id),
+            owner,
         ));
     }
     for brief in briefs {
+        let owner = brief
+            .turn_id
+            .as_deref()
+            .and_then(|turn_id| turn_owners.get(turn_id))
+            .map(ProjectionOwner::from)
+            .unwrap_or_else(|| projection_owner(brief.work_item_id.as_deref(), &agent.id));
         recent_turn_refs.push(ProjectionEvidenceRef::new(
             format!("brief:{}", brief.id),
             ProjectionEvidenceRole::Result,
-            projection_owner(brief.work_item_id.as_deref(), &agent.id),
+            owner,
         ));
     }
     for tool in tools {
+        let owner = tool
+            .turn_id
+            .as_deref()
+            .and_then(|turn_id| turn_owners.get(turn_id))
+            .map(ProjectionOwner::from)
+            .unwrap_or_else(|| projection_owner(tool.work_item_id.as_deref(), &agent.id));
         recent_turn_refs.push(ProjectionEvidenceRef::new(
             format!("tool_execution:{}", tool.id),
             ProjectionEvidenceRole::ToolResult,
-            projection_owner(tool.work_item_id.as_deref(), &agent.id),
+            owner,
         ));
     }
     recent_turn_refs.sort();
@@ -5762,6 +5790,7 @@ mod tests {
             }),
             source_message_id: "message-bound".into(),
             turn_id: "turn-bound".into(),
+            owner: None,
             work_item_id: Some(execution_owner.id.clone()),
             claimed_work_revision: Some(execution_owner.revision),
         });
@@ -5825,6 +5854,7 @@ mod tests {
             }),
             source_message_id: "message-lifecycle".into(),
             turn_id: "turn-lifecycle".into(),
+            owner: None,
             work_item_id: None,
             claimed_work_revision: None,
         });

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -1299,9 +1299,17 @@ pub async fn operator_ingress(
         .map_err(error_response)?;
 
     let reply_route_id = request.reply_route_id.and_then(non_empty_opt);
+    let conversation_ref = request.conversation_ref.and_then(non_empty_opt);
+    let interaction_id = crate::ids::interaction_id(&[
+        &agent_id,
+        "remote_operator_transport",
+        &binding.binding_id,
+        conversation_ref.as_deref().unwrap_or("default"),
+    ]);
     let metadata = json!({
         "operator_transport": {
             "binding_id": binding.binding_id,
+            "conversation_ref": conversation_ref,
             "transport": binding.transport,
             "reply_route_id": reply_route_id,
             "provider": request.provider.and_then(non_empty_opt).unwrap_or(expected_provider),
@@ -1328,6 +1336,10 @@ pub async fn operator_ingress(
         causation_id: request.causation_id,
     }
     .into_message();
+    let mut message = message;
+    message
+        .source_refs
+        .insert("interaction_id".into(), interaction_id);
     let queued = runtime.enqueue(message).await.map_err(error_response)?;
     Ok(Json(EnqueueResponse {
         ok: true,

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -165,6 +165,7 @@ pub struct OperatorIngressRequest {
     pub text: String,
     pub actor_id: String,
     pub binding_id: String,
+    pub conversation_ref: Option<String>,
     pub reply_route_id: Option<String>,
     pub provider: Option<String>,
     pub upstream_provider: Option<String>,

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -36,6 +36,17 @@ pub fn turn_id() -> String {
     runtime_id("turn")
 }
 
+pub(crate) fn interaction_id(parts: &[&str]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"holon.interaction.v1\x00");
+    for part in parts {
+        hasher.update(part.as_bytes());
+        hasher.update(b"\x00");
+    }
+    let digest = hasher.finalize();
+    format!("interaction1_{}", hex(&digest[..16]))
+}
+
 pub fn tool_execution_id() -> String {
     runtime_id("tool")
 }
@@ -196,6 +207,14 @@ mod tests {
         ] {
             assert_runtime_id(&id, prefix);
         }
+    }
+
+    #[test]
+    fn interaction_ids_are_stable_and_scope_sensitive() {
+        let first = interaction_id(&["agent", "control"]);
+        assert_eq!(first, interaction_id(&["agent", "control"]));
+        assert_ne!(first, interaction_id(&["agent", "cli"]));
+        assert!(first.starts_with("interaction1_"));
     }
 
     #[test]

--- a/src/projection_eval/baseline.rs
+++ b/src/projection_eval/baseline.rs
@@ -266,6 +266,64 @@ pub fn generate_all_manifests() -> Vec<(String, usize, ProjectionManifest)> {
     results
 }
 
+fn phase_1_owner(case_id: &str, owner: &ProjectionOwner) -> ProjectionOwner {
+    match owner {
+        ProjectionOwner::LegacyUnbound { agent_id } => ProjectionOwner::Conversation {
+            interaction_id: crate::ids::interaction_id(&[
+                agent_id,
+                "projection_eval_phase_1",
+                case_id,
+            ]),
+        },
+        owner => owner.clone(),
+    }
+}
+
+fn phase_1_evidence_owner(case_id: &str, evidence: &BaselineEvidenceSpec) -> ProjectionOwner {
+    if evidence.role == ProjectionEvidenceRole::Lifecycle
+        || matches!(
+            evidence.reference.as_str(),
+            "message:external-wake" | "message:timer-wake" | "message:lifecycle-wake"
+        )
+    {
+        return ProjectionOwner::AgentLifecycle {
+            agent_id: "agent-1".into(),
+        };
+    }
+    phase_1_owner(case_id, &evidence.owner)
+}
+
+pub fn phase_1_case_specs() -> Vec<BaselineCaseSpec> {
+    baseline_case_specs()
+        .into_iter()
+        .map(|mut spec| {
+            spec.owner = phase_1_owner(&spec.case_id, &spec.owner);
+            if let Some(binding) = spec.binding.as_mut() {
+                binding.owner = Some(spec.owner.clone());
+            }
+            for evidence in &mut spec.evidence {
+                evidence.owner = phase_1_evidence_owner(&spec.case_id, evidence);
+            }
+            spec
+        })
+        .collect()
+}
+
+pub fn generate_all_phase_1_manifests() -> Vec<(String, usize, ProjectionManifest)> {
+    let specs = phase_1_case_specs();
+    let mut results = Vec::with_capacity(specs.len() * BASELINE_BUDGETS.len());
+    for spec in &specs {
+        for &budget in BASELINE_BUDGETS {
+            results.push((
+                spec.case_id.clone(),
+                budget,
+                generate_manifest(spec, budget),
+            ));
+        }
+    }
+    results
+}
+
 /// Manifest filename for a case + budget.
 pub fn manifest_filename(case_id: &str, budget: usize) -> String {
     format!("{case_id}-{budget}.json")
@@ -294,6 +352,66 @@ pub struct BaselineScorecard {
     pub status: String,
     pub manifest_count: usize,
     pub entries: Vec<BaselineScorecardEntry>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Phase1ScorecardEntry {
+    pub case_id: String,
+    pub budget: usize,
+    pub manifest: String,
+    pub baseline_sha256: String,
+    pub candidate_sha256: String,
+    pub activation_owner_changed: bool,
+    pub provider_sections_byte_identical: bool,
+    pub invariants_pass: bool,
+    pub failed_invariants: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Phase1Scorecard {
+    pub schema_version: u32,
+    pub candidate_id: String,
+    pub baseline_id: String,
+    pub projector: String,
+    pub corpus: String,
+    pub rubric: String,
+    pub generated_at: String,
+    pub status: String,
+    pub manifest_count: usize,
+    pub provider_sections_byte_identical: bool,
+    pub entries: Vec<Phase1ScorecardEntry>,
+}
+
+fn provider_sections_byte_identical(
+    baseline: &ProjectionManifest,
+    candidate: &ProjectionManifest,
+) -> bool {
+    let equivalent =
+        |baseline: &crate::projection_eval::ProjectionSectionManifest,
+         candidate: &crate::projection_eval::ProjectionSectionManifest| {
+            baseline.order == candidate.order
+                && baseline.section_id == candidate.section_id
+                && baseline.section_name == candidate.section_name
+                && baseline.stability == candidate.stability
+                && baseline.representation == candidate.representation
+                && baseline.reason == candidate.reason
+                && baseline.requested_estimated_tokens == candidate.requested_estimated_tokens
+                && baseline.allocated_estimated_tokens == candidate.allocated_estimated_tokens
+                && baseline.rendered_chars == candidate.rendered_chars
+                && baseline.content_sha256 == candidate.content_sha256
+        };
+    baseline.system_sections.len() == candidate.system_sections.len()
+        && baseline.context_sections.len() == candidate.context_sections.len()
+        && baseline
+            .system_sections
+            .iter()
+            .zip(&candidate.system_sections)
+            .all(|(baseline, candidate)| equivalent(baseline, candidate))
+        && baseline
+            .context_sections
+            .iter()
+            .zip(&candidate.context_sections)
+            .all(|(baseline, candidate)| equivalent(baseline, candidate))
 }
 
 /// Generate the deterministic baseline scorecard.
@@ -332,6 +450,57 @@ pub fn generate_scorecard() -> BaselineScorecard {
     }
 }
 
+pub fn generate_phase_1_scorecard() -> Phase1Scorecard {
+    let baseline = generate_all_manifests();
+    let candidate = generate_all_phase_1_manifests();
+    let entries = baseline
+        .iter()
+        .zip(&candidate)
+        .map(
+            |((baseline_case, baseline_budget, baseline), (case_id, budget, candidate))| {
+                assert_eq!((baseline_case, baseline_budget), (case_id, budget));
+                let provider_sections_byte_identical =
+                    provider_sections_byte_identical(baseline, candidate);
+                let failed_invariants = candidate
+                    .invariant_results
+                    .iter()
+                    .filter(|result| {
+                        result.status == crate::projection_eval::ProjectionInvariantStatus::Fail
+                    })
+                    .map(|result| result.code.clone())
+                    .collect::<Vec<_>>();
+                Phase1ScorecardEntry {
+                    case_id: case_id.clone(),
+                    budget: *budget,
+                    manifest: manifest_filename(case_id, *budget),
+                    baseline_sha256: baseline.byte_sha256().unwrap_or_default(),
+                    candidate_sha256: candidate.byte_sha256().unwrap_or_default(),
+                    activation_owner_changed: baseline.activation_owner
+                        != candidate.activation_owner,
+                    provider_sections_byte_identical,
+                    invariants_pass: failed_invariants.is_empty(),
+                    failed_invariants,
+                }
+            },
+        )
+        .collect::<Vec<_>>();
+    Phase1Scorecard {
+        schema_version: 1,
+        candidate_id: "activation-turn-owner-identity-phase-1".into(),
+        baseline_id: "legacy-context-sections-v1-phase-0".into(),
+        projector: "legacy_context_sections_v1".into(),
+        corpus: "../corpus/cases.json".into(),
+        rubric: "../corpus/rubric.json".into(),
+        generated_at: "2026-08-28".into(),
+        status: "owner_identity_only_observation".into(),
+        manifest_count: entries.len(),
+        provider_sections_byte_identical: entries
+            .iter()
+            .all(|entry| entry.provider_sections_byte_identical),
+        entries,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,6 +511,11 @@ mod tests {
     fn manifest_dir() -> std::path::PathBuf {
         std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("benchmarks/projection-eval/baseline/manifests")
+    }
+
+    fn phase_1_manifest_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("benchmarks/projection-eval/candidate-phase-1/manifests")
     }
 
     #[test]
@@ -507,6 +681,62 @@ mod tests {
         let json2 = serde_json::to_string_pretty(&sc2).unwrap();
         assert_eq!(json1, json2, "scorecard must be deterministic");
         assert_eq!(sc1.manifest_count, 36);
+    }
+
+    #[test]
+    fn phase_1_candidate_changes_only_owner_metadata() {
+        let scorecard = generate_phase_1_scorecard();
+        assert_eq!(scorecard.manifest_count, 36);
+        assert!(scorecard.provider_sections_byte_identical);
+        assert!(scorecard
+            .entries
+            .iter()
+            .all(|entry| entry.provider_sections_byte_identical));
+        assert!(scorecard
+            .entries
+            .iter()
+            .any(|entry| entry.activation_owner_changed));
+    }
+
+    #[test]
+    fn frozen_phase_1_manifests_match_generated() {
+        let dir = phase_1_manifest_dir();
+        if !dir.exists() {
+            eprintln!("Phase 1 candidate manifest directory not found, skipping drift check");
+            return;
+        }
+        for (case_id, budget, manifest) in generate_all_phase_1_manifests() {
+            let path = dir.join(manifest_filename(&case_id, budget));
+            let committed = fs::read_to_string(&path).unwrap_or_else(|err| {
+                panic!("Phase 1 manifest {case_id}-{budget} missing at {path:?}: {err}")
+            });
+            let committed_manifest: ProjectionManifest = serde_json::from_str(&committed).unwrap();
+            assert_eq!(
+                manifest.canonical_json().unwrap(),
+                committed_manifest.canonical_json().unwrap(),
+                "Phase 1 candidate drift detected for {case_id}-{budget}"
+            );
+        }
+    }
+
+    #[test]
+    fn regenerate_phase_1_candidate() {
+        if std::env::var("REGEN_PHASE1_CANDIDATE").ok().as_deref() != Some("1") {
+            return;
+        }
+        let dir = phase_1_manifest_dir();
+        fs::create_dir_all(&dir).unwrap();
+        for (case_id, budget, manifest) in generate_all_phase_1_manifests() {
+            let path = dir.join(manifest_filename(&case_id, budget));
+            fs::write(&path, manifest.canonical_json().unwrap()).unwrap();
+            println!("wrote {path:?}");
+        }
+        let scorecard = generate_phase_1_scorecard();
+        let json = format!("{}\n", serde_json::to_string_pretty(&scorecard).unwrap());
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("benchmarks/projection-eval/candidate-phase-1/scorecard.json");
+        fs::write(&path, json).unwrap();
+        println!("wrote {path:?}");
     }
 
     #[test]

--- a/src/projection_eval/baseline_specs.rs
+++ b/src/projection_eval/baseline_specs.rs
@@ -42,6 +42,7 @@ fn binding(
     ProjectionBindingSummary {
         source_message_id: message_id.into(),
         turn_id: turn_id.into(),
+        owner: None,
         work_item_id: work_item_id.map(|s| s.into()),
         claimed_work_revision: None,
     }

--- a/src/projection_eval/mod.rs
+++ b/src/projection_eval/mod.rs
@@ -30,6 +30,23 @@ pub enum ProjectionOwner {
     Command,
 }
 
+impl From<&crate::types::TurnOwner> for ProjectionOwner {
+    fn from(owner: &crate::types::TurnOwner) -> Self {
+        match owner {
+            crate::types::TurnOwner::WorkItem { work_item_id } => Self::WorkItem {
+                work_item_id: work_item_id.clone(),
+            },
+            crate::types::TurnOwner::Conversation { interaction_id } => Self::Conversation {
+                interaction_id: interaction_id.clone(),
+            },
+            crate::types::TurnOwner::AgentLifecycle { agent_id } => Self::AgentLifecycle {
+                agent_id: agent_id.clone(),
+            },
+            crate::types::TurnOwner::Command => Self::Command,
+        }
+    }
+}
+
 impl ProjectionOwner {
     fn key(&self) -> String {
         match self {
@@ -46,6 +63,8 @@ impl ProjectionOwner {
 pub struct ProjectionBindingSummary {
     pub source_message_id: String,
     pub turn_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<ProjectionOwner>,
     pub work_item_id: Option<String>,
     pub claimed_work_revision: Option<u64>,
 }
@@ -402,17 +421,20 @@ fn activation_binding_is_consistent(manifest: &ProjectionManifest) -> Projection
             ["manifest does not include a legacy activation binding"],
         );
     };
-    let matches = match binding.work_item_id.as_ref() {
-        Some(work_item_id) => {
-            manifest.activation_owner
-                == (ProjectionOwner::WorkItem {
-                    work_item_id: work_item_id.clone(),
-                })
-        }
-        None => matches!(
-            manifest.activation_owner,
-            ProjectionOwner::LegacyUnbound { .. }
-        ),
+    let matches = match binding.owner.as_ref() {
+        Some(owner) => owner == &manifest.activation_owner,
+        None => match binding.work_item_id.as_ref() {
+            Some(work_item_id) => {
+                manifest.activation_owner
+                    == (ProjectionOwner::WorkItem {
+                        work_item_id: work_item_id.clone(),
+                    })
+            }
+            None => matches!(
+                manifest.activation_owner,
+                ProjectionOwner::LegacyUnbound { .. }
+            ),
+        },
     };
     if matches {
         invariant(
@@ -425,7 +447,12 @@ fn activation_binding_is_consistent(manifest: &ProjectionManifest) -> Projection
             "activation_binding_consistent",
             ProjectionInvariantStatus::Fail,
             [format!(
-                "binding work_item_id={} conflicts with owner={}",
+                "binding owner={} work_item_id={} conflicts with activation owner={}",
+                binding
+                    .owner
+                    .as_ref()
+                    .map(ProjectionOwner::key)
+                    .unwrap_or_else(|| "legacy".to_string()),
                 binding.work_item_id.as_deref().unwrap_or("<none>"),
                 manifest.activation_owner.key()
             )],
@@ -809,6 +836,7 @@ mod tests {
         manifest.activation_binding = Some(ProjectionBindingSummary {
             source_message_id: "message:current".into(),
             turn_id: "turn-1".into(),
+            owner: None,
             work_item_id: Some("work-1".into()),
             claimed_work_revision: Some(1),
         });

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -567,6 +567,7 @@ fn build_effective_prompt_with_tool_prompt_context_and_default_external_ingress(
             ProjectionBindingSummary {
                 source_message_id: binding.source_message_id.clone(),
                 turn_id: binding.turn_id.clone(),
+                owner: binding.owner.as_ref().map(ProjectionOwner::from),
                 work_item_id: binding.work_item_id.clone(),
                 claimed_work_revision: binding.claimed_work_revision,
             }
@@ -582,9 +583,16 @@ fn built_context_owner(session: &AgentState) -> ProjectionOwner {
     session
         .current_execution_binding
         .as_ref()
-        .and_then(|binding| binding.work_item_id.as_ref())
-        .map(|work_item_id| ProjectionOwner::WorkItem {
-            work_item_id: work_item_id.clone(),
+        .and_then(|binding| binding.owner.as_ref())
+        .map(ProjectionOwner::from)
+        .or_else(|| {
+            session
+                .current_execution_binding
+                .as_ref()
+                .and_then(|binding| binding.work_item_id.as_ref())
+                .map(|work_item_id| ProjectionOwner::WorkItem {
+                    work_item_id: work_item_id.clone(),
+                })
         })
         .unwrap_or_else(|| ProjectionOwner::LegacyUnbound {
             agent_id: session.id.clone(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -610,7 +610,8 @@ fn execution_protocol_completion_transition_from_prepared(
         }
         ExecutionBinding::Conversation { .. } => {
             anyhow::ensure!(
-                authoritative.source_revision == intent.expected_work_revision
+                attempt.agent_id == record.agent_id
+                    && authoritative.source_revision == intent.expected_work_revision
                     && !matches!(
                         authoritative.state,
                         WorkItemExecutionState::InFlight { .. }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -608,8 +608,47 @@ fn execution_protocol_completion_transition_from_prepared(
             ]);
             commands
         }
-        ExecutionBinding::Conversation { .. } | ExecutionBinding::Command => {
-            bail!("completion commit requires a WorkItem or agent-lifecycle execution")
+        ExecutionBinding::Conversation { .. } => {
+            anyhow::ensure!(
+                authoritative.source_revision == intent.expected_work_revision
+                    && !matches!(
+                        authoritative.state,
+                        WorkItemExecutionState::InFlight { .. }
+                            | WorkItemExecutionState::Terminal { .. }
+                    ),
+                "completion commit conversation WorkItem fence is stale"
+            );
+            let mut commands = Vec::with_capacity(3);
+            if !state.work_items.contains_key(&prepared.record.id) {
+                commands.push(ExecutionProtocolCommand::RegisterWorkItem(Box::new(
+                    RegisterWorkItemExecution {
+                        work_item_id: prepared.record.id.clone(),
+                        record: authoritative.clone(),
+                    },
+                )));
+            }
+            commands.extend([
+                ExecutionProtocolCommand::Settle(SettleExecution {
+                    outcome: ExecutionOutcomeRecord {
+                        outcome_id: format!("outcome:complete:{}", attempt.attempt_id),
+                        attempt_id: attempt.attempt_id.clone(),
+                        outcome: ExecutionOutcome::Conversation(ConversationOutcome::Replied),
+                        created_at: record.updated_at.to_rfc3339(),
+                    },
+                }),
+                ExecutionProtocolCommand::CompleteWorkItem(Box::new(CompleteWorkItemExecution {
+                    command_id: format!("completion:work_item:{}", attempt.attempt_id),
+                    work_item_id: prepared.record.id.clone(),
+                    expected: authoritative.clone(),
+                    completion: prepared.brief.id.clone(),
+                })),
+            ]);
+            commands
+        }
+        ExecutionBinding::Command => {
+            bail!(
+                "completion commit requires a WorkItem, conversation, or agent-lifecycle execution"
+            )
         }
     };
 
@@ -625,7 +664,7 @@ fn canonical_matching_terminal_turn(
     runtime_db: &RuntimeDb,
     record: &QueueEntryRecord,
     message: &MessageEnvelope,
-    owner_work_item_id: Option<&str>,
+    owner: &crate::types::TurnOwner,
     terminal_turn: Option<&TurnRecord>,
 ) -> Result<Option<TurnRecord>> {
     let matches_activation = |turn: &TurnRecord| {
@@ -644,7 +683,7 @@ fn canonical_matching_terminal_turn(
                 .and_then(|trigger| trigger.message_id.as_deref())
                 == Some(record.message_id.as_str())
             && matches_turn_identity
-            && turn.current_work_item_id.as_deref() == owner_work_item_id
+            && turn.effective_owner() == *owner
     };
     if let Some(turn) = terminal_turn.filter(|turn| matches_activation(turn)) {
         return Ok(Some(turn.clone()));
@@ -695,25 +734,28 @@ fn execution_protocol_settlement_transition_from_facts(
     let Some(message) = storage.read_message_by_id(&record.message_id)? else {
         return Ok(interrupted("source_message_missing"));
     };
-    let owner_work_item_id = match &attempt.binding {
-        ExecutionBinding::WorkItem { work_item_id } => Some(work_item_id.as_str()),
-        ExecutionBinding::Conversation { .. }
-        | ExecutionBinding::AgentLifecycle { .. }
-        | ExecutionBinding::Command => None,
+    let owner = match &attempt.binding {
+        ExecutionBinding::WorkItem { work_item_id } => crate::types::TurnOwner::WorkItem {
+            work_item_id: work_item_id.clone(),
+        },
+        ExecutionBinding::Conversation { interaction_id } => {
+            crate::types::TurnOwner::Conversation {
+                interaction_id: interaction_id.clone(),
+            }
+        }
+        ExecutionBinding::AgentLifecycle { agent_id } => crate::types::TurnOwner::AgentLifecycle {
+            agent_id: agent_id.clone(),
+        },
+        ExecutionBinding::Command => crate::types::TurnOwner::Command,
     };
-    let matching_terminal_turn = canonical_matching_terminal_turn(
-        runtime_db,
-        record,
-        &message,
-        owner_work_item_id,
-        terminal_turn,
-    )?;
+    let matching_terminal_turn =
+        canonical_matching_terminal_turn(runtime_db, record, &message, &owner, terminal_turn)?;
     let Some(terminal_turn) = matching_terminal_turn else {
         return Err(
             crate::domain::execution_protocol::ExecutionSettlementConflict::MissingTerminalTurn {
                 attempt_id: attempt.attempt_id.clone(),
                 message_id: record.message_id.clone(),
-                owner_work_item_id: owner_work_item_id.map(ToString::to_string),
+                owner_work_item_id: owner.work_item_id().map(ToString::to_string),
             }
             .into(),
         );
@@ -3358,19 +3400,21 @@ impl RuntimeHandle {
                     .ok_or_else(|| {
                         anyhow!("canonical execution admission references an unknown attempt")
                     })?;
-                let work_item_id = match attempt.binding {
+                let owner = match attempt.binding {
                     crate::domain::execution_protocol::ExecutionBinding::WorkItem {
                         work_item_id,
-                    } => Some(work_item_id),
+                    } => crate::types::TurnOwner::WorkItem { work_item_id },
                     crate::domain::execution_protocol::ExecutionBinding::Conversation {
-                        ..
+                        interaction_id,
+                    } => crate::types::TurnOwner::Conversation { interaction_id },
+                    crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
+                        agent_id,
+                    } => crate::types::TurnOwner::AgentLifecycle { agent_id },
+                    crate::domain::execution_protocol::ExecutionBinding::Command => {
+                        crate::types::TurnOwner::Command
                     }
-                    | crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
-                        ..
-                    }
-                    | crate::domain::execution_protocol::ExecutionBinding::Command => None,
                 };
-                Some((activation_id.clone(), work_item_id))
+                Some((activation_id.clone(), owner))
             }
             ExecutionAdmissionProvenance::LegacyCompat { .. } => None,
         };
@@ -3428,8 +3472,9 @@ impl RuntimeHandle {
             };
             guard.state.current_turn_id = Some(turn_id.clone());
             guard.state.last_turn_terminal = None;
-            if let Some((_, work_item_id)) = canonical_execution_binding.as_ref() {
-                guard.state.current_turn_work_item_id = work_item_id.clone();
+            if let Some((_, owner)) = canonical_execution_binding.as_ref() {
+                guard.state.current_turn_work_item_id =
+                    owner.work_item_id().map(ToString::to_string);
             } else if let Some((_, source_turn)) = replay_source.as_ref() {
                 guard.state.current_turn_work_item_id = source_turn
                     .as_ref()
@@ -3440,8 +3485,8 @@ impl RuntimeHandle {
             guard.state.current_execution_binding = message.map(|message| {
                 let work_item_id = canonical_execution_binding
                     .as_ref()
-                    .map(|(_, work_item_id)| work_item_id.clone())
-                    .unwrap_or_else(|| {
+                    .and_then(|(_, owner)| owner.work_item_id().map(ToString::to_string))
+                    .or_else(|| {
                         message
                             .work_item_id
                             .clone()
@@ -3466,6 +3511,9 @@ impl RuntimeHandle {
                     admission_provenance: Some(execution_admission_provenance.clone()),
                     source_message_id: message.id.clone(),
                     turn_id,
+                    owner: canonical_execution_binding
+                        .as_ref()
+                        .map(|(_, owner)| owner.clone()),
                     work_item_id,
                     claimed_work_revision,
                 }
@@ -4884,6 +4932,26 @@ impl RuntimeHandle {
             };
             let attempt = attempt.clone();
             let activation_id = attempt.attempt_id.clone();
+            let owner = match &attempt.binding {
+                crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id } => {
+                    crate::types::TurnOwner::WorkItem {
+                        work_item_id: work_item_id.clone(),
+                    }
+                }
+                crate::domain::execution_protocol::ExecutionBinding::Conversation {
+                    interaction_id,
+                } => crate::types::TurnOwner::Conversation {
+                    interaction_id: interaction_id.clone(),
+                },
+                crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
+                    agent_id: owner_agent_id,
+                } => crate::types::TurnOwner::AgentLifecycle {
+                    agent_id: owner_agent_id.clone(),
+                },
+                crate::domain::execution_protocol::ExecutionBinding::Command => {
+                    crate::types::TurnOwner::Command
+                }
+            };
             let work_item_id = match &attempt.binding {
                 crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id } => {
                     Some(work_item_id.clone())
@@ -4952,7 +5020,7 @@ impl RuntimeHandle {
                         .and_then(|trigger| trigger.message_id.as_deref())
                         == Some(entry.message_id.as_str())
                     && message.turn_id.as_deref() == Some(turn.turn_id.as_str())
-                    && turn.current_work_item_id.as_deref() == work_item_id.as_deref()
+                    && turn.effective_owner() == owner
             });
             let terminal_is_completed = terminal_turn.is_some_and(|turn| {
                 turn.terminal.as_ref().is_some_and(|terminal| {

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -1,5 +1,6 @@
 use super::message_dispatch::MessageDispatchPlan;
 use super::*;
+use crate::domain::execution_protocol::ExecutionBinding;
 use crate::types::ExecutionAdmissionProvenance;
 
 const QUEUE_HEAD_NO_PROGRESS_MAX_ATTEMPTS: u32 = 3;
@@ -1659,9 +1660,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             }
         };
         let binding = work_item.map_or_else(
-            || ExecutionBinding::AgentLifecycle {
-                agent_id: message.agent_id.clone(),
-            },
+            || unbound_execution_binding(message, admitted_wait_id),
             |(work_item, _)| ExecutionBinding::WorkItem {
                 work_item_id: work_item.id.clone(),
             },
@@ -2214,6 +2213,20 @@ fn canonical_execution_trust(
     }
 }
 
+fn unbound_execution_binding(
+    message: &MessageEnvelope,
+    admitted_wait_id: Option<&str>,
+) -> ExecutionBinding {
+    if admitted_wait_id.is_none() {
+        if let Some(interaction_id) = message.trusted_interaction_id() {
+            return ExecutionBinding::Conversation { interaction_id };
+        }
+    }
+    ExecutionBinding::AgentLifecycle {
+        agent_id: message.agent_id.clone(),
+    }
+}
+
 fn canonical_execution_origin_for_scenario(
     message: &MessageEnvelope,
     scenario: &scheduler::CanonicalActivationScenario,
@@ -2333,6 +2346,45 @@ mod tests {
             MessageDeliverySurface::HttpControlPrompt,
             AdmissionContext::ControlAuthenticated,
         )
+    }
+
+    #[test]
+    fn unbound_trusted_operator_prompt_uses_stable_conversation_owner() {
+        let first = operator_prompt("first");
+        let second = operator_prompt("second");
+        let ExecutionBinding::Conversation {
+            interaction_id: first_id,
+        } = unbound_execution_binding(&first, None)
+        else {
+            panic!("trusted operator prompt should use Conversation owner");
+        };
+        let ExecutionBinding::Conversation {
+            interaction_id: second_id,
+        } = unbound_execution_binding(&second, None)
+        else {
+            panic!("trusted operator prompt should use Conversation owner");
+        };
+        assert_eq!(first_id, second_id);
+    }
+
+    #[test]
+    fn exact_wait_and_untrusted_input_do_not_use_conversation_owner() {
+        let trusted = operator_prompt("wait resume");
+        assert!(matches!(
+            unbound_execution_binding(&trusted, Some("wait-1")),
+            ExecutionBinding::AgentLifecycle { .. }
+        ));
+
+        let mut untrusted = operator_prompt("forged interaction");
+        untrusted.authority_class = AuthorityClass::ExternalEvidence;
+        untrusted.admission_context = Some(AdmissionContext::PublicUnauthenticated);
+        untrusted
+            .source_refs
+            .insert("interaction_id".into(), "forged".into());
+        assert!(matches!(
+            unbound_execution_binding(&untrusted, None),
+            ExecutionBinding::AgentLifecycle { .. }
+        ));
     }
 
     async fn queue_candidate(runtime: &RuntimeHandle) -> QueueCandidate {

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -4189,17 +4189,20 @@ impl RuntimeHandle {
                             }
                             crate::domain::execution_protocol::ExecutionBinding::Conversation {
                                 ..
-                            } => protocol_state.work_items.get(&existing.id).map_or_else(
-                                || legacy_work_item_execution.is_some(),
-                                |work_item| {
-                                    work_item.source_revision == existing.revision
-                                        && !matches!(
-                                            work_item.state,
-                                            crate::domain::execution_protocol::WorkItemExecutionState::InFlight { .. }
-                                                | crate::domain::execution_protocol::WorkItemExecutionState::Terminal { .. }
-                                        )
-                                },
-                            ),
+                            } => {
+                                attempt.agent_id == agent_id
+                                    && protocol_state.work_items.get(&existing.id).map_or_else(
+                                        || legacy_work_item_execution.is_some(),
+                                        |work_item| {
+                                            work_item.source_revision == existing.revision
+                                                && !matches!(
+                                                    work_item.state,
+                                                    crate::domain::execution_protocol::WorkItemExecutionState::InFlight { .. }
+                                                        | crate::domain::execution_protocol::WorkItemExecutionState::Terminal { .. }
+                                                )
+                                        },
+                                    )
+                            }
                             crate::domain::execution_protocol::ExecutionBinding::Command => false,
                         }
                 });

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -4189,8 +4189,18 @@ impl RuntimeHandle {
                             }
                             crate::domain::execution_protocol::ExecutionBinding::Conversation {
                                 ..
-                            }
-                            | crate::domain::execution_protocol::ExecutionBinding::Command => false,
+                            } => protocol_state.work_items.get(&existing.id).map_or_else(
+                                || legacy_work_item_execution.is_some(),
+                                |work_item| {
+                                    work_item.source_revision == existing.revision
+                                        && !matches!(
+                                            work_item.state,
+                                            crate::domain::execution_protocol::WorkItemExecutionState::InFlight { .. }
+                                                | crate::domain::execution_protocol::WorkItemExecutionState::Terminal { .. }
+                                        )
+                                },
+                            ),
+                            crate::domain::execution_protocol::ExecutionBinding::Command => false,
                         }
                 });
                 let matching_attempt = matching_attempts

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -4874,8 +4874,8 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
     assert!(matches!(
         &admitted.attempts[&activation_id],
         crate::domain::execution_protocol::ExecutionAttempt {
-            binding: crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
-                agent_id
+            binding: crate::domain::execution_protocol::ExecutionBinding::Conversation {
+                interaction_id
             },
             source:
                 crate::domain::execution_protocol::ExecutionSource {
@@ -4887,7 +4887,7 @@ async fn lifecycle_wait_handoff_to_work_item_wait_is_atomic_idempotent_and_resta
                 },
             state: crate::domain::execution_protocol::ExecutionAttemptState::Open,
             ..
-        } if agent_id == "default" && message_id == &message.id
+        } if interaction_id.starts_with("interaction1_") && message_id == &message.id
     ));
 
     runtime
@@ -6586,6 +6586,134 @@ async fn canonical_processed_settlement_without_terminal_turn_fails_closed() {
             .attempts[&activation_id]
             .state,
         crate::domain::execution_protocol::ExecutionAttemptState::Open
+    );
+}
+
+#[tokio::test]
+async fn trusted_operator_conversation_owner_flows_from_admission_to_terminal_turn() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let message = runtime
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator {
+                    actor_id: Some("control".into()),
+                },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "continue the discussion".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::HttpControlPrompt,
+                AdmissionContext::ControlAuthenticated,
+            ),
+        )
+        .await
+        .unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("trusted operator prompt should enter a model turn");
+    };
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let interaction_id = match &execution.attempts[&activation_id].binding {
+        crate::domain::execution_protocol::ExecutionBinding::Conversation { interaction_id } => {
+            interaction_id.clone()
+        }
+        binding => panic!("expected Conversation owner, found {binding:?}"),
+    };
+
+    runtime
+        .begin_reducer_only_turn(
+            &scheduled.message,
+            scheduled
+                .dispatch_plan
+                .execution_admission_provenance
+                .clone(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime
+            .agent_state()
+            .await
+            .unwrap()
+            .current_execution_binding
+            .and_then(|binding| binding.owner),
+        Some(crate::types::TurnOwner::Conversation {
+            interaction_id: interaction_id.clone(),
+        })
+    );
+
+    let transition = runtime
+        .build_reducer_only_terminal_transition("conversation owner regression", false)
+        .await
+        .unwrap();
+    runtime
+        .persist_terminal_transition(&transition)
+        .await
+        .unwrap();
+    assert_eq!(
+        transition.turn_record.effective_owner(),
+        crate::types::TurnOwner::Conversation {
+            interaction_id: interaction_id.clone(),
+        }
+    );
+    assert!(runtime
+        .commit_queue_terminal_settlement(
+            QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+            Some(&transition),
+        )
+        .await
+        .unwrap());
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .turn_records()
+            .recent_for_owner(
+                "default",
+                &crate::types::TurnOwner::Conversation { interaction_id },
+                10,
+            )
+            .unwrap()
+            .len(),
+        1
     );
 }
 
@@ -12562,12 +12690,12 @@ async fn lifecycle_ingress_ignores_completed_work_item_lane_before_claim() {
     assert!(matches!(
         &execution.attempts[&activation_id],
         crate::domain::execution_protocol::ExecutionAttempt {
-            binding: crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
-                agent_id
+            binding: crate::domain::execution_protocol::ExecutionBinding::Conversation {
+                interaction_id
             },
             state: crate::domain::execution_protocol::ExecutionAttemptState::Open,
             ..
-        } if agent_id == "default"
+        } if interaction_id.starts_with("interaction1_")
     ));
     assert_eq!(
         runtime

--- a/src/runtime/tests/tasks.rs
+++ b/src/runtime/tests/tasks.rs
@@ -475,6 +475,7 @@ async fn execution_bound_pick_yields_without_rebinding_current_turn() {
             admission_provenance: None,
             source_message_id: "message-yield".into(),
             turn_id: "turn-yield".into(),
+            owner: None,
             work_item_id: Some(first.id.clone()),
             claimed_work_revision: Some(first.revision),
         });

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -207,6 +207,7 @@ async fn terminal_pick_ends_turn_before_later_tools_or_provider_rounds() {
             admission_provenance: None,
             source_message_id: "message-terminal-pick".into(),
             turn_id: "turn-terminal-pick".into(),
+            owner: None,
             work_item_id: Some(caller.id.clone()),
             claimed_work_revision: Some(caller.revision),
         });

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2788,6 +2788,7 @@ async fn lifecycle_execution_can_complete_without_borrowing_work_item_authority(
         admission_provenance: None,
         source_message_id: "message-lifecycle".into(),
         turn_id: "turn-lifecycle".into(),
+        owner: None,
         work_item_id: None,
         claimed_work_revision: None,
     };
@@ -2854,6 +2855,7 @@ async fn control_completion_ignores_unrelated_execution_binding() {
             admission_provenance: None,
             source_message_id: "message-active".into(),
             turn_id: "turn-active".into(),
+            owner: None,
             work_item_id: Some(active.id.clone()),
             claimed_work_revision: Some(active.revision),
         });
@@ -2912,6 +2914,7 @@ async fn work_item_execution_cannot_complete_an_unrelated_work_item() {
         admission_provenance: None,
         source_message_id: "message-active".into(),
         turn_id: "turn-active".into(),
+        owner: None,
         work_item_id: Some(active.id.clone()),
         claimed_work_revision: Some(active.revision),
     };
@@ -2976,6 +2979,7 @@ async fn completion_retry_rejects_replaced_execution_binding() {
         admission_provenance: None,
         source_message_id: "message-original".into(),
         turn_id: "turn-original".into(),
+        owner: None,
         work_item_id: Some(target.id.clone()),
         claimed_work_revision: Some(target.revision),
     };
@@ -2989,6 +2993,7 @@ async fn completion_retry_rejects_replaced_execution_binding() {
         admission_provenance: None,
         source_message_id: "message-replacement".into(),
         turn_id: "turn-replacement".into(),
+        owner: None,
         work_item_id: Some(target.id.clone()),
         claimed_work_revision: Some(target.revision),
     });
@@ -4651,6 +4656,7 @@ async fn complete_work_item_with_unfinished_todos_returns_structured_warning() {
             admission_provenance: None,
             source_message_id: "message-complete-with-warning".into(),
             turn_id: "turn-complete-with-warning".into(),
+            owner: None,
             work_item_id: Some(work_item.id.clone()),
             claimed_work_revision: Some(work_item.revision),
         });
@@ -6511,6 +6517,7 @@ async fn wait_for_falls_back_to_current_focus_for_lifecycle_execution() {
             admission_provenance: None,
             source_message_id: "message-lifecycle".into(),
             turn_id: "turn-lifecycle".into(),
+            owner: None,
             work_item_id: None,
             claimed_work_revision: None,
         });
@@ -6577,6 +6584,7 @@ async fn wait_for_uses_lifecycle_owner_without_any_work_item_binding_or_focus() 
             admission_provenance: None,
             source_message_id: "message-lifecycle".into(),
             turn_id: "turn-lifecycle".into(),
+            owner: None,
             work_item_id: None,
             claimed_work_revision: None,
         });
@@ -7325,6 +7333,7 @@ fn rebase_completion_accepts_diverged_baseline_after_concurrent_persist() {
         admission_provenance: None,
         source_message_id: "msg-1".to_string(),
         turn_id: turn_id.to_string(),
+        owner: None,
         work_item_id: Some(work_item_id.to_string()),
         claimed_work_revision: Some(1),
     });

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -756,19 +756,40 @@ impl RuntimeHandle {
                 "operator interjection attempt disagrees with the current source message"
             ));
         }
-        match &attempt.binding {
-            crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id }
-                if execution_binding.work_item_id.as_deref() == Some(work_item_id.as_str()) => {}
+        let attempt_owner = match &attempt.binding {
+            crate::domain::execution_protocol::ExecutionBinding::WorkItem { work_item_id } => {
+                crate::types::TurnOwner::WorkItem {
+                    work_item_id: work_item_id.clone(),
+                }
+            }
+            crate::domain::execution_protocol::ExecutionBinding::Conversation {
+                interaction_id,
+            } => crate::types::TurnOwner::Conversation {
+                interaction_id: interaction_id.clone(),
+            },
             crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
                 agent_id: owner_agent_id,
-            } if owner_agent_id == agent_id && execution_binding.work_item_id.is_none() => {}
-            crate::domain::execution_protocol::ExecutionBinding::Conversation { .. }
-                if execution_binding.work_item_id.is_none() => {}
-            _ => {
-                return Err(anyhow::anyhow!(
-                    "operator interjection execution binding disagrees with attempt owner"
-                ));
+            } => crate::types::TurnOwner::AgentLifecycle {
+                agent_id: owner_agent_id.clone(),
+            },
+            crate::domain::execution_protocol::ExecutionBinding::Command => {
+                crate::types::TurnOwner::Command
             }
+        };
+        let current_owner = execution_binding.owner.clone().unwrap_or_else(|| {
+            execution_binding.work_item_id.as_ref().map_or_else(
+                || crate::types::TurnOwner::AgentLifecycle {
+                    agent_id: agent_id.to_string(),
+                },
+                |work_item_id| crate::types::TurnOwner::WorkItem {
+                    work_item_id: work_item_id.clone(),
+                },
+            )
+        });
+        if current_owner != attempt_owner {
+            return Err(anyhow::anyhow!(
+                "operator interjection execution binding disagrees with attempt owner"
+            ));
         }
 
         let _ = (message, round, boundary);

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -240,7 +240,7 @@ impl RuntimeHandle {
         &self,
         terminal: &TurnTerminalRecord,
     ) -> Result<TurnRecord> {
-        let (agent_id, run_id, current_work_item_id) = {
+        let (agent_id, run_id, current_work_item_id, owner) = {
             let guard = self.inner.agent.lock().await;
             let current_work_item_id = guard
                 .state
@@ -254,10 +254,26 @@ impl RuntimeHandle {
                         .clone()
                         .or_else(|| guard.state.current_work_item_id.clone())
                 });
+            let owner = guard
+                .state
+                .current_execution_binding
+                .as_ref()
+                .and_then(|binding| binding.owner.clone())
+                .or_else(|| {
+                    current_work_item_id.as_ref().map(|work_item_id| {
+                        crate::types::TurnOwner::WorkItem {
+                            work_item_id: work_item_id.clone(),
+                        }
+                    })
+                })
+                .unwrap_or_else(|| crate::types::TurnOwner::AgentLifecycle {
+                    agent_id: guard.state.id.clone(),
+                });
             (
                 guard.state.id.clone(),
                 guard.state.current_run_id.clone(),
                 current_work_item_id,
+                owner,
             )
         };
         let turn_id = terminal.turn_id.trim();
@@ -303,6 +319,7 @@ impl RuntimeHandle {
         }
         record.run_id = run_id;
         record.current_work_item_id = current_work_item_id;
+        record.owner = Some(owner);
         record.trigger = input_messages
             .first()
             .map(|message| TurnTriggerSummary::from_message(message));

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -280,6 +280,7 @@ async fn replay_persists_a_new_turn_with_source_provenance() {
             admission_provenance: None,
             source_message_id: source_message.id.clone(),
             turn_id: "turn-replay-attempt".into(),
+            owner: None,
             work_item_id: Some("work-source".into()),
             claimed_work_revision: Some(1),
         });

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3149,6 +3149,13 @@ CREATE TABLE IF NOT EXISTS audit_event_retention_watermarks (
 );
 "#,
     },
+    Migration {
+        version: 52,
+        name: "turn_owner_identity",
+        // Columns and index live in `ensure_turn_owner_identity_schema` so
+        // baseline and downgrade/re-upgrade paths remain idempotent.
+        sql: "",
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {
@@ -3397,6 +3404,9 @@ fn apply_migration_transaction(transaction: &Transaction<'_>, migration: &Migrat
     if migration.name == "observer_sync_event_verification_proof" {
         ensure_observer_sync_event_verification_proof_schema(transaction)?;
     }
+    if migration.name == "turn_owner_identity" {
+        ensure_turn_owner_identity_schema(transaction)?;
+    }
     transaction.execute_batch(migration.sql)?;
     if migration.name == "execution_protocol_authority" {
         backfill_execution_protocol_authority(transaction)?;
@@ -3469,6 +3479,31 @@ fn ensure_brief_created_event_linkage_schema(transaction: &Transaction<'_>) -> R
         "CREATE UNIQUE INDEX IF NOT EXISTS briefs_agent_created_event_seq
            ON briefs(agent_id, created_event_seq)
            WHERE created_event_seq IS NOT NULL;",
+    )?;
+    Ok(())
+}
+
+fn ensure_turn_owner_identity_schema(transaction: &Transaction<'_>) -> Result<()> {
+    if !table_exists_tx(transaction, "turn_records")? {
+        return Ok(());
+    }
+    let columns = transaction
+        .prepare("PRAGMA table_info(turn_records)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    for (column, definition) in [
+        ("owner_kind", "owner_kind TEXT"),
+        ("owner_id", "owner_id TEXT"),
+    ] {
+        if !columns.iter().any(|existing| existing == column) {
+            transaction.execute_batch(&format!(
+                "ALTER TABLE turn_records ADD COLUMN {definition};"
+            ))?;
+        }
+    }
+    transaction.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_turn_records_owner
+           ON turn_records(agent_id, owner_kind, owner_id, turn_index, created_at);",
     )?;
     Ok(())
 }

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1827,6 +1827,37 @@ impl TurnRecordRepository<'_> {
         Ok(records)
     }
 
+    pub fn recent_for_owner(
+        &self,
+        agent_id: &str,
+        owner: &crate::types::TurnOwner,
+        limit: usize,
+    ) -> Result<Vec<TurnRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let (owner_kind, owner_id) = owner.index_parts();
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM turn_records
+             WHERE agent_id = ?1
+               AND owner_kind = ?2
+               AND owner_id IS ?3
+             ORDER BY turn_index DESC, created_at DESC, turn_id ASC
+             LIMIT ?4",
+        )?;
+        let rows = statement.query_map(params![agent_id, owner_kind, owner_id, limit], |row| {
+            row.get::<_, String>(0)
+        })?;
+        let mut records = rows
+            .map(|row| decode_turn_record_payload(&row?))
+            .collect::<Result<Vec<_>>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
     pub fn recent(&self, limit: usize) -> Result<Vec<TurnRecord>> {
         if limit == 0 {
             return Ok(Vec::new());
@@ -3958,6 +3989,18 @@ fn merge_legacy_turn_evidence_tx(tx: &Transaction<'_>, derived: &TurnRecord) -> 
 }
 
 pub(crate) fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -> Result<()> {
+    if let Some(owner) = record.owner.as_ref() {
+        let owner_work_item_id = owner.work_item_id();
+        if record.current_work_item_id.as_deref() != owner_work_item_id {
+            return Err(RuntimeStateTransitionConflict::new(
+                "turn owner",
+                &record.turn_id,
+                owner_work_item_id.unwrap_or("unbound"),
+                record.current_work_item_id.as_deref().unwrap_or("unbound"),
+            )
+            .into());
+        }
+    }
     let existing = tx
         .query_row(
             "SELECT payload_json FROM turn_records WHERE turn_id = ?1",
@@ -3981,6 +4024,7 @@ pub(crate) fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -
             && existing.turn_index == record.turn_index
             && existing.run_id == record.run_id
             && existing.current_work_item_id == record.current_work_item_id
+            && (existing.owner == record.owner || existing.owner.is_none())
             && existing
                 .trigger
                 .as_ref()
@@ -4011,12 +4055,22 @@ pub(crate) fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -
         .terminal
         .as_ref()
         .map(|terminal| timestamp(terminal.completed_at));
+    let (owner_kind, owner_id) = match record.owner.as_ref() {
+        Some(owner) => {
+            let (kind, id) = owner.index_parts();
+            (Some(kind), id)
+        }
+        None => (None, None),
+    };
     tx.execute(
         "INSERT INTO turn_records (
             turn_id, turn_index, agent_id, run_id, current_work_item_id,
-            trigger_message_id, terminal_kind, created_at, completed_at, payload_json
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            owner_kind, owner_id, trigger_message_id, terminal_kind, created_at,
+            completed_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
          ON CONFLICT(turn_id) DO UPDATE SET
+            owner_kind = COALESCE(turn_records.owner_kind, excluded.owner_kind),
+            owner_id = COALESCE(turn_records.owner_id, excluded.owner_id),
             terminal_kind = excluded.terminal_kind,
             completed_at = excluded.completed_at,
             payload_json = excluded.payload_json
@@ -4027,6 +4081,8 @@ pub(crate) fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -
             record.agent_id,
             record.run_id,
             record.current_work_item_id,
+            owner_kind,
+            owner_id,
             record
                 .trigger
                 .as_ref()

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -24,9 +24,9 @@ use crate::types::{
     AgentIdentityRecord, AgentState, AuditEvent, BriefRecord, CallbackDeliveryMode,
     ExecutionRootEntry, ExternalTriggerRecord, ExternalTriggerScope, ExternalTriggerStatus,
     MessageEnvelope, QueueEntryRecord, QueueEntryStatus, TaskRecord, TaskStatus,
-    ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind, WaitConditionKind,
-    WaitConditionRecord, WaitConditionStatus, WorkItemRecord, WorkItemState, WorkspaceEntry,
-    WorkspaceOccupancyRecord,
+    ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind, TurnOwner, TurnRecord,
+    WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WorkItemRecord, WorkItemState,
+    WorkspaceEntry, WorkspaceOccupancyRecord,
 };
 #[cfg(test)]
 use anyhow::{anyhow, bail, Context, Result};
@@ -1727,7 +1727,7 @@ INSERT INTO storage_domains (
         assert!(
             error
                 .to_string()
-                .contains("supports runtime db schemas 46 through 51, found 45"),
+                .contains("supports runtime db schemas 46 through 52, found 45"),
             "{error:#}"
         );
         Ok(())
@@ -1850,7 +1850,10 @@ INSERT INTO scheduler_rollout_command_results (
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
 
         let connection = open_connection(&db_path)?;
-        assert_eq!(current_schema_version(&connection)?, 51);
+        assert_eq!(
+            current_schema_version(&connection)?,
+            max_known_migration_version()
+        );
         for table in RETIRED_SCHEDULER_TABLES {
             assert!(
                 !table_exists(&connection, table)?,
@@ -2004,7 +2007,10 @@ INSERT INTO scheduler_rollout_command_results (
 
             RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             let connection = open_connection(&db_path)?;
-            assert_eq!(current_schema_version(&connection)?, 51);
+            assert_eq!(
+                current_schema_version(&connection)?,
+                max_known_migration_version()
+            );
             for table in RETIRED_SCHEDULER_TABLES {
                 assert!(
                     !table_exists(&connection, table)?,
@@ -2147,7 +2153,10 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 51);
+        assert_eq!(
+            current_schema_version(&open_connection(&db_path)?)?,
+            max_known_migration_version()
+        );
         Ok(())
     }
 
@@ -2254,7 +2263,7 @@ INSERT INTO scheduler_rollout_command_results (
             RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
             assert_eq!(
                 current_schema_version(&open_connection(&db_path)?)?,
-                51,
+                max_known_migration_version(),
                 "{case}"
             );
         }
@@ -2313,7 +2322,10 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 51);
+        assert_eq!(
+            current_schema_version(&open_connection(&db_path)?)?,
+            max_known_migration_version()
+        );
         Ok(())
     }
 
@@ -2373,7 +2385,10 @@ INSERT INTO scheduler_rollout_command_results (
         drop(db);
 
         RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        assert_eq!(current_schema_version(&open_connection(&db_path)?)?, 51);
+        assert_eq!(
+            current_schema_version(&open_connection(&db_path)?)?,
+            max_known_migration_version()
+        );
         Ok(())
     }
 
@@ -7146,5 +7161,52 @@ CREATE TABLE working_memory_deltas (
         assert!(foundations.runtime_identity_stable);
         assert!(!foundations.agent_identity_reserved);
         Ok(())
+    }
+
+    #[test]
+    fn turn_owner_is_indexed_and_reconstructed_after_reopen() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let owner = TurnOwner::Conversation {
+            interaction_id: "interaction1_test".into(),
+        };
+        {
+            let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+            let mut turn = TurnRecord::new("agent-owner", "turn-owner", 7);
+            turn.owner = Some(owner.clone());
+            db.turn_records().upsert(&turn)?;
+            assert_eq!(
+                db.turn_records()
+                    .recent_for_owner("agent-owner", &owner, 10)?,
+                vec![turn]
+            );
+        }
+
+        let reopened = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let turn = reopened
+            .turn_records()
+            .by_id(Some("agent-owner"), "turn-owner")?
+            .expect("turn should survive reopen");
+        assert_eq!(turn.effective_owner(), owner);
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_turn_owner_fallback_is_conservative() {
+        let mut work_item_turn = TurnRecord::new("agent-owner", "turn-work", 1);
+        work_item_turn.current_work_item_id = Some("work-1".into());
+        assert_eq!(
+            work_item_turn.effective_owner(),
+            TurnOwner::WorkItem {
+                work_item_id: "work-1".into(),
+            }
+        );
+
+        let lifecycle_turn = TurnRecord::new("agent-owner", "turn-lifecycle", 2);
+        assert_eq!(
+            lifecycle_turn.effective_owner(),
+            TurnOwner::AgentLifecycle {
+                agent_id: "agent-owner".into(),
+            }
+        );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1497,6 +1497,60 @@ impl MessageEnvelope {
             }
             _ => {}
         }
+
+        if !self.source_refs.contains_key("interaction_id") {
+            if let Some(interaction_id) = self.trusted_interaction_id() {
+                self.source_refs
+                    .insert("interaction_id".into(), interaction_id);
+            }
+        }
+    }
+
+    pub fn trusted_interaction_id(&self) -> Option<String> {
+        if self.kind != MessageKind::OperatorPrompt
+            || self.authority_class != AuthorityClass::OperatorInstruction
+            || !matches!(self.origin, MessageOrigin::Operator { .. })
+        {
+            return None;
+        }
+
+        let scope = match (self.delivery_surface, self.admission_context) {
+            (Some(MessageDeliverySurface::CliPrompt), Some(AdmissionContext::LocalProcess)) => {
+                "cli_prompt"
+            }
+            (Some(MessageDeliverySurface::RunOnce), Some(AdmissionContext::LocalProcess)) => {
+                "run_once"
+            }
+            (
+                Some(MessageDeliverySurface::HttpControlPrompt),
+                Some(AdmissionContext::ControlAuthenticated),
+            ) => "http_control_prompt",
+            (
+                Some(MessageDeliverySurface::RemoteOperatorTransport),
+                Some(AdmissionContext::OperatorTransportAuthenticated),
+            ) => "remote_operator_transport",
+            _ => return None,
+        };
+
+        self.source_refs
+            .get("interaction_id")
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|interaction_id| !interaction_id.is_empty())
+            .map(ToString::to_string)
+            .or_else(|| {
+                let actor_id = match &self.origin {
+                    MessageOrigin::Operator { actor_id } => {
+                        actor_id.as_deref().unwrap_or("operator")
+                    }
+                    _ => unreachable!("operator origin checked above"),
+                };
+                Some(crate::ids::interaction_id(&[
+                    &self.agent_id,
+                    scope,
+                    actor_id,
+                ]))
+            })
     }
 
     fn metadata_binding_fields_are_trusted(&self) -> bool {
@@ -1740,6 +1794,33 @@ pub struct TurnReplayProvenance {
     pub prior_terminal: Option<TurnTerminalSummary>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TurnOwner {
+    WorkItem { work_item_id: String },
+    Conversation { interaction_id: String },
+    AgentLifecycle { agent_id: String },
+    Command,
+}
+
+impl TurnOwner {
+    pub fn work_item_id(&self) -> Option<&str> {
+        match self {
+            Self::WorkItem { work_item_id } => Some(work_item_id),
+            Self::Conversation { .. } | Self::AgentLifecycle { .. } | Self::Command => None,
+        }
+    }
+
+    pub fn index_parts(&self) -> (&'static str, Option<&str>) {
+        match self {
+            Self::WorkItem { work_item_id } => ("work_item", Some(work_item_id)),
+            Self::Conversation { interaction_id } => ("conversation", Some(interaction_id)),
+            Self::AgentLifecycle { agent_id } => ("agent_lifecycle", Some(agent_id)),
+            Self::Command => ("command", None),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TurnRecord {
     pub turn_id: String,
@@ -1749,6 +1830,8 @@ pub struct TurnRecord {
     pub run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<TurnOwner>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trigger: Option<TurnTriggerSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1778,6 +1861,7 @@ impl TurnRecord {
             agent_id: agent_id.into(),
             run_id: None,
             current_work_item_id: None,
+            owner: None,
             trigger: None,
             input_message_ids: Vec::new(),
             tool_execution_ids: Vec::new(),
@@ -1789,6 +1873,19 @@ impl TurnRecord {
             replay: None,
             created_at: Utc::now(),
         }
+    }
+
+    pub fn effective_owner(&self) -> TurnOwner {
+        self.owner.clone().unwrap_or_else(|| {
+            self.current_work_item_id.as_ref().map_or_else(
+                || TurnOwner::AgentLifecycle {
+                    agent_id: self.agent_id.clone(),
+                },
+                |work_item_id| TurnOwner::WorkItem {
+                    work_item_id: work_item_id.clone(),
+                },
+            )
+        })
     }
 }
 
@@ -2006,6 +2103,8 @@ pub struct WorkItemExecutionBinding {
     pub admission_provenance: Option<ExecutionAdmissionProvenance>,
     pub source_message_id: String,
     pub turn_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<TurnOwner>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub work_item_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -1286,8 +1286,7 @@ async fn run_once_reports_completed_when_final_result_lands_on_max_turn_boundary
     Ok(())
 }
 
-#[tokio::test]
-async fn run_once_reports_completed_when_final_text_arrives_after_last_allowed_model_round(
+async fn assert_run_once_reports_completed_when_final_text_arrives_after_last_allowed_model_round(
 ) -> Result<()> {
     let test_config = test_config();
     let host = RuntimeHost::new_with_provider(
@@ -1308,6 +1307,15 @@ async fn run_once_reports_completed_when_final_text_arrives_after_last_allowed_m
     assert_eq!(response.final_text, "two rounds complete");
     assert_eq!(response.model_rounds, 2);
     Ok(())
+}
+
+#[test]
+fn run_once_reports_completed_when_final_text_arrives_after_last_allowed_model_round() -> Result<()>
+{
+    run_on_large_stack(
+        "run-once-final-text-after-last-model-round",
+        assert_run_once_reports_completed_when_final_text_arrives_after_last_allowed_model_round,
+    )
 }
 
 async fn assert_run_once_multi_round_single_turn_does_not_exceed_max_turns() -> Result<()> {

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -1310,8 +1310,7 @@ async fn run_once_reports_completed_when_final_text_arrives_after_last_allowed_m
     Ok(())
 }
 
-#[tokio::test]
-async fn run_once_multi_round_single_turn_does_not_exceed_max_turns() -> Result<()> {
+async fn assert_run_once_multi_round_single_turn_does_not_exceed_max_turns() -> Result<()> {
     // TwoRoundProvider performs two model rounds within a single turn:
     // round 1 issues a tool call, round 2 returns terminal text.
     // With max_turns=1, this should complete because only one turn is
@@ -1337,6 +1336,14 @@ async fn run_once_multi_round_single_turn_does_not_exceed_max_turns() -> Result<
     assert_eq!(response.final_text, "two rounds complete");
     assert_eq!(response.model_rounds, 2);
     Ok(())
+}
+
+#[test]
+fn run_once_multi_round_single_turn_does_not_exceed_max_turns() -> Result<()> {
+    run_on_large_stack(
+        "run-once-multi-round-single-turn",
+        assert_run_once_multi_round_single_turn_does_not_exceed_max_turns,
+    )
 }
 
 #[tokio::test]

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -3,10 +3,33 @@ mod runtime_tasks;
 
 mod support;
 
+use std::future::Future;
+
 use tokio::sync::Semaphore;
 
 const MAX_CONCURRENT_RUNTIME_TESTS: usize = 4;
 static RUNTIME_TEST_PERMITS: Semaphore = Semaphore::const_new(MAX_CONCURRENT_RUNTIME_TESTS);
+
+fn run_on_large_stack<F, Fut>(name: &str, test: F) -> anyhow::Result<()>
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = anyhow::Result<()>> + 'static,
+{
+    let test_thread = std::thread::Builder::new()
+        .name(name.into())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?
+                .block_on(test())
+        })?;
+
+    match test_thread.join() {
+        Ok(result) => result,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
 
 macro_rules! runtime_async_tests {
     ($($name:ident),* $(,)?) => {
@@ -29,7 +52,6 @@ runtime_async_tests!(
     background_command_task_result_wakes_sleeping_agent_via_canonical_lifecycle_nudge,
     stop_task_cancels_running_background_task,
     lifecycle_stop_interrupts_active_command_task,
-    tool_use_round_trip_executes_and_returns_result,
     file_tools_can_modify_workspace_and_reenter_context,
     shell_tools_capture_command_output,
     shell_tools_truncate_large_output_before_provider_reinjection,
@@ -71,3 +93,11 @@ runtime_async_tests!(
     exec_command_reuses_equivalent_scheduled_background_task,
     exec_command_terminal_tasks_do_not_block_new_run,
 );
+
+#[test]
+fn tool_use_round_trip_executes_and_returns_result() -> anyhow::Result<()> {
+    run_on_large_stack("runtime-task-tool-use-round-trip", || async {
+        let _permit = RUNTIME_TEST_PERMITS.acquire().await?;
+        runtime_tasks::tool_use_round_trip_executes_and_returns_result().await
+    })
+}

--- a/tests/support/http_operator_ingress.rs
+++ b/tests/support/http_operator_ingress.rs
@@ -64,6 +64,7 @@ pub async fn operator_ingress_records_remote_operator_provenance() -> Result<()>
             "text": "remote operator continue",
             "actor_id": "operator:jolestar",
             "binding_id": "opbind-ingress",
+            "conversation_ref": "telegram:dm:operator",
             "reply_route_id": "route-reply-1",
             "provider": "agentinbox",
             "upstream_provider": "telegram",
@@ -122,6 +123,7 @@ pub async fn operator_ingress_records_remote_operator_provenance() -> Result<()>
         .as_ref()
         .expect("metadata should be present")["operator_transport"];
     assert_eq!(transport["binding_id"], "opbind-ingress");
+    assert_eq!(transport["conversation_ref"], "telegram:dm:operator");
     assert_eq!(transport["transport"], "agentinbox");
     assert_eq!(transport["reply_route_id"], "route-reply-1");
     assert_eq!(transport["provider"], "agentinbox");
@@ -135,6 +137,10 @@ pub async fn operator_ingress_records_remote_operator_provenance() -> Result<()>
         transport["metadata"]["conversation_ref"],
         "telegram:dm:operator"
     );
+    assert!(message
+        .source_refs
+        .get("interaction_id")
+        .is_some_and(|interaction_id| interaction_id.starts_with("interaction1_")));
     let bindings = runtime.latest_operator_transport_bindings().await?;
     let binding = bindings
         .iter()

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -361,7 +361,7 @@ pub async fn queued_task_result_wait_settles_tool_only_turn_and_reduces_result()
         ))
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let queue_entries = runtime.storage().read_recent_queue_entries(20)?;
         Ok(queue_entries.iter().any(|entry| {
             entry.message_id == message.id && entry.status == QueueEntryStatus::Processed
@@ -384,7 +384,7 @@ pub async fn queued_task_result_wait_settles_tool_only_turn_and_reduces_result()
         })
         .expect("background command should enqueue its task result");
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let queue_entries = runtime.storage().read_recent_queue_entries(20)?;
         Ok(queue_entries.iter().any(|entry| {
             entry.message_id == task_result.id && entry.status == QueueEntryStatus::Processed

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -2226,7 +2226,7 @@ class DockerE2ERunnerTests(unittest.TestCase):
         )
         self.assertEqual(waits[0]["status"], "resolved")
 
-    def test_canonical_activation_oracle_distinguishes_lifecycle_and_work_item(
+    def test_canonical_activation_oracle_distinguishes_conversation_and_work_item(
         self,
     ) -> None:
         harness = type(
@@ -2241,12 +2241,12 @@ class DockerE2ERunnerTests(unittest.TestCase):
             "execution_protocol_attempts": [
                 {
                     "agent_id": "default",
-                    "attempt_id": "attempt-lifecycle",
+                    "attempt_id": "attempt-conversation",
                     "lifecycle_state": "settled",
-                    "terminal_outcome_id": "outcome-lifecycle",
+                    "terminal_outcome_id": "outcome-conversation",
                     "payload_json": json.dumps(
                         {
-                            "attempt_id": "attempt-lifecycle",
+                            "attempt_id": "attempt-conversation",
                             "source_message_id": "message-create",
                             "source": {
                                 "identity": {
@@ -2255,8 +2255,8 @@ class DockerE2ERunnerTests(unittest.TestCase):
                                 }
                             },
                             "binding": {
-                                "kind": "agent_lifecycle",
-                                "agent_id": "default",
+                                "kind": "conversation",
+                                "interaction_id": "interaction-1",
                             },
                         }
                     ),
@@ -2288,8 +2288,8 @@ class DockerE2ERunnerTests(unittest.TestCase):
             "execution_protocol_outcomes": [
                 {
                     "agent_id": "default",
-                    "outcome_id": "outcome-lifecycle",
-                    "payload_json": json.dumps({"attempt_id": "attempt-lifecycle"}),
+                    "outcome_id": "outcome-conversation",
+                    "payload_json": json.dumps({"attempt_id": "attempt-conversation"}),
                 },
                 {
                     "agent_id": "default",
@@ -2304,27 +2304,87 @@ class DockerE2ERunnerTests(unittest.TestCase):
             snapshot,
             work_item_id="work-1",
             expected_source_kinds=("triggered_wait",),
-            lifecycle_message_ids={"message-create"},
+            conversation_message_ids={"message-create"},
         )
 
-        lifecycle = json.loads(
+        conversation = json.loads(
             snapshot["execution_protocol_attempts"][0]["payload_json"]
         )
-        lifecycle["binding"] = {"kind": "work_item", "work_item_id": "work-1"}
+        conversation["binding"] = {"kind": "work_item", "work_item_id": "work-1"}
         snapshot["execution_protocol_attempts"][0]["payload_json"] = json.dumps(
-            lifecycle
+            conversation
         )
         with self.assertRaisesRegex(
             AssertionError,
-            "lifecycle attempts did not settle without claiming a WorkItem",
+            "Conversation attempts did not settle without claiming a WorkItem",
         ):
             runner.require_scheduler_engine_activation_chain(
                 harness,
                 snapshot,
                 work_item_id="work-1",
                 expected_source_kinds=("triggered_wait",),
-                lifecycle_message_ids={"message-create"},
+                conversation_message_ids={"message-create"},
             )
+
+    def test_lifecycle_wait_adoption_accepts_exact_conversation_owner(self) -> None:
+        snapshot = {
+            "turn_records": [
+                {
+                    "agent_id": "default",
+                    "turn_id": "turn-conversation",
+                    "trigger_message_id": "message-conversation",
+                    "owner_kind": "conversation",
+                    "owner_id": "interaction-1",
+                }
+            ],
+            "execution_protocol_attempts": [
+                {
+                    "agent_id": "default",
+                    "attempt_id": "attempt-conversation",
+                    "lifecycle_state": "settled",
+                    "terminal_outcome_id": "outcome-conversation",
+                    "payload_json": json.dumps(
+                        {
+                            "attempt_id": "attempt-conversation",
+                            "source_message_id": "message-conversation",
+                            "binding": {
+                                "kind": "conversation",
+                                "interaction_id": "interaction-1",
+                            },
+                        }
+                    ),
+                }
+            ],
+            "execution_protocol_outcomes": [
+                {
+                    "agent_id": "default",
+                    "outcome_id": "outcome-conversation",
+                    "payload_json": json.dumps(
+                        {
+                            "attempt_id": "attempt-conversation",
+                            "outcome": {
+                                "owner": "conversation",
+                                "outcome": {
+                                    "kind": "handoff_to_work_item_wait",
+                                    "work_item_id": "work-1",
+                                    "wait": {"wait_id": "wait-1"},
+                                },
+                            },
+                        }
+                    ),
+                }
+            ],
+        }
+
+        runner.require_lifecycle_wait_adoption(
+            snapshot,
+            agent_id="default",
+            work_item_id="work-1",
+            wait={
+                "wait_condition_id": "wait-1",
+                "last_turn_id": "turn-conversation",
+            },
+        )
 
     def test_external_wait_resume_drains_queue_before_runtime_snapshot(self) -> None:
         source = inspect.getsource(runner.run_scheduler_external_wait_resume_case)


### PR DESCRIPTION
# Issue #2700：Phase 1 activation / Turn owner identity

## 需求解释

- 使用可信 admission facts 为每次 activation 选择规范化 owner。
- 无 WorkItem 的 trusted operator input 使用 `Conversation(interaction_id)`。
- 将 `WorkItem | Conversation | AgentLifecycle` owner 持久化到 Turn，并在 restart 后重建。
- 保留 legacy fallback 与既有 WorkItem/task/wait authority 边界。
- 不改变生产 provider 输入，不进入 Phase 2 semantic projection。

## 主要变更

- 新增 durable `TurnOwner`、interaction identity 与 owner 查询索引。
- 将 operator transport `conversation_ref` 纳入认证后的 conversation admission。
- 为 settlement、interjection、task result 与 exact wait 增加 owner 一致性约束。
- 新增 restart、legacy fallback、trusted/untrusted admission 与 authority 回归测试。
- 提交 36 份 Phase 1 candidate manifests 和 scorecard；provider sections 全部字节一致。
- 新增 focused RFC，冻结 Phase 1 契约与 Phase 2 边界。

## 验收

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `make snapshots-check`
- `make test`
- `cd benchmark && npm ci && npm test`

以上均通过。Candidate scorecard 中 33 份 manifest 全 invariant 通过；3 份仅保留已声明的 Phase 2 owner-selection 诊断失败，不改变本期 provider 输入。

## 发布

- Branch: `feature/issue-2700`
- Commit: `f9d577db`
- PR: `#2703`

Closes #2700
