### PR TITLE
feat: models.dev provider mapping audit, CLI, and refresh/validate workflows

### DIFF
--- a/.github/workflows/models-dev-refresh.yml
+++ b/.github/workflows/models-dev-refresh.yml
@@ -1,0 +1,52 @@
+name: models.dev refresh
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  refresh:
+    name: Refresh models.dev snapshot and artifact
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build holon
+        run: cargo build --locked
+
+      - name: Fetch snapshot and generate artifact
+        run: cargo run --locked -- models-dev refresh --output-dir models.dev
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --exit-code -- models.dev/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update PR
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: models-dev-refresh
+          title: "chore: refresh models.dev snapshot and artifact"
+          body: |
+            Automated models.dev snapshot refresh.
+
+            - Snapshot and artifact regenerated from `https://models.dev/api.json`.
+            - Review the provider mapping audit output.
+            - No provider enablement or route changes.
+          commit-message: "chore: refresh models.dev snapshot and artifact"
+          labels: models-dev

--- a/.github/workflows/models-dev-validate.yml
+++ b/.github/workflows/models-dev-validate.yml
@@ -1,0 +1,47 @@
+name: models.dev validate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "models.dev/**"
+      - "src/model_catalog/models_dev/**"
+      - "src/provider/registry/providers.rs"
+      - "tests/models_dev_adapter.rs"
+      - "tests/fixtures/models_dev/**"
+      - ".github/workflows/models-dev-validate.yml"
+      - "Cargo.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate models.dev mapping and artifact
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Build
+        run: cargo check --all-targets --locked
+
+      - name: Validate checked-in artifact (if present)
+        run: |
+          if [ -f models.dev/snapshot.json ] && [ -f models.dev/artifact.json ]; then
+            cargo run --locked -- models-dev validate --input-dir models.dev
+          else
+            echo "No checked-in snapshot/artifact; skipping validate."
+          fi
+
+      - name: Run models.dev tests
+        run: cargo test --locked models_dev

--- a/models.dev/README.md
+++ b/models.dev/README.md
@@ -1,0 +1,41 @@
+# models.dev snapshot and artifact
+
+This directory holds the checked-in `models.dev` snapshot and the Holon
+artifact generated from it.
+
+## Files
+
+- `snapshot.json` — raw `models.dev/api.json` output fetched by
+  `holon models-dev refresh`.
+- `artifact.json` — Holon canonical model metadata projected from the
+  snapshot using the explicit provider mapping in
+  `src/model_catalog/models_dev/projection.rs`.
+
+## Refresh
+
+```bash
+cargo run -- models-dev refresh
+```
+
+This fetches the live `models.dev` snapshot, regenerates the artifact, and
+prints a provider mapping audit summary. The GitHub Actions workflow
+`models-dev-refresh.yml` runs this weekly and opens a PR when the snapshot
+or artifact changes.
+
+## Validate
+
+```bash
+cargo run -- models-dev validate
+cargo test models_dev
+```
+
+The `models-dev-validate.yml` workflow runs these checks on PRs touching
+the relevant paths.
+
+## Safety boundaries
+
+- Refreshing the snapshot does **not** enable providers, change routes,
+  alter credentials, or modify the default model selection.
+- The artifact is a CI/review intermediate; the runtime does not load it
+  directly.
+- Provider mapping changes require code review and merge.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -241,6 +241,14 @@ pub enum Commands {
         #[command(subcommand)]
         command: DebugCommands,
     },
