### PR TITLE
chore: prepare 0.35.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,17 +326,19 @@ jobs:
         run: |
           set -euo pipefail
           cat > release-notes.md <<EOF
-          This release ships the macOS menu bar application as a universal DMG that runs natively on Apple Silicon and Intel Macs, with stronger daemon lifecycle compatibility, explicit activation and Turn ownership, a versioned model registry snapshot, and more reliable WorkItem-bound operator waits.
+          This release introduces the models.dev-backed provider mapping system — upstream adapter, projection, and artifact generation, an explicit mapping manifest with a validation engine and Anthropic and DeepSeek baselines, plus an audit CLI with refresh and validate workflows — alongside web GUI improvements including an expanded fullscreen mode for the right side panel. Runtime correctness work preserves semantic recent-turn projection and canonical AgentLifecycle binding ownership, reliably re-enters terminal task results, admits authenticated low-authority operator prompts, and respects the standard Retry-After header in provider retries.
 
           Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64. The macOS app DMG is a universal binary supporting both x86_64 and arm64. The Linux amd64 binary supports Ubuntu 22.04 or newer (glibc 2.35 or newer).
 
           ## Changes
 
-          - Add the native macOS menu bar application with daemon lifecycle compatibility, Sparkle update support, signed DMG packaging, and appcast generation ([#2701](https://github.com/holon-run/holon/pull/2701), [#2705](https://github.com/holon-run/holon/pull/2705), [#2707](https://github.com/holon-run/holon/pull/2707)).
-          - Introduce explicit activation and Turn owner identity, add a versioned model registry snapshot, and make WorkItem-bound operator waits resume reliably ([#2703](https://github.com/holon-run/holon/pull/2703), [#2704](https://github.com/holon-run/holon/pull/2704), [#2708](https://github.com/holon-run/holon/pull/2708), [#2709](https://github.com/holon-run/holon/pull/2709)).
-          - Re-enter the model for terminal task results so terminal command-task and delegated-agent results reliably resume their owning conversation ([#2714](https://github.com/holon-run/holon/pull/2714)).
-          - Harden release automation with strict tag/version verification, resilient Release E2E turn-record imports, and macOS notarization diagnostics ([#2711](https://github.com/holon-run/holon/pull/2711), [#2712](https://github.com/holon-run/holon/pull/2712)).
-          - Ship the macOS app DMG as a universal binary supporting both Apple Silicon and Intel Macs, publish the signed Sparkle appcast with the release archives, and re-sign Sparkle helper executables before notarization ([#2716](https://github.com/holon-run/holon/pull/2716), [#2717](https://github.com/holon-run/holon/pull/2717), [#2718](https://github.com/holon-run/holon/pull/2718)).
+          - Introduce the models.dev provider mapping system with an upstream adapter, projection, and artifact generation, and define the explicit mapping design ([#2721](https://github.com/holon-run/holon/pull/2721), [#2725](https://github.com/holon-run/holon/pull/2725)).
+          - Add the provider mapping manifest, validation engine, and Anthropic baseline; add the DeepSeek OpenAI-compatible baseline; add the mapping audit CLI with refresh and validate workflows ([#2726](https://github.com/holon-run/holon/pull/2726), [#2729](https://github.com/holon-run/holon/pull/2729), [#2731](https://github.com/holon-run/holon/pull/2731), [#2733](https://github.com/holon-run/holon/pull/2733)).
+          - Add an expanded fullscreen mode to the web GUI right side panel and render the model menu through a fixed-position portal to escape overflow clipping ([#2727](https://github.com/holon-run/holon/pull/2727), [#2728](https://github.com/holon-run/holon/pull/2728)).
+          - Preserve semantic recent-turn projection and canonical AgentLifecycle binding ownership, with owner-centered projection continuity test coverage ([#2723](https://github.com/holon-run/holon/pull/2723), [#2724](https://github.com/holon-run/holon/pull/2724), [#2730](https://github.com/holon-run/holon/pull/2730), [#2734](https://github.com/holon-run/holon/pull/2734)).
+          - Re-enter the model on unbound terminal task results so terminal command-task and delegated-agent results reliably resume their owning conversation, and admit authenticated low-authority operator prompts ([#2738](https://github.com/holon-run/holon/pull/2738), [#2736](https://github.com/holon-run/holon/pull/2736)).
+          - Respect the standard Retry-After header in provider retries and decouple the code review skill from the GitHub adapter ([#2722](https://github.com/holon-run/holon/pull/2722), [#2739](https://github.com/holon-run/holon/pull/2739)).
+          - Polish the macOS DMG with a baked-in drag-to-Applications Finder layout and harden its packaging script CI.
 
           ## Install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,7 +338,7 @@ jobs:
           - Preserve semantic recent-turn projection and canonical AgentLifecycle binding ownership, with owner-centered projection continuity test coverage ([#2723](https://github.com/holon-run/holon/pull/2723), [#2724](https://github.com/holon-run/holon/pull/2724), [#2730](https://github.com/holon-run/holon/pull/2730), [#2734](https://github.com/holon-run/holon/pull/2734)).
           - Re-enter the model on unbound terminal task results so terminal command-task and delegated-agent results reliably resume their owning conversation, and admit authenticated low-authority operator prompts ([#2738](https://github.com/holon-run/holon/pull/2738), [#2736](https://github.com/holon-run/holon/pull/2736)).
           - Respect the standard Retry-After header in provider retries and decouple the code review skill from the GitHub adapter ([#2722](https://github.com/holon-run/holon/pull/2722), [#2739](https://github.com/holon-run/holon/pull/2739)).
-          - Polish the macOS DMG with a baked-in drag-to-Applications Finder layout and harden its packaging script CI.
+          - Polish the macOS DMG with a baked-in drag-to-Applications Finder layout and harden its packaging script CI ([8db1dabb](https://github.com/holon-run/holon/commit/8db1dabb), [edc342a6](https://github.com/holon-run/holon/commit/edc342a6), [5622dee8](https://github.com/holon-run/holon/commit/5622dee8) — direct commits to main).
 
           ## Install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.34.2"
+version = "0.35.0"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.34.2"
+version = "0.35.0"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Status and compatibility
 
 Holon is under active development. The current recommended release is
-[`v0.34.2`](https://github.com/holon-run/holon/releases/tag/v0.34.2).
+[`v0.35.0`](https://github.com/holon-run/holon/releases/tag/v0.35.0).
 
 The current project focus remains the Rust runtime: agent lifecycle, queues,
 WaitFor/wake, tasks, WorkItems, trust boundaries, local workspaces, and

--- a/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
+++ b/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
@@ -36,7 +36,7 @@ final class HolonMenuClientTests: XCTestCase {
           "socket_path": "/tmp/holon.sock",
           "http_addr": "127.0.0.1:7878",
           "web_url": "http://127.0.0.1:7878",
-          "product_version": "0.34.2 (abcdef0)",
+          "product_version": "0.35.0 (abcdef0)",
           "control_protocol_version": 1,
           "lifecycle_owner": "standalone",
           "executable_path": "/Applications/Holon.app/Contents/Resources/bin/holon",

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -105,7 +105,7 @@ waitable, delegable, and deliverable.
 ## Status and compatibility
 
 The current recommended release is
-[`v0.34.2`](https://github.com/holon-run/holon/releases/tag/v0.34.2).
+[`v0.35.0`](https://github.com/holon-run/holon/releases/tag/v0.35.0).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project maintains

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -9184,7 +9184,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.34.2"
+    "version": "0.35.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## Summary

Prepare the v0.35.0 release.

- Bump crate version to 0.35.0 and refresh generated snapshots (OpenAPI `version` field, `Cargo.lock`).
- Update release-availability references in `README.md` / `docs/website/README.md` and the macOS app client test fixture version.
- Rewrite the embedded release notes in `.github/workflows/release.yml` for v0.35.0, covering the models.dev provider mapping system (Phase 2A+2B / 3A / 3B / audit CLI + workflows), web GUI right-panel fullscreen and model-menu portal fix, projection/lifecycle correctness fixes, Retry-After handling, operator prompt admission, and the code review skill decoupling, each with its feature/fix PR link.

Version rationale: minor bump — multiple user-facing features since v0.34.2 (models.dev provider mapping system, web GUI fullscreen mode, DeepSeek provider baseline).

## Verification

- `make snapshots-refresh` / `make snapshots-check` — pass (version-only drift)
- `make transport-types` / `make transport-types-check` — pass, no drift
- `cargo fmt --all -- --check`, `RUSTFLAGS="-D warnings" cargo check --all-targets` — pass
- Live LLM baseline (`live_llm_baseline_configured_chain_smoke`, `live_llm_baseline_tool_roundtrip`) — pass against `deepseek@default/deepseek-v4-flash`, which also exercises the new DeepSeek mapping baseline
- Local `make docker-smoke` was not runnable (no container runtime on this host); the Release E2E workflow's production image smoke test covers it against the candidate digest before tagging

## Release plan after merge

1. Release E2E attestation for the merged commit + tag `v0.35.0` with `previous_ref=v0.34.2` (protected environment approval required)
2. Push tag `v0.35.0` to trigger the Release workflow
3. Verify tarballs, universal DMG + SHA-256, appcast, checksums, GHCR tags, Homebrew formula