### PR TITLE
fix: write Sparkle appcast into the archives directory

### DIFF
--- a/scripts/generate-macos-appcast.sh
+++ b/scripts/generate-macos-appcast.sh
@@ -27,7 +27,7 @@ printf '%s' "$HOLON_SPARKLE_PRIVATE_KEY" |
     --download-url-prefix "$download_url_prefix" \
     --maximum-versions 3 \
     --maximum-deltas 2 \
-    -o "$output_name" \
+    -o "$archives_dir/$output_name" \
     "$archives_dir"
 
 test -s "$archives_dir/$output_name"


### PR DESCRIPTION
## Problem

Release run #33308329928 (v0.34.1@0a1f073c) failed in **Generate signed Sparkle appcast** right after printing `Wrote 1 new update, updated 0 existing updates, and removed 0 old updates in appcast.xml`, with no error message and exit code 1.

Root cause: Sparkle's `generate_appcast -o` takes a **cwd-relative** output path (`appcastDestPath = outputPathURL ?? …relativeTo: archivesSourceDir` in `generate_appcast/main.swift`). The release job runs the script with cwd at the repo root and archives dir `dist`, so the appcast was written to `<repo>/appcast.xml` while the script's final `test -s dist/appcast.xml` check failed silently under `set -e`.

Note: `release-e2e.yml` does not exercise the appcast step, which is why the E2E gate stayed green while the official release failed.

## Fix

Pass `-o "$archives_dir/$output_name"` so the appcast lands where the artifact upload (`dist/appcast.xml`) and publish job (`dist-artifacts/appcast.xml`) expect it.

## Validation

Reproduced locally against `Holon-0.34.0.dmg` with cwd separate from the archives dir:

- before: appcast written to cwd, `test -s dist/appcast.xml` fails, exit 1 (matches the CI failure signature)
- after: `dist/appcast.xml` written, exit 0
- with a code-signed app whose `SUPublicEDKey` matches the signing key (as CI packages it), the generated appcast contains a valid `sparkle:edSignature`

Release-blocking for v0.34.1.