### PR TITLE
fix: resume WorkItem-bound operator waits

### DIFF
--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1400,6 +1400,7 @@ pub(crate) fn resolve_canonical_activation_scenario(
                 waits.retain(|wait| {
                     wait.work_item_id.is_none()
                         || (message.kind == MessageKind::OperatorPrompt
+                            && message.priority != Priority::Interject
                             && wait.kind == WaitConditionKind::Operator)
                 });
             }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1397,7 +1397,11 @@ pub(crate) fn resolve_canonical_activation_scenario(
                     MessageKind::OperatorPrompt | MessageKind::TaskResult
                 )
             {
-                waits.retain(|wait| wait.work_item_id.is_none());
+                waits.retain(|wait| {
+                    wait.work_item_id.is_none()
+                        || (message.kind == MessageKind::OperatorPrompt
+                            && wait.kind == WaitConditionKind::Operator)
+                });
             }
             waits
         }

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -2,9 +2,9 @@ use super::super::*;
 use super::support::*;
 use crate::domain::scheduler::SchedulerOwner;
 use crate::types::{
-    AgentPostureProjection, AgentSchedulingPosture, ToolExecutionStatus, WaitConditionKind,
-    WaitConditionRecord, WaitConditionStatus, WakeSource, WorkItemPlanStatus,
-    WorkItemSchedulingState, WorkItemState, WorkReactivationMode,
+    AdmissionContext, AgentPostureProjection, AgentSchedulingPosture, MessageDeliverySurface,
+    ToolExecutionStatus, WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource,
+    WorkItemPlanStatus, WorkItemSchedulingState, WorkItemState, WorkReactivationMode,
 };
 use chrono::DateTime;
 use serde::de::DeserializeOwned;
@@ -1787,7 +1787,51 @@ fn unbound_operator_input_exactly_resumes_agent_wait_or_becomes_nudge() {
 }
 
 #[test]
-fn unbound_operator_input_exactly_resumes_work_item_wait() {
+fn explicitly_bound_operator_input_resumes_work_item_wait() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    append_open_work_item(&storage, "wi-operator", "default");
+    append_operator_wait_condition(&storage, "wait-operator", "default", Some("wi-operator"));
+
+    let mut projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    projection.enable_canonical_authority_for_test();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("operator".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "continue".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::CliPrompt,
+        AdmissionContext::LocalProcess,
+    );
+    message.message_seq = Some(1);
+    message.work_item_id = Some("wi-operator".into());
+    let candidate = scheduler::canonical_activation_candidate(&message, None, None)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        scheduler::resolve_canonical_activation_scenario(&projection, &message, candidate).unwrap(),
+        Some(
+            scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput {
+                work_item_id: "wi-operator".into(),
+                wait_id: Some("wait-operator".into()),
+            },
+        )
+    );
+}
+
+#[test]
+fn normal_operator_input_resumes_work_item_wait_but_interject_does_not() {
     let dir = tempdir().unwrap();
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let agent = AgentState::new("default");
@@ -1821,6 +1865,23 @@ fn unbound_operator_input_exactly_resumes_work_item_wait() {
             },
             wait_id: "wait-operator".into(),
         })
+    );
+
+    let interject = MessageEnvelope {
+        priority: Priority::Interject,
+        ..message
+    };
+    let candidate = scheduler::canonical_activation_candidate(&interject, None, None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        scheduler::resolve_canonical_activation_scenario(&projection, &interject, candidate)
+            .unwrap(),
+        Some(
+            scheduler::CanonicalActivationScenario::LifecycleExternalNudge {
+                agent_id: "default".into(),
+            }
+        )
     );
 }
 

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1787,6 +1787,44 @@ fn unbound_operator_input_exactly_resumes_agent_wait_or_becomes_nudge() {
 }
 
 #[test]
+fn unbound_operator_input_exactly_resumes_work_item_wait() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    append_open_work_item(&storage, "wi-operator", "default");
+    append_operator_wait_condition(&storage, "wait-operator", "default", Some("wi-operator"));
+
+    let mut projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    projection.enable_canonical_authority_for_test();
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("operator".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "continue".into(),
+        },
+    );
+    let candidate = scheduler::canonical_activation_candidate(&message, None, None)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        scheduler::resolve_canonical_activation_scenario(&projection, &message, candidate).unwrap(),
+        Some(scheduler::CanonicalActivationScenario::ExactWaitResume {
+            owner: SchedulerOwner::WorkItem {
+                work_item_id: "wi-operator".into(),
+            },
+            wait_id: "wait-operator".into(),
+        })
+    );
+}
+
+#[test]
 fn message_claim_authority_scope_is_derived_without_shadow_evidence() {
     let dir = tempdir().unwrap();
     let storage = AppStorage::new_for_test(dir.path()).unwrap();


### PR DESCRIPTION
## 问题

修复 #2706：`WaitFor(wake=operator_input)` 绑定到 `WorkItem` 后，普通 operator prompt 无法匹配该 wait condition，唤醒路径错误地创建 `AgentLifecycle` execution claim，最终导致 `CompleteWorkItem` 找不到匹配的 execution attempt。

## 修改

- 调整 scheduler 的 wait matching：无显式 `work_item_id` 的 `OperatorPrompt` 现在可以匹配 WorkItem-bound 的 operator-input wait。
- 添加 scheduler 回归测试，验证该 admission 精确恢复到等待中的 WorkItem。
- 保持现有 WorkItem execution claim 和 source-revision 对齐协议不变；匹配成功后继续走 canonical WorkItem activation 路径。

## 验证

- `cargo fmt --all -- --check`
- `cargo test --lib runtime::tests::scheduler::`
- `cargo test --lib runtime::tests::work_items::`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

以上检查均通过。

Closes #2706