+    #[command(
+        name = "models-dev",
+        about = "models.dev snapshot refresh, validation, and audit"
+    )]
+    ModelsDev {
+        #[command(subcommand)]
+        command: ModelsDevCommands,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -667,6 +675,31 @@ pub enum DebugCommands {
         stage: String,
         #[arg(long)]
         objective: String,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ModelsDevCommands {
+    #[command(
+        about = "Fetch the models.dev snapshot, generate artifact, and write to models.dev/"
+    )]
+    Refresh {
+        #[arg(long, default_value = "https://models.dev/api.json")]
+        url: String,
+        #[arg(long, default_value = "models.dev")]
+        output_dir: PathBuf,
+    },
+    #[command(about = "Validate the checked-in models.dev snapshot and artifact")]
+    Validate {
+        #[arg(long, default_value = "models.dev")]
+        input_dir: PathBuf,
+    },
+    #[command(about = "Audit provider mappings against a snapshot")]
+    Audit {
+        #[arg(long, default_value = "models.dev/snapshot.json")]
+        snapshot: PathBuf,
         #[arg(long)]
         json: bool,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,9 @@ use tracing_subscriber::EnvFilter;
 use holon::cli::{
     AgentCommands, AgentModelCommands, Cli, Commands, ConfigCommands, ConfigCredentialCommands,
     ConfigModelCommands, ConfigProviderCommands, ControlCommandAction, DaemonCommands,
-    DebugCommands, EventsCommands, MemoryIndexCommands, ServeAccess, ServeOptions, SkillsCommands,
-    TaskCommands, TimerCommands, TimerCreateArgs, WorkItemCommands, WorkspaceCommands,
+    DebugCommands, EventsCommands, MemoryIndexCommands, ModelsDevCommands, ServeAccess,
+    ServeOptions, SkillsCommands, TaskCommands, TimerCommands, TimerCreateArgs, WorkItemCommands,
+    WorkspaceCommands,
 };
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -271,6 +272,7 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         Commands::Run { .. } => unreachable!("run command is handled separately"),
         Commands::Solve { .. } => unreachable!("solve command is handled separately"),
         Commands::Debug { command } => handle_debug_command(config, command).await,
+        Commands::ModelsDev { command } => handle_models_dev_command(command).await,
         Commands::Onboard { .. } => unreachable!("onboard command is handled before runtime load"),
         Commands::Config { .. } => unreachable!("config commands are handled separately"),
     }
@@ -2998,6 +3000,138 @@ fn filter_scheduler_recovery_report(
         .task_result_claim_recoveries
         .retain(|candidate| candidate.message_id == message_id);
     Ok(())
+}
+
+async fn handle_models_dev_command(command: ModelsDevCommands) -> Result<()> {
+    use holon::model_catalog::models_dev::{
+        audit_mappings, generate_artifact, parse_snapshot, MappingAuditReport, ProviderMapping,
+    };
+    use sha2::Digest;
+
+    match command {
+        ModelsDevCommands::Refresh { url, output_dir } => {
+            println!("Fetching models.dev snapshot from {url} …");
+            let response = reqwest::blocking::get(&url)
+                .map_err(|e| anyhow!("failed to fetch models.dev snapshot: {e}"))?;
+            if !response.status().is_success() {
+                anyhow::bail!("models.dev fetch returned status {}", response.status());
+            }
+            let raw_json = response
+                .text()
+                .map_err(|e| anyhow!("failed to read models.dev response: {e}"))?;
+            let fetched_at = chrono::Utc::now().to_rfc3339();
+            let sha = sha2::Sha256::digest(raw_json.as_bytes());
+            let upstream_revision = sha.iter().map(|b| format!("{b:02x}")).collect::<String>();
+
+            std::fs::create_dir_all(&output_dir)
+                .map_err(|e| anyhow!("failed to create output dir: {e}"))?;
+            let snapshot_path = output_dir.join("snapshot.json");
+            std::fs::write(&snapshot_path, &raw_json)
+                .map_err(|e| anyhow!("failed to write snapshot: {e}"))?;
+
+            let generated = generate_artifact(
+                &raw_json,
+                &upstream_revision,
+                &fetched_at,
+                env!("HOLON_VERSION"),
+            )
+            .map_err(|e| anyhow!("artifact generation failed: {e}"))?;
+
+            let artifact_path = output_dir.join("artifact.json");
+            let artifact_json = generated
+                .artifact
+                .to_json()
+                .map_err(|e| anyhow!("failed to serialize artifact: {e}"))?;
+            std::fs::write(&artifact_path, &artifact_json)
+                .map_err(|e| anyhow!("failed to write artifact: {e}"))?;
+
+            let report = audit_mappings(
+                &parse_snapshot(&raw_json).map_err(|e| anyhow!("parse error: {e}"))?,
+                &ProviderMapping::default_mappings(),
+            );
+
+            println!("Snapshot  → {}", snapshot_path.display());
+            println!(
+                "Artifact  → {} ({} models)",
+                artifact_path.display(),
+                generated.artifact.model_count()
+            );
+            println!("Mapped    → {} providers", report.mapped.len());
+            println!(
+                "Unmapped  → {} upstream providers",
+                report.unmapped_upstream.len()
+            );
+            println!("Stale     → {} Holon mappings", report.stale_holon.len());
+            if !report.stale_holon.is_empty() {
+                eprintln!("WARNING: stale mappings (models.dev ID not in snapshot):");
+                for entry in &report.stale_holon {
+                    eprintln!("  {} → {}", entry.models_dev_id, entry.holon_provider_id);
+                }
+            }
+            Ok(())
+        }
+        ModelsDevCommands::Validate { input_dir } => {
+            let snapshot_path = input_dir.join("snapshot.json");
+            let artifact_path = input_dir.join("artifact.json");
+            let raw_json = std::fs::read_to_string(&snapshot_path)
+                .map_err(|e| anyhow!("failed to read snapshot: {e}"))?;
+            let artifact_json = std::fs::read_to_string(&artifact_path)
+                .map_err(|e| anyhow!("failed to read artifact: {e}"))?;
+            let artifact: holon::model_catalog::models_dev::ModelsDevArtifact =
+                serde_json::from_str(&artifact_json)
+                    .map_err(|e| anyhow!("failed to parse artifact JSON: {e}"))?;
+            artifact
+                .validate()
+                .map_err(|e| anyhow!("artifact validation failed: {e}"))?;
+            let snapshot =
+                parse_snapshot(&raw_json).map_err(|e| anyhow!("failed to parse snapshot: {e}"))?;
+            let report = audit_mappings(&snapshot, &ProviderMapping::default_mappings());
+            println!("Artifact valid ({} models)", artifact.model_count());
+            println!(
+                "Audit: mapped={}, unmapped={}, stale={}",
+                report.mapped.len(),
+                report.unmapped_upstream.len(),
+                report.stale_holon.len()
+            );
+            if !report.stale_holon.is_empty() {
+                eprintln!(
+                    "WARNING: {} stale mapping(s) need attention",
+                    report.stale_holon.len()
+                );
+            }
+            Ok(())
+        }
+        ModelsDevCommands::Audit { snapshot, json } => {
+            let raw_json = std::fs::read_to_string(&snapshot)
+                .map_err(|e| anyhow!("failed to read snapshot: {e}"))?;
+            let parsed =
+                parse_snapshot(&raw_json).map_err(|e| anyhow!("failed to parse snapshot: {e}"))?;
+            let report: MappingAuditReport =
+                audit_mappings(&parsed, &ProviderMapping::default_mappings());
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report)
+                        .map_err(|e| anyhow!("failed to serialize audit: {e}"))?
+                );
+            } else {
+                println!("Provider mapping audit");
+                println!("Mapped ({}):", report.mapped.len());
+                for entry in &report.mapped {
+                    println!("  {} → {}", entry.models_dev_id, entry.holon_provider_id);
+                }
+                println!("Unmapped upstream ({}):", report.unmapped_upstream.len());
+                for id in &report.unmapped_upstream {
+                    println!("  {id}");
+                }
+                println!("Stale Holon mappings ({}):", report.stale_holon.len());
+                for entry in &report.stale_holon {
+                    println!("  {} → {}", entry.models_dev_id, entry.holon_provider_id);
+                }
+            }
+            Ok(())
+        }
+    }
 }
 
 fn handle_runtime_db_debug_command(

--- a/src/model_catalog/models_dev/mod.rs
+++ b/src/model_catalog/models_dev/mod.rs
@@ -4,6 +4,8 @@
 //! (explicit provider mapping — Anthropic baseline), and Phase 3B
 //! (OpenAI-compatible baseline — DeepSeek) of the models.dev integration:
 //!
+//! Also includes provider mapping audit for CI and manual review.
+//!
 //! - [`dto`] defines an independent upstream DTO that mirrors the
 //!   `models.dev` JSON schema with tri-state `Option<T>` fields.
 //! - [`projection`] maps DTO fields to Holon `BuiltInModelMetadata` using an
@@ -16,6 +18,8 @@
 //! - [`validation`] validates a manifest against Holon's built-in provider
 //!   definitions and optionally a `models.dev` snapshot, producing a
 //!   deterministic report with rejection diagnostics.
+//! - [`audit_mappings`] compares provider mappings against a live snapshot
+//!   to surface unmapped upstream providers and stale Holon mappings.
 //!
 //! The runtime does not consume `models.dev` directly. CI uses this module
 //! to generate an immutable artifact that enters Holon through review and
@@ -82,4 +86,131 @@ pub fn generate_artifact(
 pub struct GeneratedArtifact {
     pub artifact: ModelsDevArtifact,
     pub projection: ProjectionResult,
+}
+
+/// A single mapped provider entry in a [`MappingAuditReport`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct MappedProviderEntry {
+    pub models_dev_id: String,
+    pub holon_provider_id: String,
+}
+
+/// Report comparing Holon provider mappings against a `models.dev` snapshot.
+///
+/// Produced by [`audit_mappings`]. Used by CI and manual review to detect
+/// unmapped upstream providers and stale Holon mappings.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct MappingAuditReport {
+    pub mapped: Vec<MappedProviderEntry>,
+    pub unmapped_upstream: Vec<String>,
+    pub stale_holon: Vec<MappedProviderEntry>,
+}
+
+/// Audits provider mappings against a `models.dev` snapshot.
+///
+/// Reports mapped, unmapped upstream, and stale (dead) mappings.
+/// Does not change runtime behavior.
+pub fn audit_mappings(
+    snapshot: &ModelsDevSnapshot,
+    mappings: &[ProviderMapping],
+) -> MappingAuditReport {
+    use std::collections::BTreeSet;
+    let snapshot_ids: BTreeSet<&str> = snapshot.providers.keys().map(String::as_str).collect();
+    let mapping_md_ids: BTreeSet<&str> =
+        mappings.iter().map(|m| m.models_dev_id.as_str()).collect();
+    let mapped = mappings
+        .iter()
+        .filter(|m| snapshot_ids.contains(m.models_dev_id.as_str()))
+        .map(|m| MappedProviderEntry {
+            models_dev_id: m.models_dev_id.clone(),
+            holon_provider_id: m.holon_provider_id.clone(),
+        })
+        .collect();
+    let unmapped_upstream = snapshot_ids
+        .iter()
+        .filter(|id| !mapping_md_ids.contains(**id))
+        .map(|id| id.to_string())
+        .collect();
+    let stale_holon = mappings
+        .iter()
+        .filter(|m| !snapshot_ids.contains(m.models_dev_id.as_str()))
+        .map(|m| MappedProviderEntry {
+            models_dev_id: m.models_dev_id.clone(),
+            holon_provider_id: m.holon_provider_id.clone(),
+        })
+        .collect();
+    MappingAuditReport {
+        mapped,
+        unmapped_upstream,
+        stale_holon,
+    }
+}
+
+#[cfg(test)]
+mod audit_tests {
+    use super::*;
+
+    fn sample_snapshot() -> ModelsDevSnapshot {
+        let json = r#"{
+            "openai": { "id": "openai", "models": {} },
+            "moonshotai": { "id": "moonshotai", "models": {} },
+            "hpc-ai": { "id": "hpc-ai", "models": {} }
+        }"#;
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn audit_reports_mapped_unmapped_and_stale() {
+        let snapshot = sample_snapshot();
+        let mappings = vec![
+            ProviderMapping {
+                models_dev_id: "openai".into(),
+                holon_provider_id: "openai".into(),
+            },
+            ProviderMapping {
+                models_dev_id: "moonshotai".into(),
+                holon_provider_id: "moonshot".into(),
+            },
+            ProviderMapping {
+                models_dev_id: "nonexistent".into(),
+                holon_provider_id: "ghost".into(),
+            },
+        ];
+        let report = audit_mappings(&snapshot, &mappings);
+        assert_eq!(report.mapped.len(), 2);
+        assert!(report.mapped.iter().any(|m| m.models_dev_id == "openai"));
+        assert!(report
+            .mapped
+            .iter()
+            .any(|m| m.models_dev_id == "moonshotai" && m.holon_provider_id == "moonshot"));
+        assert_eq!(report.stale_holon.len(), 1);
+        assert_eq!(report.stale_holon[0].models_dev_id, "nonexistent");
+        assert!(report.unmapped_upstream.contains(&"hpc-ai".to_string()));
+    }
+
+    #[test]
+    fn audit_default_mappings_have_no_stale() {
+        let json = r#"{
+            "openai":{"id":"openai","models":{}},"anthropic":{"id":"anthropic","models":{}},
+            "deepseek":{"id":"deepseek","models":{}},"moonshotai":{"id":"moonshotai","models":{}},
+            "togetherai":{"id":"togetherai","models":{}},"fireworks-ai":{"id":"fireworks-ai","models":{}},
+            "google":{"id":"google","models":{}},"zhipuai":{"id":"zhipuai","models":{}},
+            "alibaba":{"id":"alibaba","models":{}},"nvidia":{"id":"nvidia","models":{}},
+            "openrouter":{"id":"openrouter","models":{}},"huggingface":{"id":"huggingface","models":{}},
+            "xai":{"id":"xai","models":{}},"minimax":{"id":"minimax","models":{}},
+            "zai":{"id":"zai","models":{}},"volcengine":{"id":"volcengine","models":{}},
+            "stepfun":{"id":"stepfun","models":{}},"arcee":{"id":"arcee","models":{}},
+            "chutes":{"id":"chutes","models":{}},"nearai":{"id":"nearai","models":{}},
+            "venice":{"id":"venice","models":{}},"xiaomi":{"id":"xiaomi","models":{}},
+            "mistral":{"id":"mistral","models":{}}
+        }"#;
+        let snapshot: ModelsDevSnapshot = serde_json::from_str(json).unwrap();
+        let report = audit_mappings(&snapshot, &ProviderMapping::default_mappings());
+        assert!(
+            report.stale_holon.is_empty(),
+            "stale mappings: {:?}",
+            report.stale_holon
+        );
+        assert!(!report.mapped.is_empty());
+    }
 }

