### PR TITLE
fix: persist the WaitFor fast-path wake promise for terminal task results

### DIFF
--- a/docs/rfcs/scheduler-wait-state.md
+++ b/docs/rfcs/scheduler-wait-state.md
@@ -685,6 +685,21 @@ message and changes the exact matching `task_result` wait from `Active` to
 `Resolved(message_id)`; terminal task state alone is not sufficient evidence
 that a continuation consumed the result.
 
+When `WaitFor(task_result)` arrives after the task is already terminal (the
+fast path), the runtime re-queues the exact result message and, in the same
+atomic transition, materializes the wait directly as
+`Triggered(result_message_id)` and cancels replaced same-scope waits exactly
+like a normal registration. The wake promise of `WaitFor` must be durable even
+when the result already exists; otherwise the queued message can be resolved
+as `liveness_only` and the agent sleeps forever.
+
+For agent-scope (WorkItem-unbound) terminal task results, the continuation
+resolver treats an exact matching wait (`kind = task`,
+`trigger_message_id = message_id`, matching wake source) as reentry authority
+even when the prior closure `waiting_reason` was polluted by unrelated waits.
+Closure cleanliness is a fallback signal, not the only proof of an explicit
+wait.
+
 ### 5. Add external wait audit
 
 Surface weak external waits that have no timer, durable queue, or explicit

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1042,6 +1042,41 @@ fn exact_triggered_or_resolved_task_result_wait(
     })
 }
 
+/// Agent-scope counterpart of [`exact_triggered_or_resolved_task_result_wait`]:
+/// durable evidence that the agent explicitly waited on the exact task whose
+/// result this message carries, without any WorkItem binding.
+fn exact_agent_scope_task_result_wait(
+    storage: &AppStorage,
+    message: &MessageEnvelope,
+    task_id: &str,
+) -> Result<Option<WaitConditionRecord>> {
+    let matching_waits = storage
+        .latest_wait_conditions()?
+        .into_iter()
+        .filter(|wait| {
+            wait.agent_id == message.agent_id
+                && wait.work_item_id.is_none()
+                && matches!(
+                    wait.status,
+                    WaitConditionStatus::Triggered | WaitConditionStatus::Resolved
+                )
+                && wait.kind == crate::types::WaitConditionKind::Task
+                && wait.trigger_message_id() == Some(message.id.as_str())
+                && wait.wake_sources.iter().any(|source| {
+                    matches!(
+                        source,
+                        crate::types::WakeSource::TaskResult { task_id: expected }
+                            if expected == task_id
+                    )
+                })
+        })
+        .collect::<Vec<_>>();
+    let [wait] = matching_waits.as_slice() else {
+        return Ok(None);
+    };
+    Ok(Some(wait.clone()))
+}
+
 enum TaskResultClaimRecovery {
     Replayable {
         transition: crate::runtime_db::transitions::ExecutionProtocolTransition,

--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -11,6 +11,11 @@ pub(super) struct ContinuationTrigger {
     pub(super) task_result_outcome: Option<TaskResultOutcome>,
     pub(super) wake_hint_source: Option<String>,
     pub(super) task_work_item_id: Option<String>,
+    /// Durable evidence that an explicit same-scope WaitFor targeted the
+    /// exact task whose result this message carries.  It authorizes terminal
+    /// task result reentry even when the prior closure waiting_reason was
+    /// polluted by unrelated waits.
+    pub(super) exact_task_wait: bool,
 }
 
 impl ContinuationTrigger {
@@ -25,6 +30,7 @@ impl ContinuationTrigger {
                 task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             }),
             MessageKind::WebhookEvent | MessageKind::CallbackEvent | MessageKind::ChannelEvent => {
                 Some(Self {
@@ -33,6 +39,7 @@ impl ContinuationTrigger {
                     task_result_outcome: None,
                     wake_hint_source: None,
                     task_work_item_id: None,
+                    exact_task_wait: false,
                 })
             }
             MessageKind::TimerTick => Some(Self {
@@ -41,6 +48,7 @@ impl ContinuationTrigger {
                 task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             }),
             MessageKind::InternalFollowup => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
@@ -48,6 +56,7 @@ impl ContinuationTrigger {
                 task_result_outcome: None,
                 task_work_item_id: None,
                 wake_hint_source: None,
+                exact_task_wait: false,
             }),
             MessageKind::SystemTick => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
@@ -61,6 +70,7 @@ impl ContinuationTrigger {
                     .and_then(serde_json::Value::as_str)
                     .map(ToString::to_string),
                 task_work_item_id: None,
+                exact_task_wait: false,
             }),
             MessageKind::TaskResult => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
@@ -75,6 +85,9 @@ impl ContinuationTrigger {
                 wake_hint_source: None,
                 task_work_item_id: task
                     .and_then(|t| t.effective_work_item_id().map(ToString::to_string)),
+                // Filled by the dispatch plan builder from durable wait
+                // evidence; from_message alone cannot see wait conditions.
+                exact_task_wait: false,
             }),
             MessageKind::TaskStatus
             | MessageKind::Control
@@ -95,10 +108,11 @@ pub(super) fn resolve_continuation(
         (None, None) => {
             trigger.kind == ContinuationTriggerKind::TaskResult
                 && trigger.task_result_outcome.is_some()
-                && matches!(
-                    prior_waiting_reason,
-                    None | Some(WaitingReason::AwaitingTaskResult)
-                )
+                && (trigger.exact_task_wait
+                    || matches!(
+                        prior_waiting_reason,
+                        None | Some(WaitingReason::AwaitingTaskResult)
+                    ))
         }
         (Some(t), Some(a)) => t == a,
     };
@@ -112,6 +126,9 @@ pub(super) fn resolve_continuation(
     if let Some(outcome) = trigger.task_result_outcome {
         evidence.push("task_terminal".to_string());
         evidence.push(format!("task_result_outcome={}", enum_label(outcome)));
+    }
+    if trigger.exact_task_wait {
+        evidence.push("exact_task_wait".to_string());
     }
     if let Some(source) = trigger.wake_hint_source.as_ref() {
         evidence.push(format!("wake_hint_source={source}"));
@@ -350,6 +367,7 @@ mod tests {
                 task_result_outcome: Some(TaskResultOutcome::Succeeded),
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             },
             None,
         );
@@ -367,6 +385,7 @@ mod tests {
                 task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             },
             None,
         );
@@ -390,6 +409,7 @@ mod tests {
                 task_result_outcome: Some(TaskResultOutcome::Succeeded),
                 wake_hint_source: None,
                 task_work_item_id: Some("other-work".into()),
+                exact_task_wait: false,
             },
             Some("active-work"),
         );
