### PR TITLE
fix: allow models.dev refresh workflow to open PRs

### DIFF
--- a/.github/workflows/models-dev-refresh.yml
+++ b/.github/workflows/models-dev-refresh.yml
@@ -14,6 +14,9 @@ jobs:
   refresh:
     name: Refresh models.dev snapshot and artifact
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- grant the refresh job the write permissions required by `peter-evans/create-pull-request@v6`
- keep the workflow default permissions read-only and scope write access to the refresh job

## Verification

- `git diff --check`
- `yamllint .github/workflows/models-dev-refresh.yml` (pre-existing warnings/errors remain on document start, GitHub `on` parsing, and line 51; no new issue from this change)

Fixes the permissions gap identified after #2731.
