### PR TITLE
fix: re-sign Sparkle helper executables before notarization

### DIFF
--- a/.github/workflows/macos-notary-debug.yml
+++ b/.github/workflows/macos-notary-debug.yml
@@ -1,0 +1,131 @@
+name: macOS notary debug
+
+on:
+  push:
+    branches:
+      - debug/macos-notary
+
+jobs:
+  debug:
+    runs-on: macos-latest
+    timeout-minutes: 60
+    env:
+      MACOS_DEVELOPER_ID_APPLICATION: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}
+      MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      MACOS_NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+      MACOS_NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
+      MACOS_NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+      HOLON_SPARKLE_FEED_URL: ${{ vars.HOLON_SPARKLE_FEED_URL }}
+      HOLON_SPARKLE_PUBLIC_KEY: ${{ secrets.HOLON_SPARKLE_PUBLIC_KEY }}
+      HOLON_SPARKLE_PRIVATE_KEY: ${{ secrets.HOLON_SPARKLE_PRIVATE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Build web GUI
+        run: make web
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Select matching macOS target
+        run: rustup target add aarch64-apple-darwin
+
+      - name: Import Developer ID certificate
+        run: |
+          set -euo pipefail
+          keychain="$RUNNER_TEMP/holon-signing.keychain-db"
+          keychain_password="$(openssl rand -hex 24)"
+          certificate="$RUNNER_TEMP/holon-developer-id.p12"
+          printf '%s' "$MACOS_CERTIFICATE_P12" | base64 --decode > "$certificate"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$certificate" \
+            -P "$MACOS_CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$keychain"
+          security list-keychain -d user -s "$keychain" login.keychain-db
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$keychain_password" \
+            "$keychain"
+
+      - name: Build bundled Holon runtime
+        run: cargo build --release --locked --target aarch64-apple-darwin
+
+      - name: Package macOS app (expected to fail at stapler)
+        run: |
+          set +e
+          scripts/package-macos-menu-app.sh \
+            target/aarch64-apple-darwin/release/holon \
+            dist \
+            "0.34.1"
+          package_status=$?
+          set -e
+          echo "package script exit status: $package_status"
+
+      - name: Dump notarytool history and full submission logs
+        if: always()
+        run: |
+          set -euo pipefail
+          notary_args=(
+            --apple-id "$MACOS_NOTARY_APPLE_ID"
+            --password "$MACOS_NOTARY_PASSWORD"
+            --team-id "$MACOS_NOTARY_TEAM_ID"
+          )
+          xcrun notarytool history "${notary_args[@]}" --output-format json > history.json || true
+          echo "===== notarytool history ====="
+          cat history.json
+          echo
+          ids="$(python3 - <<'PY'
+          import json
+          try:
+              data = json.load(open("history.json"))
+          except Exception as exc:
+              print(f"failed to parse history.json: {exc}", flush=True)
+              raise SystemExit(0)
+          if isinstance(data, dict):
+              submissions = data.get("submissions") or data.get("recentSubmissions") or []
+          else:
+              submissions = data
+          known = {"482a796a-6791-45ee-8e7c-e96e91d160fa"}
+          ids = []
+          for submission in submissions[:5]:
+              submission_id = submission.get("id")
+              if submission_id:
+                  ids.append(submission_id)
+          for submission_id in sorted(known - set(ids)):
+              ids.append(submission_id)
+          print("\n".join(ids))
+          PY
+          )"
+          for submission_id in $ids; do
+            echo "===== notarytool log $submission_id ====="
+            xcrun notarytool log "$submission_id" "${notary_args[@]}" || true
+            echo
+          done
+
+      - name: Dump signature diagnostics
+        if: always()
+        run: |
+          set +e
+          echo "===== codesign -dvvv Holon.app ====="
+          codesign -dvvv dist/Holon.app
+          echo "===== Holon.app entitlements ====="
+          codesign -d --entitlements :- dist/Holon.app
+          echo "===== codesign verify ====="
+          codesign --verify --deep --strict --verbose=4 dist/Holon.app
+          echo "===== spctl assess app ====="
+          spctl -a -vvv -t open --context context:primary-signature dist/Holon.app
+          echo "===== spctl assess holon binary ====="
+          spctl -a -vvv -t execute dist/Holon.app/Contents/Resources/bin/holon
+          exit 0

--- a/scripts/package-macos-menu-app.sh
+++ b/scripts/package-macos-menu-app.sh
@@ -59,6 +59,18 @@ if [[ -n "$sparkle_framework" ]]; then
 fi
 
 if [[ -n "${MACOS_DEVELOPER_ID_APPLICATION:-}" ]]; then
+  # Sign standalone helper executables embedded in frameworks (e.g. Sparkle's
+  # Autoupdate). Framework-level signing does not replace their signature,
+  # and notarization rejects the leftover ad-hoc signature swift build leaves
+  # there, so they must be signed before the framework seals them in.
+  while IFS= read -r framework; do
+    framework_name="$(basename "$framework" .framework)"
+    while IFS= read -r helper; do
+      codesign --force --timestamp --options runtime \
+        --sign "$MACOS_DEVELOPER_ID_APPLICATION" "$helper"
+    done < <(find "$framework/Versions" -mindepth 2 -maxdepth 2 -type f \
+      -perm -111 ! -name "$framework_name" 2>/dev/null)
+  done < <(find "$contents_dir/Frameworks" -depth -name '*.framework' 2>/dev/null)
   while IFS= read -r nested; do
     codesign --force --timestamp --options runtime \
       --sign "$MACOS_DEVELOPER_ID_APPLICATION" "$nested"
@@ -77,44 +89,39 @@ submit_notarization() {
   local artifact="$1"
   local submission_output
   local submission_id
+  local submission_status
+  local -a notary_args
 
   if [[ -n "${MACOS_NOTARY_PROFILE:-}" ]]; then
-    if ! submission_output="$(xcrun notarytool submit "$artifact" \
-      --keychain-profile "$MACOS_NOTARY_PROFILE" \
-      --output-format json \
-      --wait 2>&1)"; then
-      printf '%s\n' "$submission_output" >&2
-      submission_id="$(printf '%s\n' "$submission_output" | sed -nE 's/.*"id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | tail -1)"
-      if [[ -n "$submission_id" ]]; then
-        echo "notarytool submission log for $submission_id:" >&2
-        xcrun notarytool log "$submission_id" \
-          --keychain-profile "$MACOS_NOTARY_PROFILE" \
-          --output-format json >&2 || true
-      fi
-      return 1
-    fi
+    notary_args=(--keychain-profile "$MACOS_NOTARY_PROFILE")
   else
     : "${MACOS_NOTARY_APPLE_ID:?MACOS_NOTARY_APPLE_ID is required}"
     : "${MACOS_NOTARY_PASSWORD:?MACOS_NOTARY_PASSWORD is required}"
     : "${MACOS_NOTARY_TEAM_ID:?MACOS_NOTARY_TEAM_ID is required}"
-    if ! submission_output="$(xcrun notarytool submit "$artifact" \
-      --apple-id "$MACOS_NOTARY_APPLE_ID" \
+    notary_args=(--apple-id "$MACOS_NOTARY_APPLE_ID" \
       --password "$MACOS_NOTARY_PASSWORD" \
-      --team-id "$MACOS_NOTARY_TEAM_ID" \
-      --output-format json \
-      --wait 2>&1)"; then
-      printf '%s\n' "$submission_output" >&2
-      submission_id="$(printf '%s\n' "$submission_output" | sed -nE 's/.*"id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | tail -1)"
-      if [[ -n "$submission_id" ]]; then
-        echo "notarytool submission log for $submission_id:" >&2
-        xcrun notarytool log "$submission_id" \
-          --apple-id "$MACOS_NOTARY_APPLE_ID" \
-          --password "$MACOS_NOTARY_PASSWORD" \
-          --team-id "$MACOS_NOTARY_TEAM_ID" \
-          --output-format json >&2 || true
-      fi
-      return 1
+      --team-id "$MACOS_NOTARY_TEAM_ID")
+  fi
+
+  if ! submission_output="$(xcrun notarytool submit "$artifact" \
+    "${notary_args[@]}" \
+    --output-format json \
+    --wait 2>&1)"; then
+    printf '%s\n' "$submission_output" >&2
+  fi
+  # notarytool exits 0 after --wait even when the submission ends Invalid,
+  # so gate on the reported status instead of the exit code alone.
+  submission_id="$(printf '%s\n' "$submission_output" | sed -nE 's/.*"id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | tail -1)"
+  submission_status="$(printf '%s\n' "$submission_output" | sed -nE 's/.*"status"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | tail -1)"
+  if [[ "$submission_status" != "Accepted" ]]; then
+    printf '%s\n' "$submission_output" >&2
+    if [[ -n "$submission_id" ]]; then
+      echo "notarytool submission log for $submission_id:" >&2
+      xcrun notarytool log "$submission_id" \
+        "${notary_args[@]}" \
+        --output-format json >&2 || true
     fi