@@ -409,6 +429,7 @@ mod tests {
                 task_result_outcome: None,
                 wake_hint_source: Some("callback".into()),
                 task_work_item_id: None,
+                exact_task_wait: false,
             },
             None,
         );
@@ -426,6 +447,7 @@ mod tests {
                 task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             },
             None,
         );
@@ -445,6 +467,7 @@ mod tests {
                 task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             },
             None,
         );
@@ -468,6 +491,7 @@ mod tests {
                 task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             },
             None,
         );
@@ -497,6 +521,7 @@ mod tests {
                     task_result_outcome: Some(outcome),
                     wake_hint_source: None,
                     task_work_item_id: None,
+                    exact_task_wait: false,
                 },
                 None,
             );
@@ -521,6 +546,7 @@ mod tests {
                 task_result_outcome: Some(TaskResultOutcome::Succeeded),
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             },
             None,
         );
@@ -538,6 +564,7 @@ mod tests {
                 task_result_outcome: Some(TaskResultOutcome::Succeeded),
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             },
             None,
         );
@@ -555,6 +582,7 @@ mod tests {
                 task_result_outcome: Some(TaskResultOutcome::Succeeded),
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             },
             None,
         );
@@ -572,6 +600,7 @@ mod tests {
                 task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             },
             None,
         );
@@ -590,6 +619,7 @@ mod tests {
                 task_result_outcome: None,
                 wake_hint_source: None,
                 task_work_item_id: None,
+                exact_task_wait: false,
             },
             None,
         );
@@ -635,5 +665,51 @@ mod tests {
     fn wake_hint_with_empty_reason_and_no_body_is_not_contentful() {
         let message = wake_hint_system_tick("", None);
         assert!(!system_tick_is_contentful(&message));
+    }
+
+    #[test]
+    fn exact_task_wait_overrides_polluted_closure_for_terminal_task_result() {
+        let trigger = ContinuationTrigger {
+            kind: ContinuationTriggerKind::TaskResult,
+            contentful: true,
+            task_result_outcome: Some(TaskResultOutcome::Succeeded),
+            wake_hint_source: None,
+            task_work_item_id: None,
+            exact_task_wait: true,
+        };
+        let resolution = resolve_continuation(
+            &waiting(WaitingReason::AwaitingOperatorInput),
+            &trigger,
+            None,
+        );
+        assert!(resolution.model_reentry);
+        assert_eq!(resolution.class, ContinuationClass::ResumeOverride);
+        assert!(resolution
+            .evidence
+            .iter()
+            .any(|entry| entry == "exact_task_wait"));
+    }
+
+    #[test]
+    fn polluted_closure_without_exact_task_wait_stays_liveness_only() {
+        let trigger = ContinuationTrigger {
+            kind: ContinuationTriggerKind::TaskResult,
+            contentful: true,
+            task_result_outcome: Some(TaskResultOutcome::Succeeded),
+            wake_hint_source: None,
+            task_work_item_id: None,
+            exact_task_wait: false,
+        };
+        let resolution = resolve_continuation(
+            &waiting(WaitingReason::AwaitingOperatorInput),
+            &trigger,
+            None,
+        );
+        assert!(!resolution.model_reentry);
+        assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
+        assert!(resolution
+            .evidence
+            .iter()
+            .any(|entry| entry == "does_not_satisfy_waiting_reason"));
     }
 }

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -78,8 +78,23 @@ impl RuntimeHandle {
                 .map(Some),
             _ => Ok(None),
         };
