### PR TITLE
feat: add versioned model registry snapshot

### DIFF
--- a/docs/rfcs/model-registry-snapshot.md
+++ b/docs/rfcs/model-registry-snapshot.md
@@ -83,9 +83,15 @@ metadata.
 ### 4. Treat registry data as untrusted input
 
 Every snapshot has an explicit schema version and immutable revision. Loading
-performs strict parsing and rejects unknown fields, unsupported schema
-versions, duplicate identities, dangling aliases, invalid preferred routes,
-invalid limits, and route policies that expand intrinsic capability.
+strictly parses the snapshot-owned envelope, route, alias, and preferred
+selection objects, rejecting unknown fields there. Model metadata and
+capability value objects are shared with discovery caches and runtime
+configuration, so they retain their existing forward-compatible
+deserialization behavior; the snapshot loader instead validates their
+schema-defined identities, limits, options, and route constraints after
+parsing. Loading also rejects unsupported schema versions, duplicate
+identities, dangling aliases, invalid preferred routes, invalid limits, and
+route policies that expand intrinsic boolean capability.
 
 The embedded snapshot is build-time data, so validation failure is a developer
 error and fails fast. A future remote snapshot must instead retain the previous
@@ -129,8 +135,11 @@ The checked-in JSON artifact contains:
 - compatibility `aliases`;
 - explicit preferred model and route selections.
 
-Arrays are used instead of JSON maps so duplicate keys cannot be silently
-overwritten during deserialization. All objects reject unknown fields.
+Arrays are used instead of JSON maps so duplicate identities cannot be silently
+overwritten during catalog construction. Snapshot-owned objects reject unknown
+fields. Shared model metadata and capability objects intentionally keep their
+existing forward-compatible deserialization contract; adding strictness there
+would also change discovery-cache and runtime-configuration behavior.
 
 The runtime parses and validates the artifact before constructing the existing
 `BuiltInModelCatalog` indexes. Public catalog and resolution APIs remain
@@ -144,7 +153,7 @@ Snapshot validation requires:
 - unique model, route, alias, and preferred-selection identities;
 - aliases target canonical models and do not form chains;
 - routes reference an existing canonical model;
-- route capability policy only narrows intrinsic model capability;
+- route boolean capability policy only narrows intrinsic model capability;
 - percentages are in range and token limits are positive;
 - default output limits do not exceed upper limits;
 - reasoning options are unique;
@@ -153,6 +162,12 @@ Snapshot validation requires:
 CI also compares the generated snapshot projection with the legacy Rust
 catalog during the migration. This equivalence test protects default selection,
 legacy aliases, and route behavior from accidental drift.
+
+Route numeric values are endpoint-specific facts rather than intrinsic
+capability assertions. They may therefore be higher or lower than canonical
+model values; precedence resolution still applies the route value only for that
+endpoint. The narrowing rule applies to boolean capabilities, where a route may
+disable support but cannot manufacture support absent from the canonical model.
 
 ## Follow-up
 

--- a/docs/rfcs/model-registry-snapshot.md
+++ b/docs/rfcs/model-registry-snapshot.md
@@ -1,0 +1,162 @@
+---
+title: RFC: Versioned Model Registry Snapshot
+date: 2026-08-28
+status: accepted
+issue:
+  - 2702
+---
+
+# RFC: Versioned Model Registry Snapshot
+
+## Summary
+
+Holon will separate model metadata from runtime transport behavior. The runtime
+will embed a versioned, validated model registry snapshot and later accept a
+Holon-published `models.dev` overlay without making startup or turn execution
+depend on the network.
+
+This RFC covers the contract and the first migration step. It does not add
+remote refresh.
+
+## Current Structure
+
+`BuiltInModelCatalog` currently builds model metadata from Rust provider
+modules. The resulting catalog mixes four different facts:
+
+1. properties intrinsic to a model;
+2. a provider's offering and route;
+3. availability observed from one endpoint and credential;
+4. capabilities implemented by Holon's transport.
+
+The resolver already applies local overrides, route constraints, transport
+constraints, and conservative fallbacks. The migration must preserve that
+behavior while making the built-in data independently versioned and
+validated.
+
+## Decisions
+
+### 1. Keep four fact layers separate
+
+- `ModelDefinition` describes canonical model identity, modalities, token
+  limits, and intrinsic capabilities.
+- `ProviderOffering` binds a provider-facing model ID to a model definition and
+  may conservatively narrow it.
+- `EndpointAvailability` records what one configured endpoint and credential
+  currently expose.
+- `RuntimeSupport` describes what Holon's compiled transport can encode,
+  decode, and enforce.
+
+A model is usable only where these layers intersect. Registry data can never
+create a transport, endpoint, credential, header, executable, or authentication
+method.
+
+The v1 built-in snapshot preserves the current catalog representation:
+canonical models, route policies, aliases, and explicit preferred routes.
+Later adapters may use richer source schemas, but they must project into these
+separate facts before resolution.
+
+### 2. Apply field-level precedence
+
+Resolved fields use this precedence:
+
+1. explicit user or project `ModelRuntimeOverride`;
+2. trusted fields observed from the configured endpoint;
+3. a validated Holon registry last-known-good artifact;
+4. the built-in snapshot;
+5. an explicit unknown or conservative runtime fallback.
+
+An entire model object is not replaced as one unit. Each resolved field keeps
+its provenance. Route and transport constraints run after metadata selection
+and may only narrow the result.
+
+### 3. Preserve unknown
+
+Missing metadata means `unknown`, not `unsupported`. Existing public boolean
+fields may migrate incrementally, but adapters and future snapshot versions
+must not convert absent upstream data to `false`.
+
+The v1 snapshot is a lossless representation of the current built-in catalog,
+whose booleans are already explicit assertions. A remote adapter must use
+tri-state input before projecting only validated assertions into runtime
+metadata.
+
+### 4. Treat registry data as untrusted input
+
+Every snapshot has an explicit schema version and immutable revision. Loading
+performs strict parsing and rejects unknown fields, unsupported schema
+versions, duplicate identities, dangling aliases, invalid preferred routes,
+invalid limits, and route policies that expand intrinsic capability.
+
+The embedded snapshot is build-time data, so validation failure is a developer
+error and fails fast. A future remote snapshot must instead retain the previous
+last-known-good artifact and report the rejected revision.
+
+### 5. Keep startup and turns offline
+
+The embedded snapshot is always available. Startup and turn execution never
+wait for registry network access. Future refresh will run outside the turn hot
+path with stale-while-revalidate behavior, bounded downloads, atomic
+replacement, and rollback to last-known-good.
+
+Endpoint discovery keeps its existing cache and lifecycle. A global registry
+cache must be stored separately because “known model” and “available through
+this credential” are different facts.
+
+### 6. Use one general upstream initially
+
+`models.dev` is the only general community upstream for the first remote
+adapter. Holon will pin an upstream revision, validate and adapt it in CI, then
+publish an immutable Holon artifact. Clients will not consume a floating
+`models.dev` response directly.
+
+LiteLLM may be used as a CI audit signal. Provider-specific model APIs describe
+only their own offerings and endpoint availability; they do not override other
+providers.
+
+### 7. Keep defaults release-controlled
+
+Remote registry updates cannot change preferred or default models in the first
+version. Defaults affect behavior and cost and remain controlled by a Holon
+release or explicit user configuration.
+
+## Snapshot v1
+
+The checked-in JSON artifact contains:
+
+- `schema_version` and `revision`;
+- canonical `models`;
+- endpoint-specific `routes` and narrowing policies;
+- compatibility `aliases`;
+- explicit preferred model and route selections.
+
+Arrays are used instead of JSON maps so duplicate keys cannot be silently
+overwritten during deserialization. All objects reject unknown fields.
+
+The runtime parses and validates the artifact before constructing the existing
+`BuiltInModelCatalog` indexes. Public catalog and resolution APIs remain
+unchanged.
+
+## Validation
+
+Snapshot validation requires:
+
+- supported schema version and non-empty revision;
+- unique model, route, alias, and preferred-selection identities;
+- aliases target canonical models and do not form chains;
+- routes reference an existing canonical model;
+- route capability policy only narrows intrinsic model capability;
+- percentages are in range and token limits are positive;
+- default output limits do not exceed upper limits;
+- reasoning options are unique;
+- preferred models and routes exist and agree with their keys.
+
+CI also compares the generated snapshot projection with the legacy Rust
+catalog during the migration. This equivalence test protects default selection,
+legacy aliases, and route behavior from accidental drift.
+
+## Follow-up
+
+A separate phase will add the `models.dev` adapter, immutable artifact
+publication, registry cache, refresh/status commands, provenance revision
+reporting, and last-known-good rollback tests. Provider discovery improvements
+remain independent work.

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -2,10 +2,11 @@ use std::collections::{BTreeMap, HashMap};
 
 use serde::{Deserialize, Serialize};
 
-use crate::config::{
-    built_in_provider_endpoint_identity, ModelRef, ModelRouteRef, ProviderEndpointId, ProviderId,
-};
+#[cfg(test)]
+use crate::config::built_in_provider_endpoint_identity;
+use crate::config::{ModelRef, ModelRouteRef, ProviderEndpointId, ProviderId};
 use crate::context::ContextConfig;
+#[cfg(test)]
 use crate::provider::provider_definitions;
 
 const DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT: u8 = 95;
