### PR TITLE
feat: add session-first authentication foundation

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -58,6 +58,7 @@ implementation and tests.
 ## Provenance, Policy, And Execution
 
 - [Provenance, Admission, and Authority](./default-trust-auth-and-control.md)
+- [Session-First Authentication](./session-first-authentication.md)
 - [Remote Operator Transport and Delivery](./remote-operator-transport-and-delivery.md)
 - [Execution Policy and Virtual Execution Boundary](./execution-policy-and-virtual-execution-boundary.md)
 - [Runtime Configuration Surface](./runtime-configuration-surface.md)

--- a/docs/rfcs/session-first-authentication.md
+++ b/docs/rfcs/session-first-authentication.md
@@ -1,0 +1,96 @@
+# Session-First Authentication
+
+## Status
+
+Accepted for the first authentication storage and configuration slice of
+Issue #2735. HTTP/OIDC protocol handlers are implemented in a later slice.
+
+## Context
+
+Holon supports a local, single-operator deployment as well as remote
+deployments that need OIDC-backed identities. Sending a long-lived control
+token with every request makes revocation, expiry, device management, and
+audit difficult. The authentication model therefore treats an opaque session
+as the normal request credential, regardless of how that session was created.
+
+## Contract
+
+### Authentication modes
+
+`local` is the default mode. It is intended for a single operator and does
+not require an OIDC provider. A local bootstrap/recovery credential can be
+exchanged for an opaque session by a future authentication endpoint.
+
+`oidc` requires an HTTPS issuer and client ID. OIDC authorization-code/PKCE
+login creates the same opaque session type after the callback is validated.
+Redirect URIs may use HTTPS or target `localhost` for local development.
+
+Configuration rejects an OIDC provider in `local` mode and rejects `oidc`
+mode without a provider. Session absolute and idle TTLs must both be
+positive, and idle TTL must not exceed absolute TTL.
+
+### Principals and sessions
+
+An authenticated request is associated with a principal. OIDC principals are
+identified by the pair `(issuer, subject)` and have a stable internal
+`user_id`. Display name and email are profile attributes, not identity keys.
+
+Sessions are random opaque values. Runtime storage keeps only a SHA-256
+digest (`session_digest`), never the raw session value. A session records its
+user, authentication method, creation/expiry timestamps, last-seen timestamp,
+and optional revocation timestamp. A session is active only when it is not
+revoked, has not passed its absolute expiry, and has not exceeded its idle
+expiry.
+
+Interactive clients should use a cookie jar or an equivalent secure session
+store. A bearer form may be supported by protocol adapters, but it carries
+the opaque session rather than a long-lived control token.
+
+### Bootstrap and recovery credentials
+
+Static control credentials are bootstrap/recovery credentials, not the normal
+per-request credential. They are stored as digests, have an expiry, may be
+bound to a user and scope, and can be revoked. Redemption must atomically
+mark a credential consumed so concurrent requests cannot redeem it twice.
+
+The initial implementation intentionally keeps transport and endpoint policy
+out of the domain/storage module. A later HTTP slice defines how a local
+operator or an explicitly configured recovery path presents the credential.
+Unix-socket admission remains a separate trusted local channel and must not
+be confused with an unauthenticated TCP listener.
+
+### OIDC login transactions
+
+OIDC state, nonce, and transaction values are stored as digests. Login
+transactions have a bounded lifetime and a consumed marker, allowing the
+callback handler to enforce one-time use without persisting protocol secrets.
+
+## Runtime database boundary
+
+The runtime database contains:
+
+- `auth_users`: internal user records keyed externally by issuer and subject.
+- `auth_sessions`: opaque-session digests and lifecycle state.
+- `auth_bootstrap_credentials`: one-time or short-lived bootstrap/recovery
+  credential digests and atomic consumption state.
+- `auth_login_transactions`: bounded OIDC transaction digests and consumption
+  state.
+
+Repositories operate on domain records and timestamps. They do not issue raw
+credentials, perform OIDC discovery, or make transport authorization
+decisions. Those responsibilities belong to the authentication protocol and
+admission layers.
+
+## Security invariants
+
+1. Raw session, bootstrap, state, and nonce values are not persisted.
+2. Expiry and revocation are checked at admission time.
+3. Bootstrap redemption is single-use under concurrency.
+4. OIDC identity matching uses issuer plus subject, never email alone.
+5. Local mode remains usable without an OIDC provider.
+
+## Follow-up slices
+
+The next implementation slice adds `/auth/login`, `/auth/callback`, and
+bootstrap-to-session issuance. A subsequent slice applies session admission
+to HTTP, Web, TUI, and remote operator transports.

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -1,0 +1,201 @@
+//! Authentication domain types shared by configuration and runtime storage.
+//!
+//! Protocol handling belongs to the HTTP authentication layer. This module
+//! deliberately contains no transport or provider-specific code.
+
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use url::Url;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthenticationMode {
+    #[default]
+    Local,
+    Oidc,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OidcProviderConfig {
+    pub issuer_url: String,
+    pub client_id: String,
+    pub client_secret_env: Option<String>,
+    pub redirect_uri: Option<String>,
+}
+
+impl OidcProviderConfig {
+    pub fn validate(&self) -> Result<()> {
+        let issuer = Url::parse(&self.issuer_url)?;
+        if issuer.scheme() != "https" {
+            bail!("OIDC issuer_url must use HTTPS");
+        }
+        if self.client_id.trim().is_empty() {
+            bail!("OIDC client_id must not be empty");
+        }
+        if let Some(redirect_uri) = &self.redirect_uri {
+            let redirect = Url::parse(redirect_uri)?;
+            if redirect.scheme() != "https" && redirect.host_str() != Some("localhost") {
+                bail!("OIDC redirect_uri must use HTTPS or target localhost");
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionPolicy {
+    pub absolute_ttl_seconds: u64,
+    pub idle_ttl_seconds: u64,
+}
+
+impl Default for SessionPolicy {
+    fn default() -> Self {
+        Self {
+            absolute_ttl_seconds: Duration::from_secs(8 * 60 * 60).as_secs(),
+            idle_ttl_seconds: Duration::from_secs(30 * 60).as_secs(),
+        }
+    }
+}
+
+impl SessionPolicy {
+    pub fn validate(&self) -> Result<()> {
+        if self.absolute_ttl_seconds == 0 || self.idle_ttl_seconds == 0 {
+            bail!("session TTLs must be greater than zero");
+        }
+        if self.idle_ttl_seconds > self.absolute_ttl_seconds {
+            bail!("session idle TTL must not exceed absolute TTL");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthConfig {
+    pub mode: AuthenticationMode,
+    pub oidc: Option<OidcProviderConfig>,
+    pub session: SessionPolicy,
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self {
+            mode: AuthenticationMode::Local,
+            oidc: None,
+            session: SessionPolicy::default(),
+        }
+    }
+}
+
+impl AuthConfig {
+    pub fn validate(&self) -> Result<()> {
+        self.session.validate()?;
+        match (self.mode, &self.oidc) {
+            (AuthenticationMode::Local, None) => Ok(()),
+            (AuthenticationMode::Local, Some(_)) => {
+                bail!("OIDC configuration is not allowed when auth mode is local")
+            }
+            (AuthenticationMode::Oidc, Some(oidc)) => oidc.validate(),
+            (AuthenticationMode::Oidc, None) => {
+                bail!("OIDC configuration is required when auth mode is oidc")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthUserRecord {
+    pub user_id: String,
+    pub issuer: String,
+    pub subject: String,
+    pub display_name: Option<String>,
+    pub email: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub disabled_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthSessionRecord {
+    pub session_digest: String,
+    pub user_id: String,
+    pub auth_method: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub last_seen_at: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl AuthSessionRecord {
+    pub fn is_active_at(&self, now: DateTime<Utc>, idle_ttl: Duration) -> bool {
+        self.revoked_at.is_none()
+            && self.expires_at > now
+            && self.last_seen_at + chrono::Duration::from_std(idle_ttl).unwrap_or_default() > now
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootstrapCredentialRecord {
+    pub credential_digest: String,
+    pub user_id: Option<String>,
+    pub scope: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub consumed_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl BootstrapCredentialRecord {
+    pub fn is_redeemable_at(&self, now: DateTime<Utc>) -> bool {
+        self.consumed_at.is_none() && self.revoked_at.is_none() && self.expires_at > now
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoginTransactionRecord {
+    pub transaction_digest: String,
+    pub state_digest: String,
+    pub nonce_digest: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub consumed_at: Option<DateTime<Utc>>,
+}
+
+pub fn digest_secret(secret: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(secret.as_bytes());
+    format!("{:x}", digest.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_is_stable_without_exposing_secret() {
+        let digest = digest_secret("bootstrap-secret");
+        assert_eq!(digest.len(), 64);
+        assert_ne!(digest, "bootstrap-secret");
+        assert_eq!(digest, digest_secret("bootstrap-secret"));
+    }
+
+    #[test]
+    fn oidc_configuration_requires_https() {
+        let config = OidcProviderConfig {
+            issuer_url: "http://issuer.example".into(),
+            client_id: "holon".into(),
+            client_secret_env: None,
+            redirect_uri: None,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn local_auth_is_default_and_valid() {
+        assert_eq!(AuthConfig::default().mode, AuthenticationMode::Local);
+        assert!(AuthConfig::default().validate().is_ok());
+    }
+}

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -38,7 +38,9 @@ impl OidcProviderConfig {
         }
         if let Some(redirect_uri) = &self.redirect_uri {
             let redirect = Url::parse(redirect_uri)?;
-            if redirect.scheme() != "https" && redirect.host_str() != Some("localhost") {
+            if redirect.scheme() != "https"
+                && !(redirect.scheme() == "http" && redirect.host_str() == Some("localhost"))
+            {
                 bail!("OIDC redirect_uri must use HTTPS or target localhost");
             }
         }
@@ -191,6 +193,20 @@ mod tests {
             redirect_uri: None,
         };
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn localhost_redirect_must_use_http() {
+        let mut config = OidcProviderConfig {
+            issuer_url: "https://issuer.example".into(),
+            client_id: "client".into(),
+            client_secret_env: None,
+            redirect_uri: Some("ftp://localhost/callback".into()),
+        };
+        assert!(config.validate().is_err());
+
+        config.redirect_uri = Some("http://localhost/callback".into());
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -2,6 +2,8 @@ use super::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct HolonConfigFile {
+    #[serde(default, skip_serializing_if = "AuthConfigFile::is_empty")]
+    pub auth: AuthConfigFile,
     #[serde(default, skip_serializing_if = "ApiConfigFile::is_empty")]
     pub api: ApiConfigFile,
     #[serde(default, skip_serializing_if = "ModelConfigFile::is_empty")]
@@ -24,6 +26,46 @@ pub struct HolonConfigFile {
     pub x_search: XSearchConfigFile,
     #[serde(default, skip_serializing_if = "AgentTemplatesConfigFile::is_empty")]
     pub agent_templates: AgentTemplatesConfigFile,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct AuthConfigFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<AuthenticationMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oidc: Option<OidcConfigFile>,
+    #[serde(default, skip_serializing_if = "SessionConfigFile::is_empty")]
+    pub session: SessionConfigFile,
+}
+
+impl AuthConfigFile {
+    pub fn is_empty(&self) -> bool {
+        self.mode.is_none() && self.oidc.is_none() && self.session.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OidcConfigFile {
+    pub issuer_url: String,
+    pub client_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_secret_env: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redirect_uri: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct SessionConfigFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub absolute_ttl_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_ttl_seconds: Option<u64>,
+}
+
+impl SessionConfigFile {
+    pub fn is_empty(&self) -> bool {
+        self.absolute_ttl_seconds.is_none() && self.idle_ttl_seconds.is_none()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,6 +12,7 @@ use serde_json::{json, Value};
 
 use crate::{
     auth::{codex_cli_auth_file_exists, load_codex_cli_credential},
+    authentication::{AuthConfig, AuthenticationMode, OidcProviderConfig, SessionPolicy},
     context::ContextConfig,
     model_catalog::{
         BuiltInModelCatalog, BuiltInModelMetadata, ModelRuntimeOverride, ResolvedRuntimeModelPolicy,
@@ -60,6 +61,7 @@ pub struct AppConfig {
     pub max_relevant_episodes: usize,
     pub control_token: Option<String>,
     pub control_auth_mode: ControlAuthMode,
+    pub auth: AuthConfig,
     pub api_cors: ApiCorsConfigFile,
     pub config_file_path: PathBuf,
     pub stored_config: HolonConfigFile,
@@ -225,6 +227,7 @@ impl AppConfig {
             .map(|value| ControlAuthMode::parse(&value))
             .transpose()?
             .unwrap_or(ControlAuthMode::Auto);
+        let auth = materialize_auth_config(&stored_config.auth)?;
         let runtime_max_output_tokens = env::var("HOLON_MAX_OUTPUT_TOKENS")
             .ok()
             .and_then(|value| value.parse::<u32>().ok())
@@ -324,6 +327,7 @@ impl AppConfig {
             max_relevant_episodes,
             control_token,
             control_auth_mode,
+            auth,
             api_cors: stored_config.api.cors.clone(),
             config_file_path,
             stored_config,
@@ -344,7 +348,36 @@ impl AppConfig {
             providers,
         })
     }
+}
 
+fn materialize_auth_config(file: &AuthConfigFile) -> Result<AuthConfig> {
+    let defaults = SessionPolicy::default();
+    let session = SessionPolicy {
+        absolute_ttl_seconds: file
+            .session
+            .absolute_ttl_seconds
+            .unwrap_or(defaults.absolute_ttl_seconds),
+        idle_ttl_seconds: file
+            .session
+            .idle_ttl_seconds
+            .unwrap_or(defaults.idle_ttl_seconds),
+    };
+    let oidc = file.oidc.as_ref().map(|oidc| OidcProviderConfig {
+        issuer_url: oidc.issuer_url.clone(),
+        client_id: oidc.client_id.clone(),
+        client_secret_env: oidc.client_secret_env.clone(),
+        redirect_uri: oidc.redirect_uri.clone(),
+    });
+    let config = AuthConfig {
+        mode: file.mode.unwrap_or(AuthenticationMode::Local),
+        oidc,
+        session,
+    };
+    config.validate()?;
+    Ok(config)
+}
+
+impl AppConfig {
     pub fn run_dir(&self) -> PathBuf {
         self.home_dir.join("run")
     }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -13,6 +13,55 @@ pub struct ConfigSchemaEntry {
 pub fn config_schema() -> Vec<ConfigSchemaEntry> {
     vec![
         ConfigSchemaEntry {
+            key: "auth.mode",
+            kind: "string",
+            description: "Authentication mode. Changes are persisted and require restart.",
+            default: json!("local"),
+            allowed_values: vec!["local", "oidc"],
+        },
+        ConfigSchemaEntry {
+            key: "auth.oidc.issuer_url",
+            kind: "string",
+            description: "OIDC issuer URL.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "auth.oidc.client_id",
+            kind: "string",
+            description: "OIDC client identifier.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "auth.oidc.client_secret_env",
+            kind: "string",
+            description: "Environment variable containing the OIDC client secret.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "auth.oidc.redirect_uri",
+            kind: "string",
+            description: "OIDC callback redirect URI.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "auth.session.absolute_ttl_seconds",
+            kind: "positive_integer",
+            description: "Absolute authentication session lifetime in seconds.",
+            default: json!(SessionPolicy::default().absolute_ttl_seconds),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "auth.session.idle_ttl_seconds",
+            kind: "positive_integer",
+            description: "Idle authentication session lifetime in seconds.",
+            default: json!(SessionPolicy::default().idle_ttl_seconds),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
             key: "api.cors.enabled",
             kind: "boolean",
             description: "Enable CORS responses on the HTTP/control API. Enabled by default for localhost/loopback browser origins.",
@@ -632,6 +681,45 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
 
 pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
     match key {
+        "auth.mode" => Ok(json!(config.auth.mode)),
+        "auth.oidc.issuer_url" => Ok(config
+            .auth
+            .oidc
+            .as_ref()
+            .map(|oidc| json!(oidc.issuer_url))
+            .unwrap_or(Value::Null)),
+        "auth.oidc.client_id" => Ok(config
+            .auth
+            .oidc
+            .as_ref()
+            .map(|oidc| json!(oidc.client_id))
+            .unwrap_or(Value::Null)),
+        "auth.oidc.client_secret_env" => Ok(config
+            .auth
+            .oidc
+            .as_ref()
+            .and_then(|oidc| oidc.client_secret_env.as_ref())
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
+        "auth.oidc.redirect_uri" => Ok(config
+            .auth
+            .oidc
+            .as_ref()
+            .and_then(|oidc| oidc.redirect_uri.as_ref())
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
+        "auth.session.absolute_ttl_seconds" => Ok(config
+            .auth
+            .session
+            .absolute_ttl_seconds
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
+        "auth.session.idle_ttl_seconds" => Ok(config
+            .auth
+            .session
+            .idle_ttl_seconds
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
         "api.cors.enabled" => Ok(config
             .api
             .cors
@@ -995,6 +1083,27 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
 
 pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) -> Result<()> {
     match key {
+        "auth.mode" => {
+            config.auth.mode = Some(match raw_value.trim().to_ascii_lowercase().as_str() {
+                "local" => AuthenticationMode::Local,
+                "oidc" => AuthenticationMode::Oidc,
+                _ => return Err(anyhow!("{key} expects one of: local, oidc")),
+            });
+        }
+        "auth.oidc.issuer_url" => ensure_auth_oidc(config).issuer_url = raw_value.to_owned(),
+        "auth.oidc.client_id" => ensure_auth_oidc(config).client_id = raw_value.to_owned(),
+        "auth.oidc.client_secret_env" => {
+            ensure_auth_oidc(config).client_secret_env = Some(raw_value.to_owned())
+        }
+        "auth.oidc.redirect_uri" => {
+            ensure_auth_oidc(config).redirect_uri = Some(raw_value.to_owned())
+        }
+        "auth.session.absolute_ttl_seconds" => {
+            config.auth.session.absolute_ttl_seconds = Some(parse_positive_u64_key(key, raw_value)?)
+        }
+        "auth.session.idle_ttl_seconds" => {
+            config.auth.session.idle_ttl_seconds = Some(parse_positive_u64_key(key, raw_value)?)
+        }
         "api.cors.enabled" => {
             config.api.cors.enabled = Some(
                 parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
@@ -1346,6 +1455,15 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
 
 pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
     match key {
+        "auth.mode" => config.auth.mode = None,
+        "auth.oidc.issuer_url" => clear_auth_oidc_field(config, |oidc| oidc.issuer_url.clear()),
+        "auth.oidc.client_id" => clear_auth_oidc_field(config, |oidc| oidc.client_id.clear()),
+        "auth.oidc.client_secret_env" => {
+            clear_auth_oidc_field(config, |oidc| oidc.client_secret_env = None)
+        }
+        "auth.oidc.redirect_uri" => clear_auth_oidc_field(config, |oidc| oidc.redirect_uri = None),
+        "auth.session.absolute_ttl_seconds" => config.auth.session.absolute_ttl_seconds = None,
+        "auth.session.idle_ttl_seconds" => config.auth.session.idle_ttl_seconds = None,
         "api.cors.enabled" => config.api.cors.enabled = None,
         "api.cors.allowed_origins" => config.api.cors.allowed_origins.clear(),
         "api.cors.allowed_methods" => {
@@ -1639,6 +1757,24 @@ pub(crate) fn parse_url_value(key: &str, raw_value: &str) -> Result<()> {
         return Err(anyhow!("{key} expects an http or https URL"));
     }
     Ok(())
+}
+
+fn ensure_auth_oidc(config: &mut HolonConfigFile) -> &mut OidcConfigFile {
+    config.auth.oidc.get_or_insert_with(|| OidcConfigFile {
+        issuer_url: String::new(),
+        client_id: String::new(),
+        client_secret_env: None,
+        redirect_uri: None,
+    })
+}
+
+fn clear_auth_oidc_field<F>(config: &mut HolonConfigFile, clear: F)
+where
+    F: FnOnce(&mut OidcConfigFile),
+{
+    if let Some(oidc) = config.auth.oidc.as_mut() {
+        clear(oidc);
+    }
 }
 
 pub(crate) fn is_startup_only_config_key(key: &str) -> bool {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2245,6 +2245,9 @@ fn schema_contains_expected_keys() {
         .map(|entry| entry.key)
         .collect::<Vec<_>>();
     assert!(keys.contains(&"model.default"));
+    assert!(keys.contains(&"auth.mode"));
+    assert!(keys.contains(&"auth.oidc.issuer_url"));
+    assert!(keys.contains(&"auth.session.absolute_ttl_seconds"));
     assert!(keys.contains(&"models.catalog"));
     assert!(keys.contains(&"model.unknown_fallback"));
     assert!(keys.contains(&"providers.<id>.endpoints.<endpoint_id>.transport"));
@@ -2264,6 +2267,134 @@ fn schema_contains_expected_keys() {
     assert!(keys.contains(&"web.fetch.max_redirects"));
     assert!(keys.contains(&"web.search.provider"));
     assert!(keys.contains(&"web.providers.<name>.capabilities"));
+}
+
+#[test]
+fn auth_config_schema_round_trips_persisted_values() {
+    let mut config = HolonConfigFile::default();
+    set_config_key(&mut config, "auth.mode", "oidc").unwrap();
+    set_config_key(
+        &mut config,
+        "auth.oidc.issuer_url",
+        "https://issuer.example",
+    )
+    .unwrap();
+    set_config_key(&mut config, "auth.oidc.client_id", "client").unwrap();
+    set_config_key(&mut config, "auth.session.idle_ttl_seconds", "120").unwrap();
+
+    assert_eq!(get_config_key(&config, "auth.mode").unwrap(), json!("oidc"));
+    assert_eq!(
+        get_config_key(&config, "auth.oidc.issuer_url").unwrap(),
+        json!("https://issuer.example")
+    );
+    assert_eq!(
+        get_config_key(&config, "auth.session.idle_ttl_seconds").unwrap(),
+        json!(120)
+    );
+}
+
+#[test]
+fn load_persisted_config_materializes_auth_settings() {
+    let home = tempdir().unwrap();
+    save_persisted_config_at(
+        &persisted_config_path(home.path()),
+        &HolonConfigFile {
+            auth: crate::config::AuthConfigFile {
+                mode: Some(crate::authentication::AuthenticationMode::Oidc),
+                oidc: Some(crate::config::OidcConfigFile {
+                    issuer_url: "https://issuer.example".into(),
+                    client_id: "client".into(),
+                    client_secret_env: None,
+                    redirect_uri: Some("http://localhost/callback".into()),
+                }),
+                session: crate::config::SessionConfigFile {
+                    absolute_ttl_seconds: Some(900),
+                    idle_ttl_seconds: Some(300),
+                },
+            },
+            ..HolonConfigFile::default()
+        },
+    )
+    .unwrap();
+
+    let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+    assert_eq!(
+        config.auth.mode,
+        crate::authentication::AuthenticationMode::Oidc
+    );
+    let oidc = config.auth.oidc.as_ref().expect("OIDC settings");
+    assert_eq!(oidc.issuer_url, "https://issuer.example");
+    assert_eq!(oidc.client_id, "client");
+    assert_eq!(
+        oidc.redirect_uri.as_deref(),
+        Some("http://localhost/callback")
+    );
+    assert_eq!(config.auth.session.absolute_ttl_seconds, 900);
+    assert_eq!(config.auth.session.idle_ttl_seconds, 300);
+}
+
+#[test]
+fn load_persisted_config_rejects_invalid_auth_settings() {
+    let oidc = || crate::config::OidcConfigFile {
+        issuer_url: "https://issuer.example".into(),
+        client_id: "client".into(),
+        client_secret_env: None,
+        redirect_uri: None,
+    };
+    let cases = vec![
+        (
+            "local mode with OIDC settings",
+            crate::config::AuthConfigFile {
+                mode: Some(crate::authentication::AuthenticationMode::Local),
+                oidc: Some(oidc()),
+                ..Default::default()
+            },
+        ),
+        (
+            "OIDC mode without provider settings",
+            crate::config::AuthConfigFile {
+                mode: Some(crate::authentication::AuthenticationMode::Oidc),
+                ..Default::default()
+            },
+        ),
+        (
+            "zero absolute session TTL",
+            crate::config::AuthConfigFile {
+                session: crate::config::SessionConfigFile {
+                    absolute_ttl_seconds: Some(0),
+                    idle_ttl_seconds: Some(1),
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            "idle session TTL greater than absolute TTL",
+            crate::config::AuthConfigFile {
+                session: crate::config::SessionConfigFile {
+                    absolute_ttl_seconds: Some(60),
+                    idle_ttl_seconds: Some(61),
+                },
+                ..Default::default()
+            },
+        ),
+    ];
+
+    for (name, auth) in cases {
+        let home = tempdir().unwrap();
+        save_persisted_config_at(
+            &persisted_config_path(home.path()),
+            &HolonConfigFile {
+                auth,
+                ..HolonConfigFile::default()
+            },
+        )
+        .unwrap();
+
+        assert!(
+            AppConfig::load_with_home(Some(home.path().to_path_buf())).is_err(),
+            "{name} should be rejected"
+        );
+    }
 }
 
 #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -152,6 +152,7 @@ fn test_app_config(default_model: &str, fallback_models: &[&str]) -> TestAppConf
         max_relevant_episodes: 3,
         control_token: Some("control-value".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        auth: Default::default(),
         api_cors: Default::default(),
         config_file_path: home_path.join("config.json"),
         stored_config: Default::default(),

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2312,6 +2312,10 @@ fn load_persisted_config_materializes_auth_settings() {
                     idle_ttl_seconds: Some(300),
                 },
             },
+            model: ModelConfigFile {
+                default: Some("anthropic/claude-sonnet-4-6".into()),
+                ..ModelConfigFile::default()
+            },
             ..HolonConfigFile::default()
         },
     )
@@ -2385,6 +2389,10 @@ fn load_persisted_config_rejects_invalid_auth_settings() {
             &persisted_config_path(home.path()),
             &HolonConfigFile {
                 auth,
+                model: ModelConfigFile {
+                    default: Some("anthropic/claude-sonnet-4-6".into()),
+                    ..ModelConfigFile::default()
+                },
                 ..HolonConfigFile::default()
             },
         )

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -79,6 +79,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: crate::config::ControlAuthMode::Auto,
+        auth: Default::default(),
         api_cors: Default::default(),
         config_file_path: home.path().join("config.json"),
         stored_config: Default::default(),

--- a/src/host.rs
+++ b/src/host.rs
@@ -4114,6 +4114,7 @@ mod tests {
             max_relevant_episodes: 3,
             control_token: Some("secret".into()),
             control_auth_mode: ControlAuthMode::Auto,
+            auth: Default::default(),
             api_cors: Default::default(),
             config_file_path: home_path.join("config.json"),
             stored_config: Default::default(),

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -311,7 +311,14 @@ fn validate_runtime_config_candidate(
 fn is_runtime_mutable_config_key(key: &str) -> bool {
     matches!(
         key,
-        "api.cors.enabled"
+        "auth.mode"
+            | "auth.oidc.issuer_url"
+            | "auth.oidc.client_id"
+            | "auth.oidc.client_secret_env"
+            | "auth.oidc.redirect_uri"
+            | "auth.session.absolute_ttl_seconds"
+            | "auth.session.idle_ttl_seconds"
+            | "api.cors.enabled"
             | "api.cors.allowed_origins"
             | "api.cors.allowed_methods"
             | "api.cors.allowed_headers"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent_memory;
 pub mod agent_template;
 pub mod agents_md;
 mod auth;
+pub mod authentication;
 mod callbacks;
 pub mod ids;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1102,6 +1102,7 @@ mod tests {
             max_relevant_episodes: 3,
             control_token: Some("secret".into()),
             control_auth_mode: ControlAuthMode::Auto,
+            auth: Default::default(),
             api_cors: Default::default(),
             config_file_path: home.join("config.json"),
             stored_config: Default::default(),

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1032,6 +1032,7 @@ mod tests {
             max_relevant_episodes: 3,
             control_token: Some("control-value".into()),
             control_auth_mode: ControlAuthMode::Auto,
+            auth: Default::default(),
             api_cors: Default::default(),
             config_file_path: home_dir.join("config.json"),
             stored_config: Default::default(),

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -201,6 +201,7 @@ mod tests {
             max_relevant_episodes: 3,
             control_token: Some("secret".into()),
             control_auth_mode: ControlAuthMode::Auto,
+            auth: Default::default(),
             api_cors: Default::default(),
             config_file_path: home.join("config.json"),
             stored_config: Default::default(),

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -576,6 +576,7 @@ mod tests {
             max_relevant_episodes: 3,
             control_token: Some("control-value".into()),
             control_auth_mode: ControlAuthMode::Auto,
+            auth: Default::default(),
             api_cors: Default::default(),
             config_file_path: home_path.join("config.json"),
             stored_config: Default::default(),

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -302,6 +302,7 @@ pub fn test_config(
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        auth: Default::default(),
         api_cors: Default::default(),
         config_file_path: home_path.join("config.json"),
         stored_config: Default::default(),

--- a/src/runtime_db/authentication.rs
+++ b/src/runtime_db/authentication.rs
@@ -16,6 +16,21 @@ pub struct AuthenticationRepository<'a> {
 impl AuthenticationRepository<'_> {
     pub fn upsert_user(&self, user: &AuthUserRecord) -> Result<()> {
         self.db.transaction(|tx| {
+            let existing_identity = tx
+                .query_row(
+                    "SELECT issuer, subject FROM auth_users WHERE user_id = ?1",
+                    [user.user_id.as_str()],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()?;
+            if let Some((issuer, subject)) = existing_identity {
+                if issuer != user.issuer || subject != user.subject {
+                    anyhow::bail!(
+                        "authentication user_id {} is already bound to a different issuer/subject",
+                        user.user_id
+                    );
+                }
+            }
             tx.execute(
                 "INSERT INTO auth_users (
                     user_id, issuer, subject, display_name, email,
@@ -99,7 +114,8 @@ impl AuthenticationRepository<'_> {
                  SET last_seen_at = ?2
                  WHERE session_digest = ?1
                    AND revoked_at IS NULL
-                   AND expires_at > ?2",
+                   AND expires_at > ?2
+                   AND last_seen_at <= ?2",
                 params![session_digest, timestamp(last_seen_at)],
             )? == 1)
         })
@@ -289,6 +305,76 @@ mod tests {
             .authentication()
             .consume_bootstrap_credential("digest", now)?
             .is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn touching_session_does_not_move_last_seen_backwards() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            temp_dir.path().join("runtime.sqlite"),
+            temp_dir.path().join("runtime.lock"),
+        )?;
+        let now = chrono::DateTime::from_timestamp_millis(Utc::now().timestamp_millis())
+            .expect("valid timestamp");
+        db.authentication().upsert_user(&AuthUserRecord {
+            user_id: "user".into(),
+            issuer: "local".into(),
+            subject: "user".into(),
+            display_name: None,
+            email: None,
+            created_at: now,
+            updated_at: now,
+            disabled_at: None,
+        })?;
+        db.authentication().create_session(&AuthSessionRecord {
+            session_digest: "session".into(),
+            user_id: "user".into(),
+            auth_method: "local".into(),
+            created_at: now,
+            expires_at: now + chrono::Duration::hours(1),
+            last_seen_at: now + chrono::Duration::minutes(5),
+            revoked_at: None,
+        })?;
+
+        assert!(!db.authentication().touch_session("session", now)?);
+        assert_eq!(
+            db.authentication()
+                .find_session("session")?
+                .expect("session exists")
+                .last_seen_at,
+            chrono::DateTime::from_timestamp_millis(
+                (now + chrono::Duration::minutes(5)).timestamp_millis()
+            )
+            .expect("valid timestamp")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn user_identity_cannot_be_rebound_to_another_external_identity() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            temp_dir.path().join("runtime.sqlite"),
+            temp_dir.path().join("runtime.lock"),
+        )?;
+        let now = Utc::now();
+        let user = AuthUserRecord {
+            user_id: "user".into(),
+            issuer: "https://issuer.example".into(),
+            subject: "subject-a".into(),
+            display_name: None,
+            email: None,
+            created_at: now,
+            updated_at: now,
+            disabled_at: None,
+        };
+        db.authentication().upsert_user(&user)?;
+
+        let mut rebound = user;
+        rebound.subject = "subject-b".into();
+        let error = db.authentication().upsert_user(&rebound).unwrap_err();
+        assert!(error.to_string().contains("already bound"));
         Ok(())
     }
 }

--- a/src/runtime_db/authentication.rs
+++ b/src/runtime_db/authentication.rs
@@ -1,0 +1,294 @@
+//! Persistent authentication records.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use rusqlite::{params, OptionalExtension};
+
+use crate::authentication::{
+    AuthSessionRecord, AuthUserRecord, BootstrapCredentialRecord, LoginTransactionRecord,
+};
+use crate::runtime_db::RuntimeDb;
+
+pub struct AuthenticationRepository<'a> {
+    pub(crate) db: &'a RuntimeDb,
+}
+
+impl AuthenticationRepository<'_> {
+    pub fn upsert_user(&self, user: &AuthUserRecord) -> Result<()> {
+        self.db.transaction(|tx| {
+            tx.execute(
+                "INSERT INTO auth_users (
+                    user_id, issuer, subject, display_name, email,
+                    created_at, updated_at, disabled_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                 ON CONFLICT(user_id) DO UPDATE SET
+                    issuer = excluded.issuer,
+                    subject = excluded.subject,
+                    display_name = excluded.display_name,
+                    email = excluded.email,
+                    updated_at = excluded.updated_at,
+                    disabled_at = excluded.disabled_at",
+                params![
+                    user.user_id,
+                    user.issuer,
+                    user.subject,
+                    user.display_name,
+                    user.email,
+                    timestamp(user.created_at),
+                    timestamp(user.updated_at),
+                    user.disabled_at.map(timestamp),
+                ],
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn find_user(&self, issuer: &str, subject: &str) -> Result<Option<AuthUserRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT user_id, issuer, subject, display_name, email,
+                        created_at, updated_at, disabled_at
+                 FROM auth_users WHERE issuer = ?1 AND subject = ?2",
+                params![issuer, subject],
+                row_to_user,
+            )
+            .optional()
+            .context("looking up authenticated user")
+    }
+
+    pub fn create_session(&self, session: &AuthSessionRecord) -> Result<()> {
+        self.db.transaction(|tx| {
+            tx.execute(
+                "INSERT INTO auth_sessions (
+                    session_digest, user_id, auth_method,
+                    created_at, expires_at, last_seen_at, revoked_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    session.session_digest,
+                    session.user_id,
+                    session.auth_method,
+                    timestamp(session.created_at),
+                    timestamp(session.expires_at),
+                    timestamp(session.last_seen_at),
+                    session.revoked_at.map(timestamp),
+                ],
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn find_session(&self, session_digest: &str) -> Result<Option<AuthSessionRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT session_digest, user_id, auth_method,
+                        created_at, expires_at, last_seen_at, revoked_at
+                 FROM auth_sessions WHERE session_digest = ?1",
+                [session_digest],
+                row_to_session,
+            )
+            .optional()
+            .context("looking up authentication session")
+    }
+
+    pub fn touch_session(&self, session_digest: &str, last_seen_at: DateTime<Utc>) -> Result<bool> {
+        self.db.transaction(|tx| {
+            Ok(tx.execute(
+                "UPDATE auth_sessions
+                 SET last_seen_at = ?2
+                 WHERE session_digest = ?1
+                   AND revoked_at IS NULL
+                   AND expires_at > ?2",
+                params![session_digest, timestamp(last_seen_at)],
+            )? == 1)
+        })
+    }
+
+    pub fn revoke_session(&self, session_digest: &str, revoked_at: DateTime<Utc>) -> Result<bool> {
+        self.db.transaction(|tx| {
+            Ok(tx.execute(
+                "UPDATE auth_sessions
+                 SET revoked_at = ?2
+                 WHERE session_digest = ?1 AND revoked_at IS NULL",
+                params![session_digest, timestamp(revoked_at)],
+            )? == 1)
+        })
+    }
+
+    pub fn insert_bootstrap_credential(
+        &self,
+        credential: &BootstrapCredentialRecord,
+    ) -> Result<()> {
+        self.db.transaction(|tx| {
+            tx.execute(
+                "INSERT INTO auth_bootstrap_credentials (
+                    credential_digest, user_id, scope,
+                    created_at, expires_at, consumed_at, revoked_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    credential.credential_digest,
+                    credential.user_id,
+                    credential.scope,
+                    timestamp(credential.created_at),
+                    timestamp(credential.expires_at),
+                    credential.consumed_at.map(timestamp),
+                    credential.revoked_at.map(timestamp),
+                ],
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn consume_bootstrap_credential(
+        &self,
+        credential_digest: &str,
+        consumed_at: DateTime<Utc>,
+    ) -> Result<Option<BootstrapCredentialRecord>> {
+        self.db.transaction(|tx| {
+            let updated = tx.execute(
+                "UPDATE auth_bootstrap_credentials
+                 SET consumed_at = ?2
+                 WHERE credential_digest = ?1
+                   AND consumed_at IS NULL
+                   AND revoked_at IS NULL
+                   AND expires_at > ?2",
+                params![credential_digest, timestamp(consumed_at)],
+            )?;
+            if updated == 0 {
+                return Ok(None);
+            }
+            tx.query_row(
+                "SELECT credential_digest, user_id, scope,
+                        created_at, expires_at, consumed_at, revoked_at
+                 FROM auth_bootstrap_credentials
+                 WHERE credential_digest = ?1",
+                [credential_digest],
+                row_to_bootstrap,
+            )
+            .map(Some)
+            .context("reading consumed bootstrap credential")
+        })
+    }
+
+    pub fn insert_login_transaction(&self, login: &LoginTransactionRecord) -> Result<()> {
+        self.db.transaction(|tx| {
+            tx.execute(
+                "INSERT INTO auth_login_transactions (
+                    transaction_digest, state_digest, nonce_digest,
+                    created_at, expires_at, consumed_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    login.transaction_digest,
+                    login.state_digest,
+                    login.nonce_digest,
+                    timestamp(login.created_at),
+                    timestamp(login.expires_at),
+                    login.consumed_at.map(timestamp),
+                ],
+            )?;
+            Ok(())
+        })
+    }
+}
+
+fn timestamp(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+fn parse_timestamp(value: String) -> rusqlite::Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(&value)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                value.len(),
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })
+}
+
+fn row_to_user(row: &rusqlite::Row<'_>) -> rusqlite::Result<AuthUserRecord> {
+    Ok(AuthUserRecord {
+        user_id: row.get(0)?,
+        issuer: row.get(1)?,
+        subject: row.get(2)?,
+        display_name: row.get(3)?,
+        email: row.get(4)?,
+        created_at: parse_timestamp(row.get(5)?)?,
+        updated_at: parse_timestamp(row.get(6)?)?,
+        disabled_at: row
+            .get::<_, Option<String>>(7)?
+            .map(parse_timestamp)
+            .transpose()?,
+    })
+}
+
+fn row_to_session(row: &rusqlite::Row<'_>) -> rusqlite::Result<AuthSessionRecord> {
+    Ok(AuthSessionRecord {
+        session_digest: row.get(0)?,
+        user_id: row.get(1)?,
+        auth_method: row.get(2)?,
+        created_at: parse_timestamp(row.get(3)?)?,
+        expires_at: parse_timestamp(row.get(4)?)?,
+        last_seen_at: parse_timestamp(row.get(5)?)?,
+        revoked_at: row
+            .get::<_, Option<String>>(6)?
+            .map(parse_timestamp)
+            .transpose()?,
+    })
+}
+
+fn row_to_bootstrap(row: &rusqlite::Row<'_>) -> rusqlite::Result<BootstrapCredentialRecord> {
+    Ok(BootstrapCredentialRecord {
+        credential_digest: row.get(0)?,
+        user_id: row.get(1)?,
+        scope: row.get(2)?,
+        created_at: parse_timestamp(row.get(3)?)?,
+        expires_at: parse_timestamp(row.get(4)?)?,
+        consumed_at: row
+            .get::<_, Option<String>>(5)?
+            .map(parse_timestamp)
+            .transpose()?,
+        revoked_at: row
+            .get::<_, Option<String>>(6)?
+            .map(parse_timestamp)
+            .transpose()?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_db::RuntimeDb;
+
+    #[test]
+    fn bootstrap_credential_is_consumed_once() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            temp_dir.path().join("runtime.sqlite"),
+            temp_dir.path().join("runtime.lock"),
+        )?;
+        let now = Utc::now();
+        db.authentication()
+            .insert_bootstrap_credential(&BootstrapCredentialRecord {
+                credential_digest: "digest".into(),
+                user_id: None,
+                scope: "session_exchange".into(),
+                created_at: now,
+                expires_at: now + chrono::Duration::hours(1),
+                consumed_at: None,
+                revoked_at: None,
+            })?;
+
+        assert!(db
+            .authentication()
+            .consume_bootstrap_credential("digest", now)?
+            .is_some());
+        assert!(db
+            .authentication()
+            .consume_bootstrap_credential("digest", now)?
+            .is_none());
+        Ok(())
+    }
+}

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3156,6 +3156,66 @@ CREATE TABLE IF NOT EXISTS audit_event_retention_watermarks (
         // baseline and downgrade/re-upgrade paths remain idempotent.
         sql: "",
     },
+    Migration {
+        version: 53,
+        name: "authentication_foundations",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS auth_users (
+  user_id TEXT PRIMARY KEY,
+  issuer TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  display_name TEXT,
+  email TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  disabled_at TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_users_issuer_subject
+  ON auth_users (issuer, subject);
+
+CREATE TABLE IF NOT EXISTS auth_sessions (
+  session_digest TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES auth_users(user_id),
+  auth_method TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL,
+  revoked_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_user
+  ON auth_sessions (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_expiry
+  ON auth_sessions (expires_at);
+
+CREATE TABLE IF NOT EXISTS auth_bootstrap_credentials (
+  credential_digest TEXT PRIMARY KEY,
+  user_id TEXT REFERENCES auth_users(user_id),
+  scope TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  consumed_at TEXT,
+  revoked_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_bootstrap_expiry
+  ON auth_bootstrap_credentials (expires_at);
+
+CREATE TABLE IF NOT EXISTS auth_login_transactions (
+  transaction_digest TEXT PRIMARY KEY,
+  state_digest TEXT NOT NULL UNIQUE,
+  nonce_digest TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  consumed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_login_expiry
+  ON auth_login_transactions (expires_at);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -11,6 +11,7 @@
 //! - [`index_outbox`]: runtime index outbox repository.
 
 pub mod audit;
+pub mod authentication;
 pub mod connection;
 pub mod evidence;
 mod legacy_scheduler_wire;
@@ -34,6 +35,7 @@ pub use crate::runtime_db::audit::{
     RuntimeDbAuditCheck, RuntimeDbAuditDatabase, RuntimeDbAuditOptions, RuntimeDbAuditReport,
     ViolationSplit,
 };
+pub use crate::runtime_db::authentication::AuthenticationRepository;
 pub use crate::runtime_db::evidence::{
     EvidenceKind, EvidencePayloadRow, EvidenceQuery, EvidenceRow,
 };
@@ -498,6 +500,10 @@ impl RuntimeDb {
 
     pub fn audit_events(&self) -> AuditEventSink<'_> {
         AuditEventSink { db: self }
+    }
+
+    pub fn authentication(&self) -> AuthenticationRepository<'_> {
+        AuthenticationRepository { db: self }
     }
 
     pub fn agent_states(&self) -> AgentStateRepository<'_> {

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -88,7 +88,10 @@ mod tests {
             ActivationTrust, AdmitActivationCommand, AgentActivation, PreemptionPolicy, WorkDemand,
             WorkStatus,
         },
-        runtime_db::migrations::{RETAINED_SCHEDULER_AUDIT_TABLES, RETIRED_SCHEDULER_TABLES},
+        runtime_db::migrations::{
+            RETAINED_SCHEDULER_AUDIT_TABLES, RETIRED_SCHEDULER_SCHEMA_PREDECESSOR,
+            RETIRED_SCHEDULER_TABLES,
+        },
         runtime_db::observer_sync::{
             AGENT_ROSTER_LATEST_BRIEFS_SQL, EVENT_PROJECTION_EFFECT_VERIFIER_VERSION,
         },
@@ -1725,9 +1728,11 @@ INSERT INTO storage_domains (
         let error = RuntimeDb::open_for_scheduler_recovery(&db_path, &lock_path)
             .expect_err("schema 45 is too old for the schema 46 recovery contract");
         assert!(
-            error
-                .to_string()
-                .contains("supports runtime db schemas 46 through 52, found 45"),
+            error.to_string().contains(&format!(
+                "supports runtime db schemas {} through {}, found 45",
+                RETIRED_SCHEDULER_SCHEMA_PREDECESSOR,
+                max_known_migration_version()
+            )),
             "{error:#}"
         );
         Ok(())

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -64,6 +64,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: crate::config::ControlAuthMode::Auto,
+        auth: Default::default(),
         api_cors: Default::default(),
         config_file_path: temp.join("config.json"),
         stored_config: Default::default(),

--- a/tests/runtime_waiting_and_reactivation.rs
+++ b/tests/runtime_waiting_and_reactivation.rs
@@ -3,6 +3,29 @@ mod runtime_waiting;
 
 mod support;
 
+use std::future::Future;
+
+fn run_on_large_stack<F, Fut>(name: &str, test: F) -> anyhow::Result<()>
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = anyhow::Result<()>> + 'static,
+{
+    let test_thread = std::thread::Builder::new()
+        .name(name.into())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?
+                .block_on(test())
+        })?;
+
+    match test_thread.join() {
+        Ok(result) => result,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
 macro_rules! runtime_async_tests {
     ($($name:ident),* $(,)?) => {
         $(
@@ -31,5 +54,12 @@ runtime_async_tests!(
     update_work_item_creates_and_updates_persisted_snapshot,
     update_work_item_replaces_latest_plan_snapshot_for_existing_work_item,
     multi_session_state_is_isolated,
-    agent_summary_last_turn_token_usage_survives_transcript_windowing,
 );
+
+#[test]
+fn agent_summary_last_turn_token_usage_survives_transcript_windowing() -> anyhow::Result<()> {
+    run_on_large_stack(
+        "agent_summary_last_turn_token_usage_survives_transcript_windowing",
+        || runtime_waiting::agent_summary_last_turn_token_usage_survives_transcript_windowing(),
+    )
+}

--- a/tests/scripted_agent_provider.rs
+++ b/tests/scripted_agent_provider.rs
@@ -35,6 +35,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        auth: Default::default(),
         api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -199,6 +199,7 @@ impl TestConfigBuilder {
             max_relevant_episodes: 3,
             control_token: Some("secret".into()),
             control_auth_mode: self.control_auth_mode,
+            auth: Default::default(),
             api_cors: Default::default(),
             config_file_path: data_dir.join("config.json"),
             stored_config: Default::default(),

--- a/tests/wt201_multiple_worktree_tasks.rs
+++ b/tests/wt201_multiple_worktree_tasks.rs
@@ -37,6 +37,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        auth: Default::default(),
         api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),

--- a/tests/wt202_worktree_task_summary.rs
+++ b/tests/wt202_worktree_task_summary.rs
@@ -36,6 +36,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        auth: Default::default(),
         api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),

--- a/tests/wt204_parallel_worktree_workflow.rs
+++ b/tests/wt204_parallel_worktree_workflow.rs
@@ -36,6 +36,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        auth: Default::default(),
         api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),

--- a/tests/wt205_worktree_lifecycle_edge_cases.rs
+++ b/tests/wt205_worktree_lifecycle_edge_cases.rs
@@ -36,6 +36,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        auth: Default::default(),
         api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),


### PR DESCRIPTION
## Summary

Closes #2735 (PR 1/3).

本 PR 建立 session-first 认证基础设施，统一 `local` 与 `oidc` 的后续 session 建立模型：

- 新增 session-first authentication RFC，明确 local/OIDC principal、opaque session、bootstrap/recovery credential 及信任边界。
- 新增认证配置 schema 与校验，覆盖 `local`/`oidc`、session TTL、bootstrap credential 和 OIDC 参数。
- 新增认证领域类型，以及 runtime DB 的 schema migration、session/principal/bootstrap credential 持久化接口。
- 增加配置、migration、session 生命周期和 bootstrap credential 原子消费测试。
- 为新增配置字段补齐现有测试/fixture 初始化器。

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --lib authentication`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

后续 PR 将分别实现 OIDC/session issuance，以及 HTTP/Web/TUI 集成。
