### PR TITLE
feat: build universal (x86_64 + arm64) macOS app DMG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,20 +135,20 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Select matching macOS target
-        id: macos-target
-        run: |
-          set -euo pipefail
-          case "$(uname -m)" in
-            arm64) target="aarch64-apple-darwin" ;;
-            x86_64) target="x86_64-apple-darwin" ;;
-            *) echo "Unsupported macOS runner architecture: $(uname -m)" >&2; exit 1 ;;
-          esac
-          rustup target add "$target"
-          echo "target=$target" >> "$GITHUB_OUTPUT"
+      - name: Install both macOS Rust targets
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Build bundled Holon runtime
-        run: cargo build --release --locked --target "${{ steps.macos-target.outputs.target }}"
+        run: cargo build --release --locked --target aarch64-apple-darwin --target x86_64-apple-darwin
+
+      - name: Merge universal Holon runtime
+        run: |
+          set -euo pipefail
+          mkdir -p target/universal-macos/release
+          lipo -create \
+            target/aarch64-apple-darwin/release/holon \
+            target/x86_64-apple-darwin/release/holon \
+            -output target/universal-macos/release/holon
 
       - name: Test macOS menu app
         run: swift test --package-path apps/macos/HolonMenu
@@ -158,7 +158,7 @@ jobs:
           set -euo pipefail
           version="$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)"
           scripts/package-macos-menu-app.sh \
-            "target/${{ steps.macos-target.outputs.target }}/release/holon" \
+            target/universal-macos/release/holon \
             dist \
             "$version"
 

--- a/.github/workflows/macos-notary-debug.yml
+++ b/.github/workflows/macos-notary-debug.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Select matching macOS target
-        run: rustup target add aarch64-apple-darwin
+      - name: Install both macOS Rust targets
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Import Developer ID certificate
         run: |
@@ -60,13 +60,22 @@ jobs:
             "$keychain"
 
       - name: Build bundled Holon runtime
-        run: cargo build --release --locked --target aarch64-apple-darwin
+        run: cargo build --release --locked --target aarch64-apple-darwin --target x86_64-apple-darwin
+
+      - name: Merge universal Holon runtime
+        run: |
+          set -euo pipefail
+          mkdir -p target/universal-macos/release
+          lipo -create \
+            target/aarch64-apple-darwin/release/holon \
+            target/x86_64-apple-darwin/release/holon \
+            -output target/universal-macos/release/holon
 
       - name: Package macOS app (expected to fail at stapler)
         run: |
           set +e
           scripts/package-macos-menu-app.sh \
-            target/aarch64-apple-darwin/release/holon \
+            target/universal-macos/release/holon \
             dist \
             "0.34.1"
           package_status=$?

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,17 +185,8 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Select matching macOS target
-        id: macos-target
-        run: |
-          set -euo pipefail
-          case "$(uname -m)" in
-            arm64) target="aarch64-apple-darwin" ;;
-            x86_64) target="x86_64-apple-darwin" ;;
-            *) echo "Unsupported macOS runner architecture: $(uname -m)" >&2; exit 1 ;;
-          esac
-          rustup target add "$target"
-          echo "target=$target" >> "$GITHUB_OUTPUT"
+      - name: Install both macOS Rust targets
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Validate macOS release credentials
         run: |
@@ -242,7 +233,16 @@ jobs:
             "$keychain"
 
       - name: Build bundled Holon runtime
-        run: cargo build --release --locked --target "${{ steps.macos-target.outputs.target }}"
+        run: cargo build --release --locked --target aarch64-apple-darwin --target x86_64-apple-darwin
+
+      - name: Merge universal Holon runtime
+        run: |
+          set -euo pipefail
+          mkdir -p target/universal-macos/release
+          lipo -create \
+            target/aarch64-apple-darwin/release/holon \
+            target/x86_64-apple-darwin/release/holon \
+            -output target/universal-macos/release/holon
 
       - name: Test macOS menu app
         run: swift test --package-path apps/macos/HolonMenu
@@ -252,7 +252,7 @@ jobs:
           set -euo pipefail
           version="${GITHUB_REF_NAME#v}"
           scripts/package-macos-menu-app.sh \
