### PR TITLE
feat: add expanded fullscreen mode to web GUI right side panel

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -86,6 +86,8 @@ export function App() {
   const resumeRevision = useRuntimeStore((state) => state.resumeRevision);
   const rightPanelOpen = useRuntimeStore((state) => state.rightPanelOpen);
   const rightPanelView = useRuntimeStore((state) => state.rightPanelView);
+  const rightPanelMode = useRuntimeStore((state) => state.rightPanelMode);
+  const toggleRightPanelExpanded = useRuntimeStore((state) => state.toggleRightPanelExpanded);
   const navCollapsed = useRuntimeStore((state) => state.navCollapsed);
   const setRoute = useRuntimeStore((state) => state.setRoute);
   const openAgent = useRuntimeStore((state) => state.openAgent);
@@ -490,6 +492,7 @@ export function App() {
     <div
       className="app-shell"
       data-panel={rightPanelOpen ? "open" : "closed"}
+      data-panel-mode={rightPanelMode}
       data-nav-collapsed={navCollapsed}
     >
       <aside className="sidebar" aria-label="Holon navigation">
@@ -858,6 +861,8 @@ export function App() {
           session={selectedAgentSession}
           view={rightPanelView?.agentId === selectedAgent.id ? rightPanelView : undefined}
           open={rightPanelOpen}
+          mode={rightPanelMode}
+          onToggleMode={toggleRightPanelExpanded}
           onLoadWorkItemDetail={(workItemId) => loadAgentWorkItemDetail(selectedAgent.id, workItemId)}
           onOpenWorkItemDetail={(workItem) => {
             showWorkItemDetail(selectedAgent.id, workItem);

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -6,8 +6,9 @@ import {
 } from "lucide-react";
 import {
   useEffect, useLayoutEffect, useMemo, useRef, useState,
-  type DragEvent, type FormEvent, type KeyboardEvent, type MutableRefObject, type RefObject,
+  type CSSProperties, type DragEvent, type FormEvent, type KeyboardEvent, type MutableRefObject, type RefObject,
 } from "react";
+import { createPortal } from "react-dom";
 import { useVirtualizer, type VirtualItem, type Virtualizer } from "@tanstack/react-virtual";
 
 import { Button } from "../../components/ui/Button";
@@ -344,10 +345,12 @@ export function AgentPage({
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const [selectedReasoningEffort, setSelectedReasoningEffort] = useState("auto");
   const [reasoningPopoverOpen, setReasoningPopoverOpen] = useState(false);
+  const [modelMenuStyle, setModelMenuStyle] = useState<CSSProperties | null>(null);
   const [visibleTimelineItemLimit, setVisibleTimelineItemLimit] = useState(() => defaultTimelineItemLimit("info"));
   const messageListRef = useRef<HTMLDivElement | null>(null);
   const virtualWrapperRef = useRef<HTMLDivElement | null>(null);
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const modelPickerRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dragCounterRef = useRef(0);
   const preserveScrollRef = useRef<ScrollAnchor | null>(null);
@@ -356,6 +359,39 @@ export function AgentPage({
   const userScrollIntentRef = useRef(false);
   const userScrollIntentTimerRef = useRef<number | null>(null);
   const scheduledBottomScrollRef = useRef<number | null>(null);
+
+  // The model menu renders through a portal with fixed positioning so narrow
+  // main columns no longer clip it behind the sidebar. Track the picker anchor
+  // each frame while open so resizes, panel toggles, and scroll stay aligned.
+  useLayoutEffect(() => {
+    if (!modelPickerOpen) {
+      setModelMenuStyle(null);
+      return;
+    }
+    let frame = 0;
+    let lastKey = "";
+    const position = () => {
+      frame = requestAnimationFrame(position);
+      const anchor = modelPickerRef.current;
+      if (!anchor) return;
+      const rect = anchor.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) return;
+      const margin = 12;
+      const next = {
+        right: Math.max(window.innerWidth - rect.right, 0),
+        bottom: window.innerHeight - rect.top + 8,
+        width: Math.max(280, Math.min(720, rect.right - margin, window.innerWidth - margin * 2)),
+        maxHeight: Math.max(180, Math.min(480, rect.top - 16)),
+      };
+      const key = `${next.right}|${next.bottom}|${next.width}|${next.maxHeight}`;
+      if (key === lastKey) return;
+      lastKey = key;
+      setModelMenuStyle(next);
+    };
+    position();
+    return () => cancelAnimationFrame(frame);
+  }, [modelPickerOpen]);
+
   const activeAgent = detail?.agent ?? agent;
   const sourceTimeline = detail?.timeline ?? [];
   const timeline = useMemo(
@@ -923,7 +959,7 @@ export function AgentPage({
                 >
                   <Paperclip size={16} />
                 </Button>
-                <div className="model-picker">
+                <div className="model-picker" ref={modelPickerRef}>
                   <Button
                     className="model-button"
                     type="button"
@@ -971,8 +1007,9 @@ export function AgentPage({
                       ) : null}
                     </div>
                   ) : null}
-                  {modelPickerOpen ? (
-                    <div className="model-menu" role="dialog" aria-label={t("agent.switchModelAria")}>
+                  {modelPickerOpen && modelMenuStyle ? (
+                    createPortal(
+                      <div className="model-menu" role="dialog" aria-label={t("agent.switchModelAria")} style={modelMenuStyle}>
                       <div className="model-menu-header">
                         <div>
                           <strong>{t("agent.switchModel")}</strong>
@@ -1064,7 +1101,9 @@ export function AgentPage({
                           description={t("agent.modelRefreshDesc")}
                         />
                       ) : null}
-                    </div>
+                      </div>,
+                      document.body,
+                    )
                   ) : null}
                 </div>
                 <Button className="send-button" type="submit" size="icon" variant="accent" aria-label={t("common.send")} disabled={!canSendPrompt}>

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -4,6 +4,7 @@ import type { AgentSummary, RightPanelView, RuntimeConnection, SkillCatalogState
 import type { AgentControlAction, AgentDeletionStatus } from "../../runtime/types";
 import type { AgentSessionState, TimelineEventsState } from "../../runtime/runtime-store";
 import type { TaskSummary } from "../../runtime/types";
+import { Maximize2, Minimize2, X } from "lucide-react";
 import { ActivityInspectorPanel, activityInspectorTitle } from "../inspector/ActivityInspectorPanel";
 import { AgentOverviewPanel, AgentSkillManagerPanel, ToolExecutionDetailPanel, WorkItemDetailPanel } from "./AgentOverviewPanel";
 import { TaskDetailPanel } from "./TaskDetailPanel";
@@ -28,6 +29,8 @@ interface RightSidePanelProps {
   session?: AgentSessionState;
   view?: RightPanelView;
   open: boolean;
+  mode: "normal" | "expanded";
+  onToggleMode: () => void;
   onLoadWorkItemDetail: (workItemId: string) => void;
   onOpenWorkItemDetail: (workItem: WorkItemSummary) => void;
   onOpenTask: (task: TaskSummary) => void;
@@ -63,6 +66,8 @@ export function RightSidePanel({
   session,
   view,
   open,
+  mode,
+  onToggleMode,
   onLoadWorkItemDetail,
   onOpenWorkItemDetail,
   onOpenTask,
@@ -126,6 +131,31 @@ export function RightSidePanel({
     [applyPanelWidth],
   );
 
+  // Global shortcuts while the panel is open: Cmd/Ctrl+. toggles the expanded
+  // overlay; Escape steps down the ladder expanded -> normal -> closed.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.isComposing) return;
+      if ((event.metaKey || event.ctrlKey) && event.key === ".") {
+        event.preventDefault();
+        onToggleMode();
+        return;
+      }
+      if (event.key !== "Escape") return;
+      // Let dialogs (e.g. modals) consume Escape first.
+      if (document.querySelector('[role="dialog"]')) return;
+      event.preventDefault();
+      if (mode === "expanded") {
+        onToggleMode();
+      } else {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, mode, onToggleMode, onClose]);
+
   const [showSkillManager, setShowSkillManager] = useState(false);
   const [showRuntimeTrace, setShowRuntimeTrace] = useState(false);
   const activeView = view?.agentId === agent.id ? view : { kind: "agent_overview" as const, agentId: agent.id };
@@ -173,9 +203,9 @@ export function RightSidePanel({
   };
 
   return (
-    <aside className="side-panel" aria-label={t("rightPanel.contextPanel")} hidden={!open} ref={panelRef}>
-      {open ? (
-        <div className="panel-resizer" data-dragging={dragging} onMouseDown={startResize} />
+    <aside className="side-panel" data-mode={mode} aria-label={t("rightPanel.contextPanel")} hidden={!open} ref={panelRef}>
+      {open && mode === "normal" ? (
+        <div className="panel-resizer" data-dragging={dragging} onMouseDown={startResize} onDoubleClick={onToggleMode} />
       ) : null}
       <div className="panel-header">
         <div>
@@ -208,8 +238,16 @@ export function RightSidePanel({
               {runtimeTraceActive ? t("rightPanel.agentOverview") : t("runtimeTrace.shortTitle")}
             </button>
           ) : null}
+          <button
+            type="button"
+            aria-label={mode === "expanded" ? t("rightPanel.restorePanel") : t("rightPanel.expandPanel")}
+            title={mode === "expanded" ? t("rightPanel.restorePanel") : t("rightPanel.expandPanel")}
+            onClick={onToggleMode}
+          >
+            {mode === "expanded" ? <Minimize2 size={14} aria-hidden="true" /> : <Maximize2 size={14} aria-hidden="true" />}
+          </button>
           <button type="button" aria-label={t("panel.closePanel")} onClick={onClose}>
-            ×
+            <X size={16} aria-hidden="true" />
           </button>
         </div>
       </div>

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 
 import type { AgentSummary, RightPanelView, RuntimeConnection, SkillCatalogState, TaskDetailState, ToolExecutionDetailState, WorkItemDetailState, WorkItemSummary } from "../../runtime/types";
 import type { AgentControlAction, AgentDeletionStatus } from "../../runtime/types";
 import type { AgentSessionState, TimelineEventsState } from "../../runtime/runtime-store";
+import { getRuntimeTraceRevision, isRuntimeTraceEnabled, subscribeRuntimeTrace } from "../../runtime/runtime-trace";
 import type { TaskSummary } from "../../runtime/types";
 import { Maximize2, Minimize2, X } from "lucide-react";
 import { ActivityInspectorPanel, activityInspectorTitle } from "../inspector/ActivityInspectorPanel";
@@ -158,9 +159,11 @@ export function RightSidePanel({
 
   const [showSkillManager, setShowSkillManager] = useState(false);
   const [showRuntimeTrace, setShowRuntimeTrace] = useState(false);
+  useSyncExternalStore(subscribeRuntimeTrace, getRuntimeTraceRevision, getRuntimeTraceRevision);
+  const runtimeTraceEnabled = isRuntimeTraceEnabled();
   const activeView = view?.agentId === agent.id ? view : { kind: "agent_overview" as const, agentId: agent.id };
   const skillManagerActive = activeView.kind === "agent_overview" && showSkillManager;
-  const runtimeTraceActive = activeView.kind === "agent_overview" && showRuntimeTrace;
+  const runtimeTraceActive = activeView.kind === "agent_overview" && showRuntimeTrace && runtimeTraceEnabled;
   const title =
     runtimeTraceActive
       ? t("runtimeTrace.title")
@@ -195,6 +198,10 @@ export function RightSidePanel({
     setShowRuntimeTrace(false);
   }, [agent.id, activeView.kind]);
 
+  useEffect(() => {
+    if (!runtimeTraceEnabled) setShowRuntimeTrace(false);
+  }, [runtimeTraceEnabled]);
+
   const openSkillManager = () => {
     setShowSkillManager(true);
     if (!availableSkillCatalogLoading && (availableSkillCatalog?.catalog.length ?? 0) === 0) {
@@ -226,7 +233,7 @@ export function RightSidePanel({
               {t("rightPanel.agentOverview")}
             </button>
           ) : null}
-          {activeView.kind === "agent_overview" ? (
+        {activeView.kind === "agent_overview" && runtimeTraceEnabled ? (
             <button
               type="button"
               aria-label={t("runtimeTrace.open")}

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -651,6 +651,8 @@ const en = {
     contextPanel: "Context side panel",
     showOverview: "Show agent overview",
     closePanel: "Close side panel",
+    expandPanel: "Expand side panel",
+    restorePanel: "Restore side panel",
     manageSkills: "Manage agent skills",
     workItemDetail: "Work item detail",
     taskDetail: "Task detail",

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -1015,7 +1015,7 @@ const en = {
     title: "Developer diagnostics",
     enabled: "Developer diagnostics enabled",
     disabled: "Developer diagnostics disabled",
-    description: "Show Debug and Timeline Events for agents and collect bounded runtime traces in this browser.",
+    description: "Show the agent Debug, Timeline Events, and Trace controls, and collect bounded runtime traces in this browser.",
     enable: "Enable developer diagnostics in this browser",
   },
 

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -1016,7 +1016,7 @@ const zh: Record<string, any> = {
     title: "开发者诊断",
     enabled: "开发者诊断已开启",
     disabled: "开发者诊断已关闭",
-    description: "显示 Agent 的调试与 Timeline Events，并在此浏览器中采集有界运行时追踪。",
+    description: "显示 Agent 的调试、Timeline Events 与追踪入口，并在此浏览器中采集有界运行时追踪。",
     enable: "在此浏览器中开启开发者诊断",
   },
 

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -652,6 +652,8 @@ const zh: Record<string, any> = {
     contextPanel: "上下文侧面板",
     showOverview: "显示智能体概览",
     closePanel: "关闭侧面板",
+    expandPanel: "展开侧面板",
+    restorePanel: "还原侧面板",
     manageSkills: "管理智能体技能",
     workItemDetail: "工作项详情",
     taskDetail: "任务详情",

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -2036,6 +2036,53 @@ describe("agentDetailErrorKind", () => {
   });
 });
 
+describe("right panel expanded mode", () => {
+  afterEach(() => {
+    useRuntimeStore.setState({
+      rightPanelOpen: true,
+      rightPanelMode: "normal",
+      rightPanelExpandedNavWasCollapsed: undefined,
+      navCollapsed: false,
+    });
+  });
+
+  it("collapses the nav rail while expanded and restores the pre-expansion nav state", () => {
+    useRuntimeStore.setState({ navCollapsed: true, rightPanelMode: "normal" });
+
+    useRuntimeStore.getState().toggleRightPanelExpanded();
+    expect(useRuntimeStore.getState()).toMatchObject({
+      rightPanelMode: "expanded",
+      rightPanelOpen: true,
+      navCollapsed: true,
+      rightPanelExpandedNavWasCollapsed: true,
+    });
+
+    // Nav toggles issued while expanded must not leak into the restore value.
+    useRuntimeStore.getState().toggleNavCollapsed();
+    expect(useRuntimeStore.getState().navCollapsed).toBe(false);
+
+    useRuntimeStore.getState().toggleRightPanelExpanded();
+    expect(useRuntimeStore.getState()).toMatchObject({
+      rightPanelMode: "normal",
+      navCollapsed: true,
+      rightPanelExpandedNavWasCollapsed: undefined,
+    });
+  });
+
+  it("resets expansion when the panel is closed", () => {
+    useRuntimeStore.setState({ navCollapsed: false, rightPanelMode: "normal" });
+
+    useRuntimeStore.getState().toggleRightPanelExpanded();
+    useRuntimeStore.getState().setRightPanelOpen(false);
+    expect(useRuntimeStore.getState()).toMatchObject({
+      rightPanelOpen: false,
+      rightPanelMode: "normal",
+      navCollapsed: false,
+      rightPanelExpandedNavWasCollapsed: undefined,
+    });
+  });
+});
+
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -319,6 +319,9 @@ export interface RuntimeStoreState {
   displayLevelsByAgentId: Record<string, DisplayLevel>;
   rightPanelViewStack: RightPanelView[];
   rightPanelOpen: boolean;
+  rightPanelMode: "normal" | "expanded";
+  // navCollapsed snapshot restored when the expanded panel returns to normal.
+  rightPanelExpandedNavWasCollapsed?: boolean;
   rightPanelView?: RightPanelView;
   timelineEventsByAgentId: Record<string, TimelineEventsState>;
   navCollapsed: boolean;
@@ -382,6 +385,7 @@ export interface RuntimeStoreState {
   setDisplayLevel: (displayLevel: DisplayLevel, agentId?: string) => void;
   disableDeveloperDiagnosticsUi: (agentId?: string) => void;
   setRightPanelOpen: (open: boolean) => void;
+  toggleRightPanelExpanded: () => void;
   showAgentOverview: (agentId?: string) => void;
   showTimelineEvents: (agentId: string) => void;
   refreshTimelineEvents: (agentId: string) => Promise<void>;
@@ -1340,6 +1344,17 @@ export async function retryPendingReadMarker(agentId: string): Promise<void> {
   }
 }
 
+function collapseRightPanelExpansion(state: {
+  navCollapsed: boolean;
+  rightPanelExpandedNavWasCollapsed?: boolean;
+}) {
+  return {
+    rightPanelMode: "normal" as const,
+    navCollapsed: state.rightPanelExpandedNavWasCollapsed ?? false,
+    rightPanelExpandedNavWasCollapsed: undefined,
+  };
+}
+
 export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
   agentSessionRepository = new AgentSessionRepository<RuntimeStoreState>({
     get,
@@ -1528,6 +1543,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
   displayLevel: "info",
   displayLevelsByAgentId: readStoredDisplayLevels(),
   rightPanelOpen: true,
+    rightPanelMode: "normal",
   rightPanelView: undefined,
   rightPanelViewStack: [],
   timelineEventsByAgentId: {},
@@ -1679,7 +1695,25 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
         rightPanelViewStack: state.rightPanelViewStack.filter((view) => view.kind !== "timeline_events"),
       };
     }),
-  setRightPanelOpen: (open) => set({ rightPanelOpen: open }),
+  setRightPanelOpen: (open) =>
+    set((state) => {
+      if (!open && state.rightPanelMode === "expanded") {
+        return { ...collapseRightPanelExpansion(state), rightPanelOpen: false };
+      }
+      return { rightPanelOpen: open };
+    }),
+  toggleRightPanelExpanded: () =>
+    set((state) => {
+      if (state.rightPanelMode === "expanded") {
+        return collapseRightPanelExpansion(state);
+      }
+      return {
+        rightPanelMode: "expanded",
+        rightPanelOpen: true,
+        rightPanelExpandedNavWasCollapsed: state.navCollapsed,
+        navCollapsed: true,
+      };
+    }),
   showAgentOverview: (agentId) =>
     set((state) => {
       const stack = state.rightPanelView ? [...state.rightPanelViewStack, state.rightPanelView] : state.rightPanelViewStack;

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -1543,7 +1543,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
   displayLevel: "info",
   displayLevelsByAgentId: readStoredDisplayLevels(),
   rightPanelOpen: true,
-    rightPanelMode: "normal",
+  rightPanelMode: "normal",
   rightPanelView: undefined,
   rightPanelViewStack: [],
   timelineEventsByAgentId: {},

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -340,6 +340,11 @@ button {
   grid-template-columns: 72px minmax(0, 1fr) var(--panel-w, 420px);
 }
 
+/* Expanded panel renders as a fixed overlay, so the grid stops reserving its column. */
+.app-shell[data-panel="open"][data-panel-mode="expanded"] {
+  grid-template-columns: 72px minmax(0, 1fr);
+}
+
 .sidebar {
   position: relative;
   z-index: 10;
@@ -5153,6 +5158,20 @@ code {
 .panel-resizer:hover,
 .panel-resizer[data-dragging="true"] {
   background: var(--accent, #4a9eff);
+}
+
+.side-panel[data-mode="expanded"] {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 72px;
+  z-index: 50;
+  box-shadow: -12px 0 32px rgba(24, 34, 48, 0.18);
+}
+
+.side-panel[data-mode="expanded"] .panel-resizer {
+  display: none;
 }
 
 .side-panel[hidden] {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2865,11 +2865,11 @@ code {
 }
 
 .model-menu {
-  position: absolute;
-  right: 0;
-  bottom: calc(100% + 8px);
-  z-index: 20;
-  width: min(720px, calc(100vw - 56px));
+  /* Rendered via portal with fixed positioning anchored to the picker in JS:
+     escapes the overflow-hidden shells so narrow main columns stop clipping
+     the menu behind the sidebar. */
+  position: fixed;
+  z-index: 60;
   max-height: 480px;
   overflow: auto;
   padding: 10px;
@@ -3061,10 +3061,6 @@ code {
 }
 
 @media (max-width: 640px) {
-  .model-menu {
-    width: min(440px, calc(100vw - 24px));
-  }
-
   .model-picker-grid {
     display: block;
   }


### PR DESCRIPTION
## Summary

Adds an expanded (fullscreen) mode to the web GUI right context panel, plus gates the panel's Trace button behind the developer diagnostics setting.

Stacked on #2727 (`fix/model-menu-overlay`) — **base is that branch on purpose**; it will be retargeted to `main` once #2727 merges.

## What changed

**Fullscreen mode** (`0fd7bce6`)

- Panel header gains ⤢ / ↙ icon buttons (lucide `Maximize2` / `Minimize2`); the plain-text × was swapped for a lucide `X` icon.
- Fullscreen = `position: fixed` overlay that starts after a 72px collapsed nav rail and fills the rest of the viewport.
- Entering fullscreen auto-collapses the left agent nav; restoring brings back the exact previous width and collapse state (snapshot in the store, no data loss).
- Toggle affordances: header button, double-click on the panel resizer, and `⌘.` / `Ctrl+.`.
- Escape ladder: fullscreen → restore → close panel (closing while expanded resets the expanded state).
- `runtime-store.ts`: new `rightPanelMode` state machine + nav collapse snapshot, covered by 2 new unit tests.

**Trace button gating** (`2c4cec96`)

- The right panel Trace button (and its trace view) now only renders when Settings → Advanced → *Developer diagnostics* is enabled (existing browser-local `holon:runtimeTraceEnabled`, default off). That switch already gated the Debug log level and Timeline Events; the Trace entry is the same class of developer tooling and was missing the gate.
- Toggling the setting off resets the trace panel open state without a page reload; settings copy (en/zh) updated to mention the Trace entry.

## How to verify

- Expand button / double-click resizer / `Ctrl+.` all toggle fullscreen; nav collapses to the 72px rail and restores exactly on exit.
- `Escape` walks fullscreen → restored → closed.
- With Developer diagnostics off, the Trace button is absent; enabling it in Settings reveals the button and trace panel without reload.

- `npm run typecheck` clean; `npm test` — 465 tests green (463 + 2 new store tests).
- All of the above exercised in a real browser against the dev server.
