### PR TITLE
fix: support legacy turn record imports in release e2e

### DIFF
--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -1615,7 +1615,7 @@ class CaseHarness:
                 "turn_records": sqlite_rows(
                     connection,
                     "SELECT turn_id, turn_index, agent_id, run_id, "
-                    "current_work_item_id, owner_kind, owner_id, "
+                    f"current_work_item_id, {turn_record_owner_columns(connection)}"
                     "trigger_message_id, terminal_kind, "
                     "created_at, completed_at, payload_json "
                     "FROM turn_records ORDER BY turn_index, created_at",
@@ -1815,6 +1815,24 @@ def sqlite_rows(
     parameters: tuple[Any, ...] = (),
 ) -> list[dict[str, Any]]:
     return [dict(row) for row in connection.execute(query, parameters).fetchall()]
+
+
+def turn_record_owner_columns(connection: sqlite3.Connection) -> str:
+    """Return the owner identity columns present in ``turn_records``.
+
+    Turn owner columns only exist from migration 52 onward, and the
+    interrupted-upgrade case snapshots the previous release's live database,
+    whose ``turn_records`` table predates those columns.
+    """
+    columns = {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM pragma_table_info('turn_records')"
+        )
+    }
+    if {"owner_kind", "owner_id"}.issubset(columns):
+        return "owner_kind, owner_id, "
+    return ""
 
 
 def require_processed_queue_entries(

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -4062,37 +4062,75 @@ pub(crate) fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -
         }
         None => (None, None),
     };
-    tx.execute(
-        "INSERT INTO turn_records (
-            turn_id, turn_index, agent_id, run_id, current_work_item_id,
-            owner_kind, owner_id, trigger_message_id, terminal_kind, created_at,
-            completed_at, payload_json
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
-         ON CONFLICT(turn_id) DO UPDATE SET
-            owner_kind = COALESCE(turn_records.owner_kind, excluded.owner_kind),
-            owner_id = COALESCE(turn_records.owner_id, excluded.owner_id),
-            terminal_kind = excluded.terminal_kind,
-            completed_at = excluded.completed_at,
-            payload_json = excluded.payload_json
-         WHERE COALESCE(excluded.completed_at, excluded.created_at) >= COALESCE(turn_records.completed_at, turn_records.created_at)",
-        params![
-            record.turn_id,
-            record.turn_index as i64,
-            record.agent_id,
-            record.run_id,
-            record.current_work_item_id,
-            owner_kind,
-            owner_id,
-            record
-                .trigger
-                .as_ref()
-                .and_then(|trigger| trigger.message_id.as_deref()),
-            terminal_kind,
-            timestamp(record.created_at),
-            completed_at,
-            payload_json,
-        ],
-    )?;
+    let has_owner_columns = tx.query_row(
+        "SELECT EXISTS(
+            SELECT 1
+              FROM pragma_table_info('turn_records')
+             WHERE name = 'owner_kind'
+        )",
+        [],
+        |row| row.get::<_, i64>(0),
+    )? != 0;
+    if has_owner_columns {
+        tx.execute(
+            "INSERT INTO turn_records (
+                turn_id, turn_index, agent_id, run_id, current_work_item_id,
+                owner_kind, owner_id, trigger_message_id, terminal_kind, created_at,
+                completed_at, payload_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+             ON CONFLICT(turn_id) DO UPDATE SET
+                owner_kind = COALESCE(turn_records.owner_kind, excluded.owner_kind),
+                owner_id = COALESCE(turn_records.owner_id, excluded.owner_id),
+                terminal_kind = excluded.terminal_kind,
+                completed_at = excluded.completed_at,
+                payload_json = excluded.payload_json
+             WHERE COALESCE(excluded.completed_at, excluded.created_at) >= COALESCE(turn_records.completed_at, turn_records.created_at)",
+            params![
+                record.turn_id,
+                record.turn_index as i64,
+                record.agent_id,
+                record.run_id,
+                record.current_work_item_id,
+                owner_kind,
+                owner_id,
+                record
+                    .trigger
+                    .as_ref()
+                    .and_then(|trigger| trigger.message_id.as_deref()),
+                terminal_kind,
+                timestamp(record.created_at),
+                completed_at,
+                payload_json,
+            ],
+        )?;
+    } else {
+        tx.execute(
+            "INSERT INTO turn_records (
+                turn_id, turn_index, agent_id, run_id, current_work_item_id,
+                trigger_message_id, terminal_kind, created_at, completed_at, payload_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+             ON CONFLICT(turn_id) DO UPDATE SET
+                terminal_kind = excluded.terminal_kind,
+                completed_at = excluded.completed_at,
+                payload_json = excluded.payload_json
+             WHERE COALESCE(excluded.completed_at, excluded.created_at) >= COALESCE(turn_records.completed_at, turn_records.created_at)",
+            params![
+                record.turn_id,
+                record.turn_index as i64,
+                record.agent_id,
+                record.run_id,
+                record.current_work_item_id,
+                record
+                    .trigger
+                    .as_ref()
+                    .and_then(|trigger| trigger.message_id.as_deref()),
+                terminal_kind,
+                timestamp(record.created_at),
+                completed_at,
+                payload_json,
+            ],
+        )?;
+    }
     Ok(())
 }
 

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import copy
 import os
+import sqlite3
 import subprocess
 import tempfile
 import threading
@@ -2385,6 +2386,34 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 "last_turn_id": "turn-conversation",
             },
         )
+
+    def test_turn_record_owner_columns_adapt_to_previous_release_schema(self) -> None:
+        source = inspect.getsource(runner.CaseHarness.runtime_db_snapshot)
+        self.assertIn("turn_record_owner_columns(connection)", source)
+        with tempfile.TemporaryDirectory() as directory:
+            database = str(Path(directory) / "runtime.sqlite")
+            connection = sqlite3.connect(database)
+            try:
+                connection.execute(
+                    "CREATE TABLE turn_records (turn_id TEXT PRIMARY KEY)"
+                )
+                connection.commit()
+                self.assertEqual(runner.turn_record_owner_columns(connection), "")
+                connection.execute(
+                    "ALTER TABLE turn_records ADD COLUMN owner_kind TEXT"
+                )
+                connection.commit()
+                self.assertEqual(runner.turn_record_owner_columns(connection), "")
+                connection.execute(
+                    "ALTER TABLE turn_records ADD COLUMN owner_id TEXT"
+                )
+                connection.commit()
+                self.assertEqual(
+                    runner.turn_record_owner_columns(connection),
+                    "owner_kind, owner_id, ",
+                )
+            finally:
+                connection.close()
 
     def test_external_wait_resume_drains_queue_before_runtime_snapshot(self) -> None:
         source = inspect.getsource(runner.run_scheduler_external_wait_resume_case)


### PR DESCRIPTION
## Summary

- make turn-record import compatible with legacy `turn_records` schemas without `owner_kind`/`owner_id`
- preserve the current owner-aware upsert path for migrated schemas
- avoid the Release E2E `no such column: owner_kind` failure during interrupted runtime upgrade recovery

## Verification

- `cargo fmt --all -- --check`
- `cargo test -q migration_47_upgrades_v0_31_1_schema_and_preserves_scheduler_audit_evidence --lib`
- `cargo test -q turn_record_legacy_import_preserves_existing_identity --lib`

This fixes the Release E2E regression observed against release commit `021e10aa` for the upcoming `v0.34.0` release.
