### PR TITLE
chore: prepare 0.34.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,6 +338,7 @@ jobs:
 
           - Add the native macOS menu bar application with daemon lifecycle compatibility, Sparkle update support, signed DMG packaging, and appcast generation ([#2701](https://github.com/holon-run/holon/pull/2701), [#2705](https://github.com/holon-run/holon/pull/2705), [#2707](https://github.com/holon-run/holon/pull/2707)).
           - Introduce explicit activation and Turn owner identity, add a versioned model registry snapshot, and make WorkItem-bound operator waits resume reliably ([#2703](https://github.com/holon-run/holon/pull/2703), [#2704](https://github.com/holon-run/holon/pull/2708), [#2709](https://github.com/holon-run/holon/pull/2709)).
+          - Harden release automation with strict tag/version verification, resilient Release E2E turn-record imports, and macOS notarization diagnostics ([#2711](https://github.com/holon-run/holon/pull/2711), [#2712](https://github.com/holon-run/holon/pull/2712)).
 
           ## Install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,7 +337,8 @@ jobs:
           ## Changes
 
           - Add the native macOS menu bar application with daemon lifecycle compatibility, Sparkle update support, signed DMG packaging, and appcast generation ([#2701](https://github.com/holon-run/holon/pull/2701), [#2705](https://github.com/holon-run/holon/pull/2705), [#2707](https://github.com/holon-run/holon/pull/2707)).
-          - Introduce explicit activation and Turn owner identity, add a versioned model registry snapshot, and make WorkItem-bound operator waits resume reliably ([#2703](https://github.com/holon-run/holon/pull/2703), [#2704](https://github.com/holon-run/holon/pull/2708), [#2709](https://github.com/holon-run/holon/pull/2709)).
+          - Introduce explicit activation and Turn owner identity, add a versioned model registry snapshot, and make WorkItem-bound operator waits resume reliably ([#2703](https://github.com/holon-run/holon/pull/2703), [#2704](https://github.com/holon-run/holon/pull/2704), [#2708](https://github.com/holon-run/holon/pull/2708), [#2709](https://github.com/holon-run/holon/pull/2709)).
+          - Re-enter the model for terminal task results so terminal command-task and delegated-agent results reliably resume their owning conversation ([#2714](https://github.com/holon-run/holon/pull/2714)).
           - Harden release automation with strict tag/version verification, resilient Release E2E turn-record imports, and macOS notarization diagnostics ([#2711](https://github.com/holon-run/holon/pull/2711), [#2712](https://github.com/holon-run/holon/pull/2712)).
 
           ## Install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.34.0"
+version = "0.34.1"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Status and compatibility
 
 Holon is under active development. The current recommended release is
-[`v0.34.0`](https://github.com/holon-run/holon/releases/tag/v0.34.0).
+[`v0.34.1`](https://github.com/holon-run/holon/releases/tag/v0.34.1).
 
 The current project focus remains the Rust runtime: agent lifecycle, queues,
 WaitFor/wake, tasks, WorkItems, trust boundaries, local workspaces, and

--- a/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
+++ b/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
@@ -36,7 +36,7 @@ final class HolonMenuClientTests: XCTestCase {
           "socket_path": "/tmp/holon.sock",
           "http_addr": "127.0.0.1:7878",
           "web_url": "http://127.0.0.1:7878",
-          "product_version": "0.34.0 (abcdef0)",
+          "product_version": "0.34.1 (abcdef0)",
           "control_protocol_version": 1,
           "lifecycle_owner": "standalone",
           "executable_path": "/Applications/Holon.app/Contents/Resources/bin/holon",

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -105,7 +105,7 @@ waitable, delegable, and deliverable.
 ## Status and compatibility
 
 The current recommended release is
-[`v0.34.0`](https://github.com/holon-run/holon/releases/tag/v0.34.0).
+[`v0.34.1`](https://github.com/holon-run/holon/releases/tag/v0.34.1).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project maintains

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -9184,7 +9184,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.34.0"
+    "version": "0.34.1"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## Summary

Bump the workspace version from `0.34.0` to `0.34.1` so the release binary's self-reported version matches the `v0.34.1` tag.

## Why

The formal Release workflow run [#33289530421](https://github.com/holon-run/holon/actions/runs/33289530421) failed at `Package macOS app and DMG` with `unexpected version output: holon 0.34.0 (0fdf213)`: tag `v0.34.1` points at `0fdf213c`, but `Cargo.toml` on that commit still declares `0.34.0`, so `scripts/verify-release-version.sh` correctly rejected the mismatch. This PR carries the version bump as a normal main-branch change so the tag can be re-pointed at the merged commit.

## Changes

- `Cargo.toml` / `Cargo.lock`: `0.34.0` -> `0.34.1`
- `docs/website/reference/openapi.json`: info version bump
- `README.md` / `docs/website/README.md`: recommended release link -> `v0.34.1`
- `apps/macos` test fixture: expected `product_version` bump
- `.github/workflows/release.yml`: append 0.34.1 changelog entry covering #2711 and #2712

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --test openapi_snapshot`