### PR TITLE
fix: preserve canonical AgentLifecycle binding ownership

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3484,15 +3484,16 @@ impl RuntimeHandle {
                 guard.state.current_turn_work_item_id = guard.state.current_work_item_id.clone();
             }
             guard.state.current_execution_binding = message.map(|message| {
-                let work_item_id = canonical_execution_binding
-                    .as_ref()
-                    .and_then(|(_, owner)| owner.work_item_id().map(ToString::to_string))
-                    .or_else(|| {
-                        message
-                            .work_item_id
-                            .clone()
-                            .or_else(|| guard.state.current_turn_work_item_id.clone())
-                    });
+                let work_item_id = if canonical_execution_binding.is_some() {
+                    canonical_execution_binding
+                        .as_ref()
+                        .and_then(|(_, owner)| owner.work_item_id().map(ToString::to_string))
+                } else {
+                    message
+                        .work_item_id
+                        .clone()
+                        .or_else(|| guard.state.current_turn_work_item_id.clone())
+                };
                 let claimed_work_revision = work_item_id
                     .as_deref()
                     .and_then(|work_item_id| {

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -814,6 +814,119 @@ fn append_default_host_identity(runtime: &RuntimeHandle) {
         .unwrap();
 }
 
+#[tokio::test]
+async fn canonical_agent_lifecycle_binding_does_not_inherit_message_work_item() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = runtime
+        .create_work_item("unrelated focused work item".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work_item.id.clone()).await.unwrap();
+
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "agent_lifecycle".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "agent lifecycle wake".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.work_item_id = Some(work_item.id.clone());
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let state = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
+    let admitted = crate::domain::execution_protocol::admit_execution(
+        &state,
+        &crate::domain::execution_protocol::AdmitExecution {
+            attempt: crate::domain::execution_protocol::ExecutionAttempt {
+                attempt_id: activation_id.clone(),
+                agent_id: "default".into(),
+                source_message_id: Some(message.id.clone()),
+                source: crate::domain::execution_protocol::ExecutionSource {
+                    identity:
+                        crate::domain::execution_protocol::ExecutionSourceIdentity::QueueMessage {
+                            message_id: message.id.clone(),
+                        },
+                    generation: 1,
+                },
+                binding: crate::domain::execution_protocol::ExecutionBinding::AgentLifecycle {
+                    agent_id: "default".into(),
+                },
+                provenance: crate::domain::execution_protocol::ExecutionProvenance {
+                    origin: crate::domain::execution_protocol::ExecutionOrigin::System,
+                    trust: crate::domain::execution_protocol::ExecutionTrust::RuntimeInstruction,
+                    priority: crate::domain::execution_protocol::ExecutionPriority::Normal,
+                    correlation_id: None,
+                    causation_id: None,
+                },
+                admitted_fences: crate::domain::execution_protocol::AdmittedFences {
+                    source_revision: 1,
+                    work_item_source_revision: None,
+                    work_item_generation: None,
+                    rejoin: None,
+                    agent_control_revision: 1,
+                    host_registry_revision: 1,
+                },
+                state: crate::domain::execution_protocol::ExecutionAttemptState::Open,
+                run_id: None,
+                turn_id: None,
+                recovery_of_attempt_id: None,
+                terminal_outcome_id: None,
+                admitted_at: Utc::now().to_rfc3339(),
+                terminal_at: None,
+            },
+        },
+    )
+    .unwrap();
+    runtime
+        .inner
+        .runtime_db
+        .transaction(|tx| crate::runtime_db::transitions::persist_state_tx(tx, &admitted.state))
+        .unwrap();
+
+    runtime
+        .begin_interactive_turn_with_provenance(
+            Some(&message),
+            None,
+            None,
+            crate::types::ExecutionAdmissionProvenance::Canonical {
+                scenario_class: scheduler::WORK_ITEM_AUTONOMOUS_CONTINUATION_SCENARIO,
+                activation_id,
+            },
+        )
+        .await
+        .unwrap();
+    let state = runtime.agent_state().await.unwrap();
+    let binding = state.current_execution_binding.unwrap();
+    assert!(matches!(
+        binding.owner,
+        Some(crate::types::TurnOwner::AgentLifecycle { .. })
+    ));
+    assert_eq!(binding.work_item_id, None);
+    assert_eq!(state.current_turn_work_item_id, None);
+}
+
 struct OperatorInterjectionProbeProvider {
     calls: Mutex<usize>,
     requests: Mutex<Vec<ProviderTurnRequest>>,

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -815,7 +815,7 @@ fn append_default_host_identity(runtime: &RuntimeHandle) {
 }
 
 #[tokio::test]
-async fn canonical_agent_lifecycle_binding_does_not_inherit_message_work_item() {
+async fn canonical_agent_lifecycle_binding_does_not_inherit_replay_or_message_work_item() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -854,6 +854,13 @@ async fn canonical_agent_lifecycle_binding_does_not_inherit_message_work_item() 
         AdmissionContext::RuntimeOwned,
     );
     message.work_item_id = Some(work_item.id.clone());
+    let source_turn_id = "turn-interrupted-agent-lifecycle";
+    let mut source_turn = TurnRecord::new("default", source_turn_id, 1);
+    source_turn.current_work_item_id = Some(work_item.id.clone());
+    runtime.storage().append_turn(&source_turn).unwrap();
+    message
+        .source_refs
+        .insert("replay_source_turn_id".into(), source_turn_id.into());
     let activation_id = scheduler_executor::canonical_activation_id(&message.id);
     let state = crate::domain::execution_protocol::ExecutionProtocolState::empty("default");
     let admitted = crate::domain::execution_protocol::admit_execution(
@@ -918,13 +925,20 @@ async fn canonical_agent_lifecycle_binding_does_not_inherit_message_work_item() 
         .await
         .unwrap();
     let state = runtime.agent_state().await.unwrap();
-    let binding = state.current_execution_binding.unwrap();
+    let binding = state.current_execution_binding.as_ref().unwrap();
     assert!(matches!(
         binding.owner,
         Some(crate::types::TurnOwner::AgentLifecycle { .. })
     ));
     assert_eq!(binding.work_item_id, None);
     assert_eq!(state.current_turn_work_item_id, None);
+    assert_eq!(
+        state
+            .current_execution_binding
+            .as_ref()
+            .and_then(|binding| binding.claimed_work_revision),
+        None
+    );
 }
 
 struct OperatorInterjectionProbeProvider {


### PR DESCRIPTION
## Summary

Closes #2732.

Canonical `AgentLifecycle` executions now derive WorkItem ownership exclusively from their canonical `ExecutionBinding`. They no longer inherit `message.work_item_id` or focused WorkItem state when the canonical binding has no WorkItem owner.

## Changes

- Preserve canonical binding ownership as the source of truth for `work_item_id`.
- Keep non-canonical message-driven executions on the existing fallback behavior.
- Add regression coverage for AgentInbox/system wake with an unrelated focused WorkItem.

## Verification

- `git diff --check`
- Canonical binding regression test passed locally.
- `cargo fmt --all -- --check` passed.
- `RUSTFLAGS="-D warnings" cargo check --all-targets` passed.
