### PR TITLE
fix(scheduler): re-enter model for terminal task results

### DIFF
--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -1615,7 +1615,7 @@ class CaseHarness:
                 "turn_records": sqlite_rows(
                     connection,
                     "SELECT turn_id, turn_index, agent_id, run_id, "
-                    "current_work_item_id, owner_kind, owner_id, "
+                    f"current_work_item_id, {turn_record_owner_columns(connection)}"
                     "trigger_message_id, terminal_kind, "
                     "created_at, completed_at, payload_json "
                     "FROM turn_records ORDER BY turn_index, created_at",
@@ -1815,6 +1815,24 @@ def sqlite_rows(
     parameters: tuple[Any, ...] = (),
 ) -> list[dict[str, Any]]:
     return [dict(row) for row in connection.execute(query, parameters).fetchall()]
+
+
+def turn_record_owner_columns(connection: sqlite3.Connection) -> str:
+    """Return the owner identity columns present in ``turn_records``.
+
+    Turn owner columns only exist from migration 52 onward, and the
+    interrupted-upgrade case snapshots the previous release's live database,
+    whose ``turn_records`` table predates those columns.
+    """
+    columns = {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM pragma_table_info('turn_records')"
+        )
+    }
+    if {"owner_kind", "owner_id"}.issubset(columns):
+        return "owner_kind, owner_id, "
+    return ""
 
 
 def require_processed_queue_entries(

--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -1,14 +1,14 @@
 use crate::types::{
     admission_trigger_kind_for_message_kind, ClosureDecision, ClosureOutcome, ContinuationClass,
     ContinuationResolution, ContinuationTriggerKind, MessageBody, MessageEnvelope, MessageKind,
-    TaskRecord, TaskStatus, WaitingReason,
+    TaskRecord, TaskResultOutcome, TaskStatus, WaitingReason,
 };
 
 #[derive(Debug, Clone)]
 pub(super) struct ContinuationTrigger {
     pub(super) kind: ContinuationTriggerKind,
     pub(super) contentful: bool,
-    pub(super) task_terminal: bool,
+    pub(super) task_result_outcome: Option<TaskResultOutcome>,
     pub(super) wake_hint_source: Option<String>,
     pub(super) task_work_item_id: Option<String>,
 }
@@ -22,7 +22,7 @@ impl ContinuationTrigger {
             MessageKind::OperatorPrompt => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
                 contentful: body_is_contentful(&message.body),
-                task_terminal: false,
+                task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
             }),
@@ -30,7 +30,7 @@ impl ContinuationTrigger {
                 Some(Self {
                     kind: admission_trigger_kind_for_message_kind(&message.kind),
                     contentful: body_is_contentful(&message.body),
-                    task_terminal: false,
+                    task_result_outcome: None,
                     wake_hint_source: None,
                     task_work_item_id: None,
                 })
@@ -38,21 +38,21 @@ impl ContinuationTrigger {
             MessageKind::TimerTick => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
                 contentful: body_is_contentful(&message.body),
-                task_terminal: false,
+                task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
             }),
             MessageKind::InternalFollowup => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
                 contentful: body_is_contentful(&message.body),
-                task_terminal: false,
+                task_result_outcome: None,
                 task_work_item_id: None,
                 wake_hint_source: None,
             }),
             MessageKind::SystemTick => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
                 contentful: system_tick_is_contentful(message),
-                task_terminal: false,
+                task_result_outcome: None,
                 wake_hint_source: message
                     .metadata
                     .as_ref()