-            "target/${{ steps.macos-target.outputs.target }}/release/holon" \
+            target/universal-macos/release/holon \
             dist \
             "$version"
 

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,13 @@ web-ci: ## Test and build the web GUI with one clean dependency install
 macos-menu-test: ## Build and test the native macOS menu app
 	swift test --package-path apps/macos/HolonMenu
 
-macos-menu-package: ## Package Holon.app and a DMG from target/release/holon
-	cargo build --release --locked
-	scripts/package-macos-menu-app.sh target/release/holon dist
+macos-menu-package: ## Package a universal (x86_64 + arm64) Holon.app and DMG
+	rustup target add aarch64-apple-darwin x86_64-apple-darwin
+	cargo build --release --locked --target aarch64-apple-darwin --target x86_64-apple-darwin
+	mkdir -p target/universal-macos/release
+	lipo -create target/aarch64-apple-darwin/release/holon target/x86_64-apple-darwin/release/holon \
+		-output target/universal-macos/release/holon
+	scripts/package-macos-menu-app.sh target/universal-macos/release/holon dist
 
 transport-types: ## Refresh OpenAPI and generated TypeScript transport types
 	cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ You can also download prebuilt binaries for Linux amd64, macOS amd64, and macOS
 arm64 from [GitHub Releases](https://github.com/holon-run/holon/releases/latest).
 The Linux amd64 binary supports Ubuntu 22.04 or newer (glibc 2.35 or newer).
 
-macOS 13 or later users can install `Holon-<version>.dmg` from the same release
-page. The native menu bar app controls the same daemon as the CLI, supports
+macOS 13 or later users on Apple Silicon or Intel Macs can install the
+universal `Holon-<version>.dmg` from the same release page. The native menu
+bar app controls the same daemon as the CLI, supports
 launch at login, and can install its bundled CLI into `~/.local/bin` without
 overwriting another installation.
 

--- a/docs/implementation-decisions/116-universal-macos-app-dmg.md
+++ b/docs/implementation-decisions/116-universal-macos-app-dmg.md
@@ -1,0 +1,21 @@
+# macOS app ships as one universal DMG
+
+## Decision
+
+The release workflow builds `Holon-<version>.dmg` as a universal (x86_64 +
+arm64) artifact. The Rust CLI is compiled for both darwin targets and merged
+with `lipo`; the Swift menu app is built with `swift build --arch arm64
+--arch x86_64`. `scripts/verify-macos-menu-app.sh` rejects any bundle whose
+`HolonMenu` or bundled `holon` binary is missing either slice.
+
+## Reason
+
+A single DMG keeps one Sparkle feed URL, one download link, and one checksum
+set, and Intel Mac users get the GUI app without Rosetta. Sparkle already
+ships prebuilt universal binaries, so no third-party slice is missing.
+
+## Preserved boundary
+
+`swift test` still runs the host-native slice because tests must execute.
+Separate per-architecture DMGs would require per-architecture Sparkle feeds
+and stay out of scope until a size-sensitive distribution channel exists.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -112,3 +112,5 @@ Current decision notes:
 - [101 Scheduler Authority Convergence](./101-scheduler-authority-convergence.md)
 - [103 DeepSeek Responses Endpoint Dialect](./103-deepseek-responses-endpoint-dialect.md)
 - [114 Reasoning Effort Scope In Model Chains](./114-reasoning-effort-scope-in-model-chains.md)
+- [115 macOS Menu App Keeps Standalone Daemon](./115-macos-menu-app-keeps-standalone-daemon.md)
+- [116 Universal macOS App DMG](./116-universal-macos-app-dmg.md)

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,12 +7,13 @@ Holon releases are published from version tags.
 The macOS release also builds `Holon.app` for macOS 13 or later. The app is a
 native SwiftUI menu bar control plane and bundles the matching Rust runtime at
 `Contents/Resources/bin/holon`.
+The DMG is a universal (x86_64 + arm64) artifact, so one download supports
+Apple Silicon and Intel Macs.
 
 Local packaging:
 
 ```bash
-cargo build --release
-scripts/package-macos-menu-app.sh target/release/holon dist
+make macos-menu-package
 ```
 
 Pull requests that change the macOS menu app, its packaging scripts, the
@@ -92,6 +93,8 @@ The release workflow builds and uploads:
 - `holon-linux-amd64.tar.gz`
 - `holon-darwin-amd64.tar.gz`
 - `holon-darwin-arm64.tar.gz`
+- `Holon-<version>.dmg` (universal macOS app) with its SHA-256 file and the
+  signed Sparkle `appcast.xml`
 - `checksums.txt`
 
 After the GitHub release is published successfully, the workflow promotes the

--- a/scripts/package-macos-menu-app.sh
+++ b/scripts/package-macos-menu-app.sh
@@ -25,14 +25,20 @@ package_dir="$repo_root/apps/macos/HolonMenu"
 rm -rf "$app_dir"
 mkdir -p "$contents_dir/MacOS" "$contents_dir/Resources/bin"
 
+# One DMG must run on Apple Silicon and Intel Macs, so the menu app and its
+# resource bundles are built as universal (arm64 + x86_64) binaries.
 swift build \
   --package-path "$package_dir" \
   -c release \
-  --product HolonMenu
+  --product HolonMenu \
+  --arch arm64 \
+  --arch x86_64
 
 swift_bin_path="$(swift build \
   --package-path "$package_dir" \
   -c release \
+  --arch arm64 \
+  --arch x86_64 \
   --show-bin-path)"
 cp "$swift_bin_path/HolonMenu" "$contents_dir/MacOS/HolonMenu"
 cp "$holon_binary" "$contents_dir/Resources/bin/holon"

--- a/scripts/verify-macos-menu-app.sh
+++ b/scripts/verify-macos-menu-app.sh
@@ -17,6 +17,20 @@ holon_binary="$app_dir/Contents/Resources/bin/holon"
   exit 1
 }
 
