### PR TITLE
feat: add DeepSeek OpenAI-compatible provider mapping baseline (Phase 3B)

### DIFF
--- a/docs/rfcs/models-dev-provider-mapping.md
+++ b/docs/rfcs/models-dev-provider-mapping.md
@@ -200,6 +200,24 @@ transport. The selection is evidence-based and does not follow provider
 popularity or offering count in `models.dev`. Gateways and token hubs are
 separate kinds and are not combined with this second pilot.
 
+#### DeepSeek (`deepseek@responses`) — selected 2026-08-31
+
+DeepSeek is the Phase 3B OpenAI-compatible baseline. The models.dev upstream
+provider ID is `deepseek`; the `npm` package is `@ai-sdk/openai-compatible`,
+confirming the wire protocol. Holon already has a `deepseek` provider
+definition (`deepseek@default` with `AnthropicMessages` transport) and
+synthesizes a derived `deepseek@responses` endpoint at runtime using
+`OpenAiResponses` transport and the same `DEEPSEEK_API_KEY` credential. The
+validation engine registers this derived route so that manifests referencing
+`deepseek@responses` resolve without requiring a standalone
+`ProviderDefinition` entry.
+
+The first model allowlist is `deepseek-v4-pro` and `deepseek-v4-flash`.
+The `deepseek-v4-flash-vision-exp` model (image input) is excluded from the
+initial allowlist. `structured_output` is conservatively set to `false` in
+the capability ceiling even though the upstream claims it; this produces a
+warning, not an error, and can be widened in a later phase.
+
 ## Rollback and non-goals
 
 Phase 3A produces a discovery/validation report or an explicitly disabled

--- a/src/model_catalog/models_dev/manifests/deepseek_v1.json
+++ b/src/model_catalog/models_dev/manifests/deepseek_v1.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "providers": [
+    {
+      "models_dev_id": "deepseek",
+      "holon_provider_id": "deepseek",
+      "kind": "open_ai_compatible",
+      "transport": "openai_responses",
+      "route_registration": "deepseek@responses",
+      "model_id": {
+        "mode": "exact_or_pattern",
+        "allow": ["deepseek-v4-pro", "deepseek-v4-flash"]
+      },
+      "capability_ceiling": {
+        "tool_calling": true,
+        "image_input": false,
+        "image_generation": false,
+        "reasoning": true,
+        "structured_output": false
+      },
+      "limit_ceiling": {
+        "context_window_tokens": 1000000,
+        "max_output_tokens": 384000
+      },
+      "credential_ref": "deepseek",
+      "enabled": false,
+      "provenance": {
+        "owner": "holon",
+        "reviewed_at": "2026-08-31"
+      }
+    }
+  ]
+}

--- a/src/model_catalog/models_dev/mapping.rs
+++ b/src/model_catalog/models_dev/mapping.rs
@@ -275,6 +275,23 @@ mod tests {
     }
 
     #[test]
+    fn parses_deepseek_manifest() {
+        let raw = include_str!("manifests/deepseek_v1.json");
+        let manifest = ProviderMappingManifest::parse(raw).unwrap();
+        assert_eq!(manifest.schema_version, 1);
+        assert_eq!(manifest.providers.len(), 1);
+        let entry = &manifest.providers[0];
+        assert_eq!(entry.models_dev_id, "deepseek");
+        assert_eq!(entry.holon_provider_id, "deepseek");
+        assert_eq!(entry.kind, ProviderKind::OpenAiCompatible);
+        assert_eq!(entry.transport, "openai_responses");
+        assert_eq!(entry.route_registration, "deepseek@responses");
+        assert!(!entry.enabled);
+        assert_eq!(entry.provenance.owner, "holon");
+        assert_eq!(entry.provenance.reviewed_at.as_deref(), Some("2026-08-31"));
+    }
+
+    #[test]
     fn exact_mode_only_matches_exact_ids() {
         let allow = ModelIdAllow {
             mode: ModelIdMatchMode::Exact,

--- a/src/model_catalog/models_dev/mod.rs
+++ b/src/model_catalog/models_dev/mod.rs
@@ -1,7 +1,8 @@
 //! `models.dev` upstream adapter: DTO, projection, and artifact generation.
 //!
-//! This module implements Phase 2A+2B (metadata ingestion) and Phase 3A
-//! (explicit provider mapping) of the models.dev integration:
+//! This module implements Phase 2A+2B (metadata ingestion), Phase 3A
+//! (explicit provider mapping — Anthropic baseline), and Phase 3B
+//! (OpenAI-compatible baseline — DeepSeek) of the models.dev integration:
 //!
 //! - [`dto`] defines an independent upstream DTO that mirrors the
 //!   `models.dev` JSON schema with tri-state `Option<T>` fields.

--- a/src/model_catalog/models_dev/validation.rs
+++ b/src/model_catalog/models_dev/validation.rs
@@ -132,6 +132,22 @@ impl ValidationEngine {
                 },
             );
         }