@@ -65,17 +65,13 @@ impl ContinuationTrigger {
             MessageKind::TaskResult => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
                 contentful: body_is_contentful(&message.body),
-                task_terminal: task
-                    .map(|task| {
-                        matches!(
-                            task.status,
-                            TaskStatus::Completed
-                                | TaskStatus::Failed
-                                | TaskStatus::Cancelled
-                                | TaskStatus::Interrupted
-                        )
-                    })
-                    .unwrap_or(false),
+                task_result_outcome: task.and_then(|task| match task.status {
+                    TaskStatus::Completed => Some(TaskResultOutcome::Succeeded),
+                    TaskStatus::Failed => Some(TaskResultOutcome::Failed),
+                    TaskStatus::Cancelled => Some(TaskResultOutcome::Cancelled),
+                    TaskStatus::Interrupted => Some(TaskResultOutcome::Interrupted),
+                    TaskStatus::Queued | TaskStatus::Running | TaskStatus::Cancelling => None,
+                }),
                 wake_hint_source: None,
                 task_work_item_id: task
                     .and_then(|t| t.effective_work_item_id().map(ToString::to_string)),
@@ -105,8 +101,9 @@ pub(super) fn resolve_continuation(
     } else {
         evidence.push("not_contentful".to_string());
     }
-    if trigger.task_terminal {
+    if let Some(outcome) = trigger.task_result_outcome {
         evidence.push("task_terminal".to_string());
+        evidence.push(format!("task_result_outcome={}", enum_label(outcome)));
     }
     if let Some(source) = trigger.wake_hint_source.as_ref() {
         evidence.push(format!("wake_hint_source={source}"));
@@ -126,7 +123,7 @@ pub(super) fn resolve_continuation(
     }
 
     let terminal_task_result = trigger.kind == ContinuationTriggerKind::TaskResult
-        && trigger.task_terminal
+        && trigger.task_result_outcome.is_some()
         && same_work_item;
     let model_reentry = terminal_task_result
         || matches!(
@@ -138,7 +135,9 @@ pub(super) fn resolve_continuation(
         || ((trigger.kind == ContinuationTriggerKind::ExternalEvent
             || trigger.kind == ContinuationTriggerKind::SystemTick)
             && trigger.contentful);
-    let class = if model_reentry {
+    let class = if terminal_task_result {
+        ContinuationClass::TaskResultReentry
+    } else if model_reentry {
         ContinuationClass::LocalContinuation
     } else {
         ContinuationClass::LivenessOnly
@@ -191,7 +190,9 @@ fn resolve_waiting(
     let override_allowed = trigger.kind == ContinuationTriggerKind::OperatorInput;
     if expected {
         let model_reentry = match trigger.kind {
-            ContinuationTriggerKind::TaskResult => trigger.task_terminal && same_work_item,
+            ContinuationTriggerKind::TaskResult => {
+                trigger.task_result_outcome.is_some() && same_work_item
+            }
             ContinuationTriggerKind::ExternalEvent => trigger.contentful,
             ContinuationTriggerKind::SystemTick => trigger.contentful,
             _ => true,
@@ -244,7 +245,7 @@ fn resolve_waiting(
     }
 
     if trigger.kind == ContinuationTriggerKind::TaskResult
-        && trigger.task_terminal
+        && trigger.task_result_outcome.is_some()
         && same_work_item
     {
         // Terminal task state is persisted before TaskResult enqueue, so
@@ -339,7 +340,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::TaskResult,
                 contentful: true,
-                task_terminal: true,
+                task_result_outcome: Some(TaskResultOutcome::Succeeded),
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
@@ -356,7 +357,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::TaskResult,
                 contentful: true,
-                task_terminal: false,
+                task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
@@ -379,7 +380,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::TaskResult,
                 contentful: true,
-                task_terminal: true,
+                task_result_outcome: Some(TaskResultOutcome::Succeeded),
                 wake_hint_source: None,
                 task_work_item_id: Some("other-work".into()),
             },
@@ -398,7 +399,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::SystemTick,
                 contentful: false,
-                task_terminal: false,
+                task_result_outcome: None,
                 wake_hint_source: Some("callback".into()),
                 task_work_item_id: None,
             },
@@ -415,7 +416,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::SystemTick,
                 contentful: true,
-                task_terminal: false,
+                task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
@@ -434,7 +435,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::OperatorInput,
                 contentful: true,
-                task_terminal: false,
+                task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
@@ -457,7 +458,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::ExternalEvent,
                 contentful: false,
-                task_terminal: false,
+                task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
@@ -480,7 +481,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::TaskResult,
                 contentful: true,
-                task_terminal: true,
+                task_result_outcome: Some(TaskResultOutcome::Succeeded),
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
@@ -503,7 +504,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::TaskResult,
                 contentful: true,
-                task_terminal: true,
+                task_result_outcome: Some(TaskResultOutcome::Succeeded),
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
@@ -520,7 +521,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::TaskResult,
                 contentful: true,
-                task_terminal: true,
+                task_result_outcome: Some(TaskResultOutcome::Succeeded),
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
@@ -537,7 +538,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::ExternalEvent,
                 contentful: false,
-                task_terminal: false,
+                task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
@@ -555,7 +556,7 @@ mod tests {
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::TimerFire,
                 contentful: true,
-                task_terminal: false,
+                task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
             },

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -77,7 +77,8 @@ impl RuntimeHandle {
                 "message_id": message.id,
                 "trigger_kind": trigger.kind,
                 "contentful": trigger.contentful,
-                "task_terminal": trigger.task_terminal,
+                "task_terminal": trigger.task_result_outcome.is_some(),
+                "task_result_outcome": trigger.task_result_outcome,
                 "wake_hint_source": trigger.wake_hint_source,
                 "prior_closure_outcome": prior_closure.outcome,
                 "prior_waiting_reason": prior_closure.waiting_reason

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -60,7 +60,16 @@ impl RuntimeHandle {
                     } else {
                         false
                     };
-                    if task.terminal_reentry() || wait_authority {
+                    let terminal_with_explicit_work_item = matches!(
+                        task.status,
+                        TaskStatus::Completed
+                            | TaskStatus::Failed
+                            | TaskStatus::Cancelled
+                            | TaskStatus::Interrupted
+                    ) && task.effective_work_item_id()
+                        == Some(message.work_item_id.as_deref().unwrap_or_default());
+                    if terminal_with_explicit_work_item || task.terminal_reentry() || wait_authority
+                    {
                         Ok(task)
                     } else {
                         Err(error)

--- a/src/runtime/tests/message_dispatch.rs
+++ b/src/runtime/tests/message_dispatch.rs
@@ -175,7 +175,7 @@ async fn terminal_task_result_uses_explicit_message_binding_after_wait_resolutio
         .continuation_resolution
         .expect("terminal task result should resolve as a continuation");
 
-    assert_eq!(resolution.class, ContinuationClass::LocalContinuation);
+    assert_eq!(resolution.class, ContinuationClass::TaskResultReentry);
     assert!(resolution.model_reentry);
 }
 

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -4062,37 +4062,75 @@ pub(crate) fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -
         }
         None => (None, None),
     };
-    tx.execute(
-        "INSERT INTO turn_records (
-            turn_id, turn_index, agent_id, run_id, current_work_item_id,
-            owner_kind, owner_id, trigger_message_id, terminal_kind, created_at,
-            completed_at, payload_json
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
-         ON CONFLICT(turn_id) DO UPDATE SET
-            owner_kind = COALESCE(turn_records.owner_kind, excluded.owner_kind),
-            owner_id = COALESCE(turn_records.owner_id, excluded.owner_id),
-            terminal_kind = excluded.terminal_kind,
-            completed_at = excluded.completed_at,
-            payload_json = excluded.payload_json
-         WHERE COALESCE(excluded.completed_at, excluded.created_at) >= COALESCE(turn_records.completed_at, turn_records.created_at)",
-        params![
-            record.turn_id,
-            record.turn_index as i64,
-            record.agent_id,
-            record.run_id,
-            record.current_work_item_id,
-            owner_kind,
-            owner_id,
-            record
-                .trigger
-                .as_ref()
-                .and_then(|trigger| trigger.message_id.as_deref()),
-            terminal_kind,
-            timestamp(record.created_at),
-            completed_at,
-            payload_json,
-        ],
-    )?;
+    let has_owner_columns = tx.query_row(
+        "SELECT EXISTS(
+            SELECT 1
+              FROM pragma_table_info('turn_records')
+             WHERE name = 'owner_kind'
+        )",
+        [],
+        |row| row.get::<_, i64>(0),
+    )? != 0;
+    if has_owner_columns {
+        tx.execute(
+            "INSERT INTO turn_records (
+                turn_id, turn_index, agent_id, run_id, current_work_item_id,
+                owner_kind, owner_id, trigger_message_id, terminal_kind, created_at,
+                completed_at, payload_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+             ON CONFLICT(turn_id) DO UPDATE SET
+                owner_kind = COALESCE(turn_records.owner_kind, excluded.owner_kind),
+                owner_id = COALESCE(turn_records.owner_id, excluded.owner_id),
+                terminal_kind = excluded.terminal_kind,
+                completed_at = excluded.completed_at,
+                payload_json = excluded.payload_json
+             WHERE COALESCE(excluded.completed_at, excluded.created_at) >= COALESCE(turn_records.completed_at, turn_records.created_at)",
+            params![
+                record.turn_id,
+                record.turn_index as i64,
+                record.agent_id,
+                record.run_id,
+                record.current_work_item_id,
+                owner_kind,
+                owner_id,
+                record
+                    .trigger
+                    .as_ref()
+                    .and_then(|trigger| trigger.message_id.as_deref()),
+                terminal_kind,
+                timestamp(record.created_at),
+                completed_at,
+                payload_json,
+            ],
+        )?;
+    } else {
+        tx.execute(
+            "INSERT INTO turn_records (
+                turn_id, turn_index, agent_id, run_id, current_work_item_id,
+                trigger_message_id, terminal_kind, created_at, completed_at, payload_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+             ON CONFLICT(turn_id) DO UPDATE SET
+                terminal_kind = excluded.terminal_kind,
+                completed_at = excluded.completed_at,
+                payload_json = excluded.payload_json
+             WHERE COALESCE(excluded.completed_at, excluded.created_at) >= COALESCE(turn_records.completed_at, turn_records.created_at)",
+            params![
+                record.turn_id,
+                record.turn_index as i64,
+                record.agent_id,
+                record.run_id,
+                record.current_work_item_id,
+                record
+                    .trigger
+                    .as_ref()
+                    .and_then(|trigger| trigger.message_id.as_deref()),
+                terminal_kind,
+                timestamp(record.created_at),
+                completed_at,
+                payload_json,
+            ],
+        )?;
+    }
     Ok(())
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1007,10 +1007,20 @@ pub enum ContinuationTriggerKind {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+pub enum TaskResultOutcome {
+    Succeeded,
+    Failed,
+    Cancelled,
+    Interrupted,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum ContinuationClass {
     ResumeExpectedWait,
     ResumeOverride,
     LocalContinuation,
+    TaskResultReentry,
     LivenessOnly,
 }
 

--- a/tests/test_docker_e2e_runner.py
+++ b/tests/test_docker_e2e_runner.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import copy
 import os
+import sqlite3
 import subprocess
 import tempfile
 import threading
@@ -2385,6 +2386,34 @@ class DockerE2ERunnerTests(unittest.TestCase):
                 "last_turn_id": "turn-conversation",
             },
         )
+
+    def test_turn_record_owner_columns_adapt_to_previous_release_schema(self) -> None:
+        source = inspect.getsource(runner.CaseHarness.runtime_db_snapshot)
+        self.assertIn("turn_record_owner_columns(connection)", source)
+        with tempfile.TemporaryDirectory() as directory:
+            database = str(Path(directory) / "runtime.sqlite")
+            connection = sqlite3.connect(database)
+            try:
+                connection.execute(
+                    "CREATE TABLE turn_records (turn_id TEXT PRIMARY KEY)"
+                )
+                connection.commit()
+                self.assertEqual(runner.turn_record_owner_columns(connection), "")
+                connection.execute(
+                    "ALTER TABLE turn_records ADD COLUMN owner_kind TEXT"
+                )
+                connection.commit()
+                self.assertEqual(runner.turn_record_owner_columns(connection), "")
+                connection.execute(
+                    "ALTER TABLE turn_records ADD COLUMN owner_id TEXT"
+                )
+                connection.commit()
+                self.assertEqual(
+                    runner.turn_record_owner_columns(connection),
+                    "owner_kind, owner_id, ",
+                )
+            finally:
+                connection.close()
 
     def test_external_wait_resume_drains_queue_before_runtime_snapshot(self) -> None:
         source = inspect.getsource(runner.run_scheduler_external_wait_resume_case)


### PR DESCRIPTION
## Summary

Closes #2713.

Terminal `task_result` messages with an explicit, matching agent/WorkItem binding now receive one controlled model re-entry even when no matching `WaitFor(wake=task_result)` exists. `WaitFor` remains useful for expressing waiting intent, but is no longer the sole admission gate for terminal task results.

## Changes

- Distinguish terminal task outcomes (`succeeded`, `failed`, `cancelled`, `interrupted`) in continuation triggers and audit context.
- Classify eligible terminal task results as `task_result_reentry` and preserve existing liveness/local continuation behavior for other events.
- Accept terminal task results using explicit message WorkItem binding, including interrupted results, while retaining existing terminal re-entry and wait-authority checks.
- Update the message-dispatch regression assertion.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test --all-targets`
- `git diff --check`

All passed.
