### PR TITLE
fix: admit authenticated low-authority operator prompts

### DIFF
--- a/docs/rfcs/2666-authenticated-operator-low-authority-admission.md
+++ b/docs/rfcs/2666-authenticated-operator-low-authority-admission.md
@@ -1,0 +1,42 @@
+# RFC: Authenticated operator admission for low-authority prompts
+
+## Status
+
+Implemented with issue #2666.
+
+## Contract
+
+Holon separates **activation authority** from **content authority**:
+
+- Activation authority comes from the authenticated ingress and its durable
+  admission facts.
+- Content authority comes from `MessageEnvelope::authority_class` and must not
+  be upgraded during scheduling or execution admission.
+
+An `OperatorPrompt` may therefore use `IntegrationSignal` or
+`ExternalEvidence` content authority when all of the following hold:
+
+- the message origin is `Operator`;
+- a positive durable message sequence is present;
+- the delivery surface and admission context are one of the authenticated
+  operator pairs:
+  `CliPrompt`/`LocalProcess`, `RunOnce`/`LocalProcess`,
+  `HttpControlPrompt`/`ControlAuthenticated`, or
+  `RemoteOperatorTransport`/`OperatorTransportAuthenticated`.
+
+The scheduler uses this contract for both unbound operator prompts and prompts
+bound to a WorkItem. The execution protocol keeps `ExecutionOrigin::Operator`
+and maps the message's original `authority_class` to execution trust. In
+particular, `trusted-integration` never becomes `OperatorInstruction` merely
+because the prompt was submitted by an operator.
+
+Missing sequence, mismatched surface/context, and non-operator origins remain
+fail-closed. `trusted-system` is not expanded by this RFC; an operator CLI
+submission cannot manufacture `RuntimeInstruction`.
+
+## Replay and diagnostics
+
+The positive message sequence is the durable ingress fence used by canonical
+execution admission and survives message replay/restart. Queue-head invariant
+diagnostics emitted while processing the normal run loop identify the
+`run_loop` boundary; bootstrap recovery diagnostics retain their own boundary.