-        let continuation_trigger =
+        let mut continuation_trigger =
             ContinuationTrigger::from_message(message, task.as_ref().ok().and_then(Option::as_ref));
+        if let Some(trigger) = continuation_trigger.as_mut() {
+            // An explicit agent-scope WaitFor that targeted this exact task
+            // authorizes terminal task result reentry even when the prior
+            // closure waiting_reason was polluted by unrelated waits.
+            if trigger.kind == crate::types::ContinuationTriggerKind::TaskResult
+                && trigger.task_result_outcome.is_some()
+                && trigger.task_work_item_id.is_none()
+            {
+                if let Some(task_id) = message.task_id.as_deref() {
+                    trigger.exact_task_wait =
+                        exact_agent_scope_task_result_wait(&self.inner.storage, message, task_id)?
+                            .is_some();
+                }
+            }
+        }
         let matching_wait_work_item_id = if continuation_trigger.is_some() {
             let matching_waits = self
                 .inner

--- a/src/runtime/tests/contracts/wait.rs
+++ b/src/runtime/tests/contracts/wait.rs
@@ -1,7 +1,8 @@
 use super::super::support::*;
 use crate::runtime::{WaitForRegistrationOutcome, WaitForWakeKind};
 use crate::types::{
-    AdmissionContext, MessageEnvelope, QueueEntryRecord, WaitConditionStatus, WorkItemState,
+    AdmissionContext, MessageEnvelope, QueueEntryRecord, WaitConditionKind, WaitConditionStatus,
+    WorkItemState,
 };
 use chrono::DateTime;
 
@@ -435,10 +436,28 @@ async fn late_task_result_queue_and_execution_settlement_are_atomic() {
             WaitForRegistrationOutcome::TaskResultQueued {
                 task_id,
                 result_message_id,
+                wait_condition_id: _,
             } if task_id == terminal.id && result_message_id == result_message.id
         ));
         let after = harness.snapshot();
-        assert!(after.wait_conditions.is_empty());
+        let triggered_waits = after
+            .wait_conditions
+            .iter()
+            .filter(|condition| condition.status == WaitConditionStatus::Triggered)
+            .collect::<Vec<_>>();
+        assert_eq!(triggered_waits.len(), 1);
+        assert_eq!(
+            triggered_waits[0].trigger_message_id().as_deref(),
+            Some(result_message.id.as_str())
+        );
+        assert_eq!(
+            triggered_waits[0].subject_ref.as_deref(),
+            Some(terminal.id.as_str())
+        );
+        assert!(after.audit_events.iter().any(|event| {
+            event.kind == "wait_condition_registered"
+                && event.data["trigger_message_id"].as_str() == Some(result_message.id.as_str())
+        }));
         assert!(after.queue_entries.iter().any(|entry| {
             entry.message_id == result_message.id && entry.status == QueueEntryStatus::Queued
         }));
@@ -532,6 +551,104 @@ async fn late_task_result_terminal_queue_states_are_already_consumed() {
         ));
         harness.assert_unchanged(&before);
     }
