### PR TITLE
feat: models.dev upstream adapter, projection, and artifact generation (Phase 2A+2B)

### DIFF
--- a/docs/rfcs/models-dev-adapter.md
+++ b/docs/rfcs/models-dev-adapter.md
@@ -87,8 +87,11 @@ conservative defaults.
 The projection cannot manufacture capabilities absent from the upstream.
 If `models.dev` says `reasoning: false`, Holon's
 `capabilities.supports_reasoning` is `false`. If `models.dev` omits the
-field, it stays `None` (unknown) and the projection skips it, letting
-runtime defaults apply.
+field, the DTO preserves `None` (unknown), but the serialized artifact's
+`ModelCapabilityFlags` uses plain `bool`, so the omitted field collapses
+to conservative `false`. Phase 3 narrowing must check the DTO's
+`Option<bool>` presence before AND-ing; it must not narrow built-in
+capabilities based on absent evidence in the artifact.
 
 ### Provider mapping
 

--- a/docs/rfcs/models-dev-adapter.md
+++ b/docs/rfcs/models-dev-adapter.md
@@ -1,0 +1,172 @@
+---
+title: RFC: models.dev Upstream Adapter and Artifact Generation
+date: 2026-08-31
+status: draft
+issue:
+  - 2702
+---
+
+# RFC: models.dev Upstream Adapter and Artifact Generation
+
+## Summary
+
+This RFC defines Phase 2A+2B of the models.dev integration: a CI-time
+adapter that reads a pinned `models.dev` snapshot, projects it into Holon's
+canonical model registry format, and emits an immutable artifact with
+provenance metadata. The runtime does not consume `models.dev` directly.
+
+This RFC builds on the accepted [Versioned Model Registry Snapshot][snap-rfc]
+and its four fact layers: `ModelDefinition`, `ProviderOffering`,
+`EndpointAvailability`, and `RuntimeSupport`.
+
+## Motivation
+
+Phase 0/1 (GitHub #2702) established the versioned built-in snapshot. The
+next step is to automate model-metadata updates from `models.dev` without
+putting network access on the startup or turn hot path.
+
+The operator confirmed the following boundary:
+
+- CI publishes side auto-follow only; no daemon runtime auto-refresh.
+- `models.dev` → Holon-format artifact → CI review/merge; no direct
+  consumption of floating upstream responses.
+- Endpoint ref uses canonical `provider@endpoint-variant` (e.g.
+  `dashscope@token-plan`). Legacy hyphenated aliases like
+  `dashscope-token-plan` are no longer supported.
+- Capabilities can only narrow, never widen. Missing upstream fields
+  stay `unknown`, not `false`.
+- Pricing, knowledge cutoff, and documentation links are provenance
+  metadata only; they do not participate in route or default selection.
+
+## Design
+
+### Dual-source separation
+
+| Source | Responsibility |
+--------|----------------|
+| `models.dev` | Model identity, capabilities, modalities, token limits, provider offering metadata |
+| Holon endpoint manifest | `base_url`, transport, credential, headers, rate limits, security policy |
+
+The two are connected by an explicit provider mapping. The adapter cannot
+guess `dashscope@token-plan` from a `models.dev` provider name alone. If no
+trusted mapping exists, the model is `unbound` and does not enter a
+resolvable route.
+
+### Upstream DTO
+
+The adapter defines an independent DTO that mirrors the `models.dev` JSON
+schema. All fields are `Option<T>` to preserve tri-state semantics: a
+missing field is `unknown`, not `false`. The DTO does not share types with
+runtime catalog structures to avoid accidental coupling.
+
+### Projection rules
+
+The projection maps `models.dev` fields to Holon `BuiltInModelMetadata`:
+
+| models.dev field | Holon field | Rule |
+|------------------|-------------|------|
+| provider `id` + model `id` | `model_ref` | Concatenate as `provider/model` |
+| `name` | `display_name` | Direct |
+| `description` | `description` | Direct |
+| `limit.context` | `context_window_tokens` | Direct |
+| `limit.output` | `default_max_output_tokens` and `max_output_tokens_upper_limit` | Same value |
+| `modalities.input` contains `"image"` | `capabilities.image_input` | Direct |
+| `modalities.output` contains `"image"` | `capabilities.image_generation` | Direct |
+| `reasoning` | `capabilities.supports_reasoning` | Direct |
+| `reasoning_options` type=`effort` | `reasoning_effort_options` | Map values |
+| `tool_call` | (not projected) | Holon transport controls tool support |
+| `cost` | (provenance only) | Not in runtime metadata |
+| `knowledge` | (provenance only) | Not in runtime metadata |
+
+Fields not listed above (e.g. `parallel_tool_calls`, `interactive_exec`,
+`auto_compact_token_limit`, `effective_context_window_percent`) use Holon
+conservative defaults.
+
+### Capability narrowing
+
+The projection cannot manufacture capabilities absent from the upstream.
+If `models.dev` says `reasoning: false`, Holon's
+`capabilities.supports_reasoning` is `false`. If `models.dev` omits the
+field, it stays `None` (unknown) and the projection skips it, letting
+runtime defaults apply.
+
+### Provider mapping
+
+An explicit `ProviderMapping` table connects `models.dev` provider IDs to
+Holon provider IDs. The default table covers direct matches (e.g.
+`anthropic`, `openai`). Unmapped providers are skipped with a warning.
+Custom mappings can be supplied at projection time.
+
+### Artifact format
+
+The artifact wraps the projected snapshot with provenance:
+
+```json
+{
+  "schema_version": 1,
+  "revision": "models-dev-<upstream-revision>",
+  "upstream": {
+    "source": "models.dev",
+    "revision": "<git-sha or tag>",
+    "fetched_at": "<ISO-8601>",
+    "content_sha256": "<sha256 of raw upstream>",
+    "adapter_version": "<crate version>"
+  },
+  "models": [ ... ],
+  "routes": [],
+  "aliases": [],
+  "preferred_models": [],
+  "preferred_routes": [],
+  "preferred_routes_by_model": []
+}
+```
+
+`routes`, `aliases`, and `preferred_*` are empty because endpoint, route,
+and default selections are Holon-controlled and not derivable from
+`models.dev` metadata alone.
+
+The artifact is a CI intermediate. After review and merge, selected model
+entries are integrated into the next built-in snapshot revision. The
+runtime does not load the artifact directly in this phase.
+
+### Artifact validation
+
+The projected data must pass the same `RegistrySnapshot::validate()` checks
+as the built-in snapshot: unique model identities, positive token limits,
+valid percentages, and no capability widening.
+
+### Legacy compatibility
+
+The projection does not generate legacy hyphenated aliases
+(e.g. `dashscope-token-plan`). Configuration that still uses such aliases
+will fail at `ModelRouteRef::parse_compatible` with an explicit error.
+
+## Implementation
+
+New module: `src/model_catalog/models_dev/`
+
+- `dto.rs` — upstream DTO types with tri-state `Option<T>` fields.
+- `projection.rs` — DTO → `BuiltInModelMetadata` projection with provider
+  mapping.
+- `artifact.rs` — artifact wrapper with provenance and SHA-256 digest.
+- `mod.rs` — public API and re-exports.
+
+Test fixtures: `tests/fixtures/models_dev/`
+
+## Non-goals
+
+- Runtime refresh or status commands (Phase 2C+2D).
+- Daemon-side network access.
+- Signature verification beyond SHA-256 content digest.
+- Automatic endpoint, route, or preferred selection generation.
+- Pricing or knowledge cutoff in runtime route decisions.
+
+## Future phases
+
+- **Phase 2C**: Local registry store, provenance/status.
+- **Phase 2D**: Explicit refresh/rollback with last-known-good.
+- **Phase 2E**: Optional background stale-while-revalidate.
+
+## Open questions
+
+None. All boundary decisions were confirmed by the operator.

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1683,6 +1683,7 @@ fn reasoning_effort_options(
     options.iter().map(|option| (*option).to_string()).collect()
 }
 
+pub mod models_dev;
 mod providers;
 mod snapshot;
 #[cfg(test)]

--- a/src/model_catalog/models_dev/artifact.rs
+++ b/src/model_catalog/models_dev/artifact.rs
@@ -1,0 +1,304 @@
+//! Artifact generation for `models.dev` projections.
+//!
+//! The artifact wraps the projected snapshot with provenance metadata:
+//! upstream source, revision, fetched-at timestamp, content SHA-256, and
+//! adapter version. The artifact is a CI intermediate; the runtime does not
+//! load it directly in this phase.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Encode bytes as lowercase hex without external dependency.
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+use crate::config::{ModelRef, ModelRouteRef, ProviderId};
+use crate::model_catalog::BuiltInModelMetadata;
+
+use super::projection::ProjectionResult;
+
+/// The schema version for models.dev artifacts.
+const ARTIFACT_SCHEMA_VERSION: u32 = 1;
+
+/// Provenance metadata for a models.dev artifact.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactProvenance {
+    /// The upstream source identifier.
+    pub source: String,
+    /// The pinned upstream revision (git SHA, tag, or timestamp).
+    pub revision: String,
+    /// When the upstream data was fetched (ISO-8601).
+    pub fetched_at: String,
+    /// SHA-256 digest of the raw upstream content.
+    pub content_sha256: String,
+    /// Version of the Holon adapter that generated this artifact.
+    pub adapter_version: String,
+}
+
+/// An immutable artifact wrapping projected models.dev data.
+///
+/// The `models`, `routes`, `aliases`, and `preferred_*` fields use the same
+/// format as the built-in registry snapshot. `routes`, `aliases`, and
+/// `preferred_*` are empty because endpoint, route, and default selections
+/// are Holon-controlled and not derivable from `models.dev` metadata alone.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModelsDevArtifact {
+    pub schema_version: u32,
+    pub revision: String,
+    pub upstream: ArtifactProvenance,
+    pub models: Vec<BuiltInModelMetadata>,
+    #[serde(default)]
+    pub routes: Vec<ArtifactRoute>,
+    #[serde(default)]
+    pub aliases: Vec<ArtifactAlias>,
+    #[serde(default)]
+    pub preferred_models: Vec<ArtifactPreferredModel>,
+    #[serde(default)]
+    pub preferred_routes: Vec<ArtifactPreferredRoute>,
+    #[serde(default)]
+    pub preferred_routes_by_model: Vec<ArtifactPreferredModelRoute>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactRoute {
+    pub route_ref: ModelRouteRef,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactAlias {
+    pub alias: ModelRef,
+    pub target: ModelRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactPreferredModel {
+    pub provider: ProviderId,
+    pub model_ref: ModelRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactPreferredRoute {
+    pub provider: ProviderId,
+    pub route_ref: ModelRouteRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactPreferredModelRoute {
+    pub model_ref: ModelRef,
+    pub route_ref: ModelRouteRef,
+}
+
+/// Builder for constructing a `ModelsDevArtifact` from a projection result.
+pub struct ArtifactBuilder {
+    upstream_source: String,
+    upstream_revision: String,
+    fetched_at: String,
+    raw_content: Vec<u8>,
+    adapter_version: String,
+}
+
+impl ArtifactBuilder {
+    /// Creates a new builder with the given provenance fields.
+    ///
+    /// `raw_content` is the original upstream bytes used to compute the
+    /// content SHA-256 digest.
+    pub fn new(
+        upstream_revision: impl Into<String>,
+        fetched_at: impl Into<String>,
+        raw_content: impl Into<Vec<u8>>,
+        adapter_version: impl Into<String>,
+    ) -> Self {
+        Self {
+            upstream_source: "models.dev".to_string(),
+            upstream_revision: upstream_revision.into(),
+            fetched_at: fetched_at.into(),
+            raw_content: raw_content.into(),
+            adapter_version: adapter_version.into(),
+        }
+    }
+
+    /// Builds the artifact from a projection result.
+    pub fn build(self, result: &ProjectionResult) -> ModelsDevArtifact {
+        let content_sha256 = hex_encode(Sha256::digest(&self.raw_content).as_slice());
+        let revision = format!("models-dev-{}", self.upstream_revision);
+
+        let models: Vec<BuiltInModelMetadata> = result
+            .projected
+            .iter()
+            .map(|pm| pm.metadata.clone())
+            .collect();
+
+        ModelsDevArtifact {
+            schema_version: ARTIFACT_SCHEMA_VERSION,
+            revision,
+            upstream: ArtifactProvenance {
+                source: self.upstream_source,
+                revision: self.upstream_revision,
+                fetched_at: self.fetched_at,
+                content_sha256,
+                adapter_version: self.adapter_version,
+            },
+            models,
+            routes: Vec::new(),
+            aliases: Vec::new(),
+            preferred_models: Vec::new(),
+            preferred_routes: Vec::new(),
+            preferred_routes_by_model: Vec::new(),
+        }
+    }
+}
+
+impl ModelsDevArtifact {
+    /// Serializes the artifact to pretty-printed JSON.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Computes the SHA-256 digest of the artifact JSON.
+    pub fn content_sha256(&self) -> String {
+        let json = self.to_json().unwrap_or_default();
+        hex_encode(Sha256::digest(json.as_bytes()).as_slice())
+    }
+
+    /// Returns the number of models in the artifact.
+    pub fn model_count(&self) -> usize {
+        self.models.len()
+    }
+
+    /// Validates the artifact's internal consistency.
+    ///
+    /// Checks that:
+    /// - schema_version is the expected version;
+    /// - revision and upstream fields are non-empty;
+    /// - model identities are unique;
+    /// - token limits are positive when present.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != ARTIFACT_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported artifact schema version {}; expected {ARTIFACT_SCHEMA_VERSION}",
+                self.schema_version
+            ));
+        }
+        if self.revision.trim().is_empty() {
+            return Err("artifact revision must not be empty".to_string());
+        }
+        if self.upstream.revision.trim().is_empty() {
+            return Err("upstream revision must not be empty".to_string());
+        }
+        if self.upstream.content_sha256.trim().is_empty() {
+            return Err("upstream content_sha256 must not be empty".to_string());
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        for model in &self.models {
+            let key = model.model_ref.as_string();
+            if !seen.insert(key.clone()) {
+                return Err(format!("duplicate model {key}"));
+            }
+            if model.context_window_tokens.is_some_and(|v| v == 0) {
+                return Err(format!("model {key} has zero context window"));
+            }
+            if model.default_max_output_tokens.is_some_and(|v| v == 0) {
+                return Err(format!("model {key} has zero default max output tokens"));
+            }
+            if let (Some(default), Some(upper)) = (
+                model.default_max_output_tokens,
+                model.max_output_tokens_upper_limit,
+            ) {
+                if default > upper {
+                    return Err(format!(
+                        "model {key} default max output {default} exceeds upper limit {upper}"
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::dto::ModelsDevSnapshot;
+    use super::super::projection::Projector;
+    use super::*;
+
+    fn sample_projection() -> ProjectionResult {
+        let json = r#"{
+            "openai": {
+                "id": "openai",
+                "models": {
+                    "gpt-5.5": {
+                        "id": "gpt-5.5",
+                        "name": "GPT-5.5",
+                        "reasoning": true,
+                        "modalities": {"input": ["text", "image"], "output": ["text"]},
+                        "limit": {"context": 1050000, "output": 128000}
+                    }
+                }
+            }
+        }"#;
+        let snapshot: ModelsDevSnapshot = serde_json::from_str(json).unwrap();
+        Projector::new().project(&snapshot)
+    }
+
+    #[test]
+    fn build_artifact_from_projection() {
+        let result = sample_projection();
+        let raw = b"raw-upstream-content";
+        let artifact =
+            ArtifactBuilder::new("abc123", "2026-08-31T00:00:00Z", raw, "0.1.0").build(&result);
+
+        assert_eq!(artifact.schema_version, 1);
+        assert_eq!(artifact.revision, "models-dev-abc123");
+        assert_eq!(artifact.upstream.source, "models.dev");
+        assert_eq!(artifact.upstream.revision, "abc123");
+        assert_eq!(artifact.upstream.fetched_at, "2026-08-31T00:00:00Z");
+        assert!(!artifact.upstream.content_sha256.is_empty());
+        assert_eq!(artifact.upstream.adapter_version, "0.1.0");
+        assert_eq!(artifact.model_count(), 1);
+        assert!(artifact.routes.is_empty());
+        assert!(artifact.aliases.is_empty());
+    }
+
+    #[test]
+    fn artifact_validates() {
+        let result = sample_projection();
+        let artifact =
+            ArtifactBuilder::new("abc123", "2026-08-31T00:00:00Z", b"raw", "0.1.0").build(&result);
+        assert!(artifact.validate().is_ok());
+    }
+
+    #[test]
+    fn artifact_rejects_duplicate_models() {
+        let result = sample_projection();
+        let mut artifact =
+            ArtifactBuilder::new("abc123", "2026-08-31T00:00:00Z", b"raw", "0.1.0").build(&result);
+        // Duplicate the first model
+        artifact.models.push(artifact.models[0].clone());
+        assert!(artifact.validate().is_err());
+    }
+
+    #[test]
+    fn artifact_json_roundtrips() {
+        let result = sample_projection();
+        let artifact =
+            ArtifactBuilder::new("abc123", "2026-08-31T00:00:00Z", b"raw", "0.1.0").build(&result);
+        let json = artifact.to_json().unwrap();
+        let parsed: ModelsDevArtifact = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, artifact);
+    }
+
+    #[test]
+    fn content_sha256_deterministic() {
+        let result = sample_projection();
+        let mk = || ArtifactBuilder::new("abc123", "2026-08-31T00:00:00Z", b"raw", "0.1.0");
+        let a1 = mk().build(&result);
+        let a2 = mk().build(&result);
+        assert_eq!(a1.content_sha256(), a2.content_sha256());
+    }
+}

--- a/src/model_catalog/models_dev/artifact.rs
+++ b/src/model_catalog/models_dev/artifact.rs
@@ -160,7 +160,9 @@ impl ModelsDevArtifact {
 
     /// Computes the SHA-256 digest of the artifact JSON.
     pub fn content_sha256(&self) -> String {
-        let json = self.to_json().unwrap_or_default();
+        let json = self
+            .to_json()
+            .expect("artifact serialization must not fail");
         hex_encode(Sha256::digest(json.as_bytes()).as_slice())
     }
 
@@ -243,7 +245,7 @@ mod tests {
             }
         }"#;
         let snapshot: ModelsDevSnapshot = serde_json::from_str(json).unwrap();
-        Projector::new().project(&snapshot)
+        Projector::new().project(&snapshot).unwrap()
     }
 
     #[test]

--- a/src/model_catalog/models_dev/dto.rs
+++ b/src/model_catalog/models_dev/dto.rs
@@ -1,0 +1,230 @@
+//! Upstream DTO for the `models.dev` API.
+//!
+//! All fields are `Option<T>` to preserve tri-state semantics: a missing field
+//! is `unknown`, not `false`. The DTO does not share types with runtime
+//! catalog structures to avoid accidental coupling.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// The top-level `models.dev` API response: a map of provider ID to provider.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModelsDevSnapshot {
+    #[serde(flatten)]
+    pub providers: BTreeMap<String, ModelsDevProvider>,
+}
+
+/// A single provider entry in the `models.dev` API.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModelsDevProvider {
+    pub id: String,
+    #[serde(default)]
+    pub env: Vec<String>,
+    #[serde(default)]
+    pub npm: Option<String>,
+    #[serde(default)]
+    pub api: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub doc: Option<String>,
+    #[serde(default)]
+    pub models: BTreeMap<String, ModelsDevModel>,
+}
+
+/// A single model entry within a provider.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModelsDevModel {
+    pub id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub family: Option<String>,
+    /// Whether the model accepts file/image attachments.
+    #[serde(default)]
+    pub attachment: Option<bool>,
+    /// Whether the model supports reasoning.
+    #[serde(default)]
+    pub reasoning: Option<bool>,
+    /// Reasoning configuration options.
+    #[serde(default)]
+    pub reasoning_options: Vec<ModelsDevReasoningOption>,
+    /// Whether the model supports tool calls.
+    #[serde(default)]
+    pub tool_call: Option<bool>,
+    /// Whether the model supports structured output.
+    #[serde(default)]
+    pub structured_output: Option<bool>,
+    /// Whether the model supports temperature parameter.
+    #[serde(default)]
+    pub temperature: Option<bool>,
+    /// Knowledge cutoff date (e.g. "2025-05").
+    #[serde(default)]
+    pub knowledge: Option<String>,
+    /// Release date of the model.
+    #[serde(default)]
+    pub release_date: Option<String>,
+    /// Last updated date.
+    #[serde(default)]
+    pub last_updated: Option<String>,
+    /// Input and output modalities.
+    #[serde(default)]
+    pub modalities: Option<ModelsDevModalities>,
+    /// Whether model weights are open.
+    #[serde(default)]
+    pub open_weights: Option<bool>,
+    /// Token limits.
+    #[serde(default)]
+    pub limit: Option<ModelsDevLimit>,
+    /// Cost information (provenance only, not used in runtime decisions).
+    #[serde(default)]
+    pub cost: Option<ModelsDevCost>,
+    /// Interleaved reasoning content configuration.
+    #[serde(default)]
+    pub interleaved: Option<ModelsDevInterleaved>,
+}
+
+/// Reasoning option type (e.g. effort levels or toggle).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModelsDevReasoningOption {
+    #[serde(default)]
+    pub r#type: Option<String>,
+    #[serde(default)]
+    pub values: Vec<String>,
+}
+
+/// Input and output modalities.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModelsDevModalities {
+    #[serde(default)]
+    pub input: Vec<String>,
+    #[serde(default)]
+    pub output: Vec<String>,
+}
+
+/// Token limits for a model.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModelsDevLimit {
+    #[serde(default)]
+    pub context: Option<u64>,
+    #[serde(default)]
+    pub output: Option<u64>,
+    #[serde(default)]
+    pub input: Option<u64>,
+}
+
+/// Cost information (provenance metadata only).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModelsDevCost {
+    #[serde(default)]
+    pub input: Option<f64>,
+    #[serde(default)]
+    pub output: Option<f64>,
+    #[serde(default)]
+    pub cache_read: Option<f64>,
+    #[serde(default)]
+    pub cache_write: Option<f64>,
+}
+
+/// Interleaved reasoning content configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModelsDevInterleaved {
+    #[serde(default)]
+    pub field: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal_model() {
+        let json = r#"{
+            "test-provider": {
+                "id": "test-provider",
+                "models": {
+                    "test-model": {
+                        "id": "test-model"
+                    }
+                }
+            }
+        }"#;
+        let snapshot: ModelsDevSnapshot = serde_json::from_str(json).unwrap();
+        let provider = &snapshot.providers["test-provider"];
+        assert_eq!(provider.id, "test-provider");
+        assert!(provider.env.is_empty());
+        assert!(provider.api.is_none());
+        let model = &provider.models["test-model"];
+        assert_eq!(model.id, "test-model");
+        assert!(model.name.is_none());
+        assert!(model.reasoning.is_none());
+    }
+
+    #[test]
+    fn parse_full_model() {
+        let json = r#"{
+            "openai": {
+                "id": "openai",
+                "env": ["OPENAI_API_KEY"],
+                "npm": "@ai-sdk/openai",
+                "api": "https://api.openai.com/v1",
+                "name": "OpenAI",
+                "doc": "https://platform.openai.com/docs",
+                "models": {
+                    "gpt-5.5": {
+                        "id": "gpt-5.5",
+                        "name": "GPT-5.5",
+                        "description": "Default frontier GPT",
+                        "family": "gpt",
+                        "attachment": true,
+                        "reasoning": true,
+                        "reasoning_options": [{"type": "effort", "values": ["none", "low", "high"]}],
+                        "tool_call": true,
+                        "structured_output": true,
+                        "temperature": true,
+                        "knowledge": "2025-12-01",
+                        "release_date": "2026-04-23",
+                        "last_updated": "2026-04-23",
+                        "modalities": {"input": ["text", "image"], "output": ["text"]},
+                        "open_weights": false,
+                        "limit": {"context": 1050000, "output": 128000},
+                        "cost": {"input": 5, "output": 30, "cache_read": 0.5}
+                    }
+                }
+            }
+        }"#;
+        let snapshot: ModelsDevSnapshot = serde_json::from_str(json).unwrap();
+        let model = &snapshot.providers["openai"].models["gpt-5.5"];
+        assert_eq!(model.name.as_deref(), Some("GPT-5.5"));
+        assert_eq!(model.reasoning, Some(true));
+        assert_eq!(model.reasoning_options.len(), 1);
+        assert_eq!(model.reasoning_options[0].r#type.as_deref(), Some("effort"));
+        assert_eq!(
+            model.reasoning_options[0].values,
+            vec!["none", "low", "high"]
+        );
+        assert_eq!(model.limit.as_ref().unwrap().context, Some(1050000));
+        assert_eq!(
+            model.modalities.as_ref().unwrap().input,
+            vec!["text", "image"]
+        );
+    }
+
+    #[test]
+    fn ignores_unknown_fields() {
+        let json = r#"{
+            "test": {
+                "id": "test",
+                "future_field": "ignored",
+                "models": {
+                    "m": {"id": "m", "another_future_field": 42}
+                }
+            }
+        }"#;
+        let snapshot: ModelsDevSnapshot = serde_json::from_str(json).unwrap();
+        assert_eq!(snapshot.providers["test"].models["m"].id, "m");
+    }
+}