@@ -203,7 +204,8 @@ impl ModelCapabilityOverride {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
 pub struct BuiltInModelRoutePolicy {
     display_name: Option<String>,
     description: Option<String>,
@@ -219,6 +221,7 @@ pub struct BuiltInModelRoutePolicy {
 }
 
 impl BuiltInModelRoutePolicy {
+    #[cfg(test)]
     fn from_legacy_route_entry(
         route_entry: &BuiltInModelMetadata,
         model_entry: &BuiltInModelMetadata,
@@ -329,6 +332,7 @@ impl BuiltInModelRoutePolicy {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(test)]
 struct BuiltInModelRouteDefinition {
     legacy_provider: ProviderId,
     model_ref: ModelRef,
@@ -563,6 +567,12 @@ pub struct BuiltInModelCatalog {
 
 impl BuiltInModelCatalog {
     pub fn new() -> Self {
+        snapshot::built_in_catalog()
+            .unwrap_or_else(|error| panic!("invalid built-in model registry snapshot: {error}"))
+    }
+
+    #[cfg(test)]
+    fn from_legacy_definitions() -> Self {
         let mut entries = HashMap::new();
         let mut preferred_models = HashMap::new();
         let mut route_entries = HashMap::new();
@@ -683,6 +693,7 @@ impl BuiltInModelCatalog {
     }
 
     /// Legacy model ref → canonical model ref aliases for backward compatibility.
+    #[cfg(test)]
     fn legacy_aliases() -> HashMap<ModelRef, ModelRef> {
         let mut aliases = HashMap::new();
         aliases.insert(
@@ -1549,6 +1560,7 @@ fn select_field<T, const N: usize>(
     None
 }
 
+#[cfg(test)]
 fn field_diff<T: PartialEq>(route: T, model: T) -> Option<T> {
     (route != model).then_some(route)
 }
@@ -1610,6 +1622,7 @@ fn percent_of(total: usize, percent: usize) -> usize {
     total.saturating_mul(percent) / 100
 }
 
+#[cfg(test)]
 fn provider_id(provider: &str) -> ProviderId {
     ProviderId::parse(provider).expect("valid built-in provider id")
 }
@@ -1671,11 +1684,13 @@ fn reasoning_effort_options(
 }
 
 mod providers;
+mod snapshot;
 #[cfg(test)]
 use providers::common::catalog_model;
 
 pub(crate) use providers::is_tencent_tokenhub_model_id;
 
+#[cfg(test)]
 fn built_in_entries() -> Vec<BuiltInModelMetadata> {
     let mut registrations = provider_definitions()
         .iter()
@@ -1688,10 +1703,12 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
         .collect()
 }
 
+#[cfg(test)]
 fn built_in_route_definitions() -> Vec<BuiltInModelRouteDefinition> {
     providers::route_definitions()
 }
 
+#[cfg(test)]
 fn is_turn_default_candidate(entry: &BuiltInModelMetadata) -> bool {
     entry.context_window_tokens.is_some()
         || entry.capabilities.parallel_tool_calls

--- a/src/model_catalog/builtin_snapshot_v1.json
+++ b/src/model_catalog/builtin_snapshot_v1.json
@@ -1,0 +1,12583 @@
+{
+  "schema_version": 1,
+  "revision": "builtin-2026-08-28",
+  "models": [
+    {
+      "model_ref": "anthropic/claude-fable-5",
+      "display_name": "Claude Fable 5",
+      "description": "Anthropic Claude Fable 5 runtime defaults aligned with the official model overview.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 90,
+      "auto_compact_token_limit": 900000,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "anthropic/claude-haiku-4-5",
+      "display_name": "Claude Haiku 4.5",
+      "description": "Anthropic Claude Haiku 4.5 runtime defaults aligned with the official model overview.",
+      "context_window_tokens": 200000,
+      "effective_context_window_percent": 90,
+      "auto_compact_token_limit": 180000,
+      "default_max_output_tokens": 64000,
+      "max_output_tokens_upper_limit": 64000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "anthropic/claude-opus-4-8",
+      "display_name": "Claude Opus 4.8",
+      "description": "Anthropic Claude Opus 4.8 runtime defaults aligned with the official model overview.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 90,
+      "auto_compact_token_limit": 900000,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "anthropic/claude-sonnet-5",
+      "display_name": "Claude Sonnet 5",
+      "description": "Anthropic Claude Sonnet 5 runtime defaults aligned with the official model overview.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 90,
+      "auto_compact_token_limit": 900000,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "arcee/trinity-large-preview",
+      "display_name": "Trinity Large Preview",
+      "description": "Holon conservative built-in metadata for the Arcee hosted trinity-large-preview model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "arcee/trinity-mini",
+      "display_name": "Trinity Mini 26B",
+      "description": "Holon conservative built-in metadata for the Arcee hosted trinity-mini model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "bigmodel/glm-4-flash-250414",
+      "display_name": "GLM-4 Flash 250414",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4-flash-250414 compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4-flashx-250414",
+      "display_name": "GLM-4 FlashX 250414",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4-flashx-250414 compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4-long",
+      "display_name": "GLM-4 Long",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4-long compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 4096,
+      "max_output_tokens_upper_limit": 4096,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.1v-thinking-flash",
+      "display_name": "GLM-4.1V Thinking Flash",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4.1v-thinking-flash compatible provider model.",
+      "context_window_tokens": 65536,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.1v-thinking-flashx",
+      "display_name": "GLM-4.1V Thinking FlashX",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4.1v-thinking-flashx compatible provider model.",
+      "context_window_tokens": 65536,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.5-air",
+      "display_name": "GLM-4.5 Air",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4.5-air compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 98304,
+      "max_output_tokens_upper_limit": 98304,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.5-airx",
+      "display_name": "GLM-4.5 AirX",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4.5-airx compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 98304,
+      "max_output_tokens_upper_limit": 98304,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.5-flash",
+      "display_name": "GLM-4.5 Flash",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4.5-flash compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 98304,
+      "max_output_tokens_upper_limit": 98304,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.6",
+      "display_name": "GLM-4.6",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4.6 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.6v",
+      "display_name": "GLM-4.6V",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4.6v compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.6v-flash",
+      "display_name": "GLM-4.6V Flash",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4.6v-flash compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.7",
+      "display_name": "GLM-4.7",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4.7 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.7-flash",
+      "display_name": "GLM-4.7 Flash",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4.7-flash compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.7-flashx",
+      "display_name": "GLM-4.7 FlashX",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4.7-flashx compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-4v-flash",
+      "display_name": "GLM-4V Flash",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-4v-flash compatible provider model.",
+      "context_window_tokens": 16384,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 1024,
+      "max_output_tokens_upper_limit": 1024,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-5",
+      "display_name": "GLM-5",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-5 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-5-turbo",
+      "display_name": "GLM-5 Turbo",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-5-turbo compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-5.1",
+      "display_name": "GLM-5.1",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-5.1 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-5.2",
+      "display_name": "GLM-5.2",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-5.2 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-5.3",
+      "display_name": "GLM-5.3",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-5.3 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-5.3-flash",
+      "display_name": "GLM-5.3 Flash",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-5.3-flash compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "bigmodel/glm-5v-turbo",
+      "display_name": "GLM-5V Turbo",
+      "description": "Holon built-in runtime metadata for the bigmodel/glm-5v-turbo compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/MiniMaxAI/MiniMax-M2.5-TEE",
+      "display_name": "MiniMaxAI/MiniMax-M2.5-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/MiniMaxAI/MiniMax-M2.5-TEE compatible provider model.",
+      "context_window_tokens": 196608,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
+      "display_name": "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/Qwen/Qwen3-235B-A22B-Thinking-2507-TEE compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/Qwen/Qwen3-32B-TEE",
+      "display_name": "Qwen/Qwen3-32B-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/Qwen/Qwen3-32B-TEE compatible provider model.",
+      "context_window_tokens": 40960,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 40960,
+      "max_output_tokens_upper_limit": 40960,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/Qwen/Qwen3.5-397B-A17B-TEE",
+      "display_name": "Qwen/Qwen3.5-397B-A17B-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/Qwen/Qwen3.5-397B-A17B-TEE compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/Qwen/Qwen3.6-27B-TEE",
+      "display_name": "Qwen/Qwen3.6-27B-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/Qwen/Qwen3.6-27B-TEE compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/deepseek-ai/DeepSeek-V3.2-TEE",
+      "display_name": "deepseek-ai/DeepSeek-V3.2-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/deepseek-ai/DeepSeek-V3.2-TEE compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/google/gemma-4-31B-turbo-TEE",
+      "display_name": "google/gemma-4-31B-turbo-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/google/gemma-4-31B-turbo-TEE compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/moonshotai/Kimi-K2.5-TEE",
+      "display_name": "moonshotai/Kimi-K2.5-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/moonshotai/Kimi-K2.5-TEE compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65535,
+      "max_output_tokens_upper_limit": 65535,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/moonshotai/Kimi-K2.6-TEE",
+      "display_name": "moonshotai/Kimi-K2.6-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/moonshotai/Kimi-K2.6-TEE compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65535,
+      "max_output_tokens_upper_limit": 65535,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/unsloth/Mistral-Nemo-Instruct-2407-TEE",
+      "display_name": "unsloth/Mistral-Nemo-Instruct-2407-TEE",
+      "description": "Holon conservative built-in metadata for the Chutes unsloth/Mistral-Nemo-Instruct-2407-TEE model; the public model entry does not publish complete capability fields.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "chutes/zai-org/GLM-5-TEE",
+      "display_name": "zai-org/GLM-5-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/zai-org/GLM-5-TEE compatible provider model.",
+      "context_window_tokens": 202752,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65535,
+      "max_output_tokens_upper_limit": 65535,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/zai-org/GLM-5.1-TEE",
+      "display_name": "zai-org/GLM-5.1-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/zai-org/GLM-5.1-TEE compatible provider model.",
+      "context_window_tokens": 202752,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65535,
+      "max_output_tokens_upper_limit": 65535,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "chutes/zai-org/GLM-5.2-TEE",
+      "display_name": "zai-org/GLM-5.2-TEE",
+      "description": "Holon built-in runtime metadata for the chutes/zai-org/GLM-5.2-TEE compatible provider model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65535,
+      "max_output_tokens_upper_limit": 65535,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/MiniMax-M2.5",
+      "display_name": "MiniMax-M2.5",
+      "description": "Holon built-in runtime metadata for the dashscope/MiniMax-M2.5 compatible provider model.",
+      "context_window_tokens": 196608,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/MiniMax/MiniMax-M3",
+      "display_name": "MiniMax/MiniMax-M3",
+      "description": "Holon built-in runtime metadata for the dashscope/MiniMax/MiniMax-M3 compatible provider model.",
+      "context_window_tokens": 196608,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/ZHIPU/GLM-5.2",
+      "display_name": "ZHIPU/GLM-5.2",
+      "description": "Holon built-in runtime metadata for the dashscope/ZHIPU/GLM-5.2 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/ZHIPU/GLM-5.3",
+      "display_name": "ZHIPU/GLM-5.3",
+      "description": "Holon built-in runtime metadata for the dashscope/ZHIPU/GLM-5.3 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/deepseek-v3.2",
+      "display_name": "DeepSeek V3.2",
+      "description": "Holon built-in runtime metadata for the dashscope/deepseek-v3.2 compatible provider model.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/deepseek-v4-flash",
+      "display_name": "DeepSeek V4 Flash",
+      "description": "Holon built-in runtime metadata for the dashscope/deepseek-v4-flash compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 384000,
+      "max_output_tokens_upper_limit": 384000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/deepseek-v4-flash-0731",
+      "display_name": "DeepSeek V4 Flash 0731",
+      "description": "Holon built-in runtime metadata for the dashscope/deepseek-v4-flash-0731 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 384000,
+      "max_output_tokens_upper_limit": 384000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/deepseek-v4-pro",
+      "display_name": "DeepSeek V4 Pro",
+      "description": "Holon built-in runtime metadata for the dashscope/deepseek-v4-pro compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 384000,
+      "max_output_tokens_upper_limit": 384000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/glm-4.7",
+      "display_name": "glm-4.7",
+      "description": "Holon built-in runtime metadata for the dashscope/glm-4.7 compatible provider model.",
+      "context_window_tokens": 202752,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/glm-5",
+      "display_name": "glm-5",
+      "description": "Holon built-in runtime metadata for the dashscope/glm-5 compatible provider model.",
+      "context_window_tokens": 202752,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/glm-5.1",
+      "display_name": "glm-5.1",
+      "description": "Holon built-in runtime metadata for the dashscope/glm-5.1 compatible provider model.",
+      "context_window_tokens": 202752,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/glm-5.2",
+      "display_name": "glm-5.2",
+      "description": "Holon built-in runtime metadata for the dashscope/glm-5.2 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/kimi-k2.5",
+      "display_name": "kimi-k2.5",
+      "description": "Holon built-in runtime metadata for the dashscope/kimi-k2.5 compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/kimi-k2.6",
+      "display_name": "kimi-k2.6",
+      "description": "Holon built-in runtime metadata for the dashscope/kimi-k2.6 compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 98304,
+      "max_output_tokens_upper_limit": 98304,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/kimi-k2.7-code",
+      "display_name": "kimi-k2.7-code",
+      "description": "Holon built-in runtime metadata for the dashscope/kimi-k2.7-code compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 98304,
+      "max_output_tokens_upper_limit": 98304,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/mimo-v2.5-pro",
+      "display_name": "MiMo V2.5 Pro",
+      "description": "Holon built-in runtime metadata for the dashscope/mimo-v2.5-pro compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3-coder-flash",
+      "display_name": "qwen3-coder-flash",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3-coder-flash compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3-coder-next",
+      "display_name": "qwen3-coder-next",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3-coder-next compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3-coder-plus",
+      "display_name": "qwen3-coder-plus",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3-coder-plus compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3-max-2026-01-23",
+      "display_name": "qwen3-max-2026-01-23",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3-max-2026-01-23 compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.5-flash",
+      "display_name": "qwen3.5-flash",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.5-flash compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.5-plus",
+      "display_name": "qwen3.5-plus",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.5-plus compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.6-flash",
+      "display_name": "qwen3.6-flash",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.6-flash compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.6-plus",
+      "display_name": "qwen3.6-plus",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.6-plus compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.7-max",
+      "display_name": "qwen3.7-max",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.7-max compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.7-max-2026-05-20",
+      "display_name": "qwen3.7-max-2026-05-20",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.7-max-2026-05-20 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.7-max-2026-06-08",
+      "display_name": "qwen3.7-max-2026-06-08",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.7-max-2026-06-08 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.7-plus",
+      "display_name": "qwen3.7-plus",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.7-plus compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.7-plus-2026-05-26",
+      "display_name": "qwen3.7-plus-2026-05-26",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.7-plus-2026-05-26 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.8-flash",
+      "display_name": "qwen3.8-flash",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.8-flash compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.8-max",
+      "display_name": "qwen3.8-max",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.8-max compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "dashscope/qwen3.8-max-preview",
+      "display_name": "qwen3.8-max-preview",
+      "description": "Holon built-in runtime metadata for the dashscope/qwen3.8-max-preview compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "deepseek/deepseek-v4-flash",
+      "display_name": "DeepSeek V4 Flash",
+      "description": "Holon built-in runtime metadata for the deepseek/deepseek-v4-flash compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 384000,
+      "max_output_tokens_upper_limit": 384000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "deepseek/deepseek-v4-pro",
+      "display_name": "DeepSeek V4 Pro",
+      "description": "Holon built-in runtime metadata for the deepseek/deepseek-v4-pro compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 384000,
+      "max_output_tokens_upper_limit": 384000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/deepseek-v4-flash",
+      "display_name": "DeepSeek V4 Flash",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/deepseek-v4-flash model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/deepseek-v4-pro",
+      "display_name": "DeepSeek V4 Pro",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/deepseek-v4-pro model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/glm-5p1",
+      "display_name": "GLM 5.1",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/glm-5p1 model.",
+      "context_window_tokens": 202752,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/glm-5p2",
+      "display_name": "GLM 5.2",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/glm-5p2 model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/gpt-oss-120b",
+      "display_name": "GPT-OSS 120B",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/gpt-oss-120b model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/kimi-k2p6",
+      "display_name": "Kimi K2.6",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/kimi-k2p6 model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/kimi-k2p7-code",
+      "display_name": "Kimi K2.7 Code",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/kimi-k2p7-code model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/minimax-m2p7",
+      "display_name": "MiniMax M2.7",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/minimax-m2p7 model.",
+      "context_window_tokens": 196608,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/minimax-m3",
+      "display_name": "MiniMax M3",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/minimax-m3 model.",
+      "context_window_tokens": 524288,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/nemotron-3-ultra-nvfp4",
+      "display_name": "Nemotron 3 Ultra NVFP4",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/nemotron-3-ultra-nvfp4 model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/qwen3p6-plus",
+      "display_name": "Qwen 3.6 Plus",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/qwen3p6-plus model.",
+      "context_window_tokens": null,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/qwen3p7-plus",
+      "display_name": "Qwen 3.7 Plus",
+      "description": "Holon conservative built-in metadata for the Fireworks serverless accounts/fireworks/models/qwen3p7-plus model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "gemini/gemini-2.5-flash",
+      "display_name": "Gemini 2.5 Flash",
+      "description": "Holon built-in runtime metadata for the gemini/gemini-2.5-flash compatible provider model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "gemini/gemini-2.5-flash-lite",
+      "display_name": "Gemini 2.5 Flash-Lite",
+      "description": "Holon built-in runtime metadata for the gemini/gemini-2.5-flash-lite compatible provider model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "gemini/gemini-2.5-pro",
+      "display_name": "Gemini 2.5 Pro",
+      "description": "Holon built-in runtime metadata for the gemini/gemini-2.5-pro compatible provider model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "gemini/gemini-3.1-flash-lite",
+      "display_name": "Gemini 3.1 Flash-Lite",
+      "description": "Holon built-in runtime metadata for the gemini/gemini-3.1-flash-lite compatible provider model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "gemini/gemini-3.1-pro-preview",
+      "display_name": "Gemini 3.1 Pro Preview",
+      "description": "Holon built-in runtime metadata for the gemini/gemini-3.1-pro-preview compatible provider model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "gemini/gemini-3.5-flash",
+      "display_name": "Gemini 3.5 Flash",
+      "description": "Holon built-in runtime metadata for the gemini/gemini-3.5-flash compatible provider model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "huggingface/openai/gpt-oss-120b",
+      "display_name": "OpenAI GPT OSS 120B",
+      "description": "Holon conservative built-in metadata for the Hugging Face Inference Providers quick-start chat model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "reasoning_effort_options": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "kilocode/kilo-auto/balanced",
+      "display_name": "Kilo Auto Balanced",
+      "description": "Holon conservative built-in metadata for the Kilo Gateway Kilo Auto Balanced virtual model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "kilocode/kilo-auto/efficient",
+      "display_name": "Kilo Auto Efficient",
+      "description": "Holon conservative built-in metadata for the Kilo Gateway Kilo Auto Efficient virtual model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "kilocode/kilo-auto/free",
+      "display_name": "Kilo Auto Free",
+      "description": "Holon conservative built-in metadata for the Kilo Gateway Kilo Auto Free virtual model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": 10000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "kilocode/kilo-auto/frontier",
+      "display_name": "Kilo Auto Frontier",
+      "description": "Holon conservative built-in metadata for the Kilo Gateway Kilo Auto Frontier virtual model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2",
+      "display_name": "MiniMax M2",
+      "description": "Holon built-in runtime metadata for the minimax/MiniMax-M2 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.1",
+      "display_name": "MiniMax M2.1",
+      "description": "Holon built-in runtime metadata for the minimax/MiniMax-M2.1 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.1-highspeed",
+      "display_name": "MiniMax M2.1 Highspeed",
+      "description": "Holon built-in runtime metadata for the minimax/MiniMax-M2.1-highspeed compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.5",
+      "display_name": "MiniMax M2.5",
+      "description": "Holon built-in runtime metadata for the minimax/MiniMax-M2.5 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.5-highspeed",
+      "display_name": "MiniMax M2.5 Highspeed",
+      "description": "Holon built-in runtime metadata for the minimax/MiniMax-M2.5-highspeed compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.7",
+      "display_name": "MiniMax M2.7",
+      "description": "Holon built-in runtime metadata for the minimax/MiniMax-M2.7 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.7-highspeed",
+      "display_name": "MiniMax M2.7 Highspeed",
+      "description": "Holon built-in runtime metadata for the minimax/MiniMax-M2.7-highspeed compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M3",
+      "display_name": "MiniMax M3",
+      "description": "Holon built-in runtime metadata for the minimax/MiniMax-M3 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "mistral/codestral-latest",
+      "display_name": "Codestral (latest)",
+      "description": "Holon built-in runtime metadata for the mistral/codestral-latest compatible provider model.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 4096,
+      "max_output_tokens_upper_limit": 4096,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "mistral/mistral-large-latest",
+      "display_name": "Mistral Large 3 (latest)",
+      "description": "Holon built-in runtime metadata for the mistral/mistral-large-latest compatible provider model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "mistral/mistral-medium-latest",
+      "display_name": "Mistral Medium 3.5 (latest)",
+      "description": "Holon built-in runtime metadata for the mistral/mistral-medium-latest compatible provider model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 8192,
+      "max_output_tokens_upper_limit": 8192,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "mistral/mistral-small-latest",
+      "display_name": "Mistral Small 4 (latest)",
+      "description": "Holon built-in runtime metadata for the mistral/mistral-small-latest compatible provider model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/kimi-k2.5",
+      "display_name": "Kimi K2.5",
+      "description": "Holon built-in runtime metadata for the moonshot/kimi-k2.5 compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/kimi-k2.6",
+      "display_name": "Kimi K2.6",
+      "description": "Holon built-in runtime metadata for the moonshot/kimi-k2.6 compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/kimi-k2.7-code",
+      "display_name": "Kimi K2.7 Code",
+      "description": "Holon built-in runtime metadata for the moonshot/kimi-k2.7-code compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/kimi-k2.7-code-highspeed",
+      "display_name": "Kimi K2.7 Code HighSpeed",
+      "description": "Holon built-in runtime metadata for the moonshot/kimi-k2.7-code-highspeed compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/kimi-k3",
+      "display_name": "Kimi K3",
+      "description": "Holon built-in runtime metadata for the moonshot/kimi-k3 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-128k",
+      "display_name": "Moonshot V1 128K",
+      "description": "Holon built-in runtime metadata for the moonshot/moonshot-v1-128k compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-128k-vision-preview",
+      "display_name": "Moonshot V1 128K Vision Preview",
+      "description": "Holon built-in runtime metadata for the moonshot/moonshot-v1-128k-vision-preview compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-32k",
+      "display_name": "Moonshot V1 32K",
+      "description": "Holon built-in runtime metadata for the moonshot/moonshot-v1-32k compatible provider model.",
+      "context_window_tokens": 32768,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-32k-vision-preview",
+      "display_name": "Moonshot V1 32K Vision Preview",
+      "description": "Holon built-in runtime metadata for the moonshot/moonshot-v1-32k-vision-preview compatible provider model.",
+      "context_window_tokens": 32768,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-8k",
+      "display_name": "Moonshot V1 8K",
+      "description": "Holon built-in runtime metadata for the moonshot/moonshot-v1-8k compatible provider model.",
+      "context_window_tokens": 8192,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 8192,
+      "max_output_tokens_upper_limit": 8192,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-8k-vision-preview",
+      "display_name": "Moonshot V1 8K Vision Preview",
+      "description": "Holon built-in runtime metadata for the moonshot/moonshot-v1-8k-vision-preview compatible provider model.",
+      "context_window_tokens": 8192,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 8192,
+      "max_output_tokens_upper_limit": 8192,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-auto",
+      "display_name": "Moonshot V1 Auto",
+      "description": "Holon built-in runtime metadata for the moonshot/moonshot-v1-auto compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "nearai/Qwen/Qwen3-VL-30B-A3B-Instruct",
+      "display_name": "Qwen3 VL 30B A3B Instruct (NEAR AI Cloud TEE)",
+      "description": "Holon built-in runtime metadata for the nearai/Qwen/Qwen3-VL-30B-A3B-Instruct compatible provider model.",
+      "context_window_tokens": 16384,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 8192,
+      "max_output_tokens_upper_limit": 8192,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "nearai/Qwen/Qwen3.5-122B-A10B",
+      "display_name": "Qwen 3.5 122B A10B (NEAR AI Cloud TEE)",
+      "description": "Holon built-in runtime metadata for the nearai/Qwen/Qwen3.5-122B-A10B compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "nearai/Qwen/Qwen3.6-35B-A3B-FP8",
+      "display_name": "Qwen 3.6 35B A3B FP8 (NEAR AI Cloud TEE)",
+      "description": "Holon built-in runtime metadata for the nearai/Qwen/Qwen3.6-35B-A3B-FP8 compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 8192,
+      "max_output_tokens_upper_limit": 8192,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "nearai/google/gemma-4-31B-it",
+      "display_name": "Gemma 4 31B Instruct (NEAR AI Cloud TEE)",
+      "description": "Holon built-in runtime metadata for the nearai/google/gemma-4-31B-it compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 8192,
+      "max_output_tokens_upper_limit": 8192,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "nearai/zai-org/GLM-5.1-FP8",
+      "display_name": "GLM 5.1 (NEAR AI Cloud TEE)",
+      "description": "Holon built-in runtime metadata for the nearai/zai-org/GLM-5.1-FP8 compatible provider model.",
+      "context_window_tokens": 202752,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "nvidia/minimaxai/minimax-m2.7",
+      "display_name": "MiniMax M2.7",
+      "description": "Holon conservative built-in metadata for the NVIDIA-hosted minimaxai/minimax-m2.7 model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "nvidia/minimaxai/minimax-m3",
+      "display_name": "MiniMax M3",
+      "description": "Holon conservative built-in metadata for the NVIDIA-hosted minimaxai/minimax-m3 model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "nvidia/moonshotai/kimi-k2.6",
+      "display_name": "Kimi K2.6",
+      "description": "Holon conservative built-in metadata for the NVIDIA-hosted moonshotai/kimi-k2.6 model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "nvidia/nvidia/nemotron-3-super-120b-a12b",
+      "display_name": "NVIDIA Nemotron 3 Super 120B",
+      "description": "Holon conservative built-in metadata for the NVIDIA-hosted nvidia/nemotron-3-super-120b-a12b model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "nvidia/z-ai/glm-5.2",
+      "display_name": "GLM-5.2",
+      "description": "Holon conservative built-in metadata for the NVIDIA-hosted z-ai/glm-5.2 model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.3-codex-spark",
+      "display_name": "GPT-5.3 Codex Spark (Codex)",
+      "description": "Codex Spark runtime defaults mirrored from the local OpenAI Codex model metadata contract.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": "low",
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": true
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.4",
+      "display_name": "GPT-5.4 (Codex)",
+      "description": "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.",
+      "context_window_tokens": 272000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": "low",
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": true,
+        "supports_reasoning": true,
+        "interactive_exec": true
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.4-mini",
+      "display_name": "GPT-5.4-Mini (Codex)",
+      "description": "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.",
+      "context_window_tokens": 272000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": "medium",
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": true,
+        "supports_reasoning": true,
+        "interactive_exec": true
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.5",
+      "display_name": "GPT-5.5 (Codex)",
+      "description": "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.",
+      "context_window_tokens": 272000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": "low",
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": true,
+        "supports_reasoning": true,
+        "interactive_exec": true
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.6-luna",
+      "display_name": "GPT-5.6-Luna (Codex)",
+      "description": "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.",
+      "context_window_tokens": 372000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": "low",
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": true,
+        "supports_reasoning": true,
+        "interactive_exec": true
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.6-sol",
+      "display_name": "GPT-5.6-Sol (Codex)",
+      "description": "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.",
+      "context_window_tokens": 372000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": "low",
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": true,
+        "supports_reasoning": true,
+        "interactive_exec": true
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.6-terra",
+      "display_name": "GPT-5.6-Terra (Codex)",
+      "description": "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.",
+      "context_window_tokens": 372000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": "low",
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": true,
+        "supports_reasoning": true,
+        "interactive_exec": true
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "openai/gpt-5.3",
+      "display_name": "GPT-5.3",
+      "description": "Conservative GPT-5.3 runtime defaults used when explicit model metadata is not available locally.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "openai/gpt-5.4",
+      "display_name": "GPT-5.4",
+      "description": "Conservative GPT-5.4 runtime defaults aligned with local Codex model behavior.",
+      "context_window_tokens": 272000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "openai/gpt-5.4-mini",
+      "display_name": "GPT-5.4 Mini",
+      "description": "Conservative GPT-5.4 Mini runtime defaults used when explicit model metadata is not available locally.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "openai/gpt-5.6-luna",
+      "display_name": "GPT-5.6 Luna",
+      "description": "Holon built-in runtime metadata for the openai/gpt-5.6-luna compatible provider model.",
+      "context_window_tokens": 372000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "openai/gpt-5.6-sol",
+      "display_name": "GPT-5.6 Sol",
+      "description": "Holon built-in runtime metadata for the openai/gpt-5.6-sol compatible provider model.",
+      "context_window_tokens": 372000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "openai/gpt-5.6-terra",
+      "display_name": "GPT-5.6 Terra",
+      "description": "Holon built-in runtime metadata for the openai/gpt-5.6-terra compatible provider model.",
+      "context_window_tokens": 372000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "openai/gpt-image-2",
+      "display_name": "GPT Image 2",
+      "description": "OpenAI image generation model for the Images API.",
+      "context_window_tokens": null,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": true,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "opencode-go/deepseek-v4-flash",
+      "display_name": "DeepSeek V4 Flash",
+      "description": "Holon conservative built-in metadata for the OpenCode Go deepseek-v4-flash route.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 384000,
+      "max_output_tokens_upper_limit": 384000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/deepseek-v4-pro",
+      "display_name": "DeepSeek V4 Pro",
+      "description": "Holon conservative built-in metadata for the OpenCode Go deepseek-v4-pro route.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 384000,
+      "max_output_tokens_upper_limit": 384000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/glm-5.1",
+      "display_name": "GLM-5.1",
+      "description": "Holon conservative built-in metadata for the OpenCode Go glm-5.1 route.",
+      "context_window_tokens": 202800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/glm-5.2",
+      "display_name": "GLM-5.2",
+      "description": "Holon conservative built-in metadata for the OpenCode Go glm-5.2 route.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/kimi-k2.6",
+      "display_name": "Kimi K2.6",
+      "description": "Holon conservative built-in metadata for the OpenCode Go kimi-k2.6 route.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/kimi-k2.7-code",
+      "display_name": "Kimi K2.7 Code",
+      "description": "Holon conservative built-in metadata for the OpenCode Go kimi-k2.7-code route.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/mimo-v2.5",
+      "display_name": "MiMo V2.5",
+      "description": "Holon conservative built-in metadata for the OpenCode Go mimo-v2.5 route.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/mimo-v2.5-pro",
+      "display_name": "MiMo V2.5 Pro",
+      "description": "Holon conservative built-in metadata for the OpenCode Go mimo-v2.5-pro route.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/minimax-m2.5",
+      "display_name": "MiniMax M2.5",
+      "description": "Holon conservative built-in metadata for the OpenCode Go minimax-m2.5 route.",
+      "context_window_tokens": 196608,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/minimax-m2.7",
+      "display_name": "MiniMax M2.7",
+      "description": "Holon conservative built-in metadata for the OpenCode Go minimax-m2.7 route.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/minimax-m3",
+      "display_name": "MiniMax M3",
+      "description": "Holon conservative built-in metadata for the OpenCode Go minimax-m3 route.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/qwen3.6-plus",
+      "display_name": "Qwen3.6 Plus",
+      "description": "Holon conservative built-in metadata for the OpenCode Go qwen3.6-plus route.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/qwen3.7-max",
+      "display_name": "Qwen3.7 Max",
+      "description": "Holon conservative built-in metadata for the OpenCode Go qwen3.7-max route.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "opencode-go/qwen3.7-plus",
+      "display_name": "Qwen3.7 Plus",
+      "description": "Holon conservative built-in metadata for the OpenCode Go qwen3.7-plus route.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "openrouter/auto",
+      "display_name": "OpenRouter Auto",
+      "description": "OpenRouter Auto Router metadata aligned with the official Models API; the selected upstream model and provider are dynamic.",
+      "context_window_tokens": 2000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "qianfan/deepseek-v3.2",
+      "display_name": "DEEPSEEK V3.2",
+      "description": "Holon built-in runtime metadata for the qianfan/deepseek-v3.2 compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "qianfan/deepseek-v3.2-think",
+      "display_name": "DEEPSEEK V3.2 Think",
+      "description": "Holon built-in runtime metadata for the qianfan/deepseek-v3.2-think compatible provider model.",
+      "context_window_tokens": 163840,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "qianfan/ernie-5.0",
+      "display_name": "ERNIE 5.0",
+      "description": "Holon built-in runtime metadata for the qianfan/ernie-5.0 compatible provider model.",
+      "context_window_tokens": 248832,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "qianfan/ernie-5.0-thinking-preview",
+      "display_name": "ERNIE 5.0 Thinking Preview",
+      "description": "Holon built-in runtime metadata for the qianfan/ernie-5.0-thinking-preview compatible provider model.",
+      "context_window_tokens": 248832,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "qianfan/ernie-5.1",
+      "display_name": "ERNIE 5.1",
+      "description": "Holon built-in runtime metadata for the qianfan/ernie-5.1 compatible provider model.",
+      "context_window_tokens": 248832,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "qianfan/ernie-x1.1",
+      "display_name": "ERNIE X1.1",
+      "description": "Holon built-in runtime metadata for the qianfan/ernie-x1.1 compatible provider model.",
+      "context_window_tokens": 121856,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "stepfun/step-3.5-flash",
+      "display_name": "Step 3.5 Flash",
+      "description": "Holon built-in runtime metadata for the StepFun step-3.5-flash model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "stepfun/step-3.5-flash-2603",
+      "display_name": "Step 3.5 Flash 2603",
+      "description": "Holon built-in runtime metadata for the StepFun step-3.5-flash-2603 model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "stepfun/step-3.7-flash",
+      "display_name": "Step 3.7 Flash",
+      "description": "Holon built-in runtime metadata for the StepFun step-3.7-flash model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "synthetic/hf:MiniMaxAI/MiniMax-M3",
+      "display_name": "MiniMax M3",
+      "description": "Holon built-in runtime metadata for the synthetic/hf:MiniMaxAI/MiniMax-M3 compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "synthetic/hf:Qwen/Qwen3.6-27B",
+      "display_name": "Qwen3.6 27B",
+      "description": "Holon built-in runtime metadata for the synthetic/hf:Qwen/Qwen3.6-27B compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "synthetic/hf:moonshotai/Kimi-K2.7-Code",
+      "display_name": "Moonshot AI Kimi K2.7 Code",
+      "description": "Holon built-in runtime metadata for the synthetic/hf:moonshotai/Kimi-K2.7-Code compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "synthetic/hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+      "display_name": "NVIDIA Nemotron 3 Super 120B A12B NVFP4",
+      "description": "Holon built-in runtime metadata for the synthetic/hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "synthetic/hf:openai/gpt-oss-120b",
+      "display_name": "OpenAI GPT OSS 120B",
+      "description": "Holon built-in runtime metadata for the synthetic/hf:openai/gpt-oss-120b compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "synthetic/hf:zai-org/GLM-4.7-Flash",
+      "display_name": "Z.ai GLM-4.7 Flash",
+      "description": "Holon built-in runtime metadata for the synthetic/hf:zai-org/GLM-4.7-Flash compatible provider model.",
+      "context_window_tokens": 196608,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "synthetic/hf:zai-org/GLM-5.2",
+      "display_name": "Z.ai GLM-5.2",
+      "description": "Holon built-in runtime metadata for the synthetic/hf:zai-org/GLM-5.2 compatible provider model.",
+      "context_window_tokens": 524288,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "synthetic/syn:large:text",
+      "display_name": "Synthetic Large Text",
+      "description": "Holon built-in runtime metadata for the synthetic/syn:large:text compatible provider model.",
+      "context_window_tokens": 524288,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "synthetic/syn:large:vision",
+      "display_name": "Synthetic Large Vision",
+      "description": "Holon built-in runtime metadata for the synthetic/syn:large:vision compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "synthetic/syn:small:text",
+      "display_name": "Synthetic Small Text",
+      "description": "Holon built-in runtime metadata for the synthetic/syn:small:text compatible provider model.",
+      "context_window_tokens": 196608,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "synthetic/syn:small:vision",
+      "display_name": "Synthetic Small Vision",
+      "description": "Holon built-in runtime metadata for the synthetic/syn:small:vision compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "tencent-tokenhub/deepseek-v3.2",
+      "display_name": "DeepSeek V3.2",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub deepseek-v3.2 model.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/deepseek-v4-flash",
+      "display_name": "DeepSeek V4 Flash",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub deepseek-v4-flash model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 384000,
+      "max_output_tokens_upper_limit": 384000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/deepseek-v4-pro",
+      "display_name": "DeepSeek V4 Pro",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub deepseek-v4-pro model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 384000,
+      "max_output_tokens_upper_limit": 384000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/glm-5",
+      "display_name": "GLM-5",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub glm-5 model.",
+      "context_window_tokens": 202800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/glm-5-turbo",
+      "display_name": "GLM-5 Turbo",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub glm-5-turbo model.",
+      "context_window_tokens": 202800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/glm-5.1",
+      "display_name": "GLM-5.1",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub glm-5.1 model.",
+      "context_window_tokens": 202800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/glm-5.2",
+      "display_name": "GLM-5.2",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub glm-5.2 model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/glm-5v-turbo",
+      "display_name": "GLM-5V Turbo",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub glm-5v-turbo model.",
+      "context_window_tokens": 202800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hunyuan-role-latest",
+      "display_name": "Hy-Role-Latest",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub hunyuan-role-latest model.",
+      "context_window_tokens": null,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hunyuan-t1-vision-20250916",
+      "display_name": "HY-Vision-1.5-Thinking",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub hunyuan-t1-vision-20250916 model.",
+      "context_window_tokens": null,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy-mt2-lite",
+      "display_name": "Hy-MT2-Lite",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub hy-mt2-lite model.",
+      "context_window_tokens": null,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy-mt2-plus",
+      "display_name": "Hy-MT2-Plus",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub hy-mt2-plus model.",
+      "context_window_tokens": null,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy-mt2-pro",
+      "display_name": "Hy-MT2-Pro",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub hy-mt2-pro model.",
+      "context_window_tokens": null,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy-role",
+      "display_name": "Hy-Role",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub hy-role model.",
+      "context_window_tokens": null,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy-vision-2.0-instruct",
+      "display_name": "HY-Vision-2.0-Instruct",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub hy-vision-2.0-instruct model.",
+      "context_window_tokens": null,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy3",
+      "display_name": "Hy3",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub hy3 model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy3-preview",
+      "display_name": "Hy3 Preview",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub hy3-preview model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/kimi-k2.5",
+      "display_name": "Kimi K2.5",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub kimi-k2.5 model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/kimi-k2.6",
+      "display_name": "Kimi K2.6",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub kimi-k2.6 model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/kimi-k2.7-code",
+      "display_name": "Kimi K2.7 Code",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub kimi-k2.7-code model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/kimi-k2.7-code-highspeed",
+      "display_name": "Kimi K2.7 Code HighSpeed",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub kimi-k2.7-code-highspeed model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262144,
+      "max_output_tokens_upper_limit": 262144,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/minimax-m2.5",
+      "display_name": "MiniMax M2.5",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub minimax-m2.5 model.",
+      "context_window_tokens": 196608,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/minimax-m2.7",
+      "display_name": "MiniMax M2.7",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub minimax-m2.7 model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/minimax-m3",
+      "display_name": "MiniMax M3",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub minimax-m3 model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/qwen3.5-flash",
+      "display_name": "Qwen3.5 Flash",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub qwen3.5-flash model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/qwen3.5-plus",
+      "display_name": "Qwen3.5 Plus",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub qwen3.5-plus model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "tencent-tokenhub/youtu-vita",
+      "display_name": "YT-VITA",
+      "description": "Holon conservative built-in metadata for the Tencent TokenHub youtu-vita model.",
+      "context_window_tokens": null,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "together/MiniMaxAI/MiniMax-M2.7",
+      "display_name": "MiniMax M2.7",
+      "description": "Holon conservative built-in metadata for the Together serverless MiniMaxAI/MiniMax-M2.7 model.",
+      "context_window_tokens": 202752,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "together/MiniMaxAI/MiniMax-M3",
+      "display_name": "MiniMax M3",
+      "description": "Holon conservative built-in metadata for the Together serverless MiniMaxAI/MiniMax-M3 model.",
+      "context_window_tokens": 524288,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "together/Qwen/Qwen3.5-9B",
+      "display_name": "Qwen3.5 9B",
+      "description": "Holon conservative built-in metadata for the Together serverless Qwen/Qwen3.5-9B model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "together/deepseek-ai/DeepSeek-V4-Pro",
+      "display_name": "DeepSeek V4 Pro",
+      "description": "Holon conservative built-in metadata for the Together serverless deepseek-ai/DeepSeek-V4-Pro model.",
+      "context_window_tokens": 512000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "together/meta-llama/Llama-3.3-70B-Instruct-Turbo",
+      "display_name": "Llama 3.3 70B Instruct Turbo",
+      "description": "Holon conservative built-in metadata for the Together serverless meta-llama/Llama-3.3-70B-Instruct-Turbo model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "together/moonshotai/Kimi-K2.6",
+      "display_name": "Kimi K2.6",
+      "description": "Holon conservative built-in metadata for the Together serverless moonshotai/Kimi-K2.6 model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "together/moonshotai/Kimi-K2.7-Code",
+      "display_name": "Kimi K2.7 Code",
+      "description": "Holon conservative built-in metadata for the Together serverless moonshotai/Kimi-K2.7-Code model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "together/nvidia/nemotron-3-ultra-550b-a55b",
+      "display_name": "NVIDIA Nemotron 3 Ultra 550B",
+      "description": "Holon conservative built-in metadata for the Together serverless nvidia/nemotron-3-ultra-550b-a55b model.",
+      "context_window_tokens": 512300,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "together/openai/gpt-oss-120b",
+      "display_name": "GPT-OSS 120B",
+      "description": "Holon conservative built-in metadata for the Together serverless openai/gpt-oss-120b model.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "together/zai-org/GLM-5.2",
+      "display_name": "GLM-5.2",
+      "description": "Holon conservative built-in metadata for the Together serverless zai-org/GLM-5.2 model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "venice/qwen3-235b-a22b-thinking-2507",
+      "display_name": "Qwen3 235B A22B Thinking 2507 (via Venice)",
+      "description": "Holon conservative built-in metadata for the Venice qwen3-235b-a22b-thinking-2507 text model.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "reasoning_effort_options": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "venice/qwen3-coder-480b-a35b-instruct-turbo",
+      "display_name": "Qwen3 Coder 480B Turbo (via Venice)",
+      "description": "Holon conservative built-in metadata for the Venice qwen3-coder-480b-a35b-instruct-turbo text model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "venice/qwen3-vl-235b-a22b",
+      "display_name": "Qwen3 VL 235B (via Venice)",
+      "description": "Holon conservative built-in metadata for the Venice qwen3-vl-235b-a22b text model.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "venice/venice-uncensored-1-2",
+      "display_name": "Venice Uncensored 1.2",
+      "description": "Holon conservative built-in metadata for the Venice venice-uncensored-1-2 text model.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 8192,
+      "max_output_tokens_upper_limit": 8192,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "venice/zai-org-glm-4.7",
+      "display_name": "GLM 4.7 (via Venice)",
+      "description": "Holon conservative built-in metadata for the Venice zai-org-glm-4.7 text model.",
+      "context_window_tokens": 198000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "reasoning_effort_options": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "source": "conservative_builtin"
+    },
+    {
+      "model_ref": "vercel-ai-gateway/anthropic/claude-opus-4.6",
+      "display_name": "Claude Opus 4.6",
+      "description": "Holon built-in runtime metadata for the vercel-ai-gateway/anthropic/claude-opus-4.6 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "vercel-ai-gateway/moonshotai/kimi-k2.6",
+      "display_name": "Kimi K2.6",
+      "description": "Holon built-in runtime metadata for the vercel-ai-gateway/moonshotai/kimi-k2.6 compatible provider model.",
+      "context_window_tokens": 262000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 262000,
+      "max_output_tokens_upper_limit": 262000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "vercel-ai-gateway/openai/gpt-5.4",
+      "display_name": "GPT 5.4",
+      "description": "Holon built-in runtime metadata for the vercel-ai-gateway/openai/gpt-5.4 compatible provider model.",
+      "context_window_tokens": 1050000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "vercel-ai-gateway/openai/gpt-5.4-pro",
+      "display_name": "GPT 5.4 Pro",
+      "description": "Holon built-in runtime metadata for the vercel-ai-gateway/openai/gpt-5.4-pro compatible provider model.",
+      "context_window_tokens": 1050000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/MiniMax-M3",
+      "display_name": "MiniMax M3",
+      "description": "Holon built-in runtime metadata for the volcengine-agent/MiniMax-M3 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 8192,
+      "max_output_tokens_upper_limit": 8192,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/ark-code-latest",
+      "display_name": "Ark Code Latest",
+      "description": "Holon built-in runtime metadata for the volcengine-coding/ark-code-latest compatible provider model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 65536,
+      "max_output_tokens_upper_limit": 65536,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/deepseek-v3-2-251201",
+      "display_name": "DeepSeek V3.2",
+      "description": "Holon built-in runtime metadata for the volcengine/deepseek-v3-2-251201 compatible provider model.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 4096,
+      "max_output_tokens_upper_limit": 4096,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/deepseek-v4-flash",
+      "display_name": "DeepSeek V4 Flash",
+      "description": "Holon built-in runtime metadata for the volcengine-coding/deepseek-v4-flash compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 8192,
+      "max_output_tokens_upper_limit": 8192,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/deepseek-v4-pro",
+      "display_name": "DeepSeek V4 Pro",
+      "description": "Holon built-in runtime metadata for the volcengine-coding/deepseek-v4-pro compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 8192,
+      "max_output_tokens_upper_limit": 8192,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/doubao-seed-1-8-251228",
+      "display_name": "Doubao Seed 1.8",
+      "description": "Holon built-in runtime metadata for the volcengine/doubao-seed-1-8-251228 compatible provider model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 4096,
+      "max_output_tokens_upper_limit": 4096,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/doubao-seed-2-0-code-preview-260215",
+      "display_name": "Doubao Seed 2.0 Code Preview",
+      "description": "Holon built-in runtime metadata for the volcengine/doubao-seed-2-0-code-preview-260215 compatible provider model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 4096,
+      "max_output_tokens_upper_limit": 4096,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/doubao-seed-2-0-lite-260215",
+      "display_name": "Doubao Seed 2.0 Lite",
+      "description": "Holon built-in runtime metadata for the volcengine/doubao-seed-2-0-lite-260215 compatible provider model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 4096,
+      "max_output_tokens_upper_limit": 4096,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/doubao-seed-2-0-mini-260215",
+      "display_name": "Doubao Seed 2.0 Mini",
+      "description": "Holon built-in runtime metadata for the volcengine-agent/doubao-seed-2-0-mini-260215 compatible provider model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 4096,
+      "max_output_tokens_upper_limit": 4096,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/doubao-seed-2-0-pro-260215",
+      "display_name": "Doubao Seed 2.0 Pro",
+      "description": "Holon built-in runtime metadata for the volcengine/doubao-seed-2-0-pro-260215 compatible provider model.",
+      "context_window_tokens": 256000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 4096,
+      "max_output_tokens_upper_limit": 4096,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/doubao-seedream-5.0-lite",
+      "display_name": "Doubao Seedream 5.0 Lite",
+      "description": "Volcengine Ark Seedream image generation model for the OpenAI Images-compatible API.",
+      "context_window_tokens": null,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": true,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/glm-5.2",
+      "display_name": "GLM-5.2",
+      "description": "Holon built-in runtime metadata for the volcengine-coding/glm-5.2 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/glm-5.3",
+      "display_name": "GLM-5.3",
+      "description": "Holon built-in runtime metadata for the volcengine-coding/glm-5.3 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/kimi-k2.6",
+      "display_name": "Kimi K2.6",
+      "description": "Holon built-in runtime metadata for the volcengine-coding/kimi-k2.6 compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "volcengine/kimi-k2.7-code",
+      "display_name": "Kimi K2.7 Code",
+      "description": "Holon built-in runtime metadata for the volcengine-coding/kimi-k2.7-code compatible provider model.",
+      "context_window_tokens": 262144,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "xai/grok-4.3",
+      "display_name": "Grok 4.3",
+      "description": "xAI Grok 4.3 runtime defaults aligned with the official model page.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 90,
+      "auto_compact_token_limit": 900000,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "xai/grok-4.5",
+      "display_name": "Grok 4.5",
+      "description": "xAI Grok 4.5 runtime defaults aligned with the official model page.",
+      "context_window_tokens": 500000,
+      "effective_context_window_percent": 90,
+      "auto_compact_token_limit": 450000,
+      "default_max_output_tokens": null,
+      "max_output_tokens_upper_limit": null,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "xiaomi/mimo-v2.5",
+      "display_name": "Xiaomi MiMo V2.5",
+      "description": "Holon built-in runtime metadata for the xiaomi/mimo-v2.5 compatible provider model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "xiaomi/mimo-v2.5-pro",
+      "display_name": "Xiaomi MiMo V2.5 Pro",
+      "description": "Holon built-in runtime metadata for the xiaomi/mimo-v2.5-pro compatible provider model.",
+      "context_window_tokens": 1048576,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4-32b-0414-128k",
+      "display_name": "GLM-4 32B 0414 128K",
+      "description": "Holon built-in runtime metadata for the zai/glm-4-32b-0414-128k compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": false,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.5",
+      "display_name": "GLM-4.5",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.5 compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 98304,
+      "max_output_tokens_upper_limit": 98304,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.5-air",
+      "display_name": "GLM-4.5 Air",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.5-air compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 98304,
+      "max_output_tokens_upper_limit": 98304,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.5-airx",
+      "display_name": "GLM-4.5 AirX",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.5-airx compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 98304,
+      "max_output_tokens_upper_limit": 98304,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.5-flash",
+      "display_name": "GLM-4.5 Flash",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.5-flash compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 98304,
+      "max_output_tokens_upper_limit": 98304,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.5-x",
+      "display_name": "GLM-4.5 X",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.5-x compatible provider model.",
+      "context_window_tokens": 131072,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 98304,
+      "max_output_tokens_upper_limit": 98304,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.5v",
+      "display_name": "GLM-4.5V",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.5v compatible provider model.",
+      "context_window_tokens": 64000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 16384,
+      "max_output_tokens_upper_limit": 16384,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.6",
+      "display_name": "GLM-4.6",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.6 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.6v",
+      "display_name": "GLM-4.6V",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.6v compatible provider model.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.6v-flash",
+      "display_name": "GLM-4.6V Flash",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.6v-flash compatible provider model.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.6v-flashx",
+      "display_name": "GLM-4.6V FlashX",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.6v-flashx compatible provider model.",
+      "context_window_tokens": 128000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 32768,
+      "max_output_tokens_upper_limit": 32768,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.7",
+      "display_name": "GLM-4.7",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.7 compatible provider model.",
+      "context_window_tokens": 204800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.7-flash",
+      "display_name": "GLM-4.7 Flash",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.7-flash compatible provider model.",
+      "context_window_tokens": 200000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-4.7-flashx",
+      "display_name": "GLM-4.7 FlashX",
+      "description": "Holon built-in runtime metadata for the zai/glm-4.7-flashx compatible provider model.",
+      "context_window_tokens": 200000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 128000,
+      "max_output_tokens_upper_limit": 128000,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-5",
+      "display_name": "GLM-5",
+      "description": "Holon built-in runtime metadata for the zai/glm-5 compatible provider model.",
+      "context_window_tokens": 202800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-5-turbo",
+      "display_name": "GLM-5 Turbo",
+      "description": "Holon built-in runtime metadata for the zai/glm-5-turbo compatible provider model.",
+      "context_window_tokens": 202800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-5.1",
+      "display_name": "GLM-5.1",
+      "description": "Holon built-in runtime metadata for the zai/glm-5.1 compatible provider model.",
+      "context_window_tokens": 202800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-5.2",
+      "display_name": "GLM-5.2",
+      "description": "Holon built-in runtime metadata for the zai/glm-5.2 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-5.3",
+      "display_name": "GLM-5.3",
+      "description": "Holon built-in runtime metadata for the zai/glm-5.3 compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": false,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-5.3-flash",
+      "display_name": "GLM-5.3 Flash",
+      "description": "Holon built-in runtime metadata for the zai/glm-5.3-flash compatible provider model.",
+      "context_window_tokens": 1000000,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    },
+    {
+      "model_ref": "zai/glm-5v-turbo",
+      "display_name": "GLM-5V Turbo",
+      "description": "Holon built-in runtime metadata for the zai/glm-5v-turbo compatible provider model.",
+      "context_window_tokens": 202800,
+      "effective_context_window_percent": 95,
+      "auto_compact_token_limit": null,
+      "default_max_output_tokens": 131072,
+      "max_output_tokens_upper_limit": 131072,
+      "default_verbosity": null,
+      "tool_output_truncation_estimated_tokens": 2500,
+      "capabilities": {
+        "parallel_tool_calls": false,
+        "image_input": true,
+        "image_generation": false,
+        "supports_reasoning": true,
+        "interactive_exec": false
+      },
+      "source": "built_in_catalog"
+    }
+  ],
+  "routes": [
+    {
+      "route_ref": "anthropic@default/claude-fable-5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "anthropic@default/claude-haiku-4-5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "anthropic@default/claude-opus-4-8",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "anthropic@default/claude-sonnet-5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "arcee@default/trinity-large-preview",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "arcee@default/trinity-mini",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4-flash-250414",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4-flashx-250414",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4-long",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4.1v-thinking-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4.1v-thinking-flashx",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4.5-air",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4.5-airx",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4.5-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4.6v",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4.6v-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4.7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4.7-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4.7-flashx",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-4v-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-5-turbo",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-5.1",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-5.3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-5.3-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "bigmodel@default/glm-5v-turbo",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/MiniMaxAI/MiniMax-M2.5-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/Qwen/Qwen3-32B-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/Qwen/Qwen3.5-397B-A17B-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/Qwen/Qwen3.6-27B-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/deepseek-ai/DeepSeek-V3.2-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/google/gemma-4-31B-turbo-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/moonshotai/Kimi-K2.5-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/moonshotai/Kimi-K2.6-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/unsloth/Mistral-Nemo-Instruct-2407-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/zai-org/GLM-5-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/zai-org/GLM-5.1-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "chutes@default/zai-org/GLM-5.2-TEE",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@coding-plan/MiniMax-M2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@coding-plan/glm-4.7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@coding-plan/glm-5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@coding-plan/kimi-k2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@coding-plan/qwen3-coder-next",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@coding-plan/qwen3-coder-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@coding-plan/qwen3-max-2026-01-23",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@coding-plan/qwen3.5-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@coding-plan/qwen3.6-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@coding-plan/qwen3.7-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/MiniMax-M2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/MiniMax/MiniMax-M3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/ZHIPU/GLM-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/ZHIPU/GLM-5.3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/deepseek-v3.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/deepseek-v4-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/deepseek-v4-flash-0731",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/deepseek-v4-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/glm-4.7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/glm-5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/glm-5.1",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/glm-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/kimi-k2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/kimi-k2.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/kimi-k2.7-code",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/mimo-v2.5-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3-coder-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3-coder-next",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3-coder-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3-max-2026-01-23",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.5-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.5-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.6-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.6-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.7-max",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.7-max-2026-05-20",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.7-max-2026-06-08",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.7-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.7-plus-2026-05-26",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.8-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.8-max",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@default/qwen3.8-max-preview",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/MiniMax-M2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/deepseek-v3.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/deepseek-v4-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": 65536,
+        "max_output_tokens_upper_limit": 65536,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/deepseek-v4-flash-0731",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": 65536,
+        "max_output_tokens_upper_limit": 65536,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/deepseek-v4-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": 65536,
+        "max_output_tokens_upper_limit": 65536,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/glm-5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/glm-5.1",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": 65536,
+        "max_output_tokens_upper_limit": 65536,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/glm-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": 1000000,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": 65536,
+        "max_output_tokens_upper_limit": 65536,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/kimi-k2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/kimi-k2.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": 65536,
+        "max_output_tokens_upper_limit": 65536,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/kimi-k2.7-code",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": 65536,
+        "max_output_tokens_upper_limit": 65536,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/qwen3.6-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/qwen3.6-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/qwen3.7-max",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/qwen3.7-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/qwen3.8-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/qwen3.8-max",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "dashscope@token-plan/qwen3.8-max-preview",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "deepseek@default/deepseek-v4-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "deepseek@default/deepseek-v4-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "deepseek@responses/deepseek-v4-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "deepseek@responses/deepseek-v4-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/deepseek-v4-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/deepseek-v4-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/glm-5p1",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/glm-5p2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/gpt-oss-120b",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/kimi-k2p6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/kimi-k2p7-code",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/minimax-m2p7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/minimax-m3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/nemotron-3-ultra-nvfp4",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/qwen3p6-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "fireworks@default/accounts/fireworks/models/qwen3p7-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "gemini@default/gemini-2.5-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "gemini@default/gemini-2.5-flash-lite",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "gemini@default/gemini-2.5-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "gemini@default/gemini-3.1-flash-lite",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "gemini@default/gemini-3.1-pro-preview",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "gemini@default/gemini-3.5-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "huggingface@default/openai/gpt-oss-120b",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "kilocode@default/kilo-auto/balanced",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "kilocode@default/kilo-auto/efficient",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "kilocode@default/kilo-auto/free",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "kilocode@default/kilo-auto/frontier",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "minimax@default/MiniMax-M2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "minimax@default/MiniMax-M2.1",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "minimax@default/MiniMax-M2.1-highspeed",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "minimax@default/MiniMax-M2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "minimax@default/MiniMax-M2.5-highspeed",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "minimax@default/MiniMax-M2.7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "minimax@default/MiniMax-M2.7-highspeed",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "minimax@default/MiniMax-M3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "mistral@default/codestral-latest",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "mistral@default/mistral-large-latest",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "mistral@default/mistral-medium-latest",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "mistral@default/mistral-small-latest",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/kimi-k2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/kimi-k2.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/kimi-k2.7-code",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/kimi-k2.7-code-highspeed",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/kimi-k3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/moonshot-v1-128k",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/moonshot-v1-128k-vision-preview",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/moonshot-v1-32k",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/moonshot-v1-32k-vision-preview",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/moonshot-v1-8k",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/moonshot-v1-8k-vision-preview",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "moonshot@default/moonshot-v1-auto",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "nearai@default/Qwen/Qwen3-VL-30B-A3B-Instruct",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "nearai@default/Qwen/Qwen3.5-122B-A10B",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "nearai@default/Qwen/Qwen3.6-35B-A3B-FP8",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "nearai@default/google/gemma-4-31B-it",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "nearai@default/zai-org/GLM-5.1-FP8",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "nvidia@default/minimaxai/minimax-m2.7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "nvidia@default/minimaxai/minimax-m3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "nvidia@default/moonshotai/kimi-k2.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "nvidia@default/nvidia/nemotron-3-super-120b-a12b",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "nvidia@default/z-ai/glm-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai-codex@default/gpt-5.3-codex-spark",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai-codex@default/gpt-5.4",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai-codex@default/gpt-5.4-mini",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai-codex@default/gpt-5.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai-codex@default/gpt-5.6-luna",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai-codex@default/gpt-5.6-sol",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai-codex@default/gpt-5.6-terra",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai@default/gpt-5.3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai@default/gpt-5.4",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai@default/gpt-5.4-mini",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai@default/gpt-5.6-luna",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai@default/gpt-5.6-sol",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai@default/gpt-5.6-terra",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openai@default/gpt-image-2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@default/deepseek-v4-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@default/deepseek-v4-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@default/glm-5.1",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@default/glm-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@default/kimi-k2.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@default/kimi-k2.7-code",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@default/mimo-v2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@default/mimo-v2.5-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@messages/minimax-m2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@messages/minimax-m2.7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@messages/minimax-m3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@messages/qwen3.6-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@messages/qwen3.7-max",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "opencode-go@messages/qwen3.7-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "openrouter@default/auto",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "qianfan@default/deepseek-v3.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "qianfan@default/deepseek-v3.2-think",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "qianfan@default/ernie-5.0",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "qianfan@default/ernie-5.0-thinking-preview",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "qianfan@default/ernie-5.1",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "qianfan@default/ernie-x1.1",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "stepfun@default/step-3.5-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "stepfun@default/step-3.5-flash-2603",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "stepfun@default/step-3.7-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "stepfun@plan/step-3.5-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "stepfun@plan/step-3.5-flash-2603",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "stepfun@plan/step-3.7-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "synthetic@default/hf:MiniMaxAI/MiniMax-M3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "synthetic@default/hf:Qwen/Qwen3.6-27B",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "synthetic@default/hf:moonshotai/Kimi-K2.7-Code",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "synthetic@default/hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "synthetic@default/hf:openai/gpt-oss-120b",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "synthetic@default/hf:zai-org/GLM-4.7-Flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "synthetic@default/hf:zai-org/GLM-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "synthetic@default/syn:large:text",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "synthetic@default/syn:large:vision",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "synthetic@default/syn:small:text",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "synthetic@default/syn:small:vision",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/deepseek-v3.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/deepseek-v4-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/deepseek-v4-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/glm-5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/glm-5-turbo",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/glm-5.1",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/glm-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/glm-5v-turbo",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/hunyuan-role-latest",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/hunyuan-t1-vision-20250916",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/hy-mt2-lite",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/hy-mt2-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/hy-mt2-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/hy-role",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/hy-vision-2.0-instruct",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/hy3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/hy3-preview",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/kimi-k2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/kimi-k2.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/kimi-k2.7-code",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/kimi-k2.7-code-highspeed",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/minimax-m2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/minimax-m2.7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/minimax-m3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/qwen3.5-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/qwen3.5-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@default/youtu-vita",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/deepseek-v3.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/deepseek-v4-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/deepseek-v4-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/glm-5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/glm-5-turbo",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/glm-5.1",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/glm-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/glm-5v-turbo",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/hunyuan-role-latest",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/hunyuan-t1-vision-20250916",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/hy-mt2-lite",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/hy-mt2-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/hy-mt2-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/hy-role",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/hy-vision-2.0-instruct",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/hy3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/hy3-preview",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/kimi-k2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/kimi-k2.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/kimi-k2.7-code",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/kimi-k2.7-code-highspeed",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/minimax-m2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/minimax-m2.7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/minimax-m3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/qwen3.5-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/qwen3.5-plus",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "tencent-tokenhub@messages/youtu-vita",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "together@default/MiniMaxAI/MiniMax-M2.7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "together@default/MiniMaxAI/MiniMax-M3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "together@default/Qwen/Qwen3.5-9B",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "together@default/deepseek-ai/DeepSeek-V4-Pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "together@default/meta-llama/Llama-3.3-70B-Instruct-Turbo",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "together@default/moonshotai/Kimi-K2.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "together@default/moonshotai/Kimi-K2.7-Code",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "together@default/nvidia/nemotron-3-ultra-550b-a55b",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "together@default/openai/gpt-oss-120b",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "together@default/zai-org/GLM-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "venice@default/qwen3-235b-a22b-thinking-2507",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "venice@default/qwen3-coder-480b-a35b-instruct-turbo",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "venice@default/qwen3-vl-235b-a22b",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "venice@default/venice-uncensored-1-2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "venice@default/zai-org-glm-4.7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "vercel-ai-gateway@default/anthropic/claude-opus-4.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "vercel-ai-gateway@default/moonshotai/kimi-k2.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "vercel-ai-gateway@default/openai/gpt-5.4",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "vercel-ai-gateway@default/openai/gpt-5.4-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@coding/ark-code-latest",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@coding/deepseek-v3-2-251201",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@coding/deepseek-v4-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@coding/deepseek-v4-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@coding/doubao-seed-2-0-code-preview-260215",
+      "policy": {
+        "display_name": "Doubao Seed 2.0 Code",
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@coding/doubao-seed-2-0-lite-260215",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@coding/doubao-seed-2-0-pro-260215",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@coding/glm-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@coding/glm-5.3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@coding/kimi-k2.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@coding/kimi-k2.7-code",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@default/deepseek-v3-2-251201",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@default/doubao-seed-1-8-251228",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@default/doubao-seed-2-0-code-preview-260215",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@default/doubao-seed-2-0-lite-260215",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@default/doubao-seed-2-0-pro-260215",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@default/doubao-seedream-5.0-lite",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/MiniMax-M3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/ark-code-latest",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/deepseek-v4-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/deepseek-v4-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/doubao-seed-2-0-code-preview-260215",
+      "policy": {
+        "display_name": "Doubao Seed 2.0 Code",
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/doubao-seed-2-0-lite-260215",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/doubao-seed-2-0-mini-260215",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/doubao-seed-2-0-pro-260215",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/glm-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/glm-5.3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/kimi-k2.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "volcengine@plan/kimi-k2.7-code",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "xai@default/grok-4.3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "xai@default/grok-4.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "xiaomi@default/mimo-v2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "xiaomi@default/mimo-v2.5-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "xiaomi@token-plan/mimo-v2.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "xiaomi@token-plan/mimo-v2.5-pro",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4-32b-0414-128k",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.5-air",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.5-airx",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.5-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.5-x",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.5v",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.6",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.6v",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.6v-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.6v-flashx",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.7",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.7-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-4.7-flashx",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-5",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-5-turbo",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-5.1",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-5.2",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-5.3",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-5.3-flash",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    },
+    {
+      "route_ref": "zai@default/glm-5v-turbo",
+      "policy": {
+        "display_name": null,
+        "description": null,
+        "context_window_tokens": null,
+        "effective_context_window_percent": null,
+        "auto_compact_token_limit": null,
+        "default_max_output_tokens": null,
+        "max_output_tokens_upper_limit": null,
+        "default_verbosity": null,
+        "tool_output_truncation_estimated_tokens": null,
+        "capabilities": {},
+        "reasoning_effort_options": null
+      }
+    }
+  ],
+  "aliases": [
+    {
+      "alias": "dashscope-coding-plan/MiniMax-M2.5",
+      "target": "dashscope/MiniMax-M2.5"
+    },
+    {
+      "alias": "dashscope-coding-plan/glm-4.7",
+      "target": "dashscope/glm-4.7"
+    },
+    {
+      "alias": "dashscope-coding-plan/glm-5",
+      "target": "dashscope/glm-5"
+    },
+    {
+      "alias": "dashscope-coding-plan/kimi-k2.5",
+      "target": "dashscope/kimi-k2.5"
+    },
+    {
+      "alias": "dashscope-coding-plan/qwen3-coder-next",
+      "target": "dashscope/qwen3-coder-next"
+    },
+    {
+      "alias": "dashscope-coding-plan/qwen3-coder-plus",
+      "target": "dashscope/qwen3-coder-plus"
+    },
+    {
+      "alias": "dashscope-coding-plan/qwen3-max-2026-01-23",
+      "target": "dashscope/qwen3-max-2026-01-23"
+    },
+    {
+      "alias": "dashscope-coding-plan/qwen3.5-plus",
+      "target": "dashscope/qwen3.5-plus"
+    },
+    {
+      "alias": "dashscope-coding-plan/qwen3.6-plus",
+      "target": "dashscope/qwen3.6-plus"
+    },
+    {
+      "alias": "dashscope-coding-plan/qwen3.7-plus",
+      "target": "dashscope/qwen3.7-plus"
+    },
+    {
+      "alias": "dashscope-token-plan/MiniMax-M2.5",
+      "target": "dashscope/MiniMax-M2.5"
+    },
+    {
+      "alias": "dashscope-token-plan/deepseek-v3.2",
+      "target": "dashscope/deepseek-v3.2"
+    },
+    {
+      "alias": "dashscope-token-plan/deepseek-v4-flash",
+      "target": "dashscope/deepseek-v4-flash"
+    },
+    {
+      "alias": "dashscope-token-plan/deepseek-v4-flash-0731",
+      "target": "dashscope/deepseek-v4-flash-0731"
+    },
+    {
+      "alias": "dashscope-token-plan/deepseek-v4-pro",
+      "target": "dashscope/deepseek-v4-pro"
+    },
+    {
+      "alias": "dashscope-token-plan/glm-5",
+      "target": "dashscope/glm-5"
+    },
+    {
+      "alias": "dashscope-token-plan/glm-5.1",
+      "target": "dashscope/glm-5.1"
+    },
+    {
+      "alias": "dashscope-token-plan/glm-5.2",
+      "target": "dashscope/glm-5.2"
+    },
+    {
+      "alias": "dashscope-token-plan/kimi-k2.5",
+      "target": "dashscope/kimi-k2.5"
+    },
+    {
+      "alias": "dashscope-token-plan/kimi-k2.6",
+      "target": "dashscope/kimi-k2.6"
+    },
+    {
+      "alias": "dashscope-token-plan/kimi-k2.7-code",
+      "target": "dashscope/kimi-k2.7-code"
+    },
+    {
+      "alias": "dashscope-token-plan/qwen-3.7",
+      "target": "dashscope/qwen3.7-max"
+    },
+    {
+      "alias": "dashscope-token-plan/qwen3.6-flash",
+      "target": "dashscope/qwen3.6-flash"
+    },
+    {
+      "alias": "dashscope-token-plan/qwen3.6-plus",
+      "target": "dashscope/qwen3.6-plus"
+    },
+    {
+      "alias": "dashscope-token-plan/qwen3.7-max",
+      "target": "dashscope/qwen3.7-max"
+    },
+    {
+      "alias": "dashscope-token-plan/qwen3.7-plus",
+      "target": "dashscope/qwen3.7-plus"
+    },
+    {
+      "alias": "dashscope-token-plan/qwen3.8-flash",
+      "target": "dashscope/qwen3.8-flash"
+    },
+    {
+      "alias": "dashscope-token-plan/qwen3.8-max",
+      "target": "dashscope/qwen3.8-max"
+    },
+    {
+      "alias": "dashscope-token-plan/qwen3.8-max-preview",
+      "target": "dashscope/qwen3.8-max-preview"
+    },
+    {
+      "alias": "dashscope/qwen-3.7",
+      "target": "dashscope/qwen3.7-max"
+    },
+    {
+      "alias": "mistral/devstral-medium-latest",
+      "target": "mistral/mistral-medium-latest"
+    },
+    {
+      "alias": "mistral/magistral-small",
+      "target": "mistral/mistral-small-latest"
+    },
+    {
+      "alias": "mistral/mistral-medium-2508",
+      "target": "mistral/mistral-medium-latest"
+    },
+    {
+      "alias": "mistral/pixtral-large-latest",
+      "target": "mistral/mistral-medium-latest"
+    },
+    {
+      "alias": "stepfun-plan/step-3.5-flash",
+      "target": "stepfun/step-3.5-flash"
+    },
+    {
+      "alias": "stepfun-plan/step-3.5-flash-2603",
+      "target": "stepfun/step-3.5-flash-2603"
+    },
+    {
+      "alias": "stepfun-plan/step-3.7-flash",
+      "target": "stepfun/step-3.7-flash"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/deepseek-v3.2",
+      "target": "tencent-tokenhub/deepseek-v3.2"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/deepseek-v4-flash",
+      "target": "tencent-tokenhub/deepseek-v4-flash"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/deepseek-v4-pro",
+      "target": "tencent-tokenhub/deepseek-v4-pro"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/glm-5",
+      "target": "tencent-tokenhub/glm-5"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/glm-5-turbo",
+      "target": "tencent-tokenhub/glm-5-turbo"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/glm-5.1",
+      "target": "tencent-tokenhub/glm-5.1"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/glm-5.2",
+      "target": "tencent-tokenhub/glm-5.2"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/glm-5v-turbo",
+      "target": "tencent-tokenhub/glm-5v-turbo"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/hunyuan-role-latest",
+      "target": "tencent-tokenhub/hunyuan-role-latest"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/hunyuan-t1-vision-20250916",
+      "target": "tencent-tokenhub/hunyuan-t1-vision-20250916"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/hy-mt2-lite",
+      "target": "tencent-tokenhub/hy-mt2-lite"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/hy-mt2-plus",
+      "target": "tencent-tokenhub/hy-mt2-plus"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/hy-mt2-pro",
+      "target": "tencent-tokenhub/hy-mt2-pro"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/hy-role",
+      "target": "tencent-tokenhub/hy-role"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/hy-vision-2.0-instruct",
+      "target": "tencent-tokenhub/hy-vision-2.0-instruct"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/hy3",
+      "target": "tencent-tokenhub/hy3"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/hy3-preview",
+      "target": "tencent-tokenhub/hy3-preview"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/kimi-k2.5",
+      "target": "tencent-tokenhub/kimi-k2.5"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/kimi-k2.6",
+      "target": "tencent-tokenhub/kimi-k2.6"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/kimi-k2.7-code",
+      "target": "tencent-tokenhub/kimi-k2.7-code"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/kimi-k2.7-code-highspeed",
+      "target": "tencent-tokenhub/kimi-k2.7-code-highspeed"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/minimax-m2.5",
+      "target": "tencent-tokenhub/minimax-m2.5"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/minimax-m2.7",
+      "target": "tencent-tokenhub/minimax-m2.7"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/minimax-m3",
+      "target": "tencent-tokenhub/minimax-m3"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/qwen3.5-flash",
+      "target": "tencent-tokenhub/qwen3.5-flash"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/qwen3.5-plus",
+      "target": "tencent-tokenhub/qwen3.5-plus"
+    },
+    {
+      "alias": "tencent-tokenhub-messages/youtu-vita",
+      "target": "tencent-tokenhub/youtu-vita"
+    },
+    {
+      "alias": "volcengine-agent/MiniMax-M3",
+      "target": "volcengine/MiniMax-M3"
+    },
+    {
+      "alias": "volcengine-agent/ark-code-latest",
+      "target": "volcengine/ark-code-latest"
+    },
+    {
+      "alias": "volcengine-agent/deepseek-v4-flash",
+      "target": "volcengine/deepseek-v4-flash"
+    },
+    {
+      "alias": "volcengine-agent/deepseek-v4-pro",
+      "target": "volcengine/deepseek-v4-pro"
+    },
+    {
+      "alias": "volcengine-agent/doubao-seed-2-0-code-preview-260215",
+      "target": "volcengine/doubao-seed-2-0-code-preview-260215"
+    },
+    {
+      "alias": "volcengine-agent/doubao-seed-2-0-lite-260215",
+      "target": "volcengine/doubao-seed-2-0-lite-260215"
+    },
+    {
+      "alias": "volcengine-agent/doubao-seed-2-0-mini-260215",
+      "target": "volcengine/doubao-seed-2-0-mini-260215"
+    },
+    {
+      "alias": "volcengine-agent/doubao-seed-2-0-pro-260215",
+      "target": "volcengine/doubao-seed-2-0-pro-260215"
+    },
+    {
+      "alias": "volcengine-agent/glm-5.2",
+      "target": "volcengine/glm-5.2"
+    },
+    {
+      "alias": "volcengine-agent/glm-5.3",
+      "target": "volcengine/glm-5.3"
+    },
+    {
+      "alias": "volcengine-agent/kimi-k2.6",
+      "target": "volcengine/kimi-k2.6"
+    },
+    {
+      "alias": "volcengine-agent/kimi-k2.7-code",
+      "target": "volcengine/kimi-k2.7-code"
+    },
+    {
+      "alias": "volcengine-coding/ark-code-latest",
+      "target": "volcengine/ark-code-latest"
+    },
+    {
+      "alias": "volcengine-coding/deepseek-v3-2-251201",
+      "target": "volcengine/deepseek-v3-2-251201"
+    },
+    {
+      "alias": "volcengine-coding/deepseek-v4-flash",
+      "target": "volcengine/deepseek-v4-flash"
+    },
+    {
+      "alias": "volcengine-coding/deepseek-v4-pro",
+      "target": "volcengine/deepseek-v4-pro"
+    },
+    {
+      "alias": "volcengine-coding/doubao-seed-2-0-code-preview-260215",
+      "target": "volcengine/doubao-seed-2-0-code-preview-260215"
+    },
+    {
+      "alias": "volcengine-coding/doubao-seed-2-0-lite-260215",
+      "target": "volcengine/doubao-seed-2-0-lite-260215"
+    },
+    {
+      "alias": "volcengine-coding/doubao-seed-2-0-pro-260215",
+      "target": "volcengine/doubao-seed-2-0-pro-260215"
+    },
+    {
+      "alias": "volcengine-coding/glm-5.2",
+      "target": "volcengine/glm-5.2"
+    },
+    {
+      "alias": "volcengine-coding/glm-5.3",
+      "target": "volcengine/glm-5.3"
+    },
+    {
+      "alias": "volcengine-coding/kimi-k2.6",
+      "target": "volcengine/kimi-k2.6"
+    },
+    {
+      "alias": "volcengine-coding/kimi-k2.7-code",
+      "target": "volcengine/kimi-k2.7-code"
+    },
+    {
+      "alias": "volcengine-image-openai/doubao-seedream-5.0-lite",
+      "target": "volcengine/doubao-seedream-5.0-lite"
+    },
+    {
+      "alias": "xiaomi-token-plan/mimo-v2.5",
+      "target": "xiaomi/mimo-v2.5"
+    },
+    {
+      "alias": "xiaomi-token-plan/mimo-v2.5-pro",
+      "target": "xiaomi/mimo-v2.5-pro"
+    }
+  ],
+  "preferred_models": [
+    {
+      "provider": "anthropic",
+      "model_ref": "anthropic/claude-fable-5"
+    },
+    {
+      "provider": "arcee",
+      "model_ref": "arcee/trinity-mini"
+    },
+    {
+      "provider": "bigmodel",
+      "model_ref": "bigmodel/glm-5.3"
+    },
+    {
+      "provider": "chutes",
+      "model_ref": "chutes/moonshotai/Kimi-K2.6-TEE"
+    },
+    {
+      "provider": "dashscope",
+      "model_ref": "dashscope/qwen3.7-plus"
+    },
+    {
+      "provider": "dashscope-coding-plan",
+      "model_ref": "dashscope/qwen3.7-plus"
+    },
+    {
+      "provider": "dashscope-token-plan",
+      "model_ref": "dashscope/qwen3.7-max"
+    },
+    {
+      "provider": "deepseek",
+      "model_ref": "deepseek/deepseek-v4-flash"
+    },
+    {
+      "provider": "fireworks",
+      "model_ref": "fireworks/accounts/fireworks/models/kimi-k2p6"
+    },
+    {
+      "provider": "gemini",
+      "model_ref": "gemini/gemini-3.5-flash"
+    },
+    {
+      "provider": "huggingface",
+      "model_ref": "huggingface/openai/gpt-oss-120b"
+    },
+    {
+      "provider": "kilocode",
+      "model_ref": "kilocode/kilo-auto/frontier"
+    },
+    {
+      "provider": "minimax",
+      "model_ref": "minimax/MiniMax-M3"
+    },
+    {
+      "provider": "mistral",
+      "model_ref": "mistral/codestral-latest"
+    },
+    {
+      "provider": "moonshot",
+      "model_ref": "moonshot/kimi-k2.7-code"
+    },
+    {
+      "provider": "nearai",
+      "model_ref": "nearai/zai-org/GLM-5.1-FP8"
+    },
+    {
+      "provider": "nvidia",
+      "model_ref": "nvidia/nvidia/nemotron-3-super-120b-a12b"
+    },
+    {
+      "provider": "openai",
+      "model_ref": "openai/gpt-5.4"
+    },
+    {
+      "provider": "openai-codex",
+      "model_ref": "openai-codex/gpt-5.5"
+    },
+    {
+      "provider": "opencode-go",
+      "model_ref": "opencode-go/deepseek-v4-pro"
+    },
+    {
+      "provider": "openrouter",
+      "model_ref": "openrouter/auto"
+    },
+    {
+      "provider": "qianfan",
+      "model_ref": "qianfan/deepseek-v3.2"
+    },
+    {
+      "provider": "stepfun",
+      "model_ref": "stepfun/step-3.7-flash"
+    },
+    {
+      "provider": "stepfun-plan",
+      "model_ref": "stepfun/step-3.7-flash"
+    },
+    {
+      "provider": "synthetic",
+      "model_ref": "synthetic/syn:large:text"
+    },
+    {
+      "provider": "tencent-tokenhub",
+      "model_ref": "tencent-tokenhub/hy3"
+    },
+    {
+      "provider": "tencent-tokenhub-messages",
+      "model_ref": "tencent-tokenhub/hy3"
+    },
+    {
+      "provider": "together",
+      "model_ref": "together/MiniMaxAI/MiniMax-M3"
+    },
+    {
+      "provider": "venice",
+      "model_ref": "venice/zai-org-glm-4.7"
+    },
+    {
+      "provider": "vercel-ai-gateway",
+      "model_ref": "vercel-ai-gateway/anthropic/claude-opus-4.6"
+    },
+    {
+      "provider": "volcengine",
+      "model_ref": "volcengine/doubao-seed-1-8-251228"
+    },
+    {
+      "provider": "volcengine-agent",
+      "model_ref": "volcengine/doubao-seed-2-0-mini-260215"
+    },
+    {
+      "provider": "volcengine-coding",
+      "model_ref": "volcengine/ark-code-latest"
+    },
+    {
+      "provider": "xai",
+      "model_ref": "xai/grok-4.3"
+    },
+    {
+      "provider": "xiaomi",
+      "model_ref": "xiaomi/mimo-v2.5-pro"
+    },
+    {
+      "provider": "xiaomi-token-plan",
+      "model_ref": "xiaomi/mimo-v2.5-pro"
+    },
+    {
+      "provider": "zai",
+      "model_ref": "zai/glm-5.3"
+    }
+  ],
+  "preferred_routes": [
+    {
+      "provider": "anthropic",
+      "route_ref": "anthropic@default/claude-fable-5"
+    },
+    {
+      "provider": "arcee",
+      "route_ref": "arcee@default/trinity-mini"
+    },
+    {
+      "provider": "bigmodel",
+      "route_ref": "bigmodel@default/glm-5.3"
+    },
+    {
+      "provider": "chutes",
+      "route_ref": "chutes@default/moonshotai/Kimi-K2.6-TEE"
+    },
+    {
+      "provider": "dashscope",
+      "route_ref": "dashscope@default/qwen3.7-plus"
+    },
+    {
+      "provider": "dashscope-coding-plan",
+      "route_ref": "dashscope@coding-plan/qwen3.7-plus"
+    },
+    {
+      "provider": "dashscope-token-plan",
+      "route_ref": "dashscope@token-plan/qwen3.7-max"
+    },
+    {
+      "provider": "deepseek",
+      "route_ref": "deepseek@default/deepseek-v4-flash"
+    },
+    {
+      "provider": "fireworks",
+      "route_ref": "fireworks@default/accounts/fireworks/models/kimi-k2p6"
+    },
+    {
+      "provider": "gemini",
+      "route_ref": "gemini@default/gemini-3.5-flash"
+    },
+    {
+      "provider": "huggingface",
+      "route_ref": "huggingface@default/openai/gpt-oss-120b"
+    },
+    {
+      "provider": "kilocode",
+      "route_ref": "kilocode@default/kilo-auto/frontier"
+    },
+    {
+      "provider": "minimax",
+      "route_ref": "minimax@default/MiniMax-M3"
+    },
+    {
+      "provider": "mistral",
+      "route_ref": "mistral@default/codestral-latest"
+    },
+    {
+      "provider": "moonshot",
+      "route_ref": "moonshot@default/kimi-k2.7-code"
+    },
+    {
+      "provider": "nearai",
+      "route_ref": "nearai@default/zai-org/GLM-5.1-FP8"
+    },
+    {
+      "provider": "nvidia",
+      "route_ref": "nvidia@default/nvidia/nemotron-3-super-120b-a12b"
+    },
+    {
+      "provider": "openai",
+      "route_ref": "openai@default/gpt-5.4"
+    },
+    {
+      "provider": "openai-codex",
+      "route_ref": "openai-codex@default/gpt-5.5"
+    },
+    {
+      "provider": "opencode-go",
+      "route_ref": "opencode-go@default/deepseek-v4-pro"
+    },
+    {
+      "provider": "openrouter",
+      "route_ref": "openrouter@default/auto"
+    },
+    {
+      "provider": "qianfan",
+      "route_ref": "qianfan@default/deepseek-v3.2"
+    },
+    {
+      "provider": "stepfun",
+      "route_ref": "stepfun@default/step-3.7-flash"
+    },
+    {
+      "provider": "stepfun-plan",
+      "route_ref": "stepfun@plan/step-3.7-flash"
+    },
+    {
+      "provider": "synthetic",
+      "route_ref": "synthetic@default/syn:large:text"
+    },
+    {
+      "provider": "tencent-tokenhub",
+      "route_ref": "tencent-tokenhub@default/hy3"
+    },
+    {
+      "provider": "tencent-tokenhub-messages",
+      "route_ref": "tencent-tokenhub@messages/hy3"
+    },
+    {
+      "provider": "together",
+      "route_ref": "together@default/MiniMaxAI/MiniMax-M3"
+    },
+    {
+      "provider": "venice",
+      "route_ref": "venice@default/zai-org-glm-4.7"
+    },
+    {
+      "provider": "vercel-ai-gateway",
+      "route_ref": "vercel-ai-gateway@default/anthropic/claude-opus-4.6"
+    },
+    {
+      "provider": "volcengine",
+      "route_ref": "volcengine@default/doubao-seed-1-8-251228"
+    },
+    {
+      "provider": "volcengine-agent",
+      "route_ref": "volcengine@plan/doubao-seed-2-0-mini-260215"
+    },
+    {
+      "provider": "volcengine-coding",
+      "route_ref": "volcengine@coding/ark-code-latest"
+    },
+    {
+      "provider": "xai",
+      "route_ref": "xai@default/grok-4.3"
+    },
+    {
+      "provider": "xiaomi",
+      "route_ref": "xiaomi@default/mimo-v2.5-pro"
+    },
+    {
+      "provider": "xiaomi-token-plan",
+      "route_ref": "xiaomi@token-plan/mimo-v2.5-pro"
+    },
+    {
+      "provider": "zai",
+      "route_ref": "zai@default/glm-5.3"
+    }
+  ],
+  "preferred_routes_by_model": [
+    {
+      "model_ref": "anthropic/claude-fable-5",
+      "route_ref": "anthropic@default/claude-fable-5"
+    },
+    {
+      "model_ref": "anthropic/claude-haiku-4-5",
+      "route_ref": "anthropic@default/claude-haiku-4-5"
+    },
+    {
+      "model_ref": "anthropic/claude-opus-4-8",
+      "route_ref": "anthropic@default/claude-opus-4-8"
+    },
+    {
+      "model_ref": "anthropic/claude-sonnet-5",
+      "route_ref": "anthropic@default/claude-sonnet-5"
+    },
+    {
+      "model_ref": "arcee/trinity-large-preview",
+      "route_ref": "arcee@default/trinity-large-preview"
+    },
+    {
+      "model_ref": "arcee/trinity-mini",
+      "route_ref": "arcee@default/trinity-mini"
+    },
+    {
+      "model_ref": "bigmodel/glm-4-flash-250414",
+      "route_ref": "bigmodel@default/glm-4-flash-250414"
+    },
+    {
+      "model_ref": "bigmodel/glm-4-flashx-250414",
+      "route_ref": "bigmodel@default/glm-4-flashx-250414"
+    },
+    {
+      "model_ref": "bigmodel/glm-4-long",
+      "route_ref": "bigmodel@default/glm-4-long"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.1v-thinking-flash",
+      "route_ref": "bigmodel@default/glm-4.1v-thinking-flash"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.1v-thinking-flashx",
+      "route_ref": "bigmodel@default/glm-4.1v-thinking-flashx"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.5-air",
+      "route_ref": "bigmodel@default/glm-4.5-air"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.5-airx",
+      "route_ref": "bigmodel@default/glm-4.5-airx"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.5-flash",
+      "route_ref": "bigmodel@default/glm-4.5-flash"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.6",
+      "route_ref": "bigmodel@default/glm-4.6"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.6v",
+      "route_ref": "bigmodel@default/glm-4.6v"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.6v-flash",
+      "route_ref": "bigmodel@default/glm-4.6v-flash"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.7",
+      "route_ref": "bigmodel@default/glm-4.7"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.7-flash",
+      "route_ref": "bigmodel@default/glm-4.7-flash"
+    },
+    {
+      "model_ref": "bigmodel/glm-4.7-flashx",
+      "route_ref": "bigmodel@default/glm-4.7-flashx"
+    },
+    {
+      "model_ref": "bigmodel/glm-4v-flash",
+      "route_ref": "bigmodel@default/glm-4v-flash"
+    },
+    {
+      "model_ref": "bigmodel/glm-5",
+      "route_ref": "bigmodel@default/glm-5"
+    },
+    {
+      "model_ref": "bigmodel/glm-5-turbo",
+      "route_ref": "bigmodel@default/glm-5-turbo"
+    },
+    {
+      "model_ref": "bigmodel/glm-5.1",
+      "route_ref": "bigmodel@default/glm-5.1"
+    },
+    {
+      "model_ref": "bigmodel/glm-5.2",
+      "route_ref": "bigmodel@default/glm-5.2"
+    },
+    {
+      "model_ref": "bigmodel/glm-5.3",
+      "route_ref": "bigmodel@default/glm-5.3"
+    },
+    {
+      "model_ref": "bigmodel/glm-5.3-flash",
+      "route_ref": "bigmodel@default/glm-5.3-flash"
+    },
+    {
+      "model_ref": "bigmodel/glm-5v-turbo",
+      "route_ref": "bigmodel@default/glm-5v-turbo"
+    },
+    {
+      "model_ref": "chutes/MiniMaxAI/MiniMax-M2.5-TEE",
+      "route_ref": "chutes@default/MiniMaxAI/MiniMax-M2.5-TEE"
+    },
+    {
+      "model_ref": "chutes/Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
+      "route_ref": "chutes@default/Qwen/Qwen3-235B-A22B-Thinking-2507-TEE"
+    },
+    {
+      "model_ref": "chutes/Qwen/Qwen3-32B-TEE",
+      "route_ref": "chutes@default/Qwen/Qwen3-32B-TEE"
+    },
+    {
+      "model_ref": "chutes/Qwen/Qwen3.5-397B-A17B-TEE",
+      "route_ref": "chutes@default/Qwen/Qwen3.5-397B-A17B-TEE"
+    },
+    {
+      "model_ref": "chutes/Qwen/Qwen3.6-27B-TEE",
+      "route_ref": "chutes@default/Qwen/Qwen3.6-27B-TEE"
+    },
+    {
+      "model_ref": "chutes/deepseek-ai/DeepSeek-V3.2-TEE",
+      "route_ref": "chutes@default/deepseek-ai/DeepSeek-V3.2-TEE"
+    },
+    {
+      "model_ref": "chutes/google/gemma-4-31B-turbo-TEE",
+      "route_ref": "chutes@default/google/gemma-4-31B-turbo-TEE"
+    },
+    {
+      "model_ref": "chutes/moonshotai/Kimi-K2.5-TEE",
+      "route_ref": "chutes@default/moonshotai/Kimi-K2.5-TEE"
+    },
+    {
+      "model_ref": "chutes/moonshotai/Kimi-K2.6-TEE",
+      "route_ref": "chutes@default/moonshotai/Kimi-K2.6-TEE"
+    },
+    {
+      "model_ref": "chutes/unsloth/Mistral-Nemo-Instruct-2407-TEE",
+      "route_ref": "chutes@default/unsloth/Mistral-Nemo-Instruct-2407-TEE"
+    },
+    {
+      "model_ref": "chutes/zai-org/GLM-5-TEE",
+      "route_ref": "chutes@default/zai-org/GLM-5-TEE"
+    },
+    {
+      "model_ref": "chutes/zai-org/GLM-5.1-TEE",
+      "route_ref": "chutes@default/zai-org/GLM-5.1-TEE"
+    },
+    {
+      "model_ref": "chutes/zai-org/GLM-5.2-TEE",
+      "route_ref": "chutes@default/zai-org/GLM-5.2-TEE"
+    },
+    {
+      "model_ref": "dashscope/MiniMax-M2.5",
+      "route_ref": "dashscope@default/MiniMax-M2.5"
+    },
+    {
+      "model_ref": "dashscope/MiniMax/MiniMax-M3",
+      "route_ref": "dashscope@default/MiniMax/MiniMax-M3"
+    },
+    {
+      "model_ref": "dashscope/ZHIPU/GLM-5.2",
+      "route_ref": "dashscope@default/ZHIPU/GLM-5.2"
+    },
+    {
+      "model_ref": "dashscope/ZHIPU/GLM-5.3",
+      "route_ref": "dashscope@default/ZHIPU/GLM-5.3"
+    },
+    {
+      "model_ref": "dashscope/deepseek-v3.2",
+      "route_ref": "dashscope@default/deepseek-v3.2"
+    },
+    {
+      "model_ref": "dashscope/deepseek-v4-flash",
+      "route_ref": "dashscope@default/deepseek-v4-flash"
+    },
+    {
+      "model_ref": "dashscope/deepseek-v4-flash-0731",
+      "route_ref": "dashscope@default/deepseek-v4-flash-0731"
+    },
+    {
+      "model_ref": "dashscope/deepseek-v4-pro",
+      "route_ref": "dashscope@default/deepseek-v4-pro"
+    },
+    {
+      "model_ref": "dashscope/glm-4.7",
+      "route_ref": "dashscope@default/glm-4.7"
+    },
+    {
+      "model_ref": "dashscope/glm-5",
+      "route_ref": "dashscope@default/glm-5"
+    },
+    {
+      "model_ref": "dashscope/glm-5.1",
+      "route_ref": "dashscope@default/glm-5.1"
+    },
+    {
+      "model_ref": "dashscope/glm-5.2",
+      "route_ref": "dashscope@default/glm-5.2"
+    },
+    {
+      "model_ref": "dashscope/kimi-k2.5",
+      "route_ref": "dashscope@default/kimi-k2.5"
+    },
+    {
+      "model_ref": "dashscope/kimi-k2.6",
+      "route_ref": "dashscope@default/kimi-k2.6"
+    },
+    {
+      "model_ref": "dashscope/kimi-k2.7-code",
+      "route_ref": "dashscope@default/kimi-k2.7-code"
+    },
+    {
+      "model_ref": "dashscope/mimo-v2.5-pro",
+      "route_ref": "dashscope@default/mimo-v2.5-pro"
+    },
+    {
+      "model_ref": "dashscope/qwen3-coder-flash",
+      "route_ref": "dashscope@default/qwen3-coder-flash"
+    },
+    {
+      "model_ref": "dashscope/qwen3-coder-next",
+      "route_ref": "dashscope@default/qwen3-coder-next"
+    },
+    {
+      "model_ref": "dashscope/qwen3-coder-plus",
+      "route_ref": "dashscope@default/qwen3-coder-plus"
+    },
+    {
+      "model_ref": "dashscope/qwen3-max-2026-01-23",
+      "route_ref": "dashscope@default/qwen3-max-2026-01-23"
+    },
+    {
+      "model_ref": "dashscope/qwen3.5-flash",
+      "route_ref": "dashscope@default/qwen3.5-flash"
+    },
+    {
+      "model_ref": "dashscope/qwen3.5-plus",
+      "route_ref": "dashscope@default/qwen3.5-plus"
+    },
+    {
+      "model_ref": "dashscope/qwen3.6-flash",
+      "route_ref": "dashscope@default/qwen3.6-flash"
+    },
+    {
+      "model_ref": "dashscope/qwen3.6-plus",
+      "route_ref": "dashscope@default/qwen3.6-plus"
+    },
+    {
+      "model_ref": "dashscope/qwen3.7-max",
+      "route_ref": "dashscope@default/qwen3.7-max"
+    },
+    {
+      "model_ref": "dashscope/qwen3.7-max-2026-05-20",
+      "route_ref": "dashscope@default/qwen3.7-max-2026-05-20"
+    },
+    {
+      "model_ref": "dashscope/qwen3.7-max-2026-06-08",
+      "route_ref": "dashscope@default/qwen3.7-max-2026-06-08"
+    },
+    {
+      "model_ref": "dashscope/qwen3.7-plus",
+      "route_ref": "dashscope@default/qwen3.7-plus"
+    },
+    {
+      "model_ref": "dashscope/qwen3.7-plus-2026-05-26",
+      "route_ref": "dashscope@default/qwen3.7-plus-2026-05-26"
+    },
+    {
+      "model_ref": "dashscope/qwen3.8-flash",
+      "route_ref": "dashscope@default/qwen3.8-flash"
+    },
+    {
+      "model_ref": "dashscope/qwen3.8-max",
+      "route_ref": "dashscope@default/qwen3.8-max"
+    },
+    {
+      "model_ref": "dashscope/qwen3.8-max-preview",
+      "route_ref": "dashscope@default/qwen3.8-max-preview"
+    },
+    {
+      "model_ref": "deepseek/deepseek-v4-flash",
+      "route_ref": "deepseek@default/deepseek-v4-flash"
+    },
+    {
+      "model_ref": "deepseek/deepseek-v4-pro",
+      "route_ref": "deepseek@default/deepseek-v4-pro"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/deepseek-v4-flash",
+      "route_ref": "fireworks@default/accounts/fireworks/models/deepseek-v4-flash"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/deepseek-v4-pro",
+      "route_ref": "fireworks@default/accounts/fireworks/models/deepseek-v4-pro"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/glm-5p1",
+      "route_ref": "fireworks@default/accounts/fireworks/models/glm-5p1"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/glm-5p2",
+      "route_ref": "fireworks@default/accounts/fireworks/models/glm-5p2"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/gpt-oss-120b",
+      "route_ref": "fireworks@default/accounts/fireworks/models/gpt-oss-120b"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/kimi-k2p6",
+      "route_ref": "fireworks@default/accounts/fireworks/models/kimi-k2p6"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/kimi-k2p7-code",
+      "route_ref": "fireworks@default/accounts/fireworks/models/kimi-k2p7-code"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/minimax-m2p7",
+      "route_ref": "fireworks@default/accounts/fireworks/models/minimax-m2p7"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/minimax-m3",
+      "route_ref": "fireworks@default/accounts/fireworks/models/minimax-m3"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/nemotron-3-ultra-nvfp4",
+      "route_ref": "fireworks@default/accounts/fireworks/models/nemotron-3-ultra-nvfp4"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/qwen3p6-plus",
+      "route_ref": "fireworks@default/accounts/fireworks/models/qwen3p6-plus"
+    },
+    {
+      "model_ref": "fireworks/accounts/fireworks/models/qwen3p7-plus",
+      "route_ref": "fireworks@default/accounts/fireworks/models/qwen3p7-plus"
+    },
+    {
+      "model_ref": "gemini/gemini-2.5-flash",
+      "route_ref": "gemini@default/gemini-2.5-flash"
+    },
+    {
+      "model_ref": "gemini/gemini-2.5-flash-lite",
+      "route_ref": "gemini@default/gemini-2.5-flash-lite"
+    },
+    {
+      "model_ref": "gemini/gemini-2.5-pro",
+      "route_ref": "gemini@default/gemini-2.5-pro"
+    },
+    {
+      "model_ref": "gemini/gemini-3.1-flash-lite",
+      "route_ref": "gemini@default/gemini-3.1-flash-lite"
+    },
+    {
+      "model_ref": "gemini/gemini-3.1-pro-preview",
+      "route_ref": "gemini@default/gemini-3.1-pro-preview"
+    },
+    {
+      "model_ref": "gemini/gemini-3.5-flash",
+      "route_ref": "gemini@default/gemini-3.5-flash"
+    },
+    {
+      "model_ref": "huggingface/openai/gpt-oss-120b",
+      "route_ref": "huggingface@default/openai/gpt-oss-120b"
+    },
+    {
+      "model_ref": "kilocode/kilo-auto/balanced",
+      "route_ref": "kilocode@default/kilo-auto/balanced"
+    },
+    {
+      "model_ref": "kilocode/kilo-auto/efficient",
+      "route_ref": "kilocode@default/kilo-auto/efficient"
+    },
+    {
+      "model_ref": "kilocode/kilo-auto/free",
+      "route_ref": "kilocode@default/kilo-auto/free"
+    },
+    {
+      "model_ref": "kilocode/kilo-auto/frontier",
+      "route_ref": "kilocode@default/kilo-auto/frontier"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2",
+      "route_ref": "minimax@default/MiniMax-M2"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.1",
+      "route_ref": "minimax@default/MiniMax-M2.1"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.1-highspeed",
+      "route_ref": "minimax@default/MiniMax-M2.1-highspeed"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.5",
+      "route_ref": "minimax@default/MiniMax-M2.5"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.5-highspeed",
+      "route_ref": "minimax@default/MiniMax-M2.5-highspeed"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.7",
+      "route_ref": "minimax@default/MiniMax-M2.7"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M2.7-highspeed",
+      "route_ref": "minimax@default/MiniMax-M2.7-highspeed"
+    },
+    {
+      "model_ref": "minimax/MiniMax-M3",
+      "route_ref": "minimax@default/MiniMax-M3"
+    },
+    {
+      "model_ref": "mistral/codestral-latest",
+      "route_ref": "mistral@default/codestral-latest"
+    },
+    {
+      "model_ref": "mistral/mistral-large-latest",
+      "route_ref": "mistral@default/mistral-large-latest"
+    },
+    {
+      "model_ref": "mistral/mistral-medium-latest",
+      "route_ref": "mistral@default/mistral-medium-latest"
+    },
+    {
+      "model_ref": "mistral/mistral-small-latest",
+      "route_ref": "mistral@default/mistral-small-latest"
+    },
+    {
+      "model_ref": "moonshot/kimi-k2.5",
+      "route_ref": "moonshot@default/kimi-k2.5"
+    },
+    {
+      "model_ref": "moonshot/kimi-k2.6",
+      "route_ref": "moonshot@default/kimi-k2.6"
+    },
+    {
+      "model_ref": "moonshot/kimi-k2.7-code",
+      "route_ref": "moonshot@default/kimi-k2.7-code"
+    },
+    {
+      "model_ref": "moonshot/kimi-k2.7-code-highspeed",
+      "route_ref": "moonshot@default/kimi-k2.7-code-highspeed"
+    },
+    {
+      "model_ref": "moonshot/kimi-k3",
+      "route_ref": "moonshot@default/kimi-k3"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-128k",
+      "route_ref": "moonshot@default/moonshot-v1-128k"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-128k-vision-preview",
+      "route_ref": "moonshot@default/moonshot-v1-128k-vision-preview"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-32k",
+      "route_ref": "moonshot@default/moonshot-v1-32k"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-32k-vision-preview",
+      "route_ref": "moonshot@default/moonshot-v1-32k-vision-preview"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-8k",
+      "route_ref": "moonshot@default/moonshot-v1-8k"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-8k-vision-preview",
+      "route_ref": "moonshot@default/moonshot-v1-8k-vision-preview"
+    },
+    {
+      "model_ref": "moonshot/moonshot-v1-auto",
+      "route_ref": "moonshot@default/moonshot-v1-auto"
+    },
+    {
+      "model_ref": "nearai/Qwen/Qwen3-VL-30B-A3B-Instruct",
+      "route_ref": "nearai@default/Qwen/Qwen3-VL-30B-A3B-Instruct"
+    },
+    {
+      "model_ref": "nearai/Qwen/Qwen3.5-122B-A10B",
+      "route_ref": "nearai@default/Qwen/Qwen3.5-122B-A10B"
+    },
+    {
+      "model_ref": "nearai/Qwen/Qwen3.6-35B-A3B-FP8",
+      "route_ref": "nearai@default/Qwen/Qwen3.6-35B-A3B-FP8"
+    },
+    {
+      "model_ref": "nearai/google/gemma-4-31B-it",
+      "route_ref": "nearai@default/google/gemma-4-31B-it"
+    },
+    {
+      "model_ref": "nearai/zai-org/GLM-5.1-FP8",
+      "route_ref": "nearai@default/zai-org/GLM-5.1-FP8"
+    },
+    {
+      "model_ref": "nvidia/minimaxai/minimax-m2.7",
+      "route_ref": "nvidia@default/minimaxai/minimax-m2.7"
+    },
+    {
+      "model_ref": "nvidia/minimaxai/minimax-m3",
+      "route_ref": "nvidia@default/minimaxai/minimax-m3"
+    },
+    {
+      "model_ref": "nvidia/moonshotai/kimi-k2.6",
+      "route_ref": "nvidia@default/moonshotai/kimi-k2.6"
+    },
+    {
+      "model_ref": "nvidia/nvidia/nemotron-3-super-120b-a12b",
+      "route_ref": "nvidia@default/nvidia/nemotron-3-super-120b-a12b"
+    },
+    {
+      "model_ref": "nvidia/z-ai/glm-5.2",
+      "route_ref": "nvidia@default/z-ai/glm-5.2"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.3-codex-spark",
+      "route_ref": "openai-codex@default/gpt-5.3-codex-spark"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.4",
+      "route_ref": "openai-codex@default/gpt-5.4"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.4-mini",
+      "route_ref": "openai-codex@default/gpt-5.4-mini"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.5",
+      "route_ref": "openai-codex@default/gpt-5.5"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.6-luna",
+      "route_ref": "openai-codex@default/gpt-5.6-luna"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.6-sol",
+      "route_ref": "openai-codex@default/gpt-5.6-sol"
+    },
+    {
+      "model_ref": "openai-codex/gpt-5.6-terra",
+      "route_ref": "openai-codex@default/gpt-5.6-terra"
+    },
+    {
+      "model_ref": "openai/gpt-5.3",
+      "route_ref": "openai@default/gpt-5.3"
+    },
+    {
+      "model_ref": "openai/gpt-5.4",
+      "route_ref": "openai@default/gpt-5.4"
+    },
+    {
+      "model_ref": "openai/gpt-5.4-mini",
+      "route_ref": "openai@default/gpt-5.4-mini"
+    },
+    {
+      "model_ref": "openai/gpt-5.6-luna",
+      "route_ref": "openai@default/gpt-5.6-luna"
+    },
+    {
+      "model_ref": "openai/gpt-5.6-sol",
+      "route_ref": "openai@default/gpt-5.6-sol"
+    },
+    {
+      "model_ref": "openai/gpt-5.6-terra",
+      "route_ref": "openai@default/gpt-5.6-terra"
+    },
+    {
+      "model_ref": "openai/gpt-image-2",
+      "route_ref": "openai@default/gpt-image-2"
+    },
+    {
+      "model_ref": "opencode-go/deepseek-v4-flash",
+      "route_ref": "opencode-go@default/deepseek-v4-flash"
+    },
+    {
+      "model_ref": "opencode-go/deepseek-v4-pro",
+      "route_ref": "opencode-go@default/deepseek-v4-pro"
+    },
+    {
+      "model_ref": "opencode-go/glm-5.1",
+      "route_ref": "opencode-go@default/glm-5.1"
+    },
+    {
+      "model_ref": "opencode-go/glm-5.2",
+      "route_ref": "opencode-go@default/glm-5.2"
+    },
+    {
+      "model_ref": "opencode-go/kimi-k2.6",
+      "route_ref": "opencode-go@default/kimi-k2.6"
+    },
+    {
+      "model_ref": "opencode-go/kimi-k2.7-code",
+      "route_ref": "opencode-go@default/kimi-k2.7-code"
+    },
+    {
+      "model_ref": "opencode-go/mimo-v2.5",
+      "route_ref": "opencode-go@default/mimo-v2.5"
+    },
+    {
+      "model_ref": "opencode-go/mimo-v2.5-pro",
+      "route_ref": "opencode-go@default/mimo-v2.5-pro"
+    },
+    {
+      "model_ref": "opencode-go/minimax-m2.5",
+      "route_ref": "opencode-go@messages/minimax-m2.5"
+    },
+    {
+      "model_ref": "opencode-go/minimax-m2.7",
+      "route_ref": "opencode-go@messages/minimax-m2.7"
+    },
+    {
+      "model_ref": "opencode-go/minimax-m3",
+      "route_ref": "opencode-go@messages/minimax-m3"
+    },
+    {
+      "model_ref": "opencode-go/qwen3.6-plus",
+      "route_ref": "opencode-go@messages/qwen3.6-plus"
+    },
+    {
+      "model_ref": "opencode-go/qwen3.7-max",
+      "route_ref": "opencode-go@messages/qwen3.7-max"
+    },
+    {
+      "model_ref": "opencode-go/qwen3.7-plus",
+      "route_ref": "opencode-go@messages/qwen3.7-plus"
+    },
+    {
+      "model_ref": "openrouter/auto",
+      "route_ref": "openrouter@default/auto"
+    },
+    {
+      "model_ref": "qianfan/deepseek-v3.2",
+      "route_ref": "qianfan@default/deepseek-v3.2"
+    },
+    {
+      "model_ref": "qianfan/deepseek-v3.2-think",
+      "route_ref": "qianfan@default/deepseek-v3.2-think"
+    },
+    {
+      "model_ref": "qianfan/ernie-5.0",
+      "route_ref": "qianfan@default/ernie-5.0"
+    },
+    {
+      "model_ref": "qianfan/ernie-5.0-thinking-preview",
+      "route_ref": "qianfan@default/ernie-5.0-thinking-preview"
+    },
+    {
+      "model_ref": "qianfan/ernie-5.1",
+      "route_ref": "qianfan@default/ernie-5.1"
+    },
+    {
+      "model_ref": "qianfan/ernie-x1.1",
+      "route_ref": "qianfan@default/ernie-x1.1"
+    },
+    {
+      "model_ref": "stepfun/step-3.5-flash",
+      "route_ref": "stepfun@default/step-3.5-flash"
+    },
+    {
+      "model_ref": "stepfun/step-3.5-flash-2603",
+      "route_ref": "stepfun@default/step-3.5-flash-2603"
+    },
+    {
+      "model_ref": "stepfun/step-3.7-flash",
+      "route_ref": "stepfun@default/step-3.7-flash"
+    },
+    {
+      "model_ref": "synthetic/hf:MiniMaxAI/MiniMax-M3",
+      "route_ref": "synthetic@default/hf:MiniMaxAI/MiniMax-M3"
+    },
+    {
+      "model_ref": "synthetic/hf:Qwen/Qwen3.6-27B",
+      "route_ref": "synthetic@default/hf:Qwen/Qwen3.6-27B"
+    },
+    {
+      "model_ref": "synthetic/hf:moonshotai/Kimi-K2.7-Code",
+      "route_ref": "synthetic@default/hf:moonshotai/Kimi-K2.7-Code"
+    },
+    {
+      "model_ref": "synthetic/hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+      "route_ref": "synthetic@default/hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"
+    },
+    {
+      "model_ref": "synthetic/hf:openai/gpt-oss-120b",
+      "route_ref": "synthetic@default/hf:openai/gpt-oss-120b"
+    },
+    {
+      "model_ref": "synthetic/hf:zai-org/GLM-4.7-Flash",
+      "route_ref": "synthetic@default/hf:zai-org/GLM-4.7-Flash"
+    },
+    {
+      "model_ref": "synthetic/hf:zai-org/GLM-5.2",
+      "route_ref": "synthetic@default/hf:zai-org/GLM-5.2"
+    },
+    {
+      "model_ref": "synthetic/syn:large:text",
+      "route_ref": "synthetic@default/syn:large:text"
+    },
+    {
+      "model_ref": "synthetic/syn:large:vision",
+      "route_ref": "synthetic@default/syn:large:vision"
+    },
+    {
+      "model_ref": "synthetic/syn:small:text",
+      "route_ref": "synthetic@default/syn:small:text"
+    },
+    {
+      "model_ref": "synthetic/syn:small:vision",
+      "route_ref": "synthetic@default/syn:small:vision"
+    },
+    {
+      "model_ref": "tencent-tokenhub/deepseek-v3.2",
+      "route_ref": "tencent-tokenhub@default/deepseek-v3.2"
+    },
+    {
+      "model_ref": "tencent-tokenhub/deepseek-v4-flash",
+      "route_ref": "tencent-tokenhub@default/deepseek-v4-flash"
+    },
+    {
+      "model_ref": "tencent-tokenhub/deepseek-v4-pro",
+      "route_ref": "tencent-tokenhub@default/deepseek-v4-pro"
+    },
+    {
+      "model_ref": "tencent-tokenhub/glm-5",
+      "route_ref": "tencent-tokenhub@default/glm-5"
+    },
+    {
+      "model_ref": "tencent-tokenhub/glm-5-turbo",
+      "route_ref": "tencent-tokenhub@default/glm-5-turbo"
+    },
+    {
+      "model_ref": "tencent-tokenhub/glm-5.1",
+      "route_ref": "tencent-tokenhub@default/glm-5.1"
+    },
+    {
+      "model_ref": "tencent-tokenhub/glm-5.2",
+      "route_ref": "tencent-tokenhub@default/glm-5.2"
+    },
+    {
+      "model_ref": "tencent-tokenhub/glm-5v-turbo",
+      "route_ref": "tencent-tokenhub@default/glm-5v-turbo"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hunyuan-role-latest",
+      "route_ref": "tencent-tokenhub@default/hunyuan-role-latest"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hunyuan-t1-vision-20250916",
+      "route_ref": "tencent-tokenhub@default/hunyuan-t1-vision-20250916"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy-mt2-lite",
+      "route_ref": "tencent-tokenhub@default/hy-mt2-lite"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy-mt2-plus",
+      "route_ref": "tencent-tokenhub@default/hy-mt2-plus"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy-mt2-pro",
+      "route_ref": "tencent-tokenhub@default/hy-mt2-pro"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy-role",
+      "route_ref": "tencent-tokenhub@default/hy-role"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy-vision-2.0-instruct",
+      "route_ref": "tencent-tokenhub@default/hy-vision-2.0-instruct"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy3",
+      "route_ref": "tencent-tokenhub@default/hy3"
+    },
+    {
+      "model_ref": "tencent-tokenhub/hy3-preview",
+      "route_ref": "tencent-tokenhub@default/hy3-preview"
+    },
+    {
+      "model_ref": "tencent-tokenhub/kimi-k2.5",
+      "route_ref": "tencent-tokenhub@default/kimi-k2.5"
+    },
+    {
+      "model_ref": "tencent-tokenhub/kimi-k2.6",
+      "route_ref": "tencent-tokenhub@default/kimi-k2.6"
+    },
+    {
+      "model_ref": "tencent-tokenhub/kimi-k2.7-code",
+      "route_ref": "tencent-tokenhub@default/kimi-k2.7-code"
+    },
+    {
+      "model_ref": "tencent-tokenhub/kimi-k2.7-code-highspeed",
+      "route_ref": "tencent-tokenhub@default/kimi-k2.7-code-highspeed"
+    },
+    {
+      "model_ref": "tencent-tokenhub/minimax-m2.5",
+      "route_ref": "tencent-tokenhub@default/minimax-m2.5"
+    },
+    {
+      "model_ref": "tencent-tokenhub/minimax-m2.7",
+      "route_ref": "tencent-tokenhub@default/minimax-m2.7"
+    },
+    {
+      "model_ref": "tencent-tokenhub/minimax-m3",
+      "route_ref": "tencent-tokenhub@default/minimax-m3"
+    },
+    {
+      "model_ref": "tencent-tokenhub/qwen3.5-flash",
+      "route_ref": "tencent-tokenhub@default/qwen3.5-flash"
+    },
+    {
+      "model_ref": "tencent-tokenhub/qwen3.5-plus",
+      "route_ref": "tencent-tokenhub@default/qwen3.5-plus"
+    },
+    {
+      "model_ref": "tencent-tokenhub/youtu-vita",
+      "route_ref": "tencent-tokenhub@default/youtu-vita"
+    },
+    {
+      "model_ref": "together/MiniMaxAI/MiniMax-M2.7",
+      "route_ref": "together@default/MiniMaxAI/MiniMax-M2.7"
+    },
+    {
+      "model_ref": "together/MiniMaxAI/MiniMax-M3",
+      "route_ref": "together@default/MiniMaxAI/MiniMax-M3"
+    },
+    {
+      "model_ref": "together/Qwen/Qwen3.5-9B",
+      "route_ref": "together@default/Qwen/Qwen3.5-9B"
+    },
+    {
+      "model_ref": "together/deepseek-ai/DeepSeek-V4-Pro",
+      "route_ref": "together@default/deepseek-ai/DeepSeek-V4-Pro"
+    },
+    {
+      "model_ref": "together/meta-llama/Llama-3.3-70B-Instruct-Turbo",
+      "route_ref": "together@default/meta-llama/Llama-3.3-70B-Instruct-Turbo"
+    },
+    {
+      "model_ref": "together/moonshotai/Kimi-K2.6",
+      "route_ref": "together@default/moonshotai/Kimi-K2.6"
+    },
+    {
+      "model_ref": "together/moonshotai/Kimi-K2.7-Code",
+      "route_ref": "together@default/moonshotai/Kimi-K2.7-Code"
+    },
+    {
+      "model_ref": "together/nvidia/nemotron-3-ultra-550b-a55b",
+      "route_ref": "together@default/nvidia/nemotron-3-ultra-550b-a55b"
+    },
+    {
+      "model_ref": "together/openai/gpt-oss-120b",
+      "route_ref": "together@default/openai/gpt-oss-120b"
+    },
+    {
+      "model_ref": "together/zai-org/GLM-5.2",
+      "route_ref": "together@default/zai-org/GLM-5.2"
+    },
+    {
+      "model_ref": "venice/qwen3-235b-a22b-thinking-2507",
+      "route_ref": "venice@default/qwen3-235b-a22b-thinking-2507"
+    },
+    {
+      "model_ref": "venice/qwen3-coder-480b-a35b-instruct-turbo",
+      "route_ref": "venice@default/qwen3-coder-480b-a35b-instruct-turbo"
+    },
+    {
+      "model_ref": "venice/qwen3-vl-235b-a22b",
+      "route_ref": "venice@default/qwen3-vl-235b-a22b"
+    },
+    {
+      "model_ref": "venice/venice-uncensored-1-2",
+      "route_ref": "venice@default/venice-uncensored-1-2"
+    },
+    {
+      "model_ref": "venice/zai-org-glm-4.7",
+      "route_ref": "venice@default/zai-org-glm-4.7"
+    },
+    {
+      "model_ref": "vercel-ai-gateway/anthropic/claude-opus-4.6",
+      "route_ref": "vercel-ai-gateway@default/anthropic/claude-opus-4.6"
+    },
+    {
+      "model_ref": "vercel-ai-gateway/moonshotai/kimi-k2.6",
+      "route_ref": "vercel-ai-gateway@default/moonshotai/kimi-k2.6"
+    },
+    {
+      "model_ref": "vercel-ai-gateway/openai/gpt-5.4",
+      "route_ref": "vercel-ai-gateway@default/openai/gpt-5.4"
+    },
+    {
+      "model_ref": "vercel-ai-gateway/openai/gpt-5.4-pro",
+      "route_ref": "vercel-ai-gateway@default/openai/gpt-5.4-pro"
+    },
+    {
+      "model_ref": "volcengine/MiniMax-M3",
+      "route_ref": "volcengine@plan/MiniMax-M3"
+    },
+    {
+      "model_ref": "volcengine/ark-code-latest",
+      "route_ref": "volcengine@coding/ark-code-latest"
+    },
+    {
+      "model_ref": "volcengine/deepseek-v3-2-251201",
+      "route_ref": "volcengine@default/deepseek-v3-2-251201"
+    },
+    {
+      "model_ref": "volcengine/deepseek-v4-flash",
+      "route_ref": "volcengine@coding/deepseek-v4-flash"
+    },
+    {
+      "model_ref": "volcengine/deepseek-v4-pro",
+      "route_ref": "volcengine@coding/deepseek-v4-pro"
+    },
+    {
+      "model_ref": "volcengine/doubao-seed-1-8-251228",
+      "route_ref": "volcengine@default/doubao-seed-1-8-251228"
+    },
+    {
+      "model_ref": "volcengine/doubao-seed-2-0-code-preview-260215",
+      "route_ref": "volcengine@default/doubao-seed-2-0-code-preview-260215"
+    },
+    {
+      "model_ref": "volcengine/doubao-seed-2-0-lite-260215",
+      "route_ref": "volcengine@default/doubao-seed-2-0-lite-260215"
+    },
+    {
+      "model_ref": "volcengine/doubao-seed-2-0-mini-260215",
+      "route_ref": "volcengine@plan/doubao-seed-2-0-mini-260215"
+    },
+    {
+      "model_ref": "volcengine/doubao-seed-2-0-pro-260215",
+      "route_ref": "volcengine@default/doubao-seed-2-0-pro-260215"
+    },
+    {
+      "model_ref": "volcengine/doubao-seedream-5.0-lite",
+      "route_ref": "volcengine@default/doubao-seedream-5.0-lite"
+    },
+    {
+      "model_ref": "volcengine/glm-5.2",
+      "route_ref": "volcengine@coding/glm-5.2"
+    },
+    {
+      "model_ref": "volcengine/glm-5.3",
+      "route_ref": "volcengine@coding/glm-5.3"
+    },
+    {
+      "model_ref": "volcengine/kimi-k2.6",
+      "route_ref": "volcengine@coding/kimi-k2.6"
+    },
+    {
+      "model_ref": "volcengine/kimi-k2.7-code",
+      "route_ref": "volcengine@coding/kimi-k2.7-code"
+    },
+    {
+      "model_ref": "xai/grok-4.3",
+      "route_ref": "xai@default/grok-4.3"
+    },
+    {
+      "model_ref": "xai/grok-4.5",
+      "route_ref": "xai@default/grok-4.5"
+    },
+    {
+      "model_ref": "xiaomi/mimo-v2.5",
+      "route_ref": "xiaomi@default/mimo-v2.5"
+    },
+    {
+      "model_ref": "xiaomi/mimo-v2.5-pro",
+      "route_ref": "xiaomi@default/mimo-v2.5-pro"
+    },
+    {
+      "model_ref": "zai/glm-4-32b-0414-128k",
+      "route_ref": "zai@default/glm-4-32b-0414-128k"
+    },
+    {
+      "model_ref": "zai/glm-4.5",
+      "route_ref": "zai@default/glm-4.5"
+    },
+    {
+      "model_ref": "zai/glm-4.5-air",
+      "route_ref": "zai@default/glm-4.5-air"
+    },
+    {
+      "model_ref": "zai/glm-4.5-airx",
+      "route_ref": "zai@default/glm-4.5-airx"
+    },
+    {
+      "model_ref": "zai/glm-4.5-flash",
+      "route_ref": "zai@default/glm-4.5-flash"
+    },
+    {
+      "model_ref": "zai/glm-4.5-x",
+      "route_ref": "zai@default/glm-4.5-x"
+    },
+    {
+      "model_ref": "zai/glm-4.5v",
+      "route_ref": "zai@default/glm-4.5v"
+    },
+    {
+      "model_ref": "zai/glm-4.6",
+      "route_ref": "zai@default/glm-4.6"
+    },
+    {
+      "model_ref": "zai/glm-4.6v",
+      "route_ref": "zai@default/glm-4.6v"
+    },
+    {
+      "model_ref": "zai/glm-4.6v-flash",
+      "route_ref": "zai@default/glm-4.6v-flash"
+    },
+    {
+      "model_ref": "zai/glm-4.6v-flashx",
+      "route_ref": "zai@default/glm-4.6v-flashx"
+    },
+    {
+      "model_ref": "zai/glm-4.7",
+      "route_ref": "zai@default/glm-4.7"
+    },
+    {
+      "model_ref": "zai/glm-4.7-flash",
+      "route_ref": "zai@default/glm-4.7-flash"
+    },
+    {
+      "model_ref": "zai/glm-4.7-flashx",
+      "route_ref": "zai@default/glm-4.7-flashx"
+    },
+    {
+      "model_ref": "zai/glm-5",
+      "route_ref": "zai@default/glm-5"
+    },
+    {
+      "model_ref": "zai/glm-5-turbo",
+      "route_ref": "zai@default/glm-5-turbo"
+    },
+    {
+      "model_ref": "zai/glm-5.1",
+      "route_ref": "zai@default/glm-5.1"
+    },
+    {
+      "model_ref": "zai/glm-5.2",
+      "route_ref": "zai@default/glm-5.2"
+    },
+    {
+      "model_ref": "zai/glm-5.3",
+      "route_ref": "zai@default/glm-5.3"
+    },
+    {
+      "model_ref": "zai/glm-5.3-flash",
+      "route_ref": "zai@default/glm-5.3-flash"
+    },
+    {
+      "model_ref": "zai/glm-5v-turbo",
+      "route_ref": "zai@default/glm-5v-turbo"
+    }
+  ]
+}

--- a/src/model_catalog/providers/mod.rs
+++ b/src/model_catalog/providers/mod.rs
@@ -1,12 +1,18 @@
+#[cfg(test)]
 mod china;
+#[cfg(test)]
 pub(super) mod common;
+#[cfg(test)]
 mod core;
+#[cfg(test)]
 mod gateways;
+#[cfg(test)]
 mod hosted;
 mod tencent_tokenhub;
 
 pub(crate) use tencent_tokenhub::is_tencent_tokenhub_model_id;
 
+#[cfg(test)]
 pub(super) fn entries_for_registration(
     registration: crate::provider::ProviderCatalogRegistration,
 ) -> Vec<super::BuiltInModelMetadata> {
@@ -25,6 +31,7 @@ pub(super) fn entries_for_registration(
     }
 }
 
+#[cfg(test)]
 pub(super) fn route_definitions() -> Vec<super::BuiltInModelRouteDefinition> {
     let mut definitions = china::route_definitions();
     definitions.extend(tencent_tokenhub::route_definitions());

--- a/src/model_catalog/providers/tencent_tokenhub.rs
+++ b/src/model_catalog/providers/tencent_tokenhub.rs
@@ -1,5 +1,7 @@
+#[cfg(test)]
 use super::super::*;
 
+#[cfg(test)]
 fn tencent_tokenhub_model(
     model: &str,
     display_name: &str,
@@ -218,6 +220,7 @@ pub(crate) fn is_tencent_tokenhub_model_id(id: &str) -> bool {
     TENCENT_TOKENHUB_MODELS.iter().any(|model| model.0 == id)
 }
 
+#[cfg(test)]
 pub(super) fn entries() -> Vec<BuiltInModelMetadata> {
     TENCENT_TOKENHUB_MODELS
         .iter()
@@ -225,6 +228,7 @@ pub(super) fn entries() -> Vec<BuiltInModelMetadata> {
         .collect()
 }
 
+#[cfg(test)]
 pub(super) fn route_definitions() -> Vec<BuiltInModelRouteDefinition> {
     TENCENT_TOKENHUB_MODELS
         .iter()

--- a/src/model_catalog/snapshot.rs
+++ b/src/model_catalog/snapshot.rs
@@ -1,0 +1,446 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    BuiltInModelCatalog, BuiltInModelMetadata, BuiltInModelRoutePolicy, ModelRef, ModelRouteRef,
+    ProviderId,
+};
+
+const SCHEMA_VERSION: u32 = 1;
+const BUILT_IN_SNAPSHOT: &str = include_str!("builtin_snapshot_v1.json");
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RegistrySnapshot {
+    schema_version: u32,
+    revision: String,
+    models: Vec<BuiltInModelMetadata>,
+    routes: Vec<SnapshotRoute>,
+    aliases: Vec<SnapshotAlias>,
+    preferred_models: Vec<SnapshotPreferredModel>,
+    preferred_routes: Vec<SnapshotPreferredRoute>,
+    preferred_routes_by_model: Vec<SnapshotPreferredModelRoute>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotRoute {
+    route_ref: ModelRouteRef,
+    policy: BuiltInModelRoutePolicy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotAlias {
+    alias: ModelRef,
+    target: ModelRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotPreferredModel {
+    provider: ProviderId,
+    model_ref: ModelRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotPreferredRoute {
+    provider: ProviderId,
+    route_ref: ModelRouteRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotPreferredModelRoute {
+    model_ref: ModelRef,
+    route_ref: ModelRouteRef,
+}
+
+pub(super) fn built_in_catalog() -> Result<BuiltInModelCatalog, String> {
+    parse_and_validate(BUILT_IN_SNAPSHOT)
+}
+
+fn parse_and_validate(raw: &str) -> Result<BuiltInModelCatalog, String> {
+    let snapshot = serde_json::from_str::<RegistrySnapshot>(raw)
+        .map_err(|error| format!("failed to parse snapshot: {error}"))?;
+    snapshot.validate()?;
+    Ok(snapshot.into_catalog())
+}
+
+impl RegistrySnapshot {
+    fn validate(&self) -> Result<(), String> {
+        if self.schema_version != SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported schema version {}; expected {SCHEMA_VERSION}",
+                self.schema_version
+            ));
+        }
+        if self.revision.trim().is_empty() {
+            return Err("revision must not be empty".to_string());
+        }
+
+        let mut models = HashMap::new();
+        for model in &self.models {
+            if model.model_ref.model.trim().is_empty() {
+                return Err("model id must not be empty".to_string());
+            }
+            if model.endpoint.is_some() {
+                return Err(format!(
+                    "canonical model {} must not declare an endpoint",
+                    model.model_ref.as_string()
+                ));
+            }
+            if model.effective_context_window_percent == 0
+                || model.effective_context_window_percent > 100
+            {
+                return Err(format!(
+                    "model {} has invalid effective context window percent {}",
+                    model.model_ref.as_string(),
+                    model.effective_context_window_percent
+                ));
+            }
+            if model.context_window_tokens.is_some_and(|value| value == 0)
+                || model
+                    .default_max_output_tokens
+                    .is_some_and(|value| value == 0)
+                || model
+                    .max_output_tokens_upper_limit
+                    .is_some_and(|value| value == 0)
+            {
+                return Err(format!(
+                    "model {} token limits must be positive",
+                    model.model_ref.as_string()
+                ));
+            }
+            if let (Some(default), Some(upper)) = (
+                model.default_max_output_tokens,
+                model.max_output_tokens_upper_limit,
+            ) {
+                if default > upper {
+                    return Err(format!(
+                        "model {} default max output {default} exceeds upper limit {upper}",
+                        model.model_ref.as_string()
+                    ));
+                }
+            }
+            let mut reasoning_options = HashSet::new();
+            if model
+                .reasoning_effort_options
+                .iter()
+                .any(|option| !reasoning_options.insert(option))
+            {
+                return Err(format!(
+                    "model {} has duplicate reasoning effort options",
+                    model.model_ref.as_string()
+                ));
+            }
+            if models.insert(model.model_ref.clone(), model).is_some() {
+                return Err(format!("duplicate model {}", model.model_ref.as_string()));
+            }
+        }
+
+        let mut routes = HashSet::new();
+        for route in &self.routes {
+            if !routes.insert(route.route_ref.clone()) {
+                return Err(format!("duplicate route {}", route.route_ref.as_string()));
+            }
+            let model_ref = route.route_ref.model_ref();
+            let model = models.get(&model_ref).ok_or_else(|| {
+                format!(
+                    "route {} references missing model {}",
+                    route.route_ref.as_string(),
+                    model_ref.as_string()
+                )
+            })?;
+            route
+                .policy
+                .validate_narrowing(model)
+                .map_err(|error| format!("route {}: {error}", route.route_ref.as_string()))?;
+        }
+
+        let mut aliases = HashMap::new();
+        for alias in &self.aliases {
+            if models.contains_key(&alias.alias) {
+                return Err(format!(
+                    "alias {} conflicts with a canonical model",
+                    alias.alias.as_string()
+                ));
+            }
+            if !models.contains_key(&alias.target) {
+                return Err(format!(
+                    "alias {} references missing model {}",
+                    alias.alias.as_string(),
+                    alias.target.as_string()
+                ));
+            }
+            if aliases
+                .insert(alias.alias.clone(), alias.target.clone())
+                .is_some()
+            {
+                return Err(format!("duplicate alias {}", alias.alias.as_string()));
+            }
+        }
+        for (alias, target) in &aliases {
+            if aliases.contains_key(target) {
+                return Err(format!(
+                    "alias {} targets another alias {}",
+                    alias.as_string(),
+                    target.as_string()
+                ));
+            }
+        }
+
+        validate_preferred_models(&self.preferred_models, &models)?;
+        validate_preferred_routes(&self.preferred_routes, &routes)?;
+
+        let mut preferred_models = HashSet::new();
+        for preferred in &self.preferred_routes_by_model {
+            if !preferred_models.insert(preferred.model_ref.clone()) {
+                return Err(format!(
+                    "duplicate preferred route for model {}",
+                    preferred.model_ref.as_string()
+                ));
+            }
+            if !models.contains_key(&preferred.model_ref) {
+                return Err(format!(
+                    "preferred route references missing model {}",
+                    preferred.model_ref.as_string()
+                ));
+            }
+            if preferred.route_ref.model_ref() != preferred.model_ref {
+                return Err(format!(
+                    "preferred route {} does not match model {}",
+                    preferred.route_ref.as_string(),
+                    preferred.model_ref.as_string()
+                ));
+            }
+            if !routes.contains(&preferred.route_ref) {
+                return Err(format!(
+                    "preferred route {} is not registered",
+                    preferred.route_ref.as_string()
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn into_catalog(self) -> BuiltInModelCatalog {
+        BuiltInModelCatalog {
+            entries: self
+                .models
+                .into_iter()
+                .map(|model| (model.model_ref.clone(), model))
+                .collect(),
+            route_entries: self
+                .routes
+                .into_iter()
+                .map(|route| (route.route_ref, route.policy))
+                .collect(),
+            aliases: self
+                .aliases
+                .into_iter()
+                .map(|alias| (alias.alias, alias.target))
+                .collect(),
+            preferred_models: self
+                .preferred_models
+                .into_iter()
+                .map(|preferred| (preferred.provider, preferred.model_ref))
+                .collect(),
+            preferred_routes: self
+                .preferred_routes
+                .into_iter()
+                .map(|preferred| (preferred.provider, preferred.route_ref))
+                .collect(),
+            preferred_routes_by_model: self
+                .preferred_routes_by_model
+                .into_iter()
+                .map(|preferred| (preferred.model_ref, preferred.route_ref))
+                .collect(),
+        }
+    }
+
+    #[cfg(test)]
+    fn from_catalog(revision: impl Into<String>, catalog: &BuiltInModelCatalog) -> Self {
+        let mut models = catalog.entries.values().cloned().collect::<Vec<_>>();
+        models.sort_by_key(|model| model.model_ref.as_string());
+        let mut routes = catalog
+            .route_entries
+            .iter()
+            .map(|(route_ref, policy)| SnapshotRoute {
+                route_ref: route_ref.clone(),
+                policy: policy.clone(),
+            })
+            .collect::<Vec<_>>();
+        routes.sort_by_key(|route| route.route_ref.as_string());
+        let mut aliases = catalog
+            .aliases
+            .iter()
+            .map(|(alias, target)| SnapshotAlias {
+                alias: alias.clone(),
+                target: target.clone(),
+            })
+            .collect::<Vec<_>>();
+        aliases.sort_by_key(|alias| alias.alias.as_string());
+        let mut preferred_models = catalog
+            .preferred_models
+            .iter()
+            .map(|(provider, model_ref)| SnapshotPreferredModel {
+                provider: provider.clone(),
+                model_ref: model_ref.clone(),
+            })
+            .collect::<Vec<_>>();
+        preferred_models.sort_by_key(|preferred| preferred.provider.as_str().to_string());
+        let mut preferred_routes = catalog
+            .preferred_routes
+            .iter()
+            .map(|(provider, route_ref)| SnapshotPreferredRoute {
+                provider: provider.clone(),
+                route_ref: route_ref.clone(),
+            })
+            .collect::<Vec<_>>();
+        preferred_routes.sort_by_key(|preferred| preferred.provider.as_str().to_string());
+        let mut preferred_routes_by_model = catalog
+            .preferred_routes_by_model
+            .iter()
+            .map(|(model_ref, route_ref)| SnapshotPreferredModelRoute {
+                model_ref: model_ref.clone(),
+                route_ref: route_ref.clone(),
+            })
+            .collect::<Vec<_>>();
+        preferred_routes_by_model.sort_by_key(|preferred| preferred.model_ref.as_string());
+        Self {
+            schema_version: SCHEMA_VERSION,
+            revision: revision.into(),
+            models,
+            routes,
+            aliases,
+            preferred_models,
+            preferred_routes,
+            preferred_routes_by_model,
+        }
+    }
+}
+
+fn validate_preferred_models(
+    preferred_models: &[SnapshotPreferredModel],
+    models: &HashMap<ModelRef, &BuiltInModelMetadata>,
+) -> Result<(), String> {
+    let mut providers = HashSet::new();
+    for preferred in preferred_models {
+        if !providers.insert(preferred.provider.clone()) {
+            return Err(format!(
+                "duplicate preferred model for provider {}",
+                preferred.provider.as_str()
+            ));
+        }
+        if !models.contains_key(&preferred.model_ref) {
+            return Err(format!(
+                "preferred model {} is not registered",
+                preferred.model_ref.as_string()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_preferred_routes(
+    preferred_routes: &[SnapshotPreferredRoute],
+    routes: &HashSet<ModelRouteRef>,
+) -> Result<(), String> {
+    let mut providers = HashSet::new();
+    for preferred in preferred_routes {
+        if !providers.insert(preferred.provider.clone()) {
+            return Err(format!(
+                "duplicate preferred route for provider {}",
+                preferred.provider.as_str()
+            ));
+        }
+        if !routes.contains(&preferred.route_ref) {
+            return Err(format!(
+                "preferred route {} is not registered",
+                preferred.route_ref.as_string()
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "writes the checked-in built-in registry snapshot"]
+    fn regenerate_builtin_snapshot() {
+        let catalog = BuiltInModelCatalog::from_legacy_definitions();
+        let snapshot = RegistrySnapshot::from_catalog("builtin-2026-08-28", &catalog);
+        let json = serde_json::to_string_pretty(&snapshot).expect("snapshot must serialize");
+        std::fs::write(
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/src/model_catalog/builtin_snapshot_v1.json"
+            ),
+            format!("{json}\n"),
+        )
+        .expect("snapshot must be writable");
+    }
+
+    #[test]
+    fn built_in_snapshot_matches_legacy_catalog() {
+        let snapshot = built_in_catalog().expect("built-in snapshot must be valid");
+        let legacy = BuiltInModelCatalog::from_legacy_definitions();
+        assert_eq!(snapshot, legacy);
+    }
+
+    #[test]
+    fn rejects_unknown_schema_version() {
+        let raw = BUILT_IN_SNAPSHOT.replacen("\"schema_version\": 1", "\"schema_version\": 999", 1);
+        let error = parse_and_validate(&raw).expect_err("unknown version must fail");
+        assert!(error.contains("unsupported schema version"));
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let raw = BUILT_IN_SNAPSHOT.replacen(
+            "\"revision\":",
+            "\"unexpected\": true,\n  \"revision\":",
+            1,
+        );
+        let error = parse_and_validate(&raw).expect_err("unknown fields must fail");
+        assert!(error.contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_duplicate_models() {
+        let mut snapshot =
+            serde_json::from_str::<RegistrySnapshot>(BUILT_IN_SNAPSHOT).expect("valid fixture");
+        snapshot.models.push(snapshot.models[0].clone());
+        let raw = serde_json::to_string(&snapshot).expect("snapshot must serialize");
+        let error = parse_and_validate(&raw).expect_err("duplicate model must fail");
+        assert!(error.contains("duplicate model"));
+    }
+
+    #[test]
+    fn rejects_route_capability_expansion() {
+        let mut snapshot =
+            serde_json::from_str::<RegistrySnapshot>(BUILT_IN_SNAPSHOT).expect("valid fixture");
+        let route = snapshot
+            .routes
+            .iter_mut()
+            .find(|route| {
+                let model = snapshot
+                    .models
+                    .iter()
+                    .find(|model| model.model_ref == route.route_ref.model_ref())
+                    .expect("route model");
+                !model.capabilities.image_generation
+            })
+            .expect("route with unsupported image generation");
+        route.policy.capabilities.image_generation = Some(true);
+        let raw = serde_json::to_string(&snapshot).expect("snapshot must serialize");
+        let error = parse_and_validate(&raw).expect_err("capability expansion must fail");
+        assert!(error.contains("cannot enable intrinsic capability image_generation"));
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -37,13 +37,14 @@ pub(crate) use diagnostics::{
     resolved_model_providers_from_availability_for_runtime,
 };
 pub use http_trace::ProviderHttpTraceDiagnostics;
+#[cfg(test)]
+pub(crate) use registry::ProviderCatalogRegistration;
 pub(crate) use registry::{
     build_provider_for_route, provider_definition, provider_definitions,
     provider_transport_definition, provider_transport_definition_by_wire_name,
     provider_transport_definitions, ModelDiscoveryAuth, ModelDiscoveryDecoder,
     ModelDiscoveryDefinition, ModelDiscoveryRoute, ProviderCatalogPolicy,
-    ProviderCatalogRegistration, ProviderContextManagement, ProviderDefinition,
-    ProviderMaterializer, ProviderWebSearch,
+    ProviderContextManagement, ProviderDefinition, ProviderMaterializer, ProviderWebSearch,
 };
 pub(crate) use retry::sanitize_transport_url;
 pub(crate) use transports::OpenAiBearerAuth;

--- a/src/provider/registry.rs
+++ b/src/provider/registry.rs
@@ -14,11 +14,12 @@ use super::{
 
 mod providers;
 
+#[cfg(test)]
+pub(crate) use providers::ProviderCatalogRegistration;
 pub(crate) use providers::{
     provider_definition, provider_definitions, ModelDiscoveryAuth, ModelDiscoveryDecoder,
     ModelDiscoveryDefinition, ModelDiscoveryRoute, ProviderCatalogPolicy,
-    ProviderCatalogRegistration, ProviderContextManagement, ProviderDefinition,
-    ProviderMaterializer, ProviderWebSearch,
+    ProviderContextManagement, ProviderDefinition, ProviderMaterializer, ProviderWebSearch,
 };
 
 type ProviderBuilder = fn(&Path, &ResolvedModelRoute) -> Result<Arc<dyn AgentProvider>>;

--- a/src/provider/registry/providers.rs
+++ b/src/provider/registry/providers.rs
@@ -69,6 +69,7 @@ pub(crate) enum ProviderCatalogPolicy {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg(test)]
 pub(crate) enum ProviderCatalogRegistration {
     Core,
     HostedEarly,
@@ -102,6 +103,7 @@ pub(crate) struct ProviderDefinition {
     pub(crate) default_reasoning_effort: Option<&'static str>,
     pub(crate) discovery: Option<ModelDiscoveryDefinition>,
     pub(crate) catalog_policy: ProviderCatalogPolicy,
+    #[cfg(test)]
     pub(crate) catalog_registration: Option<ProviderCatalogRegistration>,
 }
 
@@ -135,6 +137,7 @@ macro_rules! provider {
             default_reasoning_effort: $reasoning,
             discovery: $discovery,
             catalog_policy: ProviderCatalogPolicy::$catalog,
+            #[cfg(test)]
             catalog_registration: Some(
                 ProviderCatalogRegistration::$registration,
             ),
@@ -159,6 +162,7 @@ macro_rules! provider {
             default_reasoning_effort: $reasoning,
             discovery: $discovery,
             catalog_policy: ProviderCatalogPolicy::$catalog,
+            #[cfg(test)]
             catalog_registration: None,
         }
     };


### PR DESCRIPTION
## 目标

实现 #2702 的 Phase 0/1：先固化模型目录的分层、precedence、trust、unknown 与离线契约，再把现有 Rust built-in catalog 无损投影为版本化、可校验的内嵌 snapshot；本 PR 不引入在线同步，也不改变运行时解析行为。

## 变更

- 新增 Model Registry RFC，明确四类事实层、字段级 precedence、unknown 语义、不可信上游边界、离线启动/turn 契约与首版 `models.dev` 上游决策。
- 新增 `builtin_snapshot_v1.json` 与严格 schema loader；拒绝未知字段、未知 schema、重复模型/route/alias、无效 alias、能力扩张 route 和非法约束。
- `BuiltInModelCatalog::new()` 改为读取内嵌 snapshot；旧 provider builders 仅在测试构建中保留，用于受控生成和完整等价性校验。
- 保留 Tencent TokenHub discovery 所需的静态模型 ID 表，避免把运行时 discovery 行为错误移入测试边界。

## 验证

- `cargo fmt --all && RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test model_catalog::snapshot::tests -- --nocapture`（10 passed）
- `cargo test model_catalog::tests -- --nocapture`（47 passed）
- snapshot 受控生成后无差异，JSON 可解析，`git diff --check` 通过。

Closes #2702