+        // Register the derived `deepseek@responses` route. This endpoint is
+        // synthesized at runtime from `deepseek@default` (see config::models),
+        // using OpenAiResponses transport with the same DEEPSEEK_API_KEY
+        // credential. It is not a standalone ProviderDefinition entry because
+        // its base URL and web-search config are derived from the default
+        // endpoint at runtime, but it is a valid Holon route identity.
+        if let Some(default) = routes.get("deepseek@default") {
+            routes.insert(
+                "deepseek@responses".to_string(),
+                RouteRegistration {
+                    transport: ProviderTransportKind::OpenAiResponses,
+                    credential_envs: default.credential_envs.clone(),
+                    legacy_provider: default.legacy_provider.clone(),
+                },
+            );
+        }
         Self { routes }
     }
 
@@ -942,6 +958,201 @@ mod tests {
         assert!(!report.has_errors());
         assert_eq!(report.total_upstream_providers, 0);
         assert!(report.unmapped_providers.is_empty());
+        assert!(report.offerings.is_empty());
+    }
+
+    // -- DeepSeek baseline (Phase 3B: OpenAI-compatible) --
+
+    /// A valid DeepSeek baseline manifest entry using the derived
+    /// `deepseek@responses` route with `openai_responses` transport.
+    fn deepseek_entry() -> ProviderMappingEntry {
+        ProviderMappingEntry {
+            models_dev_id: "deepseek".to_string(),
+            holon_provider_id: "deepseek".to_string(),
+            kind: ProviderKind::OpenAiCompatible,
+            transport: "openai_responses".to_string(),
+            route_registration: "deepseek@responses".to_string(),
+            model_id: ModelIdAllow {
+                mode: ModelIdMatchMode::ExactOrPattern,
+                allow: vec![
+                    "deepseek-v4-pro".to_string(),
+                    "deepseek-v4-flash".to_string(),
+                ],
+            },
+            capability_ceiling: CapabilityCeiling {
+                tool_calling: true,
+                image_input: false,
+                image_generation: false,
+                reasoning: true,
+                structured_output: false,
+            },
+            limit_ceiling: LimitCeiling {
+                context_window_tokens: Some(1_000_000),
+                max_output_tokens: Some(384_000),
+            },
+            credential_ref: "deepseek".to_string(),
+            enabled: false,
+            provenance: MappingProvenance {
+                owner: "holon".to_string(),
+                reviewed_at: Some("2026-08-31".to_string()),
+            },
+        }
+    }
+
+    /// Minimal models.dev snapshot with one DeepSeek model.
+    fn deepseek_snapshot() -> ModelsDevSnapshot {
+        let mut providers = BTreeMap::new();
+        providers.insert(
+            "deepseek".to_string(),
+            ModelsDevProvider {
+                id: "deepseek".to_string(),
+                env: vec!["DEEPSEEK_API_KEY".to_string()],
+                npm: None,
+                api: None,
+                name: None,
+                doc: None,
+                models: {
+                    let mut m = BTreeMap::new();
+                    m.insert(
+                        "deepseek-v4-flash".to_string(),
+                        ModelsDevModel {
+                            id: "deepseek-v4-flash".to_string(),
+                            name: Some("DeepSeek V4 Flash".to_string()),
+                            description: None,
+                            family: None,
+                            attachment: Some(false),
+                            reasoning: Some(true),
+                            reasoning_options: vec![],
+                            tool_call: Some(true),
+                            structured_output: Some(true),
+                            temperature: None,
+                            knowledge: None,
+                            release_date: None,
+                            last_updated: None,
+                            modalities: Some(ModelsDevModalities {
+                                input: vec!["text".to_string()],
+                                output: vec!["text".to_string()],
+                            }),
+                            open_weights: None,
+                            limit: Some(ModelsDevLimit {
+                                context: Some(1_000_000),
+                                output: Some(384_000),
+                                input: None,
+                            }),
+                            cost: None,
+                            interleaved: None,
+                        },
+                    );
+                    m
+                },
+            },
+        );
+        ModelsDevSnapshot { providers }
+    }
+
+    #[test]
+    fn validates_deepseek_baseline_without_errors() {
+        let engine = ValidationEngine::new();
+        let manifest = simple_manifest(deepseek_entry());
+        let snapshot = deepseek_snapshot();
+        let report = engine.validate(&manifest, Some(&snapshot));
+
+        assert!(
+            !report.has_errors(),
+            "expected no errors, got: {:?}",
+            report
+                .entries
+                .iter()
+                .filter(|e| e.severity == ValidationSeverity::Error)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(report.mapped_providers, 1);
+        assert_eq!(report.offerings.len(), 1);
+        assert_eq!(report.offerings[0].model_identity, "deepseek-v4-flash");
+        assert_eq!(report.offerings[0].route_registration, "deepseek@responses");
+        assert_eq!(report.offerings[0].callability, Callability::DiscoveryOnly);
+        // Should report disabled mapping as info
+        assert!(report.entries.iter().any(|e| e.code == "mapping_disabled"));
+        // structured_output=true upstream but ceiling=false → warning
+        assert!(report
+            .entries
+            .iter()
+            .any(|e| e.code == "capability_widening_structured_output"));
+    }
+
+    #[test]
+    fn deepseek_baseline_fixture_parses_and_validates() {
+        let raw = include_str!("manifests/deepseek_v1.json");
+        let manifest = ProviderMappingManifest::parse(raw).unwrap();
+        let engine = ValidationEngine::new();
+        let report = engine.validate(&manifest, None);
+        assert!(!report.has_errors());
+        // Should report disabled mapping as info
+        assert!(report
+            .entries
+            .iter()
+            .any(|e| e.code == "mapping_disabled" && e.severity == ValidationSeverity::Info));
+    }
+
+    #[test]
+    fn rejects_deepseek_transport_mismatch() {
+        let engine = ValidationEngine::new();
+        let mut entry = deepseek_entry();
+        // deepseek@responses route uses OpenAiResponses transport;
+        // claiming anthropic_messages must fail.
+        entry.transport = "anthropic_messages".to_string();
+        let manifest = simple_manifest(entry);
+        let report = engine.validate(&manifest, None);
+        assert!(report.has_errors());
+        assert!(report
+            .entries
+            .iter()
+            .any(|e| e.code == "transport_mismatch"));
+    }
+
+    #[test]
+    fn rejects_deepseek_unknown_credential_ref() {
+        let engine = ValidationEngine::new();
+        let mut entry = deepseek_entry();
+        entry.credential_ref = "totally-unknown".to_string();
+        let manifest = simple_manifest(entry);
+        let report = engine.validate(&manifest, None);
+        assert!(report.has_errors());
+        assert!(report
+            .entries
+            .iter()
+            .any(|e| e.code == "unknown_credential_ref"));
+    }
+
+    #[test]
+    fn rejects_deepseek_missing_route_registration() {
+        let engine = ValidationEngine::new();
+        let mut entry = deepseek_entry();
+        entry.route_registration = "deepseek@nonexistent".to_string();
+        let manifest = simple_manifest(entry);
+        let report = engine.validate(&manifest, None);
+        assert!(report.has_errors());
+        assert!(report
+            .entries
+            .iter()
+            .any(|e| e.code == "missing_route_registration"));
+    }
+
+    #[test]
+    fn deepseek_model_outside_allowlist_excluded() {
+        let engine = ValidationEngine::new();
+        let mut entry = deepseek_entry();
+        // Narrow allowlist to only pro; flash should be excluded.
+        entry.model_id.allow = vec!["deepseek-v4-pro".to_string()];
+        let manifest = simple_manifest(entry);
+        let snapshot = deepseek_snapshot();
+        let report = engine.validate(&manifest, Some(&snapshot));
+        assert!(!report.has_errors());
+        assert!(report
+            .entries
+            .iter()
+            .any(|e| e.code == "model_outside_allowlist"
+                && e.severity == ValidationSeverity::Warning));
         assert!(report.offerings.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Add the Phase 3B OpenAI-compatible provider mapping baseline using DeepSeek, building on the merged Phase 3A Anthropic baseline (PR #2726).

## Changes

- **New fixture**: `src/model_catalog/models_dev/manifests/deepseek_v1.json` — maps `models.dev` provider `deepseek` to the `deepseek@responses` route with `openai_responses` transport, `DEEPSEEK_API_KEY` credential ref, and a first-batch allowlist of `deepseek-v4-pro` and `deepseek-v4-flash`. `enabled=false`.
- **Validation engine**: register the derived `deepseek@responses` route in `ValidationEngine::new()`. This endpoint is synthesized at runtime from `deepseek@default` (see `config::models`), not a standalone `ProviderDefinition` entry. The derived route uses `OpenAiResponses` transport with the same `DEEPSEEK_API_KEY`.
- **Tests**: baseline acceptance (validates without errors, generates offering records), fixture parse/validate, and differential rejection tests (transport mismatch, credential ref, missing route, model outside allowlist). Also a parse test in `mapping.rs`.
- **RFC**: document the DeepSeek pilot selection in `docs/rfcs/models-dev-provider-mapping.md`, including the rationale for the derived route and the conservative `structured_output=false` ceiling.

## What does not change

- Default route, credential loading, transport implementation, and runtime refresh behavior are unchanged.
- `PROVIDER_DEFINITIONS` is not modified — the derived route registration is scoped to the validation engine only.
- `enabled=false` — the mapping is discovery-only, not callable.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib -- model_catalog::models_dev::` — 45 passed, 0 failed ✅
- `cargo test --test models_dev_adapter` — 11 passed, 0 failed ✅

## Runtime concept changed

Adds the second pilot (OpenAI-compatible dialect) to the models.dev provider mapping manifest. The validation engine now recognizes the runtime-derived `deepseek@responses` route alongside the static `deepseek@default` definition, allowing the Phase 3B manifest to validate without modifying the provider definitions list.