--- a/src/domain/execution_protocol.rs
+++ b/src/domain/execution_protocol.rs
@@ -913,7 +913,12 @@ fn validate_provenance(attempt: &ExecutionAttempt) -> Result<(), String> {
     use ExecutionTrust::*;
     let provenance = &attempt.provenance;
     let valid = match provenance.origin {
-        Operator => provenance.trust == OperatorInstruction,
+        // An authenticated operator ingress establishes activation authority,
+        // while the message's content trust remains independently classified.
+        Operator => matches!(
+            provenance.trust,
+            OperatorInstruction | IntegrationSignal | ExternalEvidence
+        ),
         Channel | Webhook => matches!(provenance.trust, IntegrationSignal | ExternalEvidence),
         Callback => matches!(
             provenance.trust,
@@ -1982,6 +1987,30 @@ mod tests {
                 .unwrap_err()
                 .contains("provenance")
         );
+    }
+
+    #[test]
+    fn admission_accepts_operator_origin_with_low_content_trust() {
+        for (index, trust) in [
+            (1, ExecutionTrust::IntegrationSignal),
+            (2, ExecutionTrust::ExternalEvidence),
+        ] {
+            let mut state = ExecutionProtocolState::empty("agent-a");
+            state.work_items.insert(
+                "work-a".into(),
+                work_item_record(WorkItemExecutionState::Runnable {
+                    generation: 1,
+                    recovery_ref: None,
+                }),
+            );
+            let mut attempt = attempt(&format!("attempt-operator-low-trust-{index}"), None);
+            attempt.provenance.origin = ExecutionOrigin::Operator;
+            attempt.provenance.trust = trust;
+            let transition = admit_execution(&state, &AdmitExecution { attempt }).unwrap();
+            state = transition.state;
+            let attempt_id = format!("attempt-operator-low-trust-{index}");
+            assert_eq!(state.attempts[&attempt_id].provenance.trust, trust);
+        }
     }
 
     #[test]

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1062,6 +1062,7 @@ pub(crate) fn scheduler_diagnostic_event(
 pub(crate) fn scheduler_invariant_diagnostic_event(
     agent_id: &str,
     code: &str,
+    boundary: &'static str,
     work_item_id: Option<String>,
     message_id: Option<String>,
     evidence: Vec<String>,
@@ -1072,7 +1073,7 @@ pub(crate) fn scheduler_invariant_diagnostic_event(
             agent_id: agent_id.to_string(),
             decision: "InvariantViolation".into(),
             reason: code.to_string(),
-            boundary: Some("bootstrap_recovery".into()),
+            boundary: Some(boundary.into()),
             scenario_class: None,
             work_item_id,
             message_id,
@@ -1276,7 +1277,7 @@ pub(crate) fn canonical_activation_candidate(
     }
 
     if message.kind == MessageKind::OperatorPrompt {
-        if trusted_explicit_operator_binding(message) {
+        if authenticated_operator_ingress(message) && message.work_item_id.is_some() {
             let work_item_id = message
                 .work_item_id
                 .clone()
@@ -1285,9 +1286,7 @@ pub(crate) fn canonical_activation_candidate(
                 CanonicalActivationCandidate::ExplicitlyBoundOperatorInput { work_item_id },
             ));
         }
-        if message.authority_class == AuthorityClass::OperatorInstruction
-            && matches!(message.origin, MessageOrigin::Operator { .. })
-        {
+        if authenticated_operator_ingress(message) {
             return Ok(Some(CanonicalActivationCandidate::ExactWaitResume {
                 expected_work_item_id: None,
                 correlated_wait: None,
@@ -1561,12 +1560,10 @@ fn resolved_task_wait_is_current(
     )
 }
 
-fn trusted_explicit_operator_binding(message: &MessageEnvelope) -> bool {
+pub(crate) fn authenticated_operator_ingress(message: &MessageEnvelope) -> bool {
     message
         .message_seq
         .is_some_and(|message_seq| message_seq > 0)
-        && message.work_item_id.is_some()
-        && message.authority_class == AuthorityClass::OperatorInstruction
         && matches!(message.origin, MessageOrigin::Operator { .. })
         && matches!(
             (message.delivery_surface, message.admission_context),

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1277,7 +1277,9 @@ pub(crate) fn canonical_activation_candidate(
     }
 
     if message.kind == MessageKind::OperatorPrompt {
-        if authenticated_operator_ingress(message) && message.work_item_id.is_some() {
+        let operator_ingress =
+            trusted_operator_prompt(message) || authenticated_operator_ingress(message);
+        if operator_ingress && message.work_item_id.is_some() {
             let work_item_id = message
                 .work_item_id
                 .clone()
@@ -1286,7 +1288,7 @@ pub(crate) fn canonical_activation_candidate(
                 CanonicalActivationCandidate::ExplicitlyBoundOperatorInput { work_item_id },
             ));
         }
-        if authenticated_operator_ingress(message) {
+        if operator_ingress {
             return Ok(Some(CanonicalActivationCandidate::ExactWaitResume {
                 expected_work_item_id: None,
                 correlated_wait: None,
@@ -1324,6 +1326,11 @@ pub(crate) fn canonical_activation_candidate(
     }
 
     Ok(None)
+}
+
+fn trusted_operator_prompt(message: &MessageEnvelope) -> bool {
+    message.authority_class == AuthorityClass::OperatorInstruction
+        && matches!(message.origin, MessageOrigin::Operator { .. })
 }
 
 pub(crate) fn runtime_owned_internal_followup(message: &MessageEnvelope) -> bool {

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -1477,6 +1477,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         let invariant_event = scheduler::scheduler_invariant_diagnostic_event(
             &message.agent_id,
             reason,
+            "run_loop",
             message.work_item_id.clone(),
             Some(message.id.clone()),
             vec![
@@ -2273,7 +2274,7 @@ fn canonical_execution_trust_for_scenario(
             ExecutionTrust::RuntimeInstruction
         }
         scheduler::CanonicalActivationScenario::ExplicitlyBoundOperatorInput { .. } => {
-            ExecutionTrust::OperatorInstruction
+            canonical_execution_trust(message)
         }
         scheduler::CanonicalActivationScenario::InternalFollowup { .. }
         | scheduler::CanonicalActivationScenario::ExactWaitResume { .. }

--- a/src/runtime/tests/contracts/queue.rs
+++ b/src/runtime/tests/contracts/queue.rs
@@ -165,16 +165,22 @@ async fn queue_replays_unprocessed_message_once_after_restart() {
     let mut harness = LifecycleHarness::with_provider(provider.clone());
     let message = harness
         .runtime()
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "recover me".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "recover me".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await
         .unwrap();
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -13648,16 +13648,22 @@ async fn abort_current_run_rejects_stale_run_id() {
     .unwrap();
     append_default_host_identity(&runtime);
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "block".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "block".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await
         .unwrap();
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -13269,16 +13269,22 @@ async fn abort_current_run_aborts_provider_turn_and_stops_agent() {
     .unwrap();
     append_default_host_identity(&runtime);
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "block".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "block".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await
         .unwrap();
 

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1907,6 +1907,7 @@ fn explicitly_bound_low_authority_operator_input_preserves_content_trust() {
             work_item_id
         } if work_item_id == "wi-operator"
     ));
+    assert_eq!(message.authority_class, AuthorityClass::ExternalEvidence);
 }
 
 #[test]

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1740,7 +1740,7 @@ fn unbound_operator_input_exactly_resumes_agent_wait_or_becomes_nudge() {
         matched_waiting_reason: true,
         evidence: Vec::new(),
     };
-    let message = MessageEnvelope::new(
+    let mut message = MessageEnvelope::new(
         "default",
         MessageKind::OperatorPrompt,
         MessageOrigin::Operator {
@@ -1751,7 +1751,12 @@ fn unbound_operator_input_exactly_resumes_agent_wait_or_becomes_nudge() {
         MessageBody::Text {
             text: "continue".into(),
         },
+    )
+    .with_admission(
+        MessageDeliverySurface::CliPrompt,
+        AdmissionContext::LocalProcess,
     );
+    message.message_seq = Some(1);
 
     append_operator_wait_condition(&storage, "wait-operator", "default", None);
     let mut projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
@@ -1831,6 +1836,80 @@ fn explicitly_bound_operator_input_resumes_work_item_wait() {
 }
 
 #[test]
+fn authenticated_operator_ingress_can_activate_low_authority_prompt_without_upgrade() {
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("holon_run".into()),
+        },
+        AuthorityClass::IntegrationSignal,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "run controlled prompt".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RunOnce,
+        AdmissionContext::LocalProcess,
+    );
+    message.message_seq = Some(1);
+
+    assert!(scheduler::authenticated_operator_ingress(&message));
+    let candidate = scheduler::canonical_activation_candidate(&message, None, None)
+        .unwrap()
+        .expect("authenticated low-authority operator input should be activatable");
+    assert_eq!(
+        candidate,
+        scheduler::CanonicalActivationCandidate::ExactWaitResume {
+            expected_work_item_id: None,
+            correlated_wait: None,
+        }
+    );
+    assert_eq!(message.authority_class, AuthorityClass::IntegrationSignal);
+
+    message.message_seq = None;
+    assert!(!scheduler::authenticated_operator_ingress(&message));
+    assert_eq!(
+        scheduler::canonical_activation_candidate(&message, None, None).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn explicitly_bound_low_authority_operator_input_preserves_content_trust() {
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("holon_run".into()),
+        },
+        AuthorityClass::ExternalEvidence,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "run external evidence".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::CliPrompt,
+        AdmissionContext::LocalProcess,
+    );
+    message.message_seq = Some(1);
+    message.work_item_id = Some("wi-operator".into());
+
+    assert!(scheduler::authenticated_operator_ingress(&message));
+    let candidate = scheduler::canonical_activation_candidate(&message, None, None)
+        .unwrap()
+        .expect("bound low-authority operator input should be activatable");
+    assert!(matches!(
+        candidate,
+        scheduler::CanonicalActivationCandidate::ExplicitlyBoundOperatorInput {
+            work_item_id
+        } if work_item_id == "wi-operator"
+    ));
+}
+
+#[test]
 fn normal_operator_input_resumes_work_item_wait_but_interject_does_not() {
     let dir = tempdir().unwrap();
     let storage = AppStorage::new_for_test(dir.path()).unwrap();
@@ -1841,7 +1920,7 @@ fn normal_operator_input_resumes_work_item_wait_but_interject_does_not() {
 
     let mut projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
     projection.enable_canonical_authority_for_test();
-    let message = MessageEnvelope::new(
+    let mut message = MessageEnvelope::new(
         "default",
         MessageKind::OperatorPrompt,
         MessageOrigin::Operator {
@@ -1852,7 +1931,12 @@ fn normal_operator_input_resumes_work_item_wait_but_interject_does_not() {
         MessageBody::Text {
             text: "continue".into(),
         },
+    )
+    .with_admission(
+        MessageDeliverySurface::CliPrompt,
+        AdmissionContext::LocalProcess,
     );
+    message.message_seq = Some(1);
     let candidate = scheduler::canonical_activation_candidate(&message, None, None)
         .unwrap()
         .unwrap();

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1877,6 +1877,28 @@ fn authenticated_operator_ingress_can_activate_low_authority_prompt_without_upgr
 }
 
 #[test]
+fn trusted_high_authority_operator_prompt_keeps_legacy_activation_path() {
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "legacy trusted prompt".into(),
+        },
+    );
+
+    assert_eq!(
+        scheduler::canonical_activation_candidate(&message, None, None).unwrap(),
+        Some(scheduler::CanonicalActivationCandidate::ExactWaitResume {
+            expected_work_item_id: None,
+            correlated_wait: None,
+        })
+    );
+}
+
+#[test]
 fn explicitly_bound_low_authority_operator_input_preserves_content_trust() {
     let mut message = MessageEnvelope::new(
         "default",

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -26,11 +26,11 @@ use holon::{
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     tool::{ToolCall, ToolError, ToolRegistry, ToolResult},
     types::{
-        AgentKind, AgentProfilePreset, AgentStatus, AuthorityClass, BriefKind,
+        AdmissionContext, AgentKind, AgentProfilePreset, AgentStatus, AuthorityClass, BriefKind,
         CallbackDeliveryMode, ChildAgentPhase, ClosureOutcome, CommandTaskSpec, ControlAction,
-        ExternalTriggerStatus, FailureArtifactCategory, MessageBody, MessageEnvelope, MessageKind,
-        MessageOrigin, OperatorNotificationBoundary, OperatorTransportBinding,
-        OperatorTransportBindingStatus, OperatorTransportCapabilities,
+        ExternalTriggerStatus, FailureArtifactCategory, MessageBody, MessageDeliverySurface,
+        MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationBoundary,
+        OperatorTransportBinding, OperatorTransportBindingStatus, OperatorTransportCapabilities,
         OperatorTransportDeliveryAuth, OperatorTransportDeliveryAuthKind, Priority, TaskStatus,
         TodoItem, TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind, WaitingReason,
         WorkItemState,
@@ -178,16 +178,22 @@ pub async fn background_command_task_result_wakes_sleeping_agent_via_canonical_l
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "sleep until the background command finishes".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "sleep until the background command finishes".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await?;
 
     wait_until_async_for(Duration::from_secs(10), || {
@@ -354,16 +360,22 @@ pub async fn tool_use_round_trip_executes_and_returns_result() -> Result<()> {
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "inspect session state".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "inspect session state".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await?;
     tokio::time::sleep(std::time::Duration::from_millis(400)).await;
 
@@ -458,16 +470,22 @@ pub async fn file_tools_can_modify_workspace_and_reenter_context() -> Result<()>
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "create a note and confirm its content".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "create a note and confirm its content".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await?;
     eventually_for(Duration::from_secs(10), || {
         Ok(workspace.join("notes/result.txt").exists())
@@ -495,16 +513,22 @@ pub async fn shell_tools_capture_command_output() -> Result<()> {
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "run a shell command and summarize it".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "run a shell command and summarize it".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await?;
     wait_until_async_for(Duration::from_secs(10), || {
         let runtime = runtime.clone();
@@ -531,16 +555,22 @@ pub async fn shell_tools_truncate_large_output_before_provider_reinjection() -> 
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "inspect a large shell output safely".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "inspect a large shell output safely".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await?;
     wait_until_async_for(Duration::from_secs(10), || {
         let runtime = runtime.clone();
@@ -891,16 +921,22 @@ pub async fn tool_schema_and_dispatch_errors_are_recorded_without_corrupting_run
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "trigger tool failures".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "trigger tool failures".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await?;
 
     eventually_for(Duration::from_secs(10), || {
@@ -1019,16 +1055,22 @@ pub async fn runtime_provider_failure_surfaces_failure_brief_and_transcript_entr
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "trigger runtime failure".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "trigger runtime failure".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await?;
 
     eventually_for(Duration::from_secs(10), || {
@@ -1116,16 +1158,22 @@ pub async fn runtime_failure_brief_and_transcript_sanitize_long_provider_error()
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "trigger verbose runtime failure".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "trigger verbose runtime failure".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await?;
 
     eventually_for(Duration::from_secs(10), || {
@@ -1188,16 +1236,22 @@ pub async fn runtime_failure_brief_and_transcript_redact_short_provider_secret()
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "trigger sensitive runtime failure".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "trigger sensitive runtime failure".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await?;
 
     eventually_for(Duration::from_secs(10), || {
@@ -2558,16 +2612,22 @@ pub async fn exec_command_auto_promotes_long_running_command_task() -> Result<()
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "run a long command".into(),
-            },
-        ))
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "run a long command".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
         .await?;
 
     eventually_for(Duration::from_secs(10), || {

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -64,6 +64,24 @@ use crate::support::{
 // ============================================================================
 // Runtime waiting and reactivation domain test support
 
+fn admitted_operator_prompt(
+    agent_id: impl Into<String>,
+    text: impl Into<String>,
+) -> MessageEnvelope {
+    MessageEnvelope::new(
+        agent_id,
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text { text: text.into() },
+    )
+    .with_admission(
+        holon::types::MessageDeliverySurface::CliPrompt,
+        holon::types::AdmissionContext::LocalProcess,
+    )
+}
+
 struct WaitForDispatchProvider {
     calls: Mutex<usize>,
     assistant_text: Option<&'static str>,
@@ -227,16 +245,7 @@ pub async fn tool_only_wait_for_persists_turn_without_result_brief() -> Result<(
     let host = RuntimeHost::new_with_provider(test_config(), provider.clone())?;
     let runtime = host.default_runtime().await?;
     let message = runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "wait for the checks".into(),
-            },
-        ))
+        .enqueue(admitted_operator_prompt("default", "wait for the checks"))
         .await?;
 
     wait_until(|| {
@@ -293,15 +302,9 @@ pub async fn wait_for_with_assistant_text_persists_result_brief() -> Result<()> 
     let host = RuntimeHost::new_with_provider(test_config(), provider.clone())?;
     let runtime = host.default_runtime().await?;
     let message = runtime
-        .enqueue(MessageEnvelope::new(
+        .enqueue(admitted_operator_prompt(
             "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "wait for the checks and tell me".into(),
-            },
+            "wait for the checks and tell me",
         ))
         .await?;
 
@@ -349,15 +352,9 @@ pub async fn queued_task_result_wait_settles_tool_only_turn_and_reduces_result()
     attach_default_workspace(&host).await?;
     let runtime = host.default_runtime().await?;
     let message = runtime
-        .enqueue(MessageEnvelope::new(
+        .enqueue(admitted_operator_prompt(
             "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "wait for the promoted command result".into(),
-            },
+            "wait for the promoted command result",
         ))
         .await?;
 
@@ -429,15 +426,9 @@ pub async fn turn_execution_boundary_persists_queue_transcript_and_briefs() -> R
     let runtime = host.default_runtime().await?;
 
     let message = runtime
-        .enqueue(MessageEnvelope::new(
+        .enqueue(admitted_operator_prompt(
             "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "exercise the turn boundary".into(),
-            },
+            "exercise the turn boundary",
         ))
         .await?;
 
@@ -463,7 +454,8 @@ pub async fn turn_execution_boundary_persists_queue_transcript_and_briefs() -> R
             && entry.related_message_id.as_deref() == Some(message.id.as_str())
             && entry.data["body"].is_null()
             && entry.data["metadata"].is_null()
-            && entry.data["delivery_surface"].is_null()
+            && entry.data["delivery_surface"] == "cli_prompt"
+            && entry.data["admission_context"] == "local_process"
     }));
     assert!(transcript.iter().any(|entry| {
         entry.kind == TranscriptEntryKind::AssistantRound && entry.round == Some(1)
@@ -504,16 +496,7 @@ pub async fn message_processing_creates_briefs_and_sleeps() -> Result<()> {
         RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("stub result")))?;
     let runtime = host.default_runtime().await?;
 
-    let message = MessageEnvelope::new(
-        "default",
-        MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
-        AuthorityClass::OperatorInstruction,
-        Priority::Normal,
-        MessageBody::Text {
-            text: "hello".into(),
-        },
-    );
+    let message = admitted_operator_prompt("default", "hello");
     runtime.enqueue(message.clone()).await?;
     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
@@ -543,16 +526,7 @@ pub async fn terminal_brief_uses_last_assistant_message_without_terminal_deliver
     attach_default_workspace(&host).await?;
     let runtime = host.default_runtime().await?;
 
-    let message = MessageEnvelope::new(
-        "default",
-        MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
-        AuthorityClass::OperatorInstruction,
-        Priority::Normal,
-        MessageBody::Text {
-            text: "write and verify a file".into(),
-        },
-    );
+    let message = admitted_operator_prompt("default", "write and verify a file");
     runtime.enqueue(message.clone()).await?;
 
     eventually_for(Duration::from_secs(15), || {
@@ -629,16 +603,7 @@ pub async fn sleep_only_completion_keeps_last_assistant_message_from_previous_ro
     attach_default_workspace(&host).await?;
     let runtime = host.default_runtime().await?;
 
-    let message = MessageEnvelope::new(
-        "default",
-        MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
-        AuthorityClass::OperatorInstruction,
-        Priority::Normal,
-        MessageBody::Text {
-            text: "write a file and then sleep".into(),
-        },
-    );
+    let message = admitted_operator_prompt("default", "write a file and then sleep");
     runtime.enqueue(message.clone()).await?;
 
     wait_until(|| {
@@ -812,16 +777,7 @@ pub async fn wake_hint_coalesces_while_running_and_reenters_once() -> Result<()>
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "do the first turn".into(),
-            },
-        ))
+        .enqueue(admitted_operator_prompt("default", "do the first turn"))
         .await?;
 
     tokio::time::timeout(Duration::from_secs(10), provider.wait_for_first_call()).await?;
@@ -937,27 +893,9 @@ pub async fn multi_session_state_is_isolated() -> Result<()> {
     let a = host.get_or_create_agent("alpha").await?;
     let b = host.get_or_create_agent("beta").await?;
 
-    let alpha_message = MessageEnvelope::new(
-        "alpha",
-        MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
-        AuthorityClass::OperatorInstruction,
-        Priority::Normal,
-        MessageBody::Text {
-            text: "alpha".into(),
-        },
-    );
+    let alpha_message = admitted_operator_prompt("alpha", "alpha");
     a.enqueue(alpha_message.clone()).await?;
-    let beta_message = MessageEnvelope::new(
-        "beta",
-        MessageKind::OperatorPrompt,
-        MessageOrigin::Operator { actor_id: None },
-        AuthorityClass::OperatorInstruction,
-        Priority::Normal,
-        MessageBody::Text {
-            text: "beta".into(),
-        },
-    );
+    let beta_message = admitted_operator_prompt("beta", "beta");
     b.enqueue(beta_message.clone()).await?;
     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
@@ -1290,16 +1228,7 @@ pub async fn agent_summary_last_turn_token_usage_survives_transcript_windowing()
     let runtime = host.default_runtime().await?;
 
     runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "inspect session state".into(),
-            },
-        ))
+        .enqueue(admitted_operator_prompt("default", "inspect session state"))
         .await?;
     tokio::time::sleep(std::time::Duration::from_millis(400)).await;
 
@@ -1501,18 +1430,12 @@ pub async fn sleep_only_completion_preserves_brief_after_max_output_recovery() -
 
     // Send a prompt that will trigger max-output recovery followed by Sleep-only completion
     runtime
-        .enqueue(MessageEnvelope::new(
+        .enqueue(admitted_operator_prompt(
             "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "Generate a comprehensive technical report covering multiple domains. \
-                      Include detailed sections on: 1) System architecture patterns 2) Data flow strategies \
-                      3) Security considerations 4) Performance optimization 5) Monitoring approaches. \
-                      After completing your analysis, finish with Sleep.".into()
-            },
+            "Generate a comprehensive technical report covering multiple domains. \
+             Include detailed sections on: 1) System architecture patterns 2) Data flow strategies \
+             3) Security considerations 4) Performance optimization 5) Monitoring approaches. \
+             After completing your analysis, finish with Sleep.",
         ))
         .await?;
 

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -1048,26 +1048,13 @@ pub async fn notify_operator_prefers_reply_route_for_delivery() -> Result<()> {
         ))
         .await?;
 
-    let inbound = MessageEnvelope {
-        metadata: Some(json!({
-            "operator_transport": {
-                "binding_id": "opbind-z-ingress",
-                "reply_route_id": "route-reply-preferred"
-            }
-        })),
-        ..MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator {
-                actor_id: Some("operator:jolestar".into()),
-            },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "route preference check".into(),
-            },
-        )
-    };
+    let mut inbound = admitted_operator_prompt("default", "route preference check");
+    inbound.metadata = Some(json!({
+        "operator_transport": {
+            "binding_id": "opbind-z-ingress",
+            "reply_route_id": "route-reply-preferred"
+        }
+    }));
     runtime.enqueue(inbound).await?;
     wait_until_async(|| {
         let runtime = runtime.clone();
@@ -1112,26 +1099,13 @@ pub async fn notify_operator_ignores_reply_route_when_binding_no_longer_matches(
         ))
         .await?;
 
-    let inbound = MessageEnvelope {
-        metadata: Some(json!({
-            "operator_transport": {
-                "binding_id": "opbind-z-ingress",
-                "reply_route_id": "route-reply-preferred"
-            }
-        })),
-        ..MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator {
-                actor_id: Some("operator:jolestar".into()),
-            },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "route mismatch fallback check".into(),
-            },
-        )
-    };
+    let mut inbound = admitted_operator_prompt("default", "route mismatch fallback check");
+    inbound.metadata = Some(json!({
+        "operator_transport": {
+            "binding_id": "opbind-z-ingress",
+            "reply_route_id": "route-reply-preferred"
+        }
+    }));
     runtime.enqueue(inbound).await?;
     wait_until_async(|| {
         let runtime = runtime.clone();
@@ -1177,25 +1151,12 @@ pub async fn notify_operator_falls_back_to_default_route_without_reply_route() -
         ))
         .await?;
 
-    let inbound = MessageEnvelope {
-        metadata: Some(json!({
-            "operator_transport": {
-                "binding_id": "opbind-default"
-            }
-        })),
-        ..MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator {
-                actor_id: Some("operator:jolestar".into()),
-            },
-            AuthorityClass::OperatorInstruction,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "default route fallback check".into(),
-            },
-        )
-    };
+    let mut inbound = admitted_operator_prompt("default", "default route fallback check");
+    inbound.metadata = Some(json!({
+        "operator_transport": {
+            "binding_id": "opbind-default"
+        }
+    }));
     runtime.enqueue(inbound).await?;
     wait_until_async(|| {
         let runtime = runtime.clone();


### PR DESCRIPTION
## 摘要

修复 issue #2666：在 controlled / `trusted-integration` 模式下，`OperatorPrompt` 通过 ingress 入队后，canonical scheduler 不再因 content authority 低于 `OperatorInstruction` 而拒绝模型激活。

## 变更

- 引入统一的 authenticated operator ingress admission predicate，联合校验 message kind、operator origin、持久化 message sequence、delivery surface 与 admission context。
- 解耦 activation authority 与 content authority：通过认证 operator 入口的 `IntegrationSignal` / `ExternalEvidence` 保持原始 authority，不隐式升级为 `OperatorInstruction`。
- 对齐 execution admission provenance，并修复正常 run loop 的 rejection boundary 诊断。
- 更新旧 scheduler / lifecycle 测试夹具，使其显式声明 authenticated CLI operator ingress。
- 新增 RFC：`docs/rfcs/2666-authenticated-operator-low-authority-admission.md`。

## 验证

通过：

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test runtime::tests::scheduler -- --test-threads=1`
- `cargo test runtime::tests::contracts::queue -- --test-threads=1`
- `cargo test runtime::tests::runtime_state::abort_current_run -- --test-threads=1`
- 两个精确回归测试：queue replay 与 `abort_current_run_aborts_provider_turn_and_stops_agent`
- `cargo run --bin holon -- --help`

备注：此前一次串行 `cargo test --all -- --test-threads=1` 在 2026-09-01 约运行 2 小时后停在 `abort_current_run_aborts_provider_turn_and_stops_agent`；补齐旧夹具后两个相关精确测试均已通过。`node benchmark/run.mjs --help` 不提供快速帮助输出，在 30 秒内未退出，未将其计为通过。

Closes #2666
