### PR TITLE
chore: prepare 0.34.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,9 +330,9 @@ jobs:
 
           Holon ${GITHUB_REF_NAME} is part of the Rust runtime line. The Rust runtime is now the main \`holon\` binary.
 
-          This release adds the native macOS menu bar application, stronger daemon lifecycle compatibility, explicit activation and Turn ownership, a versioned model registry snapshot, and more reliable WorkItem-bound operator waits.
+          This release ships the macOS menu bar application as a universal DMG that runs natively on Apple Silicon and Intel Macs, with stronger daemon lifecycle compatibility, explicit activation and Turn ownership, a versioned model registry snapshot, and more reliable WorkItem-bound operator waits.
 
-          Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64. The Linux amd64 binary supports Ubuntu 22.04 or newer (glibc 2.35 or newer).
+          Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64. The macOS app DMG is a universal binary supporting both x86_64 and arm64. The Linux amd64 binary supports Ubuntu 22.04 or newer (glibc 2.35 or newer).
 
           ## Changes
 
@@ -340,6 +340,7 @@ jobs:
           - Introduce explicit activation and Turn owner identity, add a versioned model registry snapshot, and make WorkItem-bound operator waits resume reliably ([#2703](https://github.com/holon-run/holon/pull/2703), [#2704](https://github.com/holon-run/holon/pull/2704), [#2708](https://github.com/holon-run/holon/pull/2708), [#2709](https://github.com/holon-run/holon/pull/2709)).
           - Re-enter the model for terminal task results so terminal command-task and delegated-agent results reliably resume their owning conversation ([#2714](https://github.com/holon-run/holon/pull/2714)).
           - Harden release automation with strict tag/version verification, resilient Release E2E turn-record imports, and macOS notarization diagnostics ([#2711](https://github.com/holon-run/holon/pull/2711), [#2712](https://github.com/holon-run/holon/pull/2712)).
+          - Ship the macOS app DMG as a universal binary supporting both Apple Silicon and Intel Macs, publish the signed Sparkle appcast with the release archives, and re-sign Sparkle helper executables before notarization ([#2716](https://github.com/holon-run/holon/pull/2716), [#2717](https://github.com/holon-run/holon/pull/2717), [#2718](https://github.com/holon-run/holon/pull/2718)).
 
           ## Install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.34.1"
+version = "0.34.2"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Status and compatibility
 
 Holon is under active development. The current recommended release is
-[`v0.34.1`](https://github.com/holon-run/holon/releases/tag/v0.34.1).
+[`v0.34.2`](https://github.com/holon-run/holon/releases/tag/v0.34.2).
 
 The current project focus remains the Rust runtime: agent lifecycle, queues,
 WaitFor/wake, tasks, WorkItems, trust boundaries, local workspaces, and

--- a/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
+++ b/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
@@ -36,7 +36,7 @@ final class HolonMenuClientTests: XCTestCase {
           "socket_path": "/tmp/holon.sock",
           "http_addr": "127.0.0.1:7878",
           "web_url": "http://127.0.0.1:7878",
-          "product_version": "0.34.1 (abcdef0)",
+          "product_version": "0.34.2 (abcdef0)",
           "control_protocol_version": 1,
           "lifecycle_owner": "standalone",
           "executable_path": "/Applications/Holon.app/Contents/Resources/bin/holon",

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -105,7 +105,7 @@ waitable, delegable, and deliverable.
 ## Status and compatibility
 
 The current recommended release is
-[`v0.34.1`](https://github.com/holon-run/holon/releases/tag/v0.34.1).
+[`v0.34.2`](https://github.com/holon-run/holon/releases/tag/v0.34.2).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project maintains

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -9184,7 +9184,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.34.1"
+    "version": "0.34.2"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## Summary

Bump the crate version to 0.34.2 and refresh the release surface for the v0.34.2 tag:

- `Cargo.toml` / `Cargo.lock` → 0.34.2
- Regenerated `docs/website/reference/openapi.json` snapshot (version bump only)
- Recommended-release links in `README.md` and `docs/website/README.md` → v0.34.2
- `HolonMenuClientTests.swift` product-version fixture → 0.34.2
- Release notes template: universal macOS DMG headline and entries for #2716, #2717, #2718

## Release content since v0.34.1

- Ship the macOS app DMG as a universal (x86_64 + arm64) binary ([#2718](https://github.com/holon-run/holon/pull/2718))
- Publish the signed Sparkle appcast with the release archives ([#2717](https://github.com/holon-run/holon/pull/2717))
- Re-sign Sparkle helper executables before notarization ([#2716](https://github.com/holon-run/holon/pull/2716))

## Verification

- `cargo test --test openapi_snapshot` passes (snapshot matches generated schema)
- `cargo fmt --all -- --check` passes
- `cargo check` clean; `Cargo.lock` aligned