--- a/src/model_catalog/models_dev/projection.rs
+++ b/src/model_catalog/models_dev/projection.rs
@@ -30,47 +30,61 @@ pub struct ProviderMapping {
 }
 
 impl ProviderMapping {
-    /// Returns the default set of direct provider ID matches.
+    /// Returns the default set of provider mappings.
     ///
-    /// These are providers whose `models.dev` ID directly matches the Holon
-    /// canonical provider ID. Unmapped providers are skipped during
-    /// projection.
+    /// Includes both direct ID matches (models.dev ID == Holon provider ID)
+    /// and name-mismatched mappings (e.g. `moonshotai` → `moonshot`).
+    /// Unmapped providers are skipped during projection.
     pub fn default_mappings() -> Vec<Self> {
-        [
+        // Direct matches: models.dev provider ID == Holon provider ID.
+        let direct = [
             "anthropic",
             "openai",
             "deepseek",
             "mistral",
-            "moonshot",
             "nvidia",
             "openrouter",
-            "together",
-            "fireworks",
             "huggingface",
             "xai",
-            "gemini",
             "minimax",
             "zai",
-            "bigmodel",
             "volcengine",
             "stepfun",
-            "qianfan",
-            "byteplus",
             "arcee",
             "chutes",
             "nearai",
             "venice",
-            "vllm",
-            "ollama",
             "xiaomi",
-            "dashscope",
         ]
         .into_iter()
         .map(|id| Self {
             models_dev_id: id.to_string(),
             holon_provider_id: id.to_string(),
         })
-        .collect()
+        .collect::<Vec<_>>();
+
+        // Name-mismatched mappings: the models.dev provider ID differs from
+        // the Holon canonical provider ID. Verified against the live
+        // `models.dev/api.json` snapshot.
+        let mismatched = [
+            ("moonshotai", "moonshot"),
+            ("togetherai", "together"),
+            ("fireworks-ai", "fireworks"),
+            ("google", "gemini"),
+            ("zhipuai", "bigmodel"),
+            ("alibaba", "dashscope"),
+        ];
+        let mismatched = mismatched
+            .into_iter()
+            .map(|(md_id, holon_id)| Self {
+                models_dev_id: md_id.to_string(),
+                holon_provider_id: holon_id.to_string(),
+            })
+            .collect::<Vec<_>>();
+
+        let mut mappings = direct;
+        mappings.extend(mismatched);
+        mappings
     }
 }
 

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -1190,6 +1190,71 @@
     "aliases": []
   },
   {
+    "path": "models-dev",
+    "positionals": [],
+    "flags": [],
+    "aliases": []
+  },
+  {
+    "path": "models-dev.audit",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "json",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
+        "long": "snapshot",
+        "short": null,
+        "default_value": "models.dev/snapshot.json",
+        "possible_values": null,
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
+    "path": "models-dev.refresh",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "output-dir",
+        "short": null,
+        "default_value": "models.dev",
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "url",
+        "short": null,
+        "default_value": "https://models.dev/api.json",
+        "possible_values": null,
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
+    "path": "models-dev.validate",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "input-dir",
+        "short": null,
+        "default_value": "models.dev",
+        "possible_values": null,
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "onboard",
     "positionals": [],
     "flags": [


### PR DESCRIPTION
## Summary

Implements the models.dev provider mapping audit, CLI commands, and GitHub Actions refresh/validate workflows.

## Changes

### Provider mapping fixes

Audited Holon's 32 built-in provider IDs against the live `models.dev/api.json` snapshot and corrected the mapping in `ProviderMapping::default_mappings()`:

- **Fixed 6 name-mismatched mappings** where the models.dev ID differs from the Holon canonical ID:
  - `moonshotai` → `moonshot`
  - `togetherai` → `together`
  - `fireworks-ai` → `fireworks`
  - `google` → `gemini`
  - `zhipuai` → `bigmodel`
  - `alibaba` → `dashscope`
- **Removed 4 mappings** with no models.dev upstream equivalent: `qianfan`, `byteplus`, `vllm`, `ollama`

### Audit function

Added `audit_mappings()` and `MappingAuditReport` to `src/model_catalog/models_dev/mod.rs`. Reports:
- `mapped`: mappings whose `models_dev_id` exists in the snapshot
- `unmapped_upstream`: snapshot provider IDs with no Holon mapping
- `stale_holon`: mappings whose `models_dev_id` is absent from the snapshot

Includes unit tests verifying both the audit logic and that `default_mappings()` has no stale entries against a fixture containing all mapped provider IDs.

### CLI commands

Added `holon models-dev` top-level command with three subcommands:
- `refresh` — fetches the models.dev snapshot, generates the artifact, writes both to `models.dev/`, and prints an audit summary
- `validate` — validates the checked-in snapshot and artifact
- `audit` — prints a provider mapping audit report (text or JSON)

### GitHub Actions workflows

- **`models-dev-refresh.yml`** — weekly (Mon 06:00 UTC) + manual. Fetches snapshot, generates artifact, and opens a PR only when content changes. No provider enablement or route changes.
- **`models-dev-validate.yml`** — triggered on PRs touching `models.dev/**`, `src/model_catalog/models_dev/**`, provider registry, tests, or `Cargo.toml`. Runs `cargo fmt --check`, `cargo check`, artifact validation, and `cargo test models_dev`.

### `models.dev/` directory

Contains `README.md` documenting the snapshot/artifact refresh and validation workflow.

## Safety boundaries

- Refreshing the snapshot does **not** enable providers, change routes, alter credentials, or modify the default model selection.
- The artifact is a CI/review intermediate; the runtime does not load it directly.
- Provider mapping changes require code review and merge.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test models_dev` — 16 tests passed ✅
- `holon models-dev audit --snapshot tests/fixtures/models_dev/sample.json` — correctly reports mapped/unmapped/stale ✅