--- a/src/model_catalog/models_dev/dto.rs
+++ b/src/model_catalog/models_dev/dto.rs
@@ -6,13 +6,39 @@
 
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 
 /// The top-level `models.dev` API response: a map of provider ID to provider.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct ModelsDevSnapshot {
-    #[serde(flatten)]
     pub providers: BTreeMap<String, ModelsDevProvider>,
+}
+
+impl<'de> Deserialize<'de> for ModelsDevSnapshot {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = BTreeMap::<String, Value>::deserialize(deserializer)?;
+        let mut providers = BTreeMap::new();
+
+        for (key, value) in raw {
+            let Some(object) = value.as_object() else {
+                // Keep the adapter forward-compatible with future scalar
+                // metadata added alongside provider entries.
+                continue;
+            };
+            if !object.contains_key("id") {
+                continue;
+            }
+
+            let provider = serde_json::from_value(value).map_err(D::Error::custom)?;
+            providers.insert(key, provider);
+        }
+
+        Ok(Self { providers })
+    }
 }
 
 /// A single provider entry in the `models.dev` API.
@@ -226,5 +252,20 @@ mod tests {
         }"#;
         let snapshot: ModelsDevSnapshot = serde_json::from_str(json).unwrap();
         assert_eq!(snapshot.providers["test"].models["m"].id, "m");
