### PR TITLE
fix: separate current-only wait posture from queued waiting summaries

### DIFF
--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -3851,7 +3851,7 @@
       "stability": "stable"
     },
     {
-      "description": "Mark an open work item completed. Write the operator-facing completion report as assistant text in the same round; the runtime promotes that text after this tool succeeds. If this work item has a yielded direct caller, completion resumes that caller as current and the turn closes for scheduler continuation.\n",
+      "description": "Mark an open work item completed. Write the operator-facing completion report as assistant text in the same round; the runtime promotes that text after this tool succeeds. If this work item has a yielded direct caller, completion resumes that caller as current and the turn closes for scheduler continuation.\n\nThis is a terminal operation: it ends the current WorkItem/goal and closes the turn for scheduler continuation. Do not call it until the entire objective and verification is complete.\n\nAfter a plan is approved, typically update the same WorkItem's plan_status from needs_input to ready, update the todo_list, and continue implementation in the same turn — do not call CompleteWorkItem just to transition from planning to implementation.\n\nIf you must split the objective into a separate WorkItem, create and activate the successor first so it enters durable runnable state, then complete the old WorkItem. Never complete the current WorkItem before a successor or continuation is established, or the remaining work will not be resumed.\n\nAfter completion, do not claim that unfinished work will continue automatically unless a durable runnable successor or caller continuation was actually established.\n",
       "family": "core_agent",
       "freeform_grammar": null,
       "input_schema": {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3841,6 +3841,8 @@ mod tests {
         let mut blocked = WorkItemRecord::new("default", "blocked", WorkItemState::Open);
         blocked.blocked_by = Some("unstructured blocker".into());
         storage.append_work_item(&blocked).unwrap();
+        agent.current_work_item_id = Some(blocked.id.clone());
+        storage.write_agent(&agent).unwrap();
         assert_eq!(
             storage.agent_posture_projection(&agent).unwrap().posture,
             AgentSchedulingPosture::Blocked
@@ -3875,6 +3877,8 @@ mod tests {
                 triggered_at: None,
             })
             .unwrap();
+        agent.current_work_item_id = Some(external.id.clone());
+        storage.write_agent(&agent).unwrap();
         assert_eq!(
             storage.agent_posture_projection(&agent).unwrap().posture,
             AgentSchedulingPosture::WaitingForExternal
@@ -3884,10 +3888,12 @@ mod tests {
         needs_input.plan_status = WorkItemPlanStatus::NeedsInput;
         needs_input.updated_at = now + chrono::Duration::seconds(2);
         storage.append_work_item(&needs_input).unwrap();
+        agent.current_work_item_id = Some(needs_input.id.clone());
+        storage.write_agent(&agent).unwrap();
         assert_eq!(
             storage.agent_posture_projection(&agent).unwrap().posture,
-            AgentSchedulingPosture::WaitingForExternal,
-            "external wait has precedence over operator wait"
+            AgentSchedulingPosture::WaitingForOperator,
+            "current work item with plan_status needs_input projects waiting_for_operator"
         );
 
         let mut task_wait = WorkItemRecord::new("default", "task", WorkItemState::Open);
@@ -3918,6 +3924,8 @@ mod tests {
                 triggered_at: None,
             })
             .unwrap();
+        agent.current_work_item_id = Some(task_wait.id.clone());
+        storage.write_agent(&agent).unwrap();
         let task_projection = storage.agent_posture_projection(&agent).unwrap();
         assert_eq!(
             task_projection.posture,
@@ -3927,6 +3935,8 @@ mod tests {
 
         let runnable = WorkItemRecord::new("default", "runnable", WorkItemState::Open);
         storage.append_work_item(&runnable).unwrap();
+        agent.current_work_item_id = Some(runnable.id.clone());
+        storage.write_agent(&agent).unwrap();
         assert_eq!(
             storage.agent_posture_projection(&agent).unwrap().posture,
             AgentSchedulingPosture::HasRunnableWork
@@ -4050,6 +4060,8 @@ mod tests {
             WorkItemRecord::new("default", "operator decision", WorkItemState::Open);
         needs_input.plan_status = WorkItemPlanStatus::NeedsInput;
         storage.append_work_item(&needs_input).unwrap();
+        agent.current_work_item_id = Some(needs_input.id.clone());
+        storage.write_agent(&agent).unwrap();
         assert_eq!(
             posture_for(&storage, &agent),
             AgentSchedulingPosture::WaitingForOperator
@@ -4063,6 +4075,8 @@ mod tests {
         external.blocked_by = Some("github".into());
         storage.append_work_item(&external).unwrap();
         append_wait_condition(&storage, &external.id, WaitConditionKind::External);
+        agent.current_work_item_id = Some(external.id.clone());
+        storage.write_agent(&agent).unwrap();
         assert_eq!(
             posture_for(&storage, &agent),
             AgentSchedulingPosture::WaitingForExternal
@@ -4075,6 +4089,8 @@ mod tests {
         let mut blocked = WorkItemRecord::new("default", "blocked", WorkItemState::Open);
         blocked.blocked_by = Some("unstructured blocker".into());
         storage.append_work_item(&blocked).unwrap();
+        agent.current_work_item_id = Some(blocked.id.clone());
+        storage.write_agent(&agent).unwrap();
         assert_eq!(
             posture_for(&storage, &agent),
             AgentSchedulingPosture::Blocked
@@ -4087,6 +4103,8 @@ mod tests {
         let timer_wait = WorkItemRecord::new("default", "timer wait", WorkItemState::Open);
         storage.append_work_item(&timer_wait).unwrap();
         append_wait_condition(&storage, &timer_wait.id, WaitConditionKind::Timer);
+        agent.current_work_item_id = Some(timer_wait.id.clone());
+        storage.write_agent(&agent).unwrap();
         assert_eq!(
             posture_for(&storage, &agent),
             AgentSchedulingPosture::Blocked
@@ -4099,6 +4117,8 @@ mod tests {
         let system_wait = WorkItemRecord::new("default", "system wait", WorkItemState::Open);
         storage.append_work_item(&system_wait).unwrap();
         append_wait_condition(&storage, &system_wait.id, WaitConditionKind::System);
+        agent.current_work_item_id = Some(system_wait.id.clone());
+        storage.write_agent(&agent).unwrap();
         assert_eq!(
             posture_for(&storage, &agent),
             AgentSchedulingPosture::Blocked
@@ -4850,5 +4870,233 @@ mod tests {
             err_msg.contains("cannot write agent state"),
             "error should mention agent id mismatch"
         );
+    }
+
+    fn make_wait_condition(
+        id: &str,
+        agent_id: &str,
+        work_item_id: &str,
+        kind: WaitConditionKind,
+        waiting_for: &str,
+        now: DateTime<Utc>,
+    ) -> WaitConditionRecord {
+        let wake_sources = match kind {
+            WaitConditionKind::Operator => vec![WakeSource::OperatorInput],
+            WaitConditionKind::Task => vec![WakeSource::TaskResult {
+                task_id: "task-1".into(),
+            }],
+            WaitConditionKind::External => vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some("trigger-1".into()),
+            }],
+            WaitConditionKind::Timer => vec![WakeSource::Timer {
+                wake_at: now + chrono::Duration::minutes(5),
+            }],
+            WaitConditionKind::System => vec![WakeSource::SystemTick],
+        };
+        WaitConditionRecord {
+            id: id.into(),
+            agent_id: agent_id.into(),
+            work_item_id: Some(work_item_id.into()),
+            status: WaitConditionStatus::Active,
+            kind,
+            source: None,
+            subject_ref: None,
+            waiting_for: waiting_for.into(),
+            wake_sources,
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
+        }
+    }
+
+    #[test]
+    fn agent_posture_current_work_item_operator_wait_shows_waiting_for_operator() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let now = Utc::now();
+
+        let mut wi = WorkItemRecord::new("default", "current operator wait", WorkItemState::Open);
+        wi.blocked_by = Some("operator input".into());
+        wi.updated_at = now;
+        let mut agent = AgentState::new("default");
+        agent.current_work_item_id = Some(wi.id.clone());
+        storage.append_work_item(&wi).unwrap();
+        storage
+            .append_wait_condition(&make_wait_condition(
+                "wc1",
+                "default",
+                &wi.id,
+                WaitConditionKind::Operator,
+                "operator input",
+                now,
+            ))
+            .unwrap();
+        storage.write_agent(&agent).unwrap();
+
+        let posture = storage.agent_posture_projection(&agent).unwrap();
+        assert_eq!(posture.posture, AgentSchedulingPosture::WaitingForOperator);
+        assert_eq!(posture.work_item_id.as_deref(), Some(wi.id.as_str()));
+    }
+
+    #[test]
+    fn agent_posture_queued_only_operator_wait_is_idle() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let now = Utc::now();
+
+        let mut wi = WorkItemRecord::new("default", "queued operator wait", WorkItemState::Open);
+        wi.blocked_by = Some("operator input".into());
+        wi.updated_at = now;
+        let agent = AgentState::new("default");
+        storage.append_work_item(&wi).unwrap();
+        storage
+            .append_wait_condition(&make_wait_condition(
+                "wc1",
+                "default",
+                &wi.id,
+                WaitConditionKind::Operator,
+                "operator input",
+                now,
+            ))
+            .unwrap();
+        storage.write_agent(&agent).unwrap();
+
+        let posture = storage.agent_posture_projection(&agent).unwrap();
+        assert_eq!(posture.posture, AgentSchedulingPosture::Idle);
+        assert!(posture.work_item_id.is_none());
+    }
+
+    #[test]
+    fn agent_posture_queued_only_task_wait_is_idle() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let now = Utc::now();
+
+        let mut wi = WorkItemRecord::new("default", "queued task wait", WorkItemState::Open);
+        wi.blocked_by = Some("command task".into());
+        wi.updated_at = now;
+        let agent = AgentState::new("default");
+        storage.append_work_item(&wi).unwrap();
+        storage
+            .append_wait_condition(&make_wait_condition(
+                "wc1",
+                "default",
+                &wi.id,
+                WaitConditionKind::Task,
+                "task result",
+                now,
+            ))
+            .unwrap();
+        storage.write_agent(&agent).unwrap();
+
+        let posture = storage.agent_posture_projection(&agent).unwrap();
+        assert_eq!(posture.posture, AgentSchedulingPosture::Idle);
+        assert!(posture.work_item_id.is_none());
+    }
+
+    #[test]
+    fn agent_posture_queued_only_external_wait_is_idle() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let now = Utc::now();
+
+        let mut wi = WorkItemRecord::new("default", "queued external wait", WorkItemState::Open);
+        wi.blocked_by = Some("ci".into());
+        wi.updated_at = now;
+        let agent = AgentState::new("default");
+        storage.append_work_item(&wi).unwrap();
+        storage
+            .append_wait_condition(&make_wait_condition(
+                "wc1",
+                "default",
+                &wi.id,
+                WaitConditionKind::External,
+                "ci",
+                now,
+            ))
+            .unwrap();
+        storage.write_agent(&agent).unwrap();
+
+        let posture = storage.agent_posture_projection(&agent).unwrap();
+        assert_eq!(posture.posture, AgentSchedulingPosture::Idle);
+        assert!(posture.work_item_id.is_none());
+    }
+
+    #[test]
+    fn agent_posture_current_task_wait_shows_waiting_for_task() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let now = Utc::now();
+
+        let mut wi = WorkItemRecord::new("default", "current task wait", WorkItemState::Open);
+        wi.blocked_by = Some("command task".into());
+        wi.updated_at = now;
+        let mut agent = AgentState::new("default");
+        agent.current_work_item_id = Some(wi.id.clone());
+        storage.append_work_item(&wi).unwrap();
+        storage
+            .append_wait_condition(&make_wait_condition(
+                "wc1",
+                "default",
+                &wi.id,
+                WaitConditionKind::Task,
+                "task result",
+                now,
+            ))
+            .unwrap();
+        storage.write_agent(&agent).unwrap();
+
+        let posture = storage.agent_posture_projection(&agent).unwrap();
+        assert_eq!(posture.posture, AgentSchedulingPosture::WaitingForTask);
+        assert_eq!(posture.work_item_id.as_deref(), Some(wi.id.as_str()));
+    }
+
+    #[test]
+    fn agent_posture_empty_work_queue_is_idle() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let agent = AgentState::new("default");
+        storage.write_agent(&agent).unwrap();
+
+        let posture = storage.agent_posture_projection(&agent).unwrap();
+        assert_eq!(posture.posture, AgentSchedulingPosture::Idle);
+        assert!(posture.work_item_id.is_none());
+    }
+
+    #[test]
+    fn agent_posture_current_operator_wait_with_queued_runnable_shows_has_runnable_work() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let now = Utc::now();
+
+        let mut wi_current =
+            WorkItemRecord::new("default", "current operator wait", WorkItemState::Open);
+        wi_current.blocked_by = Some("operator input".into());
+        wi_current.updated_at = now;
+        let wi_queued = WorkItemRecord::new("default", "queued runnable", WorkItemState::Open);
+        let mut agent = AgentState::new("default");
+        agent.current_work_item_id = Some(wi_current.id.clone());
+        storage.append_work_item(&wi_current).unwrap();
+        storage.append_work_item(&wi_queued).unwrap();
+        storage
+            .append_wait_condition(&make_wait_condition(
+                "wc1",
+                "default",
+                &wi_current.id,
+                WaitConditionKind::Operator,
+                "operator input",
+                now,
+            ))
+            .unwrap();
+        storage.write_agent(&agent).unwrap();
+
+        let posture = storage.agent_posture_projection(&agent).unwrap();
+        assert_eq!(posture.posture, AgentSchedulingPosture::HasRunnableWork);
     }
 }

--- a/src/storage/read_models.rs
+++ b/src/storage/read_models.rs
@@ -268,11 +268,9 @@ impl RuntimeReadModels {
             });
         }
 
-        if let Some(item) = work_queue
-            .items
-            .iter()
-            .find(|item| item.scheduling_state == WorkItemSchedulingState::WaitingTask)
-        {
+        if let Some(item) = work_queue.items.iter().find(|item| {
+            item.is_current && item.scheduling_state == WorkItemSchedulingState::WaitingTask
+        }) {
             let task_id = self
                 .active_wait_conditions()?
                 .into_iter()
@@ -291,11 +289,9 @@ impl RuntimeReadModels {
             });
         }
 
-        if let Some(item) = work_queue
-            .items
-            .iter()
-            .find(|item| item.scheduling_state == WorkItemSchedulingState::WaitingExternal)
-        {
+        if let Some(item) = work_queue.items.iter().find(|item| {
+            item.is_current && item.scheduling_state == WorkItemSchedulingState::WaitingExternal
+        }) {
             return Ok(AgentPostureProjection {
                 posture: AgentSchedulingPosture::WaitingForExternal,
                 reason: item.posture_reason(),
@@ -305,7 +301,11 @@ impl RuntimeReadModels {
             });
         }
 
-        if let Some(item) = work_queue.waiting_for_operator.first() {
+        if let Some(item) = work_queue
+            .waiting_for_operator
+            .iter()
+            .find(|item| item.is_current)
+        {
             return Ok(AgentPostureProjection {
                 posture: AgentSchedulingPosture::WaitingForOperator,
                 reason: item.posture_reason(),
@@ -317,8 +317,14 @@ impl RuntimeReadModels {
 
         if let Some(item) = work_queue
             .blocked
-            .first()
-            .or_else(|| work_queue.triggered_blocked.first())
+            .iter()
+            .find(|item| item.is_current)
+            .or_else(|| {
+                work_queue
+                    .triggered_blocked
+                    .iter()
+                    .find(|item| item.is_current)
+            })
         {
             return Ok(AgentPostureProjection {
                 posture: AgentSchedulingPosture::Blocked,

--- a/src/tool/tool_descriptions/complete_work_item.md
+++ b/src/tool/tool_descriptions/complete_work_item.md
@@ -1,1 +1,9 @@
 Mark an open work item completed. Write the operator-facing completion report as assistant text in the same round; the runtime promotes that text after this tool succeeds. If this work item has a yielded direct caller, completion resumes that caller as current and the turn closes for scheduler continuation.
+
+This is a terminal operation: it ends the current WorkItem/goal and closes the turn for scheduler continuation. Do not call it until the entire objective and verification is complete.
+
+After a plan is approved, typically update the same WorkItem's plan_status from needs_input to ready, update the todo_list, and continue implementation in the same turn — do not call CompleteWorkItem just to transition from planning to implementation.
+
+If you must split the objective into a separate WorkItem, create and activate the successor first so it enters durable runnable state, then complete the old WorkItem. Never complete the current WorkItem before a successor or continuation is established, or the remaining work will not be resumed.
+
+After completion, do not claim that unfinished work will continue automatically unless a durable runnable successor or caller continuation was actually established.


### PR DESCRIPTION
## Summary

Fixes #2615.

### Problem

Two issues persisted after #2708:

1. **Queued waiting WorkItems promoted to Agent current posture**: `agent_posture_from_work_queue` searched all `work_queue.items` (including queued items) for `WaitingTask`, `WaitingForExternal`, `WaitingForOperator`, and `Blocked` states. A historical queued waiting item could mask the agent's actual idle state.

2. **CompleteWorkItem contract ambiguity**: The tool description did not clarify that plan approval should transition `plan_status` to `ready` on the same WorkItem rather than calling `CompleteWorkItem`, risking premature termination.

### Changes

**`src/storage/read_models.rs`** — Filter all wait posture lookups in `agent_posture_from_work_queue` to only `is_current == true` items:
- `WaitingForTask`: only current WorkItem's task wait
- `WaitingForExternal`: only current WorkItem's external wait
- `WaitingForOperator`: only current WorkItem's operator wait
- `Blocked`: only current WorkItem's blocked/triggered state

Queued waiting items remain in `WorkQueueReadModel` summaries (e.g. `waiting_for_operator` vec) for independent display, but no longer hijack the agent's current posture. When no current item is waiting and no runnable work exists, posture falls through to `Idle`.

**`src/tool/tool_descriptions/complete_work_item.md`** — Expand the model-facing contract:
- Explicitly state `CompleteWorkItem` is a terminal operation
- After plan approval, update `plan_status` on the same WorkItem instead of completing
- Successor-before-completion rule: create and activate successor before completing old WorkItem
- Do not claim unfinished work will continue without an established durable successor

**`src/storage/mod.rs`** — Regression tests and existing test fixes:
- 7 new tests covering current vs queued-only wait posture across operator, task, external kinds, empty queue, and mixed current-wait + queued-runnable
- Updated 2 existing tests (`agent_posture_projection_derives_precedence_from_runtime_facts` and `agent_posture_projection_acceptance_states_are_directly_derived`) to set `current_work_item_id` before asserting wait posture, matching the corrected semantics

### Scope boundaries

- Does not touch scheduler admission, revision reconciliation, or completion fence (#2708 invariants preserved)
- Does not change provider input, semantic projection, owner identity, or Track B
- Does not modify persistence, trust, origin, priority, or WorkItem binding