+# The DMG is the only macOS app artifact, so both first-party binaries must
+# carry x86_64 and arm64 slices; Sparkle ships prebuilt universal binaries.
+require_universal() {
+  local binary="$1"
+  local archs
+  archs="$(lipo -archs "$binary")"
+  if [[ "$archs" != *x86_64* || "$archs" != *arm64* ]]; then
+    echo "$binary is not a universal (x86_64 + arm64) binary: $archs" >&2
+    exit 1
+  fi
+}
+require_universal "$menu_binary"
+require_universal "$holon_binary"
+
 [[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$info_plist")" == "run.holon.menu" ]]
 [[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info_plist")" == "$expected_version" ]]
 [[ "$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$info_plist")" == "13.0" ]]


### PR DESCRIPTION
## Summary

- The macOS menu app DMG was built only for the host runner architecture (arm64 on `macos-latest`), so Intel Mac users could not install the GUI app at all. v0.34.1 shipped an arm64-only `HolonMenu` and bundled `holon` CLI; only the prebuilt Sparkle framework was universal.
- The Rust runtime is now compiled for both `aarch64-apple-darwin` and `x86_64-apple-darwin` and merged with `lipo` into `target/universal-macos/release/holon`; the Swift menu app is built with `swift build --arch arm64 --arch x86_64` (SwiftPM native multi-arch).
- `scripts/verify-macos-menu-app.sh` now fails fast unless `HolonMenu` and the bundled `holon` binary both carry x86_64 and arm64 slices, so release and CI share the same regression guard.
- `ci.yml`, `release.yml`, `macos-notary-debug.yml`, and the `macos-menu-package` Makefile target all use the same dual-target + lipo flow, keeping local packaging identical to CI artifacts.
- Docs updated (`docs/release.md`, `README.md`) and a decision note added (`docs/implementation-decisions/116-universal-macos-app-dmg.md`) recording why one universal DMG was chosen over per-architecture DMGs (single Sparkle feed, single download link, single checksum set).

## Runtime concept changed and why

Release artifact architecture contract: `Holon-<version>.dmg` is now a universal binary distribution instead of a host-arch snapshot. `swift test` still runs the host-native slice because tests must execute.

## Verification

- Local dual-target release build + `lipo`: `Architectures in the fat file: x86_64 arm64`.
- `scripts/package-macos-menu-app.sh target/universal-macos/release/holon dist` and `scripts/verify-macos-menu-app.sh dist/Holon.app 0.34.1` both pass.
- Mounted the produced DMG and confirmed `HolonMenu`, bundled `holon`, and Sparkle are all `x86_64 arm64`.
- `cargo fmt --all -- --check` passes (no Rust sources changed).