+    }
+
+    #[test]
+    fn ignores_unknown_top_level_scalar_fields() {
+        let json = r#"{
+            "schema_version": 2,
+            "generated_at": "2026-08-31T00:00:00Z",
+            "test": {
+                "id": "test",
+                "models": {}
+            }
+        }"#;
+        let snapshot: ModelsDevSnapshot = serde_json::from_str(json).unwrap();
+        assert_eq!(snapshot.providers.len(), 1);
+        assert_eq!(snapshot.providers["test"].id, "test");
     }
 }

--- a/src/model_catalog/models_dev/mod.rs
+++ b/src/model_catalog/models_dev/mod.rs
@@ -1,0 +1,70 @@
+//! `models.dev` upstream adapter: DTO, projection, and artifact generation.
+//!
+//! This module implements Phase 2A+2B of the models.dev integration:
+//!
+//! - [`dto`] defines an independent upstream DTO that mirrors the
+//!   `models.dev` JSON schema with tri-state `Option<T>` fields.
+//! - [`projection`] maps DTO fields to Holon `BuiltInModelMetadata` using an
+//!   explicit provider mapping. Capabilities can only narrow; missing fields
+//!   stay `unknown`.
+//! - [`artifact`] wraps the projected data with provenance metadata
+//!   (upstream revision, content SHA-256, adapter version).
+//!
+//! The runtime does not consume `models.dev` directly. CI uses this module
+//! to generate an immutable artifact that enters Holon through review and
+//! merge.
+
+pub mod artifact;
+pub mod dto;
+pub mod projection;
+
+pub use artifact::{
+    ArtifactAlias, ArtifactBuilder, ArtifactPreferredModel, ArtifactPreferredModelRoute,
+    ArtifactPreferredRoute, ArtifactProvenance, ArtifactRoute, ModelsDevArtifact,
+};
+pub use dto::{
+    ModelsDevCost, ModelsDevInterleaved, ModelsDevLimit, ModelsDevModalities, ModelsDevModel,
+    ModelsDevProvider, ModelsDevReasoningOption, ModelsDevSnapshot,
+};
+pub use projection::{ProjectedModel, ProjectionResult, Projector, ProviderMapping, UnmappedModel};
+
+/// Parses a `models.dev` JSON snapshot from raw bytes.
+pub fn parse_snapshot(raw: &str) -> Result<ModelsDevSnapshot, serde_json::Error> {
+    serde_json::from_str(raw)
+}
+
+/// End-to-end: parse, project, and build an artifact from raw `models.dev` JSON.
+///
+/// `upstream_revision` is the pinned revision identifier (e.g. git SHA).
+/// `fetched_at` is an ISO-8601 timestamp.
+/// `adapter_version` is the Holon crate version.
+pub fn generate_artifact(
+    raw_json: &str,
+    upstream_revision: &str,
+    fetched_at: &str,
+    adapter_version: &str,
+) -> Result<GeneratedArtifact, String> {
+    let snapshot = parse_snapshot(raw_json)
+        .map_err(|e| format!("failed to parse models.dev snapshot: {e}"))?;
+    let result = Projector::new().project(&snapshot);
+    let artifact = ArtifactBuilder::new(
+        upstream_revision,
+        fetched_at,
+        raw_json.as_bytes(),
+        adapter_version,
+    )
+    .build(&result);
+    artifact.validate()?;
+    Ok(GeneratedArtifact {
+        artifact,
+        projection: result,
+    })
+}
+
+/// The output of [`generate_artifact`]: the validated artifact plus the
+/// raw projection result (including unmapped models).
+#[derive(Debug, Clone)]
+pub struct GeneratedArtifact {
+    pub artifact: ModelsDevArtifact,
+    pub projection: ProjectionResult,
+}