+}
+
+#[tokio::test]
+async fn late_task_result_agent_scope_registers_triggered_wait_and_replaces_stale_waits() {
+    let harness = LifecycleHarness::new();
+    // A stale agent-scope wait from an earlier turn pollutes closure facts;
+    // the fast path must replace it exactly like a normal registration.
+    harness
+        .runtime()
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::OperatorInput,
+            None,
+            "stale operator wait".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let running = TaskRecord {
+        id: "task-late-agent-scope".into(),
+        work_item_id: None,
+        ..running_task("task-late-agent-scope", "unused", harness.now())
+    };
+    harness
+        .runtime()
+        .persist_task_transition(&running, "task_created")
+        .await
+        .unwrap();
+    let mut result_message = task_result_message("task-late-agent-scope").with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    result_message.task_id = Some("task-late-agent-scope".into());
+    result_message.turn_id = Some("turn-late-task-agent-scope".into());
+    let terminal = terminal_task_with_result(&running, &result_message, harness.now());
+    harness
+        .runtime()
+        .persist_task_transition_with_message(&terminal, "task_status_updated", &result_message)
+        .await
+        .unwrap();
+
+    let outcome = harness
+        .runtime()
+        .register_wait_for_outcome(
+            "default",
+            None,
+            WaitForWakeKind::TaskResult,
+            Some(terminal.id.clone()),
+            "late agent-scope result should continue".into(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let wait_condition_id = match outcome {
+        WaitForRegistrationOutcome::TaskResultQueued {
+            task_id,
+            result_message_id,
+            wait_condition_id,
+        } => {
+            assert_eq!(task_id, terminal.id);
+            assert_eq!(result_message_id, result_message.id);
+            wait_condition_id
+        }
+        other => panic!("expected queued late task result, got {other:?}"),
+    };
+    let after = harness.snapshot();
+    let cancelled = after
+        .wait_conditions
+        .iter()
+        .filter(|condition| condition.status == WaitConditionStatus::Cancelled)
+        .collect::<Vec<_>>();
+    assert_eq!(cancelled.len(), 1, "stale agent-scope wait is replaced");
+    assert_eq!(cancelled[0].kind, WaitConditionKind::Operator);
+    let triggered = after
+        .wait_conditions
+        .iter()
+        .find(|condition| condition.id == wait_condition_id)
+        .expect("triggered fast-path wait is registered");
+    assert_eq!(triggered.status, WaitConditionStatus::Triggered);
+    assert_eq!(triggered.kind, WaitConditionKind::Task);
+    assert_eq!(
+        triggered.trigger_message_id().as_deref(),
+        Some(result_message.id.as_str())
+    );
+    assert!(after.queue_entries.iter().any(|entry| {
+        entry.message_id == result_message.id && entry.status == QueueEntryStatus::Queued
+    }));
+    assert!(after
+        .audit_events
+        .iter()
+        .any(|event| event.kind == "wait_conditions_cancelled"
+            && event.data["reason"].as_str() == Some("wait_for_replaced")));
+    assert!(after.audit_events.iter().any(|event| {
+        event.kind == "wait_condition_triggered"
+            && event.data["wait_condition_id"].as_str() == Some(wait_condition_id.as_str())
+    }));
 }
 
 #[tokio::test]

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -48,6 +48,7 @@ pub(crate) enum WaitForRegistrationOutcome {
     TaskResultQueued {
         task_id: String,
         result_message_id: String,
+        wait_condition_id: String,
     },
     TaskResultAlreadyConsumed {
         task_id: String,
@@ -214,6 +215,7 @@ impl RuntimeHandle {
             WaitForRegistrationOutcome::TaskResultQueued {
                 task_id,
                 result_message_id,
+                wait_condition_id: _,
             } => Err(RuntimeError::validation(
                 "task_result_already_queued",
                 format!(
@@ -265,7 +267,7 @@ impl RuntimeHandle {
                 })?;
             self.validate_wait_for_task_owner(agent_id, work_item_id.as_deref(), &task)?;
             if task_state_reducer::is_terminal_task_status(&task.status) {
-                return self.settle_terminal_task_result(task).await;
+                return self.settle_terminal_task_result(task, reason).await;
             }
             expected_task = Some(task_expectation(&task));
         }
@@ -521,7 +523,7 @@ impl RuntimeHandle {
                             &task,
                         )?;
                         if task_state_reducer::is_terminal_task_status(&task.status) {
-                            return self.settle_terminal_task_result(task).await;
+                            return self.settle_terminal_task_result(task, reason.clone()).await;
                         }
                         if attempt + 1 == 3 {
                             return Err(error);
@@ -582,6 +584,7 @@ impl RuntimeHandle {
     async fn settle_terminal_task_result(
         &self,
         task: TaskRecord,
+        reason: String,
     ) -> Result<WaitForRegistrationOutcome> {
         let result_message_id = task.parent_message_id.clone().ok_or_else(|| {
             RuntimeError::validation(
@@ -632,6 +635,114 @@ impl RuntimeHandle {
         }
 
         let now = self.now();
+        // The fast path must leave the same durable wait semantics as a
+        // normal WaitFor registration: the re-queued result message is the
+        // exact promised wake, so the wait condition starts Triggered and
+        // replaced same-scope waits are cancelled atomically with the queue
+        // admission. Without this record the terminal result can be resolved
+        // as liveness_only and the agent never re-enters the model.
+        let current_turn_id = self.agent_state().await?.current_turn_id.clone();
+        let condition = WaitConditionRecord {
+            id: crate::ids::wait_condition_id(),
+            agent_id: task.agent_id.clone(),
+            work_item_id: task.work_item_id.clone(),
+            status: WaitConditionStatus::Triggered,
+            kind: WaitConditionKind::Task,
+            source: Some("WaitFor".to_string()),
+            subject_ref: Some(task.id.clone()),
+            waiting_for: reason,
+            wake_sources: vec![WakeSource::TaskResult {
+                task_id: task.id.clone(),
+            }],
+            continuation: Some(serde_json::json!({
+                "created_by": "WaitFor",
+                "wake": WaitForWakeKind::TaskResult,
+                "resource": task.id,
+                "recheck_after_ms": null,
+                "recheck_at": null,
+                "clear_blocker_on_task_result": true,
+                "late_result_settled": true,
+            })),
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: current_turn_id,
+            trigger_message_id: Some(result_message_id.clone()),
+            triggered_at: Some(now),
+        };
+        let mut wait_conditions = self
+            .inner
+            .storage
+            .raw_unresolved_wait_conditions_for_agent(&task.agent_id)?
+            .into_iter()
+            .filter(|record| match task.work_item_id.as_deref() {
+                Some(work_item_id) => record.work_item_id.as_deref() == Some(work_item_id),
+                None => record.work_item_id.is_none(),
+            })
+            .map(|mut record| {
+                record.status = WaitConditionStatus::Cancelled;
+                record.updated_at = now;
+                record.cancelled_at = Some(now);
+                record
+            })
+            .collect::<Vec<_>>();
+        let cancelled_wait_condition_ids = wait_conditions
+            .iter()
+            .map(|record| record.id.clone())
+            .collect::<Vec<_>>();
+        let mut audit_events = vec![AuditEvent::legacy(
+            "wait_condition_registered",
+            serde_json::json!({
+                "agent_id": task.agent_id,
+                "work_item_id": task.work_item_id,
+                "wait_condition_id": condition.id,
+                "source": "WaitFor",
+                "kind": &condition.kind,
+                "subject_ref": &condition.subject_ref,
+                "waiting_for": &condition.waiting_for,
+                "wake_sources": &condition.wake_sources,
+                "cancelled_wait_condition_ids": &cancelled_wait_condition_ids,
+                "initial_status": "triggered",
+                "trigger_message_id": result_message_id,
+            }),
+        )];
+        audit_events.extend(
+            self.inner
+                .storage
+                .wait_condition_auxiliary_events(&condition),
+        );
+        if !cancelled_wait_condition_ids.is_empty() {
+            audit_events.push(AuditEvent::legacy(
+                "wait_conditions_cancelled",
+                serde_json::json!({
+                    "agent_id": task.agent_id,
+                    "work_item_id": task.work_item_id,
+                    "reason": "wait_for_replaced",
+                    "wait_condition_ids": &cancelled_wait_condition_ids,
+                }),
+            ));
+        }
+        audit_events.push(AuditEvent::legacy(
+            "wait_condition_triggered",
+            serde_json::json!({
+                "agent_id": task.agent_id,
+                "wait_condition_id": condition.id,
+                "trigger_message_id": result_message_id,
+                "work_item_id": task.work_item_id,
+            }),
+        ));
+        wait_conditions.push(condition.clone());
+        audit_events.push(AuditEvent::legacy(
+            "late_task_result_queued",
+            serde_json::json!({
+                "agent_id": task.agent_id,
+                "task_id": task.id,
+                "result_message_id": result_message_id,
+                "wait_condition_id": condition.id,
+            }),
+        ));
         let expected_task = task_expectation(&task);
         let execution_protocol =
             self.execution_continue_settlement_transition(&task, &result_message, now)?;
@@ -664,7 +775,7 @@ impl RuntimeHandle {
                 .inner
                 .runtime_db
                 .transitions()
-                .commit_queue_with_execution_protocol_and_task_expectation(
+                .commit_queue_with_execution_protocol_task_expectation_and_wait_conditions(
                     &crate::runtime_db::transitions::QueueTransitionCommand {
                         agent_id: task.agent_id.clone(),
                         operation: crate::runtime_db::transitions::QueueOperation::Admit,
@@ -679,20 +790,14 @@ impl RuntimeHandle {
                         message_evidence: vec![result_message.clone()],
                         transcript_entries: Vec::new(),
                         turn_record: None,
-                        audit_events: vec![AuditEvent::legacy(
-                            "late_task_result_queued",
-                            serde_json::json!({
-                                "agent_id": task.agent_id,
-                                "task_id": task.id,
-                                "result_message_id": result_message_id,
-                            }),
-                        )],
+                        audit_events,
                         notify_scheduler: true,
                         fault: self.take_transition_fault(),
                         brief_evidence: Vec::new(),
                     },
                     &execution_protocol,
                     &expected_task,
+                    &wait_conditions,
                 )?;
             if !already_in_memory {
                 guard.queue.push(result_message);
@@ -705,6 +810,7 @@ impl RuntimeHandle {
         Ok(WaitForRegistrationOutcome::TaskResultQueued {
             task_id: task.id,
             result_message_id,
+            wait_condition_id: condition.id,
         })
     }
 

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -979,6 +979,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             None,
             &[],
+            &[],
         )
     }
 
@@ -987,7 +988,7 @@ impl RuntimeTransitionRepository<'_> {
         command: &QueueTransitionCommand,
         execution_protocol: &ExecutionProtocolTransition,
     ) -> Result<TransitionCommit> {
-        self.commit_queue_transaction(command, execution_protocol, None, None, None, &[])
+        self.commit_queue_transaction(command, execution_protocol, None, None, None, &[], &[])
     }
 
     pub fn commit_queue_with_execution_protocol_and_terminal_tool_executions(
@@ -1003,6 +1004,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             None,
             terminal_tool_executions,
+            &[],
         )
     }
 
@@ -1017,6 +1019,7 @@ impl RuntimeTransitionRepository<'_> {
             wait_transition,
             None,
             None,
+            &[],
             &[],
         )
     }
@@ -1034,14 +1037,16 @@ impl RuntimeTransitionRepository<'_> {
             None,
             None,
             &[],
+            &[],
         )
     }
 
-    pub fn commit_queue_with_execution_protocol_and_task_expectation(
+    pub fn commit_queue_with_execution_protocol_task_expectation_and_wait_conditions(
         &self,
         command: &QueueTransitionCommand,
         execution_protocol: &ExecutionProtocolTransition,
         task_expectation: &TaskExpectation,
+        wait_conditions: &[crate::types::WaitConditionRecord],
     ) -> Result<TransitionCommit> {
         self.commit_queue_transaction(
             command,
@@ -1050,6 +1055,7 @@ impl RuntimeTransitionRepository<'_> {
             Some(task_expectation),
             None,
             &[],
+            wait_conditions,
         )
     }
 
@@ -1066,6 +1072,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             Some(completion),
             &[],
+            &[],
         )
     }
 
@@ -1077,6 +1084,7 @@ impl RuntimeTransitionRepository<'_> {
         task_expectation: Option<&TaskExpectation>,
         completion: Option<&CompletionTransition>,
         terminal_tool_executions: &[ToolExecutionRecord],
+        extra_wait_conditions: &[crate::types::WaitConditionRecord],
     ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             validate_queue_operation(command)?;
@@ -1087,6 +1095,9 @@ impl RuntimeTransitionRepository<'_> {
                 if let Some(work_item) = wait_transition.work_item.as_ref() {
                     validate_work_item_mutation_tx(tx, work_item)?;
                 }
+            }
+            for condition in extra_wait_conditions {
+                validate_wait_condition_tx(tx, condition)?;
             }
             if let Some(task_expectation) = task_expectation {
                 validate_task_expectation_tx(tx, task_expectation)?;
@@ -1156,6 +1167,18 @@ impl RuntimeTransitionRepository<'_> {
                     .map(|completion| completion.wait_conditions.as_slice())
                     .unwrap_or_default()
             };
+            let mut merged_wait_conditions: Vec<crate::types::WaitConditionRecord>;
+            let execution_wait_conditions: &[crate::types::WaitConditionRecord] =
+                if extra_wait_conditions.is_empty() {
+                    execution_wait_conditions
+                } else {
+                    merged_wait_conditions = Vec::with_capacity(
+                        execution_wait_conditions.len() + extra_wait_conditions.len(),
+                    );
+                    merged_wait_conditions.extend_from_slice(execution_wait_conditions);
+                    merged_wait_conditions.extend_from_slice(extra_wait_conditions);
+                    &merged_wait_conditions
+                };
             let execution_continuations = completion
                 .map(|completion| completion.continuations.as_slice())
                 .unwrap_or_default();
@@ -1197,6 +1220,10 @@ impl RuntimeTransitionRepository<'_> {
                 .map(|wait_transition| upsert_wait_condition_tx(tx, &wait_transition.record))
                 .transpose()?
                 .unwrap_or(false);
+            let mut extra_wait_conditions_applied = false;
+            for condition in extra_wait_conditions {
+                extra_wait_conditions_applied |= upsert_wait_condition_tx(tx, condition)?;
+            }
             let mut wait_work_items = Vec::new();
             let wait_work_item_applied = if let Some(work_item) =
                 wait_transition.and_then(|wait_transition| wait_transition.work_item.as_ref())
@@ -1281,6 +1308,7 @@ impl RuntimeTransitionRepository<'_> {
                 || agent_state_applied
                 || execution_protocol_applied
                 || wait_transition_applied
+                || extra_wait_conditions_applied
                 || wait_work_item_applied
                 || completion_applied
                 || terminal_tool_execution_applied;

--- a/src/tool/tools/wait_for.rs
+++ b/src/tool/tools/wait_for.rs
@@ -119,6 +119,7 @@ pub(crate) async fn execute(
         WaitForRegistrationOutcome::TaskResultQueued {
             task_id,
             result_message_id,
+            wait_condition_id,
         } => {
             let mut result = ToolResult::success(
                 NAME,
@@ -126,9 +127,10 @@ pub(crate) async fn execute(
                     "disposition": "task_result_queued",
                     "task_id": task_id,
                     "result_message_id": result_message_id,
+                    "wait_condition_id": wait_condition_id,
                 }),
                 Some(format!(
-                    "task result already completed; queued exact result message {result_message_id}"
+                    "task result already completed; queued exact result message {result_message_id} and registered the triggered wait"
                 )),
             );
             result.should_sleep = true;

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -50,6 +50,7 @@ macro_rules! runtime_async_tests {
 runtime_async_tests!(
     background_task_rejoins_main_session,
     background_command_task_result_wakes_sleeping_agent_via_canonical_lifecycle_nudge,
+    late_terminal_task_wait_fast_path_wakes_agent_with_durable_wait,
     stop_task_cancels_running_background_task,
     lifecycle_stop_interrupts_active_command_task,
     file_tools_can_modify_workspace_and_reenter_context,

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -21,7 +21,8 @@ use holon::{
     ingress::{WakeDisposition, WakeHint},
     policy::validate_message_kind_for_origin,
     provider::{
-        AgentProvider, ModelBlock, ProviderTurnRequest, ProviderTurnResponse, StubProvider,
+        AgentProvider, ConversationMessage, ModelBlock, ProviderTurnRequest, ProviderTurnResponse,
+        StubProvider,
     },
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     tool::{ToolCall, ToolError, ToolRegistry, ToolResult},
@@ -254,6 +255,196 @@ pub async fn background_command_task_result_wakes_sleeping_agent_via_canonical_l
         record.id == task.id
             && record.status == TaskStatus::Completed
             && record.wait_policy() == holon::types::TaskWaitPolicy::Background
+    }));
+    Ok(())
+}
+
+struct FastPathWaitProvider {
+    requests: Mutex<Vec<String>>,
+}
+
+impl FastPathWaitProvider {
+    fn new() -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    async fn captured_requests(&self) -> Vec<String> {
+        self.requests.lock().await.clone()
+    }
+}
+
+fn first_task_id_in_tool_results(request: &ProviderTurnRequest) -> Option<String> {
+    request.conversation.iter().find_map(|message| {
+        let ConversationMessage::UserToolResults(blocks) = message else {
+            return None;
+        };
+        blocks.iter().find_map(|block| {
+            let start = block.content.find("task_")?;
+            let task_id: String = block.content[start..]
+                .chars()
+                .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
+                .collect();
+            (!task_id.is_empty()).then_some(task_id)
+        })
+    })
+}
+
+#[async_trait]
+impl AgentProvider for FastPathWaitProvider {
+    async fn complete_turn(&self, request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let prompt_text = delegated_prompt_text(&request);
+        let call = {
+            let mut requests = self.requests.lock().await;
+            requests.push(prompt_text);
+            requests.len()
+        };
+        let response = |blocks: Vec<ModelBlock>| {
+            Ok(ProviderTurnResponse {
+                blocks,
+                stop_reason: None,
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
+                request_diagnostics: None,
+            })
+        };
+        match call {
+            1 => response(vec![ModelBlock::ToolUse {
+                id: "fastpath-exec".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": "sleep 3 && printf fastpath_e2e_done",
+                    "yield_time_ms": 500
+                }),
+                kind: holon::provider::ModelToolCallKind::Function,
+            }]),
+            2 => response(vec![ModelBlock::ToolUse {
+                id: "fastpath-hold".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": "sleep 6",
+                    "yield_time_ms": 30000
+                }),
+                kind: holon::provider::ModelToolCallKind::Function,
+            }]),
+            3 => {
+                let task_id = first_task_id_in_tool_results(&request)
+                    .expect("promoted task result should expose the task id");
+                response(vec![ModelBlock::ToolUse {
+                    id: "fastpath-wait".into(),
+                    name: "WaitFor".into(),
+                    input: json!({
+                        "reason": "wait for the completed check task",
+                        "wake": "task_result",
+                        "resource": task_id
+                    }),
+                    kind: holon::provider::ModelToolCallKind::Function,
+                }])
+            }
+            4 => response(vec![ModelBlock::Text {
+                text: "fastpath result observed".into(),
+            }]),
+            _ => anyhow::bail!("unexpected provider call {call}"),
+        }
+    }
+}
+
+pub async fn late_terminal_task_wait_fast_path_wakes_agent_with_durable_wait() -> Result<()>
+{
+    let provider = Arc::new(FastPathWaitProvider::new());
+    let host = RuntimeHost::new_with_provider(test_config(), provider.clone())?;
+    let runtime = host.default_runtime().await?;
+
+    // Deterministic fast-path shape: a command task is promoted to the
+    // background, completes while the turn is still running (the inline
+    // sleep holds the turn open), and only then does the model call
+    // WaitFor(task_result) on the already-terminal task
+    // (holon-run/holon#2743). The fast path must register a durable
+    // Triggered wait and re-queue the exact result message so the sleeping
+    // agent is woken with model reentry instead of a liveness_only reduce.
+    let prompt = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "run the check and wait for its result".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::CliPrompt,
+        AdmissionContext::LocalProcess,
+    );
+    runtime.enqueue(prompt).await?;
+
+    if wait_until_async_for(Duration::from_secs(30), || {
+        let provider = provider.clone();
+        async move { Ok(provider.captured_requests().await.len() >= 4) }
+    })
+    .await
+    .is_err()
+    {
+        let requests = provider.captured_requests().await;
+        eprintln!("DIAG provider calls: {}", requests.len());
+        let events = runtime.recent_events(40).await?;
+        for event in events.iter().rev() {
+            eprintln!(
+                "DIAG event {} {} {}",
+                event.created_at,
+                event.kind,
+                serde_json::to_string(&event.data).unwrap_or_default()
+            );
+        }
+        for task in runtime.storage().latest_task_records()? {
+            eprintln!("DIAG task {} {:?}", task.id, task.status);
+        }
+        let summary = runtime.agent_summary().await?;
+        eprintln!(
+            "DIAG closure {:?} waiting {:?}",
+            summary.closure.outcome, summary.closure.waiting_reason
+        );
+        anyhow::bail!("fastpath reentry did not happen");
+    }
+
+    let requests = provider.captured_requests().await;
+    let reentry_prompt = requests
+        .get(3)
+        .expect("late task result should re-enter the model");
+    assert!(
+        reentry_prompt.contains("fastpath_e2e_done"),
+        "re-entry prompt should carry the task result: {reentry_prompt}"
+    );
+    let state = runtime.agent_state().await?;
+    assert!(state
+        .last_continuation
+        .as_ref()
+        .is_some_and(|continuation| {
+            continuation.trigger_kind == holon::types::ContinuationTriggerKind::TaskResult
+                && continuation.model_reentry
+        }));
+    let events = runtime.recent_events(50).await?;
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "late_task_result_queued"));
+    assert!(events.iter().any(|event| {
+        event.kind == "wait_condition_registered"
+            && event
+                .data
+                .get("initial_status")
+                .and_then(|value| value.as_str())
+                == Some("triggered")
+    }));
+    assert!(events.iter().any(|event| {
+        event.kind == "wait_condition_triggered"
+            && event
+                .data
+                .get("trigger_message_id")
+                .is_some_and(serde_json::Value::is_string)
     }));
     Ok(())
 }

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -353,8 +353,7 @@ impl AgentProvider for FastPathWaitProvider {
     }
 }
 