+    return 1
   fi
   printf '%s\n' "$submission_output"
 }


### PR DESCRIPTION
## What changed

`scripts/package-macos-menu-app.sh`:

1. **Sign standalone framework helper executables** (Sparkle's `Autoupdate`) with the Developer ID identity before the framework is sealed. `swift build` re-signs Sparkle artifacts ad-hoc; the old nested signing loop only covered `*.framework` / `*.xpc` / `*.app`, so `Autoupdate` kept its ad-hoc signature.
2. **Gate `submit_notarization` on the reported submission status.** `notarytool submit --wait` exits 0 even when the submission ends `Invalid`, so failures previously surfaced later as an unrelated `stapler` exit 65 (CloudKit `Record not found`) without the diagnostic notary log. Now any non-`Accepted` status prints the notarytool submission log and fails the step.

## Why

Every macOS notarization so far failed with 4 errors, all on `Holon.app/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate`:

- `The binary is not signed with a valid Developer ID certificate.` (x86_64 + arm64)
- `The signature does not include a secure timestamp.` (x86_64 + arm64)

Confirmed via notarytool log (submission `482a796a-6791-45ee-8e7c-e96e91d160fa`, captured by debug workflow #33295953564): the app bundle, `Sparkle.framework`, `Updater.app` and both XPC services were re-signed correctly by the existing loop; only the standalone `Autoupdate` binary was missed. Local inspection shows why CI never caught it: `swift build` leaves `Signature=adhoc`, and `codesign --verify --deep --strict` accepts ad-hoc signatures.

## Verification

- `bash -n` + `shellcheck` clean.
- Full local packaging with `MACOS_DEVELOPER_ID_APPLICATION=-` (ad-hoc); `bash -x` trace confirms signing order: `Autoupdate` → nested `Updater.app`/XPCs → `Sparkle.framework` (sealed last) → `holon` → app; `codesign --verify --deep --strict` passes.
- Status parsing unit-checked against `Accepted` / `Invalid` / intermediate / non-JSON outputs.
- Real-credential end-to-end notarization is being verified on `debug/macos-notary` with this commit merged in before re-tagging `v0.34.1`.