--- a/src/model_catalog/models_dev/mod.rs
+++ b/src/model_catalog/models_dev/mod.rs
@@ -46,7 +46,7 @@ pub fn generate_artifact(
 ) -> Result<GeneratedArtifact, String> {
     let snapshot = parse_snapshot(raw_json)
         .map_err(|e| format!("failed to parse models.dev snapshot: {e}"))?;
-    let result = Projector::new().project(&snapshot);
+    let result = Projector::new().project(&snapshot)?;
     let artifact = ArtifactBuilder::new(
         upstream_revision,
         fetched_at,

--- a/src/model_catalog/models_dev/projection.rs
+++ b/src/model_catalog/models_dev/projection.rs
@@ -1,0 +1,383 @@
+//! Projection from `models.dev` DTO to Holon canonical model metadata.
+//!
+//! The projection maps upstream provider/model fields to Holon
+//! `BuiltInModelMetadata`. It uses an explicit provider mapping to connect
+//! `models.dev` provider IDs to Holon provider IDs. Capabilities can only
+//! narrow; missing upstream fields stay `unknown` and are not converted to
+//! `false`.
+
+use std::collections::BTreeMap;
+
+use crate::config::{ModelRef, ProviderId};
+use crate::model_catalog::{BuiltInModelMetadata, ModelCapabilityFlags, ModelMetadataSource};
+
+use super::dto::{ModelsDevModel, ModelsDevSnapshot};
+
+/// Default effective context window percentage projected from models.dev.
+const DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT: u8 = 90;
+
+/// Default tool output truncation estimate projected from models.dev.
+const DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS: usize = 2_500;
+
+/// Maps a `models.dev` provider ID to a Holon provider ID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderMapping {
+    pub models_dev_id: String,
+    pub holon_provider_id: String,
+}
+
+impl ProviderMapping {
+    /// Returns the default set of direct provider ID matches.
+    ///
+    /// These are providers whose `models.dev` ID directly matches the Holon
+    /// canonical provider ID. Unmapped providers are skipped during
+    /// projection.
+    pub fn default_mappings() -> Vec<Self> {
+        [
+            "anthropic",
+            "openai",
+            "deepseek",
+            "mistral",
+            "moonshot",
+            "nvidia",
+            "openrouter",
+            "together",
+            "fireworks",
+            "huggingface",
+            "xai",
+            "gemini",
+            "minimax",
+            "zai",
+            "bigmodel",
+            "volcengine",
+            "stepfun",
+            "qianfan",
+            "byteplus",
+            "arcee",
+            "chutes",
+            "nearai",
+            "venice",
+            "vllm",
+            "ollama",
+            "xiaomi",
+            "dashscope",
+        ]
+        .into_iter()
+        .map(|id| Self {
+            models_dev_id: id.to_string(),
+            holon_provider_id: id.to_string(),
+        })
+        .collect()
+    }
+}
+
+/// A single projected model with its provenance.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectedModel {
+    pub metadata: BuiltInModelMetadata,
+    /// Whether the provider was explicitly mapped.
+    pub provider_mapped: bool,
+    /// The original `models.dev` provider ID.
+    pub models_dev_provider_id: String,
+    /// The original `models.dev` model ID.
+    pub models_dev_model_id: String,
+}
+
+/// Result of projecting a `models.dev` snapshot.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectionResult {
+    /// Successfully projected models (provider was mapped).
+    pub projected: Vec<ProjectedModel>,
+    /// Models whose provider was not in the mapping (skipped).
+    pub unmapped: Vec<UnmappedModel>,
+}
+
+/// A model that was skipped because its provider was not in the mapping.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnmappedModel {
+    pub models_dev_provider_id: String,
+    pub models_dev_model_id: String,
+    pub model_name: Option<String>,
+}
+
+/// Projects `models.dev` DTO data into Holon canonical model metadata.
+pub struct Projector {
+    mappings: BTreeMap<String, String>,
+}
+
+impl Projector {
+    /// Creates a projector with the default provider mappings.
+    pub fn new() -> Self {
+        Self::with_mappings(ProviderMapping::default_mappings())
+    }
+
+    /// Creates a projector with custom provider mappings.
+    pub fn with_mappings(mappings: Vec<ProviderMapping>) -> Self {
+        let map = mappings
+            .into_iter()
+            .map(|m| (m.models_dev_id, m.holon_provider_id))
+            .collect();
+        Self { mappings: map }
+    }
+
+    /// Projects an entire `models.dev` snapshot into Holon model metadata.
+    pub fn project(&self, snapshot: &ModelsDevSnapshot) -> ProjectionResult {
+        let mut projected = Vec::new();
+        let mut unmapped = Vec::new();
+
+        for (md_provider_id, provider) in &snapshot.providers {
+            let holon_provider_id = match self.mappings.get(md_provider_id) {
+                Some(id) => id.clone(),
+                None => {
+                    for (md_model_id, model) in &provider.models {
+                        unmapped.push(UnmappedModel {
+                            models_dev_provider_id: md_provider_id.clone(),
+                            models_dev_model_id: md_model_id.clone(),
+                            model_name: model.name.clone(),
+                        });
+                    }
+                    continue;
+                }
+            };
+
+            let holon_provider = ProviderId::parse(&holon_provider_id).unwrap_or_else(|_| {
+                panic!("invalid Holon provider ID from mapping: {holon_provider_id}")
+            });
+
+            for (md_model_id, model) in &provider.models {
+                let model_ref = ModelRef::new(holon_provider.clone(), md_model_id.clone());
+                let metadata = project_model(&model_ref, model);
+                projected.push(ProjectedModel {
+                    metadata,
+                    provider_mapped: true,
+                    models_dev_provider_id: md_provider_id.clone(),
+                    models_dev_model_id: md_model_id.clone(),
+                });
+            }
+        }
+
+        projected.sort_by(|a, b| {
+            a.metadata
+                .model_ref
+                .as_string()
+                .cmp(&b.metadata.model_ref.as_string())
+        });
+
+        ProjectionResult {
+            projected,
+            unmapped,
+        }
+    }
+}
+
+impl Default for Projector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn project_model(model_ref: &ModelRef, model: &ModelsDevModel) -> BuiltInModelMetadata {
+    let display_name = model.name.clone().unwrap_or_else(|| model.id.clone());
+    let description = model
+        .description
+        .clone()
+        .unwrap_or_else(|| format!("Holon projected metadata for {}.", model.id));
+
+    let context_window_tokens = model.limit.as_ref().and_then(|l| l.context);
+    let default_max_output_tokens = model.limit.as_ref().and_then(|l| l.output);
+    let max_output_tokens_upper_limit = default_max_output_tokens;
+
+    let auto_compact_token_limit = context_window_tokens
+        .map(|ctx| ctx * DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT as u64 / 100);
+
+    let capabilities = project_capabilities(model);
+
+    let reasoning_effort_options = project_reasoning_effort_options(model);
+
+    BuiltInModelMetadata {
+        model_ref: model_ref.clone(),
+        display_name,
+        description,
+        context_window_tokens: context_window_tokens.map(|v| v as usize),
+        effective_context_window_percent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+        auto_compact_token_limit: auto_compact_token_limit.map(|v| v as usize),
+        default_max_output_tokens: default_max_output_tokens.map(|v| v as u32),
+        max_output_tokens_upper_limit: max_output_tokens_upper_limit.map(|v| v as u32),
+        default_verbosity: None,
+        tool_output_truncation_estimated_tokens: Some(
+            DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
+        ),
+        capabilities,
+        reasoning_effort_options,
+        source: ModelMetadataSource::RemoteDiscovered,
+        endpoint: None,
+    }
+}
+
+fn project_capabilities(model: &ModelsDevModel) -> ModelCapabilityFlags {
+    let image_input = model
+        .modalities
+        .as_ref()
+        .map(|m| m.input.iter().any(|modality| modality == "image"))
+        .unwrap_or(false);
+
+    let image_generation = model
+        .modalities
+        .as_ref()
+        .map(|m| m.output.iter().any(|modality| modality == "image"))
+        .unwrap_or(false);
+
+    let supports_reasoning = model.reasoning.unwrap_or(false);
+
+    // These capabilities are not available from models.dev metadata.
+    // Conservative defaults: do not assume support.
+    let parallel_tool_calls = false;
+    let interactive_exec = false;
+
+    ModelCapabilityFlags {
+        parallel_tool_calls,
+        image_input,
+        image_generation,
+        supports_reasoning,
+        interactive_exec,
+    }
+}
+
+fn project_reasoning_effort_options(model: &ModelsDevModel) -> Vec<String> {
+    model
+        .reasoning_options
+        .iter()
+        .filter(|opt| opt.r#type.as_deref() == Some("effort"))
+        .flat_map(|opt| opt.values.iter().cloned())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_catalog::ModelMetadataSource;
+
+    fn sample_snapshot() -> ModelsDevSnapshot {
+        let json = r#"{
+            "openai": {
+                "id": "openai",
+                "models": {
+                    "gpt-5.5": {
+                        "id": "gpt-5.5",
+                        "name": "GPT-5.5",
+                        "description": "Default frontier GPT",
+                        "reasoning": true,
+                        "reasoning_options": [{"type": "effort", "values": ["none", "low", "high"]}],
+                        "modalities": {"input": ["text", "image"], "output": ["text"]},
+                        "limit": {"context": 1050000, "output": 128000}
+                    },
+                    "gpt-4o-mini": {
+                        "id": "gpt-4o-mini",
+                        "name": "GPT-4o mini",
+                        "reasoning": false,
+                        "modalities": {"input": ["text", "image"], "output": ["text", "image"]},
+                        "limit": {"context": 128000, "output": 16384}
+                    }
+                }
+            },
+            "unknown-provider": {
+                "id": "unknown-provider",
+                "models": {
+                    "mystery-model": {
+                        "id": "mystery-model",
+                        "name": "Mystery Model"
+                    }
+                }
+            }
+        }"#;
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn projects_mapped_provider() {
+        let snapshot = sample_snapshot();
+        let result = Projector::new().project(&snapshot);
+
+        assert_eq!(result.projected.len(), 2);
+        assert_eq!(result.unmapped.len(), 1);
+
+        let gpt55 = result
+            .projected
+            .iter()
+            .find(|m| m.models_dev_model_id == "gpt-5.5")
+            .unwrap();
+        assert_eq!(gpt55.metadata.model_ref.as_string(), "openai/gpt-5.5");
+        assert_eq!(gpt55.metadata.display_name, "GPT-5.5");
+        assert_eq!(gpt55.metadata.context_window_tokens, Some(1_050_000));
+        assert_eq!(gpt55.metadata.default_max_output_tokens, Some(128_000));
+        assert_eq!(gpt55.metadata.max_output_tokens_upper_limit, Some(128_000));
+        assert!(gpt55.metadata.capabilities.supports_reasoning);
+        assert!(gpt55.metadata.capabilities.image_input);
+        assert!(!gpt55.metadata.capabilities.image_generation);
+        assert_eq!(
+            gpt55.metadata.reasoning_effort_options,
+            vec!["none", "low", "high"]
+        );
+        assert_eq!(gpt55.metadata.source, ModelMetadataSource::RemoteDiscovered);
+        assert!(gpt55.metadata.endpoint.is_none());
+    }
+
+    #[test]
+    fn projects_image_generation() {
+        let snapshot = sample_snapshot();
+        let result = Projector::new().project(&snapshot);
+
+        let gpt4o = result
+            .projected
+            .iter()
+            .find(|m| m.models_dev_model_id == "gpt-4o-mini")
+            .unwrap();
+        assert!(gpt4o.metadata.capabilities.image_generation);
+        assert!(!gpt4o.metadata.capabilities.supports_reasoning);
+    }
+
+    #[test]
+    fn skips_unmapped_provider() {
+        let snapshot = sample_snapshot();
+        let result = Projector::new().project(&snapshot);
+
+        assert_eq!(result.unmapped.len(), 1);
+        assert_eq!(
+            result.unmapped[0].models_dev_provider_id,
+            "unknown-provider"
+        );
+        assert_eq!(result.unmapped[0].models_dev_model_id, "mystery-model");
+    }
+
+    #[test]
+    fn auto_compact_token_limit_derived() {
+        let snapshot = sample_snapshot();
+        let result = Projector::new().project(&snapshot);
+
+        let gpt55 = result
+            .projected
+            .iter()
+            .find(|m| m.models_dev_model_id == "gpt-5.5")
+            .unwrap();
+        // 1050000 * 90 / 100 = 945000
+        assert_eq!(gpt55.metadata.auto_compact_token_limit, Some(945_000));
+    }
+
+    #[test]
+    fn custom_mapping_overrides_default() {
+        let snapshot = sample_snapshot();
+        let projector = Projector::with_mappings(vec![ProviderMapping {
+            models_dev_id: "openai".to_string(),
+            holon_provider_id: "openrouter".to_string(),
+        }]);
+        let result = projector.project(&snapshot);
+
+        assert_eq!(result.projected.len(), 2);
+        assert!(result.projected[0]
+            .metadata
+            .model_ref
+            .provider
+            .as_str()
+            .contains("openrouter"));
+    }
+}

--- a/src/model_catalog/models_dev/projection.rs
+++ b/src/model_catalog/models_dev/projection.rs
@@ -3,8 +3,11 @@
 //! The projection maps upstream provider/model fields to Holon
 //! `BuiltInModelMetadata`. It uses an explicit provider mapping to connect
 //! `models.dev` provider IDs to Holon provider IDs. Capabilities can only
-//! narrow; missing upstream fields stay `unknown` and are not converted to
-//! `false`.
+//! narrow, never widen. The DTO preserves tri-state (`Option<bool>`), but
+//! the serialized artifact's `ModelCapabilityFlags` uses plain `bool`;
+//! omitted upstream capability fields collapse to conservative `false`.
+//! Phase 3 narrowing must check the DTO's `Option<bool>` presence before
+//! AND-ing, not the artifact's bool value.
 
 use std::collections::BTreeMap;
 
@@ -14,7 +17,7 @@ use crate::model_catalog::{BuiltInModelMetadata, ModelCapabilityFlags, ModelMeta
 use super::dto::{ModelsDevModel, ModelsDevSnapshot};
 
 /// Default effective context window percentage projected from models.dev.
-const DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT: u8 = 90;
+const DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT: u8 = 95;
 
 /// Default tool output truncation estimate projected from models.dev.
 const DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS: usize = 2_500;
@@ -121,7 +124,7 @@ impl Projector {
     }
 
     /// Projects an entire `models.dev` snapshot into Holon model metadata.
-    pub fn project(&self, snapshot: &ModelsDevSnapshot) -> ProjectionResult {
+    pub fn project(&self, snapshot: &ModelsDevSnapshot) -> Result<ProjectionResult, String> {
         let mut projected = Vec::new();
         let mut unmapped = Vec::new();
 
@@ -140,9 +143,9 @@ impl Projector {
                 }
             };
 
-            let holon_provider = ProviderId::parse(&holon_provider_id).unwrap_or_else(|_| {
-                panic!("invalid Holon provider ID from mapping: {holon_provider_id}")
-            });
+            let holon_provider = ProviderId::parse(&holon_provider_id).map_err(|e| {
+                format!("invalid Holon provider ID from mapping: {holon_provider_id}: {e}")
+            })?;
 
             for (md_model_id, model) in &provider.models {
                 let model_ref = ModelRef::new(holon_provider.clone(), md_model_id.clone());
@@ -163,10 +166,10 @@ impl Projector {
                 .cmp(&b.metadata.model_ref.as_string())
         });
 
-        ProjectionResult {
+        Ok(ProjectionResult {
             projected,
             unmapped,
-        }
+        })
     }
 }
 
@@ -296,7 +299,7 @@ mod tests {
     #[test]
     fn projects_mapped_provider() {
         let snapshot = sample_snapshot();
-        let result = Projector::new().project(&snapshot);
+        let result = Projector::new().project(&snapshot).unwrap();
 
         assert_eq!(result.projected.len(), 2);
         assert_eq!(result.unmapped.len(), 1);
@@ -325,7 +328,7 @@ mod tests {
     #[test]
     fn projects_image_generation() {
         let snapshot = sample_snapshot();
-        let result = Projector::new().project(&snapshot);
+        let result = Projector::new().project(&snapshot).unwrap();
 
         let gpt4o = result
             .projected
@@ -339,7 +342,7 @@ mod tests {
     #[test]
     fn skips_unmapped_provider() {
         let snapshot = sample_snapshot();
-        let result = Projector::new().project(&snapshot);
+        let result = Projector::new().project(&snapshot).unwrap();
 
         assert_eq!(result.unmapped.len(), 1);
         assert_eq!(
@@ -352,15 +355,15 @@ mod tests {
     #[test]
     fn auto_compact_token_limit_derived() {
         let snapshot = sample_snapshot();
-        let result = Projector::new().project(&snapshot);
+        let result = Projector::new().project(&snapshot).unwrap();
 
         let gpt55 = result
             .projected
             .iter()
             .find(|m| m.models_dev_model_id == "gpt-5.5")
             .unwrap();
-        // 1050000 * 90 / 100 = 945000
-        assert_eq!(gpt55.metadata.auto_compact_token_limit, Some(945_000));
+        // 1050000 * 95 / 100 = 997500
+        assert_eq!(gpt55.metadata.auto_compact_token_limit, Some(997_500));
     }
 
     #[test]
@@ -370,7 +373,7 @@ mod tests {
             models_dev_id: "openai".to_string(),
             holon_provider_id: "openrouter".to_string(),
         }]);
-        let result = projector.project(&snapshot);
+        let result = projector.project(&snapshot).unwrap();
 
         assert_eq!(result.projected.len(), 2);
         assert!(result.projected[0]

--- a/tests/fixtures/models_dev/sample.json
+++ b/tests/fixtures/models_dev/sample.json
@@ -1,0 +1,99 @@
+{
+  "openai": {
+    "id": "openai",
+    "env": ["OPENAI_API_KEY"],
+    "npm": "@ai-sdk/openai",
+    "api": "https://api.openai.com/v1",
+    "name": "OpenAI",
+    "doc": "https://platform.openai.com/docs",
+    "models": {
+      "gpt-5.5": {
+        "id": "gpt-5.5",
+        "name": "GPT-5.5",
+        "description": "Default frontier GPT for coding, computer use, research, and knowledge work",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [{"type": "effort", "values": ["none", "low", "medium", "high"]}],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-12-01",
+        "release_date": "2026-04-23",
+        "last_updated": "2026-04-23",
+        "modalities": {"input": ["text", "image"], "output": ["text"]},
+        "open_weights": false,
+        "limit": {"context": 1050000, "output": 128000},
+        "cost": {"input": 5, "output": 30, "cache_read": 0.5}
+      },
+      "gpt-4o-mini": {
+        "id": "gpt-4o-mini",
+        "name": "GPT-4o mini",
+        "description": "Cost-efficient small model for fast tasks",
+        "family": "gpt-4o",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "modalities": {"input": ["text", "image"], "output": ["text", "image"]},
+        "limit": {"context": 128000, "output": 16384}
+      }
+    }
+  },
+  "anthropic": {
+    "id": "anthropic",
+    "env": ["ANTHROPIC_API_KEY"],
+    "api": "https://api.anthropic.com/v1",
+    "name": "Anthropic",
+    "models": {
+      "claude-opus-4.7": {
+        "id": "claude-opus-4.7",
+        "name": "Claude Opus 4.7",
+        "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [{"type": "effort", "values": ["low", "medium", "high"]}],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2026-01-31",
+        "modalities": {"input": ["text", "image"], "output": ["text"]},
+        "limit": {"context": 1000000, "output": 128000},
+        "cost": {"input": 5, "output": 25, "cache_read": 0.5}
+      }
+    }
+  },
+  "hpc-ai": {
+    "id": "hpc-ai",
+    "env": ["HPC_AI_API_KEY"],
+    "api": "https://api.hpc-ai.com/inference/v1",
+    "name": "HPC-AI",
+    "models": {
+      "deepseek/deepseek-v4-flash": {
+        "id": "deepseek/deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "reasoning": true,
+        "reasoning_options": [{"type": "effort", "values": ["high", "max"]}],
+        "tool_call": true,
+        "modalities": {"input": ["text"], "output": ["text"]},
+        "limit": {"context": 1048576, "output": 128000},
+        "cost": {"input": 0.14, "output": 0.28}
+      }
+    }
+  },
+  "zai-org": {
+    "id": "zai-org",
+    "models": {
+      "glm-5.2": {
+        "id": "glm-5.2",
+        "name": "GLM-5.2",
+        "reasoning": true,
+        "reasoning_options": [{"type": "effort", "values": ["high", "max"]}],
+        "tool_call": true,
+        "modalities": {"input": ["text"], "output": ["text"]},
+        "limit": {"context": 1048576, "output": 131072}
+      }
+    }
+  }
+}

--- a/tests/models_dev_adapter.rs
+++ b/tests/models_dev_adapter.rs
@@ -30,7 +30,7 @@ fn parse_fixture_snapshot() {
 fn project_fixture_with_default_mappings() {
     let json = fixture_json();
     let snapshot = parse_snapshot(&json).unwrap();
-    let result = Projector::new().project(&snapshot);
+    let result = Projector::new().project(&snapshot).unwrap();
 
     // openai and anthropic are mapped; hpc-ai and zai-org are not.
     assert!(result.projected.len() >= 3); // 2 openai + 1 anthropic
@@ -41,7 +41,7 @@ fn project_fixture_with_default_mappings() {
 fn projected_model_has_correct_capabilities() {
     let json = fixture_json();
     let snapshot = parse_snapshot(&json).unwrap();
-    let result = Projector::new().project(&snapshot);
+    let result = Projector::new().project(&snapshot).unwrap();
 
     let gpt55 = result
         .projected
@@ -64,7 +64,7 @@ fn projected_model_has_correct_capabilities() {
 fn projected_image_generation_model() {
     let json = fixture_json();
     let snapshot = parse_snapshot(&json).unwrap();
-    let result = Projector::new().project(&snapshot);
+    let result = Projector::new().project(&snapshot).unwrap();
 
     let gpt4o = result
         .projected
@@ -80,7 +80,7 @@ fn projected_image_generation_model() {
 fn unmapped_providers_are_skipped() {
     let json = fixture_json();
     let snapshot = parse_snapshot(&json).unwrap();
-    let result = Projector::new().project(&snapshot);
+    let result = Projector::new().project(&snapshot).unwrap();
 
     assert!(result
         .unmapped
@@ -143,7 +143,7 @@ fn artifact_rejects_zero_context_window() {
         }
     }"#;
     let snapshot = parse_snapshot(json).unwrap();
-    let result = Projector::new().project(&snapshot);
+    let result = Projector::new().project(&snapshot).unwrap();
     let artifact = ArtifactBuilder::new("rev", "ts", b"raw", "v").build(&result);
     // The artifact validate should catch zero context window.
     assert!(artifact.validate().is_err());
@@ -166,7 +166,7 @@ fn schema_drift_unknown_fields_ignored() {
         }
     }"#;
     let snapshot = parse_snapshot(json).expect("unknown fields must not break parsing");
-    let result = Projector::new().project(&snapshot);
+    let result = Projector::new().project(&snapshot).unwrap();
     assert_eq!(result.projected.len(), 1);
     assert!(result.projected[0].metadata.capabilities.supports_reasoning);
 }
@@ -184,7 +184,7 @@ fn missing_fields_do_not_become_true() {
         }
     }"#;
     let snapshot = parse_snapshot(json).unwrap();
-    let result = Projector::new().project(&snapshot);
+    let result = Projector::new().project(&snapshot).unwrap();
 
     let model = &result.projected[0].metadata;
     assert!(!model.capabilities.supports_reasoning);
@@ -208,7 +208,7 @@ fn custom_provider_mapping_projects_unmapped() {
     });
 
     let projector = Projector::with_mappings(mappings);
-    let result = projector.project(&snapshot);
+    let result = projector.project(&snapshot).unwrap();
 
     assert!(result.projected.iter().any(|m| {
         m.metadata.model_ref.provider.as_str() == "zai" && m.metadata.model_ref.model == "glm-5.2"

--- a/tests/models_dev_adapter.rs
+++ b/tests/models_dev_adapter.rs
@@ -1,0 +1,216 @@
+//! Integration tests for the models.dev upstream adapter (Phase 2A+2B).
+//!
+//! These tests verify the end-to-end flow: parse a `models.dev` fixture,
+//! project it into Holon canonical model metadata, build an immutable
+//! artifact with provenance, and validate internal consistency.
+
+use std::fs;
+
+use holon::model_catalog::models_dev::{
+    generate_artifact, parse_snapshot, ArtifactBuilder, ModelsDevArtifact, Projector,
+};
+
+const FIXTURE_PATH: &str = "tests/fixtures/models_dev/sample.json";
+
+fn fixture_json() -> String {
+    fs::read_to_string(FIXTURE_PATH).expect("fixture must be readable")
+}
+
+#[test]
+fn parse_fixture_snapshot() {
+    let json = fixture_json();
+    let snapshot = parse_snapshot(&json).expect("parse must succeed");
+    assert!(snapshot.providers.contains_key("openai"));
+    assert!(snapshot.providers.contains_key("anthropic"));
+    assert!(snapshot.providers.contains_key("hpc-ai"));
+    assert!(snapshot.providers.contains_key("zai-org"));
+}
+
+#[test]
+fn project_fixture_with_default_mappings() {
+    let json = fixture_json();
+    let snapshot = parse_snapshot(&json).unwrap();
+    let result = Projector::new().project(&snapshot);
+
+    // openai and anthropic are mapped; hpc-ai and zai-org are not.
+    assert!(result.projected.len() >= 3); // 2 openai + 1 anthropic
+    assert_eq!(result.unmapped.len(), 2); // 1 hpc-ai + 1 zai-org
+}
+
+#[test]
+fn projected_model_has_correct_capabilities() {
+    let json = fixture_json();
+    let snapshot = parse_snapshot(&json).unwrap();
+    let result = Projector::new().project(&snapshot);
+
+    let gpt55 = result
+        .projected
+        .iter()
+        .find(|m| m.models_dev_model_id == "gpt-5.5")
+        .expect("gpt-5.5 must be projected");
+
+    assert!(gpt55.metadata.capabilities.supports_reasoning);
+    assert!(gpt55.metadata.capabilities.image_input);
+    assert!(!gpt55.metadata.capabilities.image_generation);
+    assert_eq!(
+        gpt55.metadata.reasoning_effort_options,
+        vec!["none", "low", "medium", "high"]
+    );
+    assert_eq!(gpt55.metadata.context_window_tokens, Some(1_050_000));
+    assert_eq!(gpt55.metadata.default_max_output_tokens, Some(128_000));
+}
+
+#[test]
+fn projected_image_generation_model() {
+    let json = fixture_json();
+    let snapshot = parse_snapshot(&json).unwrap();
+    let result = Projector::new().project(&snapshot);
+
+    let gpt4o = result
+        .projected
+        .iter()
+        .find(|m| m.models_dev_model_id == "gpt-4o-mini")
+        .expect("gpt-4o-mini must be projected");
+
+    assert!(!gpt4o.metadata.capabilities.supports_reasoning);
+    assert!(gpt4o.metadata.capabilities.image_generation);
+}
+
+#[test]
+fn unmapped_providers_are_skipped() {
+    let json = fixture_json();
+    let snapshot = parse_snapshot(&json).unwrap();
+    let result = Projector::new().project(&snapshot);
+
+    assert!(result
+        .unmapped
+        .iter()
+        .any(|u| u.models_dev_provider_id == "hpc-ai"));
+    assert!(result
+        .unmapped
+        .iter()
+        .any(|u| u.models_dev_provider_id == "zai-org"));
+}
+
+#[test]
+fn generate_artifact_end_to_end() {
+    let json = fixture_json();
+    let generated = generate_artifact(
+        &json,
+        "fixture-rev-001",
+        "2026-08-31T00:00:00Z",
+        "test-0.1.0",
+    )
+    .expect("artifact generation must succeed");
+
+    assert_eq!(generated.artifact.schema_version, 1);
+    assert_eq!(generated.artifact.revision, "models-dev-fixture-rev-001");
+    assert_eq!(generated.artifact.upstream.source, "models.dev");
+    assert_eq!(generated.artifact.upstream.revision, "fixture-rev-001");
+    assert!(!generated.artifact.upstream.content_sha256.is_empty());
+    assert!(generated.artifact.model_count() >= 3);
+    assert!(generated.artifact.routes.is_empty());
+    assert!(generated.artifact.aliases.is_empty());
+    assert!(generated.artifact.preferred_models.is_empty());
+}
+
+#[test]
+fn artifact_json_roundtrips_through_serde() {
+    let json = fixture_json();
+    let generated = generate_artifact(
+        &json,
+        "fixture-rev-001",
+        "2026-08-31T00:00:00Z",
+        "test-0.1.0",
+    )
+    .unwrap();
+    let serialized = generated.artifact.to_json().unwrap();
+    let parsed: ModelsDevArtifact = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(parsed, generated.artifact);
+}
+
+#[test]
+fn artifact_rejects_zero_context_window() {
+    let json = r#"{
+        "openai": {
+            "id": "openai",
+            "models": {
+                "bad-model": {
+                    "id": "bad-model",
+                    "limit": {"context": 0, "output": 128000}
+                }
+            }
+        }
+    }"#;
+    let snapshot = parse_snapshot(json).unwrap();
+    let result = Projector::new().project(&snapshot);
+    let artifact = ArtifactBuilder::new("rev", "ts", b"raw", "v").build(&result);
+    // The artifact validate should catch zero context window.
+    assert!(artifact.validate().is_err());
+}
+
+#[test]
+fn schema_drift_unknown_fields_ignored() {
+    let json = r#"{
+        "openai": {
+            "id": "openai",
+            "future_provider_field": "ignored",
+            "models": {
+                "gpt-5.5": {
+                    "id": "gpt-5.5",
+                    "name": "GPT-5.5",
+                    "future_model_field": 42,
+                    "reasoning": true
+                }
+            }
+        }
+    }"#;
+    let snapshot = parse_snapshot(json).expect("unknown fields must not break parsing");
+    let result = Projector::new().project(&snapshot);
+    assert_eq!(result.projected.len(), 1);
+    assert!(result.projected[0].metadata.capabilities.supports_reasoning);
+}
+
+#[test]
+fn missing_fields_do_not_become_true() {
+    let json = r#"{
+        "openai": {
+            "id": "openai",
+            "models": {
+                "minimal": {
+                    "id": "minimal"
+                }
+            }
+        }
+    }"#;
+    let snapshot = parse_snapshot(json).unwrap();
+    let result = Projector::new().project(&snapshot);
+
+    let model = &result.projected[0].metadata;
+    assert!(!model.capabilities.supports_reasoning);
+    assert!(!model.capabilities.image_input);
+    assert!(!model.capabilities.image_generation);
+    assert!(model.context_window_tokens.is_none());
+    assert!(model.default_max_output_tokens.is_none());
+}
+
+#[test]
+fn custom_provider_mapping_projects_unmapped() {
+    let json = fixture_json();
+    let snapshot = parse_snapshot(&json).unwrap();
+
+    // Map zai-org to the Holon "zai" provider.
+    use holon::model_catalog::models_dev::ProviderMapping;
+    let mut mappings = ProviderMapping::default_mappings();
+    mappings.push(ProviderMapping {
+        models_dev_id: "zai-org".to_string(),
+        holon_provider_id: "zai".to_string(),
+    });
+
+    let projector = Projector::with_mappings(mappings);
+    let result = projector.project(&snapshot);
+
+    assert!(result.projected.iter().any(|m| {
+        m.metadata.model_ref.provider.as_str() == "zai" && m.metadata.model_ref.model == "glm-5.2"
+    }));
+}


### PR DESCRIPTION
## Summary

Implements Phase 2A+2B of the models.dev integration: a CI-time adapter that reads a pinned `models.dev` snapshot, projects it into Holon's canonical model registry format, and emits an immutable artifact with provenance metadata.

Follow-up to #2702.

## Changes

### New module: `src/model_catalog/models_dev/`

- **`dto.rs`** — Upstream DTO with tri-state `Option<T>` fields mirroring the `models.dev` JSON schema. Missing fields are `unknown`, not `false`. Unknown upstream fields are silently ignored for forward compatibility.
- **`projection.rs`** — Maps DTO to Holon `BuiltInModelMetadata` using an explicit provider mapping (`ProviderMapping`). Capabilities can only narrow; unmapped providers are skipped with diagnostics. Routes, aliases, and preferred selections are not generated — they are Holon-controlled.
- **`artifact.rs`** — Immutable artifact wrapper (`ModelsDevArtifact`) with provenance: upstream source, revision, fetched-at timestamp, content SHA-256, and adapter version. Validates schema version, unique identities, and positive token limits.
- **`mod.rs`** — Public API including `generate_artifact` end-to-end helper.

### RFC: `docs/rfcs/models-dev-adapter.md`

Defines the dual-source boundary, projection rules, artifact format, trust boundaries, and non-goals for Phase 2A+2B.

### Tests

- `tests/fixtures/models_dev/sample.json` — fixture covering mapped and unmapped providers, various capabilities, and missing fields.
- `tests/models_dev_adapter.rs` — 11 integration tests covering parse, projection, artifact generation, schema drift, duplicate rejection, zero-limit rejection, and custom provider mapping.
- 13 unit tests within the module (DTO parsing, projection rules, artifact validation, JSON roundtrip).

## Design decisions

- **Dual-source separation**: `models.dev` provides model metadata; Holon maintains the endpoint/plan manifest. The adapter cannot guess `dashscope@token-plan` from a provider name.
- **Capabilities can only narrow**: upstream metadata cannot widen Holon endpoint capabilities.
- **Missing = unknown**: the DTO uses `Option<T>` (tri-state); the projection uses conservative defaults for missing fields but never converts them to explicit assertions.
- **No legacy aliases**: `dashscope-token-plan` hyphenated format is not generated; canonical `provider@endpoint-variant` is used.
- **No runtime changes**: the runtime still reads the built-in snapshot. The artifact is a CI intermediate.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib model_catalog::models_dev` — 13 passed ✅
- `cargo test --test models_dev_adapter` — 11 passed ✅
- `cargo test --lib model_catalog` — 75 passed, 0 failed, 1 ignored (no regressions) ✅