### PR TITLE
fix: reenter on unbound terminal task results

### DIFF
--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -546,6 +546,23 @@ mod tests {
     }
 
     #[test]
+    fn unbound_terminal_task_result_does_not_override_operator_input_wait() {
+        let resolution = resolve_continuation(
+            &waiting(WaitingReason::AwaitingOperatorInput),
+            &ContinuationTrigger {
+                kind: ContinuationTriggerKind::TaskResult,
+                contentful: true,
+                task_result_outcome: Some(TaskResultOutcome::Succeeded),
+                wake_hint_source: None,
+                task_work_item_id: None,
+            },
+            None,
+        );
+        assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
+        assert!(!resolution.model_reentry);
+    }
+
+    #[test]
     fn empty_external_event_waiting_for_external_change_is_liveness_only() {
         let resolution = resolve_continuation(
             &waiting(WaitingReason::AwaitingExternalChange),

--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -89,9 +89,17 @@ pub(super) fn resolve_continuation(
     trigger: &ContinuationTrigger,
     agent_work_item_id: Option<&str>,
 ) -> ContinuationResolution {
+    let prior_waiting_reason = prior.waiting_reason;
     let same_work_item = match (trigger.task_work_item_id.as_deref(), agent_work_item_id) {
         (Some(_), None) | (None, Some(_)) => false,
-        (None, None) => false,
+        (None, None) => {
+            trigger.kind == ContinuationTriggerKind::TaskResult
+                && trigger.task_result_outcome.is_some()
+                && matches!(
+                    prior_waiting_reason,
+                    None | Some(WaitingReason::AwaitingTaskResult)
+                )
+        }
         (Some(t), Some(a)) => t == a,
     };
     let mut evidence = Vec::new();
@@ -109,7 +117,6 @@ pub(super) fn resolve_continuation(
         evidence.push(format!("wake_hint_source={source}"));
     }
 
-    let prior_waiting_reason = prior.waiting_reason;
     let prior_closure_outcome = prior.outcome;
 
     if prior.outcome == ClosureOutcome::Waiting {
@@ -334,7 +341,7 @@ mod tests {
     }
 
     #[test]
-    fn unbound_terminal_task_result_does_not_resume_expected_wait() {
+    fn unbound_terminal_task_result_resumes_expected_wait() {
         let resolution = resolve_continuation(
             &waiting(WaitingReason::AwaitingTaskResult),
             &ContinuationTrigger {
@@ -346,8 +353,8 @@ mod tests {
             },
             None,
         );
-        assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
-        assert!(!resolution.model_reentry);
+        assert_eq!(resolution.class, ContinuationClass::ResumeExpectedWait);
+        assert!(resolution.model_reentry);
     }
 
     #[test]
@@ -469,30 +476,37 @@ mod tests {
     }
 
     #[test]
-    fn unbound_terminal_task_result_does_not_resume_without_prior_wait() {
-        let resolution = resolve_continuation(
-            &ClosureDecision {
-                outcome: ClosureOutcome::Completed,
-                waiting_reason: None,
-                work_signal: None,
-                runtime_posture: RuntimePosture::Awake,
-                evidence: vec![],
-            },
-            &ContinuationTrigger {
-                kind: ContinuationTriggerKind::TaskResult,
-                contentful: true,
-                task_result_outcome: Some(TaskResultOutcome::Succeeded),
-                wake_hint_source: None,
-                task_work_item_id: None,
-            },
-            None,
-        );
-        assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
-        assert!(!resolution.model_reentry);
+    fn unbound_terminal_task_results_reenter_without_prior_wait() {
+        for outcome in [
+            TaskResultOutcome::Succeeded,
+            TaskResultOutcome::Failed,
+            TaskResultOutcome::Cancelled,
+            TaskResultOutcome::Interrupted,
+        ] {
+            let resolution = resolve_continuation(
+                &ClosureDecision {
+                    outcome: ClosureOutcome::Completed,
+                    waiting_reason: None,
+                    work_signal: None,
+                    runtime_posture: RuntimePosture::Awake,
+                    evidence: vec![],
+                },
+                &ContinuationTrigger {
+                    kind: ContinuationTriggerKind::TaskResult,
+                    contentful: true,
+                    task_result_outcome: Some(outcome),
+                    wake_hint_source: None,
+                    task_work_item_id: None,
+                },
+                None,
+            );
+            assert_eq!(resolution.class, ContinuationClass::TaskResultReentry);
+            assert!(resolution.model_reentry);
+        }
     }
 
     #[test]
-    fn unbound_terminal_task_result_does_not_resume_from_sleeping_posture() {
+    fn unbound_terminal_task_result_reenters_from_sleeping_posture() {
         let resolution = resolve_continuation(
             &ClosureDecision {
                 outcome: ClosureOutcome::Completed,
@@ -510,8 +524,8 @@ mod tests {
             },
             None,
         );
-        assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
-        assert!(!resolution.model_reentry);
+        assert_eq!(resolution.class, ContinuationClass::TaskResultReentry);
+        assert!(resolution.model_reentry);
     }
 
     #[test]

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -6029,7 +6029,7 @@ async fn exact_task_rejoin_claim_is_atomic_and_restart_safe() {
 }
 
 #[tokio::test]
-async fn terminal_task_result_without_work_item_uses_non_reentrant_dispatch() {
+async fn terminal_task_result_without_work_item_uses_reentrant_dispatch() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -6093,19 +6093,19 @@ async fn terminal_task_result_without_work_item_uses_non_reentrant_dispatch() {
         .await
         .unwrap();
     let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
-        panic!("unbound terminal TaskResult should be reduced as the queued message");
+        panic!("unbound terminal TaskResult should be dispatched as the queued message");
     };
     assert_eq!(scheduled.message.id, message.id);
     assert_eq!(
         scheduled.scheduler_decision.kind,
-        scheduler::SchedulerDecisionKind::ReduceMessageOnly
+        scheduler::SchedulerDecisionKind::StartModelTurn
     );
-    assert!(!scheduled.scheduler_decision.model_reentry);
+    assert!(scheduled.scheduler_decision.model_reentry);
     assert!(scheduled
         .dispatch_plan
         .continuation_resolution
         .as_ref()
-        .is_none_or(|resolution| !resolution.model_reentry));
+        .is_some_and(|resolution| resolution.model_reentry));
     assert_eq!(
         runtime
             .inner
@@ -13858,7 +13858,7 @@ fn task_rejoin_fence_requires_live_persisted_contract() {
 }
 
 #[tokio::test]
-async fn unbound_task_result_routes_only_through_reduction() {
+async fn unbound_task_result_reenters_the_model() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let provider = Arc::new(CountingProvider {
@@ -13924,7 +13924,7 @@ async fn unbound_task_result_routes_only_through_reduction() {
         .await
         .unwrap();
 
-    assert_eq!(provider.call_count().await, 0);
+    assert_eq!(provider.call_count().await, 1);
     let active_tasks = runtime.active_tasks(10).await.unwrap();
     assert!(!active_tasks.iter().any(|task| task.id == "task-1"));
     let events = runtime.storage().read_recent_events(100).unwrap();

--- a/tests/runtime_waiting_and_reactivation.rs
+++ b/tests/runtime_waiting_and_reactivation.rs
@@ -22,7 +22,7 @@ fn policy_blocks_mismatched_origin() {
 runtime_async_tests!(
     tool_only_wait_for_persists_turn_without_result_brief,
     wait_for_with_assistant_text_persists_result_brief,
-    queued_task_result_wait_settles_tool_only_turn_and_reduces_result,
+    queued_task_result_wait_settles_tool_only_turn_and_reenters_model,
     turn_execution_boundary_persists_queue_transcript_and_briefs,
     message_processing_creates_briefs_and_sleeps,
     terminal_brief_uses_last_assistant_message_without_terminal_delivery_round,

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -241,7 +241,7 @@ pub async fn background_command_task_result_wakes_sleeping_agent_via_canonical_l
         .as_ref()
         .is_some_and(|continuation| {
             continuation.trigger_kind == holon::types::ContinuationTriggerKind::TaskResult
-                && !continuation.model_reentry
+                && continuation.model_reentry
         }));
     let tasks = runtime.storage().latest_task_records()?;
     assert!(tasks.iter().any(|record| {
@@ -2258,7 +2258,7 @@ pub async fn command_task_result_is_canonical_lifecycle_nudge_on_completion() ->
             event.kind == "continuation_resolved"
                 && event.data["message_id"] == message.id
                 && event.data["resolution"]["trigger_kind"] == "task_result"
-                && event.data["resolution"]["model_reentry"] == false
+                && event.data["resolution"]["model_reentry"] == true
         }))
     })
     .await?;

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -206,7 +206,10 @@ impl AgentProvider for QueuedTaskResultWaitProvider {
                 }),
                 kind: holon::provider::ModelToolCallKind::Function,
             }],
-            _ => anyhow::bail!("WaitFor should complete the turn after the third provider call"),
+            4 => vec![ModelBlock::Text {
+                text: "background command result observed".into(),
+            }],
+            _ => anyhow::bail!("unexpected provider call {call}"),
         };
 
         Ok(ProviderTurnResponse {
@@ -343,7 +346,7 @@ pub async fn wait_for_with_assistant_text_persists_result_brief() -> Result<()> 
     Ok(())
 }
 
-pub async fn queued_task_result_wait_settles_tool_only_turn_and_reduces_result() -> Result<()> {
+pub async fn queued_task_result_wait_settles_tool_only_turn_and_reenters_model() -> Result<()> {
     let provider = Arc::new(QueuedTaskResultWaitProvider::new());
     let host = RuntimeHost::new_with_provider(test_config(), provider.clone())?;
     attach_default_workspace(&host).await?;
@@ -369,7 +372,7 @@ pub async fn queued_task_result_wait_settles_tool_only_turn_and_reduces_result()
     })
     .await?;
 
-    assert_eq!(provider.calls().await, 3);
+    assert_eq!(provider.calls().await, 4);
     let task_id = provider
         .task_id()
         .await
@@ -409,15 +412,13 @@ pub async fn queued_task_result_wait_settles_tool_only_turn_and_reduces_result()
     let reducer_turn = turns
         .iter()
         .find(|turn| turn.input_message_ids.contains(&task_result.id))
-        .expect("queued task result should be consumed by a reducer-only turn");
-    assert!(matches!(
-        reducer_turn
-            .terminal
-            .as_ref()
-            .and_then(|terminal| terminal.no_brief_reason.as_ref()),
-        Some(TurnNoBriefReason::ReducerOnly { reason })
-            if reason == "task_result_without_model_reentry"
-    ));
+        .expect("queued task result should re-enter the model");
+    assert!(!reducer_turn.produced_brief_ids.is_empty());
+    assert!(reducer_turn
+        .terminal
+        .as_ref()
+        .and_then(|terminal| terminal.no_brief_reason.as_ref())
+        .is_none());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fixes #2737.

Terminal `TaskResult` messages for tasks started during a normal turn without a focused WorkItem are now admitted for model re-entry when both sides are unbound (`None, None`). This prevents successful, failed, cancelled, and interrupted terminal outcomes from being reduced silently as `LivenessOnly`.

Mixed or mismatched WorkItem bindings remain isolated, and non-terminal task results are unchanged.

## Verification

- `cargo test continuation --lib` — passed (51 tests)
- `cargo fmt --all -- --check` — passed
- `RUSTFLAGS="-D warnings" cargo check --all-targets` — passed
- `git diff --check` — passed