-pub async fn late_terminal_task_wait_fast_path_wakes_agent_with_durable_wait() -> Result<()>
-{
+pub async fn late_terminal_task_wait_fast_path_wakes_agent_with_durable_wait() -> Result<()> {
     let provider = Arc::new(FastPathWaitProvider::new());
     let host = RuntimeHost::new_with_provider(test_config(), provider.clone())?;
     let runtime = host.default_runtime().await?;


### PR DESCRIPTION
## Summary

修复 #2743：`WaitFor(task_result)` 命中 fast-path（任务已 terminal）时，唤醒承诺未持久化，terminal task result 在 closure 被无关等待污染后被判为 `liveness_only`，agent 永久休眠。

### 变化的 runtime 概念

**WaitFor 的等待契约（工具侧）**：`settle_terminal_task_result` 此前只重排 result 消息（`late_task_result_queued`），不注册 wait_condition、不执行注册路径的替换取消。现在 fast-path 与正常注册语义对齐——在重排消息的**同一原子 commit** 内：

- 注册 task wait，初始状态直接为 **Triggered**，`trigger_message_id` 指向被重排的 result 消息（后续照常走 Triggered → Resolved 生命周期）；
- 按正常注册路径的替换规则取消同 scope 旧等待（`wait_for_replaced`），消除污染源；
- 为此给 queue transition 增加了 `extra_wait_conditions` 穿透参数（新 wrapper `commit_queue_with_execution_protocol_task_expectation_and_wait_conditions`，替换原来只带 task expectation 的旧 wrapper），保持 fault 注入下的单 commit 原子性不变。

**Continuation resolver（resolver 侧）**：`ContinuationTrigger` 新增 `exact_task_wait` 证据。claim 时若存在与本消息精确匹配的 agent-scope task 等待（`trigger_message_id == message.id` 且 wake source 匹配 task_id，状态 Triggered/Resolved），`(None, None)` 分支据此放行 model reentry——closure `waiting_reason` 的干净性退化为兜底信号而非唯一证明。该证据同时覆盖正常路径（任务完成后 enqueue 触发等待）下的污染场景。

### 验证

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib`：2931 passed ✅
- `cargo test --tests`：全量集成通过（含新增 e2e）✅
- 新增/更新测试：
  - 契约：`late_task_result_agent_scope_registers_triggered_wait_and_replaces_stale_waits`（fast-path 注册 + 旧等待取消 + 原子性断言更新）
  - 单测：`exact_task_wait_overrides_polluted_closure_for_terminal_task_result` / `polluted_closure_without_exact_task_wait_stays_liveness_only`
  - e2e：`late_terminal_task_wait_fast_path_wakes_agent_with_durable_wait`（promoted 任务在 turn 内完成 → WaitFor fast-path → 睡眠 agent 被 model reentry 唤醒且结果可见）
- RFC：`docs/rfcs/scheduler-wait-state.md` 更新 fast-path 契约与 resolver 证据语义

Fixes #2743
