### PR TITLE
feat: add agent-aware holon CLI control plane

### DIFF
--- a/docs/rfcs/agent-aware-cli-invocation.md
+++ b/docs/rfcs/agent-aware-cli-invocation.md
@@ -1,0 +1,165 @@
+---
+title: RFC: Agent-Aware CLI Invocation Context
+date: 2026-09-02
+status: draft
+---
+
+# RFC: Agent-Aware CLI Invocation Context
+
+## Summary
+
+Holon agents may invoke the local `holon` CLI from a command task. The CLI
+needs to preserve who is making the call and where the call came from without
+turning shell-provided metadata into an authentication mechanism.
+
+This RFC defines a small, declaration-based invocation context:
+
+```text
+caller_agent_id
+source_task_id
+source_turn_id
+source_work_item_id?
+source_activation_id?
+inherited_authority_class
+```
+
+The runtime supplies this context to agent-owned command tasks. The CLI parses
+it and forwards the claims to the control plane as request provenance. A CLI
+started without agent context retains the existing operator-mode behavior.
+
+The context is a **provenance and behavioral contract**, not a proof of
+identity. A local process can alter its environment or construct a request
+that claims to be another caller. Control authentication remains the bearer
+control token, and admission policy remains the authority boundary.
+
+## Goals
+
+- identify the declared agent caller and target separately;
+- preserve source task, turn, work item, and activation lineage where present;
+- inherit the source activation's effective authority in agent mode;
+- keep ordinary, context-free CLI usage in operator mode;
+- provide stable machine-readable context and command-discovery surfaces;
+- make malformed explicit context fail with a structured diagnostic;
+- make the same provenance shape available to existing control mutations.
+
+## Non-goals
+
+- preventing a local CLI process from pretending to be an agent or operator;
+- introducing `HOLON_CALLER_CONTEXT_TOKEN` or another caller bearer capability;
+- replacing the existing control bearer token;
+- adding a new authority class such as `AgentInstruction`;
+- expanding the first release to unrestricted recursive `run` or `prompt`;
+- redesigning the existing task or WorkItem lifecycle API.
+
+## Invocation modes
+
+The CLI has two semantic modes:
+
+1. **Operator mode**: no agent context is present. The caller and origin use
+   the existing operator semantics.
+2. **Agent mode**: a complete declared context is present. The caller is the
+   declared agent, the target is selected independently, and authority is
+   inherited from the source activation.
+
+An explicit but malformed or incomplete context is a usage/control error. It
+must not silently fall back to operator mode, because doing so would hide an
+agent integration defect.
+
+`HOLON_AGENT_ID` may continue to select an agent for existing commands where
+that behavior is already documented, but it is not caller authentication and
+must not override the declared caller context.
+
+## Target semantics
+
+Existing commands that accept an agent target use these rules:
+
+- omitting `--agent` means the current caller's self target in agent mode;
+- omitting `--agent` retains the existing operator default in operator mode;
+- `--agent B` selects target `B` and does not change the caller;
+- self and cross-agent operations are evaluated by the same admission policy.
+
+The initial CLI surface uses `holon context` for the current non-sensitive
+claims and `holon commands` for machine-readable command discovery. It does
+not add a separate `holon self` namespace.
+
+## Authority and origin
+
+In agent mode, the request's effective authority is inherited from the source
+activation. CLI flags and request bodies cannot raise it. A conflicting
+authority value is rejected or ignored with an auditable diagnostic; it is
+never treated as an upgrade.
+
+The request retains its original `origin` and `root_origin`. A call that
+originated from an operator remains operator-originated after an agent
+delegates it, while an external, runtime, or integration-originated call
+cannot become an `OperatorInstruction` merely because a CLI field says so.
+
+The first implementation does not add a new `AgentInstruction` authority
+variant. A need for a distinct authority class requires a separate RFC.
+
+## Transport and audit
+
+The CLI forwards declared caller claims through the local control client to the
+server admission layer. The server records caller, target, source task, source
+turn, source work item, source activation, origin, delivery surface, and
+effective authority when those values are available.
+
+No context token, credential, or secret is emitted by `holon context`,
+`holon commands`, stdout results, or audit projections. The context fields are
+safe-to-display identifiers and provenance claims only.
+
+Control bearer authentication is performed before mutation admission. Declared
+context is interpreted after authentication and cannot replace that check.
+
+## CLI output and errors
+
+The agent-facing contract is:
+
+- `--output auto|json|jsonl|text`, with `auto` selecting compact JSON for
+  non-TTY and agent-mode invocations;
+- stdout contains successful results only;
+- stderr contains diagnostics only;
+- exit code `0` means success, `1` means an operational or control failure,
+  and `2` means CLI usage failure;
+- structured errors contain stable `code`, human-readable `message`,
+  `retryable`, `details`, and an optional `recovery_hint`;
+- existing successful payloads remain compatible unless a command explicitly
+  opts into a new envelope.
+
+## Initial implementation scope
+
+Phase 1 and Phase 2 cover:
+
+1. command-task-scoped declared caller context and admission propagation;
+2. `holon context`;
+3. `holon commands`;
+4. `holon task list`;
+5. WorkItem `create`, `pick`, and `update`;
+6. WorkItem `complete --report-file <path|->` using the existing completion
+   report contract;
+7. caller, authority, target, and malformed-context regression tests.
+
+Agent lifecycle, model override, destructive workspace control, and unrestricted
+recursive `holon run`/`holon prompt` remain outside this scope.
+
+## Acceptance matrix
+
+| Case | Required result |
+| --- | --- |
+| Context-free CLI | Existing operator mode |
+| Complete context | Agent caller and inherited authority are preserved |
+| Missing required context field | Structured error; no operator fallback |
+| Self target | `caller_agent_id == target_agent_id` |
+| Cross-agent target | Caller remains source agent; target is independent |
+| Conflicting authority flag | No escalation; reject or auditable ignore |
+| Forged environment value | Not treated as authenticated identity |
+| External/runtime source | Cannot become operator authority via CLI fields |
+| `holon context` | Non-sensitive claims only |
+| `holon commands` | Stable, machine-readable command metadata |
+
+## Compatibility
+
+This RFC is additive. Existing operator CLI calls, control bearer
+authentication, task handles, and WorkItem completion semantics remain the
+baseline. The implementation should introduce context handling at shared
+client/admission boundaries rather than duplicating policy in each subcommand.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -2726,6 +2726,58 @@
               "null"
             ]
           },
+          "invocation_context": {
+            "description": "Declaration-based provenance supplied to a CLI launched by an agent.\n\n These values describe the caller and its source activation, but are not\n authentication material. A local process can forge them.",
+            "properties": {
+              "caller_agent_id": {
+                "type": "string"
+              },
+              "inherited_authority_class": {
+                "enum": [
+                  "operator_instruction",
+                  "runtime_instruction",
+                  "integration_signal",
+                  "external_evidence",
+                  null
+                ],
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_activation_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_task_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_turn_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_work_item_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "caller_agent_id"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "report_text": {
             "type": "string"
           }
@@ -3888,6 +3940,58 @@
           "clear_blocker": {
             "default": false,
             "type": "boolean"
+          },
+          "invocation_context": {
+            "description": "Declaration-based provenance supplied to a CLI launched by an agent.\n\n These values describe the caller and its source activation, but are not\n authentication material. A local process can forge them.",
+            "properties": {
+              "caller_agent_id": {
+                "type": "string"
+              },
+              "inherited_authority_class": {
+                "enum": [
+                  "operator_instruction",
+                  "runtime_instruction",
+                  "integration_signal",
+                  "external_evidence",
+                  null
+                ],
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_activation_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_task_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_turn_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_work_item_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "caller_agent_id"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "reason": {
             "type": [
@@ -8802,6 +8906,58 @@
             ]
           },
           "blocked_by": true,
+          "invocation_context": {
+            "description": "Declaration-based provenance supplied to a CLI launched by an agent.\n\n These values describe the caller and its source activation, but are not\n authentication material. A local process can forge them.",
+            "properties": {
+              "caller_agent_id": {
+                "type": "string"
+              },
+              "inherited_authority_class": {
+                "enum": [
+                  "operator_instruction",
+                  "runtime_instruction",
+                  "integration_signal",
+                  "external_evidence",
+                  null
+                ],
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_activation_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_task_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_turn_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_work_item_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "caller_agent_id"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "objective": {
             "type": [
               "string",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,6 +79,10 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
+    #[command(about = "Show the declared caller context for this CLI invocation")]
+    Context,
+    #[command(about = "Show machine-readable CLI command metadata")]
+    Commands,
     #[command(about = "Interactively set up Holon or print secret-safe onboarding diagnostics")]
     Onboard {
         #[arg(long)]
@@ -445,6 +449,12 @@ pub enum WorkspaceCommands {
 
 #[derive(Debug, Subcommand)]
 pub enum TaskCommands {
+    List {
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+        #[arg(long)]
+        agent: Option<String>,
+    },
     Run {
         summary: String,
         #[arg(long)]
@@ -575,6 +585,44 @@ pub enum WorkItemCommands {
     },
     Get {
         work_item_id: String,
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    Create {
+        objective: String,
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    Pick {
+        work_item_id: String,
+        #[arg(long)]
+        reason: Option<String>,
+        #[arg(long)]
+        clear_blocker: bool,
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    Update {
+        work_item_id: String,
+        #[arg(long)]
+        objective: Option<String>,
+        #[arg(long)]
+        plan_status: Option<String>,
+        #[arg(long)]
+        todo_json: Option<String>,
+        #[arg(long)]
+        blocked_by_json: Option<String>,
+        #[arg(long)]
+        recheck_after: Option<u64>,
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    Complete {
+        work_item_id: String,
+        #[arg(long, conflicts_with = "report_file")]
+        report: Option<String>,
+        #[arg(long, conflicts_with = "report")]
+        report_file: Option<PathBuf>,
         #[arg(long)]
         agent: Option<String>,
     },
@@ -1013,6 +1061,14 @@ mod tests {
             .filter(|e| !e.path.contains('.'))
             .map(|e| e.path.as_str())
             .collect();
+        assert!(
+            top_level.contains(&"context"),
+            "context should be in snapshot"
+        );
+        assert!(
+            top_level.contains(&"commands"),
+            "commands should be in snapshot"
+        );
         assert!(top_level.contains(&"serve"), "serve should be in snapshot");
         assert!(top_level.contains(&"run"), "run should be in snapshot");
         assert!(top_level.contains(&"agent"), "agent should be in snapshot");

--- a/src/client.rs
+++ b/src/client.rs
@@ -622,6 +622,7 @@ impl LocalClient {
             &TaskInputRequest {
                 text: text.into(),
                 authority_class: Some(AuthorityClass::OperatorInstruction),
+                invocation_context: None,
             },
         )
         .await
@@ -632,6 +633,7 @@ impl LocalClient {
             &format!("/control/agents/{agent_id}/tasks/{task_id}/stop"),
             &TaskStopRequest {
                 authority_class: Some(AuthorityClass::OperatorInstruction),
+                invocation_context: None,
             },
         )
         .await

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -134,6 +134,7 @@ pub use skills::{
     add_skill_to_catalog, disable_skill, enable_skill, install_skill, list_skills,
     remove_skill_from_catalog, skills_catalog, uninstall_skill,
 };
+pub(crate) use state::validate_invocation_context;
 pub use state::{
     agent_state, brief, briefs, briefs_batch_get, briefs_default, enqueue, enqueue_default,
     state_default, status, status_default, transcript, transcript_batch_get, transcript_default,

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -43,6 +43,26 @@ pub(crate) fn control_admission_context(state: &AppState) -> AdmissionContext {
     }
 }
 
+pub(crate) fn validate_invocation_context(
+    invocation_context: Option<&crate::types::AgentInvocationContext>,
+    authority_class: Option<crate::types::AuthorityClass>,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    let Some(invocation_context) = invocation_context else {
+        return Ok(());
+    };
+    if let (Some(inherited), Some(provided)) = (
+        invocation_context.inherited_authority_class,
+        authority_class,
+    ) {
+        if inherited != provided {
+            return Err(bad_request(
+                "authority_class conflicts with declared invocation context",
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub(crate) async fn current_boundary_metadata(
     runtime: &crate::runtime::RuntimeHandle,
 ) -> Result<Value> {

--- a/src/http/tasks.rs
+++ b/src/http/tasks.rs
@@ -221,6 +221,7 @@ pub async fn task_input(
     let authority_class = request
         .authority_class
         .unwrap_or(AuthorityClass::OperatorInstruction);
+    validate_invocation_context(request.invocation_context.as_ref(), Some(authority_class))?;
     let result = runtime
         .managed_tasks()
         .task_input_with_trust(&task_id, &request.text, &authority_class)
@@ -252,6 +253,7 @@ pub async fn task_stop(
     let authority_class = request
         .authority_class
         .unwrap_or(AuthorityClass::OperatorInstruction);
+    validate_invocation_context(request.invocation_context.as_ref(), Some(authority_class))?;
     let task = runtime
         .managed_tasks()
         .stop_task(&task_id, &authority_class)
@@ -286,6 +288,7 @@ pub async fn create_command_task(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let admission_context = control_admission_context(&state);
     let provided_trust = request.authority_class;
+    validate_invocation_context(request.invocation_context.as_ref(), provided_trust)?;
     let effective_trust = provided_trust
         .clone()
         .unwrap_or(AuthorityClass::OperatorInstruction);
@@ -341,6 +344,7 @@ pub async fn create_work_item(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let admission_context = control_admission_context(&state);
     let provided_trust = request.authority_class;
+    validate_invocation_context(request.invocation_context.as_ref(), provided_trust)?;
     let objective = request.objective.trim().to_string();
     if objective.is_empty() {
         return Err(bad_request("objective must not be empty"));
@@ -377,6 +381,7 @@ pub async fn pick_work_item(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let admission_context = control_admission_context(&state);
     let provided_trust = request.authority_class;
+    validate_invocation_context(request.invocation_context.as_ref(), provided_trust)?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
@@ -425,6 +430,7 @@ pub async fn update_work_item(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let admission_context = control_admission_context(&state);
     let provided_trust = request.authority_class;
+    validate_invocation_context(request.invocation_context.as_ref(), provided_trust)?;
     let objective = request
         .objective
         .map(|value| {
@@ -505,6 +511,7 @@ pub async fn complete_work_item(
     }
     let admission_context = control_admission_context(&state);
     let provided_trust = request.authority_class;
+    validate_invocation_context(request.invocation_context.as_ref(), provided_trust)?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -202,12 +202,16 @@ pub(crate) const TASK_OUTPUT_DEFAULT_TIMEOUT_MS: u64 = 30_000;
 pub struct TaskInputRequest {
     pub text: String,
     pub authority_class: Option<AuthorityClass>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation_context: Option<crate::types::AgentInvocationContext>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TaskStopRequest {
     pub authority_class: Option<AuthorityClass>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation_context: Option<crate::types::AgentInvocationContext>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -356,12 +360,16 @@ pub struct CreateCommandTaskRequest {
     pub max_output_tokens: Option<u64>,
     pub accepts_input: Option<bool>,
     pub authority_class: Option<AuthorityClass>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation_context: Option<crate::types::AgentInvocationContext>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct CreateWorkItemRequest {
     pub objective: String,
     pub authority_class: Option<AuthorityClass>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation_context: Option<crate::types::AgentInvocationContext>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -371,6 +379,8 @@ pub struct PickWorkItemRequest {
     #[serde(default)]
     pub clear_blocker: bool,
     pub authority_class: Option<AuthorityClass>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation_context: Option<crate::types::AgentInvocationContext>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -383,6 +393,8 @@ pub struct UpdateWorkItemRequest {
     #[schemars(range(min = 1))]
     pub recheck_after: Option<u64>,
     pub authority_class: Option<AuthorityClass>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation_context: Option<crate::types::AgentInvocationContext>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -390,6 +402,8 @@ pub struct UpdateWorkItemRequest {
 pub struct CompleteWorkItemRequest {
     pub report_text: String,
     pub authority_class: Option<AuthorityClass>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation_context: Option<crate::types::AgentInvocationContext>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ use holon::{
     types::{
         AgentDeletionPhase, AgentDeletionStatus, AgentInvocationContext, AgentRegistryStatus,
         AuditEvent, AuthorityClass, ControlAction, TimerStatus, TodoItem, WorkItemPlanStatus,
+        HOLON_CALLER_AUTHORITY_CLASS_ENV,
     },
 };
 use tokio::net::TcpListener;
@@ -1138,6 +1139,30 @@ mod tests {
             providers: provider_registry_for_tests(None, Some("dummy"), home.join(".codex")),
             web_config: holon::web::WebConfig::default(),
         }
+    }
+
+    #[test]
+    fn agent_cli_context_without_inherited_authority_rejects_operator_fallback() {
+        let error = authority_class_for_cli_context(Some(AgentInvocationContext {
+            caller_agent_id: "agent-a".into(),
+            source_task_id: None,
+            source_turn_id: None,
+            source_work_item_id: None,
+            source_activation_id: None,
+            inherited_authority_class: None,
+        }))
+        .unwrap_err();
+
+        assert!(error.to_string().contains(HOLON_CALLER_AUTHORITY_CLASS_ENV));
+        assert!(error.to_string().contains("operator authority"));
+    }
+
+    #[test]
+    fn context_free_cli_uses_operator_authority() {
+        assert_eq!(
+            authority_class_for_cli_context(None).unwrap(),
+            AuthorityClass::OperatorInstruction
+        );
     }
 
     #[test]
@@ -4202,9 +4227,21 @@ fn cli_invocation_context() -> Result<Option<AgentInvocationContext>> {
 }
 
 fn cli_authority_class() -> Result<AuthorityClass> {
-    Ok(cli_invocation_context()?
-        .and_then(|context| context.inherited_authority_class)
-        .unwrap_or(AuthorityClass::OperatorInstruction))
+    authority_class_for_cli_context(cli_invocation_context()?)
+}
+
+fn authority_class_for_cli_context(
+    context: Option<AgentInvocationContext>,
+) -> Result<AuthorityClass> {
+    match context {
+        Some(context) => context.inherited_authority_class.ok_or_else(|| {
+            anyhow!(
+                "agent invocation context is missing {HOLON_CALLER_AUTHORITY_CLASS_ENV}; \
+                 refusing to fall back to operator authority"
+            )
+        }),
+        None => Ok(AuthorityClass::OperatorInstruction),
+    }
 }
 
 fn parse_work_item_plan_status(value: &str) -> Result<WorkItemPlanStatus> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::{
     collections::BTreeMap,
     ffi::OsString,
     fs,
-    io::{IsTerminal, Write},
+    io::{IsTerminal, Read, Write},
     net::SocketAddr,
     path::{Path, PathBuf},
     time::Duration,
@@ -30,7 +30,11 @@ use holon::{
     },
     fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
     host::RuntimeHost,
-    http::{self, AppState, ControlRequest, CreateCommandTaskRequest},
+    http::{
+        self, AppState, CompleteWorkItemRequest, ControlRequest, CreateCommandTaskRequest,
+        CreateWorkItemRequest, PickWorkItemRequest, TaskInputRequest, TaskStopRequest,
+        UpdateWorkItemRequest,
+    },
     memory::{rebuild_memory_index, request_memory_index_rebuild},
     model_discovery::{discovery_cache_path, refresh_provider_models},
     onboarding::{
@@ -48,8 +52,8 @@ use holon::{
     storage::AppStorage,
     tui::run_tui,
     types::{
-        AgentDeletionPhase, AgentDeletionStatus, AgentRegistryStatus, AuditEvent, AuthorityClass,
-        ControlAction, TimerStatus,
+        AgentDeletionPhase, AgentDeletionStatus, AgentInvocationContext, AgentRegistryStatus,
+        AuditEvent, AuthorityClass, ControlAction, TimerStatus, TodoItem, WorkItemPlanStatus,
     },
 };
 use tokio::net::TcpListener;
@@ -188,6 +192,16 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         AppConfig::load()?
     };
     match command {
+        Commands::Context => {
+            let context = AgentInvocationContext::from_env().map_err(|error| anyhow!(error))?;
+            print_json(&serde_json::json!({
+                "mode": if context.is_some() { "agent" } else { "operator" },
+                "context": context,
+                "declaration_based": true,
+                "authenticated": false,
+            }))
+        }
+        Commands::Commands => print_json(&serde_json::to_value(holon::cli::collect_snapshot())?),
         Commands::Serve { options } => serve(config, options).await,
         Commands::Daemon { command } => handle_daemon_command(config, command).await,
         Commands::Prompt { text, agent } => {
@@ -281,13 +295,16 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
 fn runtime_command_uses_config_inspection(command: &Commands) -> bool {
     matches!(
         command,
-        Commands::Events {
-            command: EventsCommands::Tail { offline: true, .. }
-        } | Commands::Debug {
-            command: DebugCommands::SchedulerRecovery { .. }
-                | DebugCommands::SchedulerRecoveryFixture { .. }
-                | DebugCommands::SchedulerRestartFixture { .. }
-        }
+        Commands::Context
+            | Commands::Commands
+            | Commands::Events {
+                command: EventsCommands::Tail { offline: true, .. }
+            }
+            | Commands::Debug {
+                command: DebugCommands::SchedulerRecovery { .. }
+                    | DebugCommands::SchedulerRecoveryFixture { .. }
+                    | DebugCommands::SchedulerRestartFixture { .. }
+            }
     )
 }
 
@@ -1422,6 +1439,17 @@ mod tests {
 
     #[test]
     fn task_lifecycle_commands_parse_with_agent_options() {
+        let cli = Cli::parse_from(["holon", "task", "list", "--limit", "12"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Task {
+                command: TaskCommands::List {
+                    limit: 12,
+                    agent: None
+                }
+            }
+        ));
+
         let cli = Cli::parse_from(["holon", "task", "status", "task-1", "--agent", "runner"]);
         let Commands::Task {
             command: TaskCommands::Status { task_id, agent },
@@ -1528,6 +1556,28 @@ mod tests {
         };
         assert_eq!(work_item_id, "work_123");
         assert_eq!(agent, None);
+
+        assert!(Cli::try_parse_from(["holon", "work-item", "complete", "work_123"]).is_ok());
+        assert!(Cli::try_parse_from([
+            "holon",
+            "work-item",
+            "complete",
+            "work_123",
+            "--report",
+            "completed"
+        ])
+        .is_ok());
+        assert!(Cli::try_parse_from([
+            "holon",
+            "work-item",
+            "complete",
+            "work_123",
+            "--report",
+            "completed",
+            "--report-file",
+            "-"
+        ])
+        .is_err());
     }
 
     #[test]
@@ -1739,6 +1789,8 @@ mod tests {
     #[test]
     fn hidden_offline_scheduler_commands_skip_runtime_model_resolution() {
         for args in [
+            vec!["holon", "context"],
+            vec!["holon", "commands"],
             vec!["holon", "events", "tail", "--agent", "runner", "--offline"],
             vec!["holon", "debug", "scheduler-recovery"],
             vec![
@@ -3913,6 +3965,12 @@ async fn handle_workspace_command(config: &AppConfig, command: WorkspaceCommands
 async fn handle_task_command(config: &AppConfig, command: TaskCommands) -> Result<()> {
     let client = LocalClient::new(config.clone())?;
     match command {
+        TaskCommands::List { limit, agent } => {
+            let agent = cli_target_agent(config, agent)?;
+            print_json(&serde_json::to_value(
+                client.agent_tasks(&agent, limit).await?,
+            )?)
+        }
         TaskCommands::Run {
             summary,
             cmd,
@@ -3924,7 +3982,7 @@ async fn handle_task_command(config: &AppConfig, command: TaskCommands) -> Resul
             max_output_tokens,
             agent,
         } => {
-            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            let agent = cli_target_agent(config, agent)?;
             post_control_json(
                 config,
                 &format!("/control/agents/{agent}/tasks"),
@@ -3938,13 +3996,14 @@ async fn handle_task_command(config: &AppConfig, command: TaskCommands) -> Resul
                     yield_time_ms,
                     max_output_tokens,
                     accepts_input: Some(false),
-                    authority_class: Some(AuthorityClass::OperatorInstruction),
+                    authority_class: Some(cli_authority_class()?),
+                    invocation_context: cli_invocation_context()?,
                 },
             )
             .await
         }
         TaskCommands::Status { task_id, agent } => {
-            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            let agent = cli_target_agent(config, agent)?;
             print_json(&serde_json::to_value(
                 client.task_status(&agent, &task_id).await?,
             )?)
@@ -3955,7 +4014,7 @@ async fn handle_task_command(config: &AppConfig, command: TaskCommands) -> Resul
             timeout_ms,
             agent,
         } => {
-            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            let agent = cli_target_agent(config, agent)?;
             print_json(&serde_json::to_value(
                 client
                     .task_output(&agent, &task_id, block, timeout_ms)
@@ -3967,16 +4026,29 @@ async fn handle_task_command(config: &AppConfig, command: TaskCommands) -> Resul
             text,
             agent,
         } => {
-            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
-            print_json(&serde_json::to_value(
-                client.task_input(&agent, &task_id, text).await?,
-            )?)
+            let agent = cli_target_agent(config, agent)?;
+            post_control_json(
+                config,
+                &format!("/control/agents/{agent}/tasks/{task_id}/input"),
+                &TaskInputRequest {
+                    text,
+                    authority_class: Some(cli_authority_class()?),
+                    invocation_context: cli_invocation_context()?,
+                },
+            )
+            .await
         }
         TaskCommands::Stop { task_id, agent } => {
-            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
-            print_json(&serde_json::to_value(
-                client.task_stop(&agent, &task_id).await?,
-            )?)
+            let agent = cli_target_agent(config, agent)?;
+            post_control_json(
+                config,
+                &format!("/control/agents/{agent}/tasks/{task_id}/stop"),
+                &TaskStopRequest {
+                    authority_class: Some(cli_authority_class()?),
+                    invocation_context: cli_invocation_context()?,
+                },
+            )
+            .await
         }
     }
 }
@@ -4011,7 +4083,7 @@ async fn handle_work_item_command(config: &AppConfig, command: WorkItemCommands)
     let client = LocalClient::new(config.clone())?;
     match command {
         WorkItemCommands::List { limit, agent } => {
-            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            let agent = cli_target_agent(config, agent)?;
             print_json(&serde_json::to_value(
                 client.agent_work_items(&agent, limit).await?,
             )?)
@@ -4020,12 +4092,148 @@ async fn handle_work_item_command(config: &AppConfig, command: WorkItemCommands)
             work_item_id,
             agent,
         } => {
-            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            let agent = cli_target_agent(config, agent)?;
             print_json(&serde_json::to_value(
                 client.work_item(&agent, &work_item_id).await?,
             )?)
         }
+        WorkItemCommands::Create { objective, agent } => {
+            let agent = cli_target_agent(config, agent)?;
+            post_control_json(
+                config,
+                &format!("/control/agents/{agent}/work-items"),
+                &CreateWorkItemRequest {
+                    objective,
+                    authority_class: Some(cli_authority_class()?),
+                    invocation_context: cli_invocation_context()?,
+                },
+            )
+            .await
+        }
+        WorkItemCommands::Pick {
+            work_item_id,
+            reason,
+            clear_blocker,
+            agent,
+        } => {
+            let agent = cli_target_agent(config, agent)?;
+            post_control_json(
+                config,
+                &format!("/control/agents/{agent}/work-items/{work_item_id}/pick"),
+                &PickWorkItemRequest {
+                    reason,
+                    clear_blocker,
+                    authority_class: Some(cli_authority_class()?),
+                    invocation_context: cli_invocation_context()?,
+                },
+            )
+            .await
+        }
+        WorkItemCommands::Update {
+            work_item_id,
+            objective,
+            plan_status,
+            todo_json,
+            blocked_by_json,
+            recheck_after,
+            agent,
+        } => {
+            let agent = cli_target_agent(config, agent)?;
+            let plan_status = plan_status
+                .map(|value| parse_work_item_plan_status(&value))
+                .transpose()?;
+            let todo_list = todo_json
+                .map(|value| serde_json::from_str::<Vec<TodoItem>>(&value))
+                .transpose()
+                .context("--todo-json must contain a JSON array of todo items")?;
+            let blocked_by = blocked_by_json
+                .map(|value| serde_json::from_str::<serde_json::Value>(&value))
+                .transpose()
+                .context("--blocked-by-json must contain valid JSON")?;
+            post_control_json(
+                config,
+                &format!("/control/agents/{agent}/work-items/{work_item_id}"),
+                &UpdateWorkItemRequest {
+                    objective,
+                    plan_status,
+                    todo_list,
+                    blocked_by,
+                    recheck_after,
+                    authority_class: Some(cli_authority_class()?),
+                    invocation_context: cli_invocation_context()?,
+                },
+            )
+            .await
+        }
+        WorkItemCommands::Complete {
+            work_item_id,
+            report,
+            report_file,
+            agent,
+        } => {
+            let agent = cli_target_agent(config, agent)?;
+            let report_text = read_report_input(report, report_file)?;
+            post_control_json(
+                config,
+                &format!("/control/agents/{agent}/work-items/{work_item_id}/complete"),
+                &CompleteWorkItemRequest {
+                    report_text,
+                    authority_class: Some(cli_authority_class()?),
+                    invocation_context: cli_invocation_context()?,
+                },
+            )
+            .await
+        }
     }
+}
+
+fn cli_target_agent(config: &AppConfig, explicit: Option<String>) -> Result<String> {
+    let context = cli_invocation_context()?;
+    if let Some(agent) = explicit {
+        return Ok(agent);
+    }
+    Ok(context
+        .map(|context| context.caller_agent_id)
+        .unwrap_or_else(|| config.default_agent_id.clone()))
+}
+
+fn cli_invocation_context() -> Result<Option<AgentInvocationContext>> {
+    AgentInvocationContext::from_env().map_err(|error| anyhow!(error))
+}
+
+fn cli_authority_class() -> Result<AuthorityClass> {
+    Ok(cli_invocation_context()?
+        .and_then(|context| context.inherited_authority_class)
+        .unwrap_or(AuthorityClass::OperatorInstruction))
+}
+
+fn parse_work_item_plan_status(value: &str) -> Result<WorkItemPlanStatus> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "draft" => Ok(WorkItemPlanStatus::Draft),
+        "ready" => Ok(WorkItemPlanStatus::Ready),
+        "needs_input" | "needs-input" => Ok(WorkItemPlanStatus::NeedsInput),
+        _ => Err(anyhow!(
+            "invalid --plan-status {value:?}; expected draft, ready, or needs_input"
+        )),
+    }
+}
+
+fn read_report_input(report: Option<String>, report_file: Option<PathBuf>) -> Result<String> {
+    if let Some(report) = report {
+        return Ok(report);
+    }
+    let Some(path) = report_file else {
+        return Err(anyhow!(
+            "one of --report or --report-file <path|-> is required"
+        ));
+    };
+    if path == Path::new("-") {
+        let mut report = String::new();
+        std::io::stdin().read_to_string(&mut report)?;
+        return Ok(report);
+    }
+    fs::read_to_string(&path)
+        .with_context(|| format!("failed to read completion report {}", path.display()))
 }
 
 async fn handle_agent_command(config: &AppConfig, command: Option<AgentCommands>) -> Result<()> {

--- a/src/prompt/tool_guidance/tool_holon_cli.md
+++ b/src/prompt/tool_guidance/tool_holon_cli.md
@@ -1,0 +1,22 @@
+When `ExecCommand` is available, use the local `holon` CLI as a machine-readable
+control-plane surface only when a native runtime tool does not already express
+the operation. Discover the current contract with `holon commands`; inspect the
+declared invocation mode and provenance with `holon context`.
+
+In an agent command task, the runtime supplies the caller context automatically.
+Do not manually set, copy, print, or treat `HOLON_CALLER_*` values as
+credentials. They are declaration-based provenance, not authentication. A
+context-free CLI invocation is operator mode; an explicit malformed context is
+an error and must not be converted to operator mode.
+
+For target-aware commands, omit `--agent` for the current caller's self target
+in agent mode, or pass `--agent <id>` for a cross-agent target. The target does
+not change the caller or authority. Preserve inherited authority and never use
+CLI fields to upgrade it.
+
+Prefer `--output json` or the default non-TTY JSON output. Keep stdout for
+results and stderr for diagnostics. Use exit code `0` for success, `1` for an
+operational/control failure, and `2` for CLI usage failure. Use
+`holon task list` and `holon work-item` lifecycle commands for inspection and
+bounded mutations; do not use recursive `holon run` or `holon prompt` as a
+replacement for `Enqueue`, `SpawnAgent`, or the current WorkItem lifecycle.

--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -146,6 +146,11 @@ pub fn tool_sections_with_context(
             PromptStability::Stable,
             guidance(include_str!("tool_guidance/tool_exec_command.md")),
         ));
+        sections.push(section(
+            "holon_cli_contract",
+            PromptStability::Stable,
+            guidance(include_str!("tool_guidance/tool_holon_cli.md")),
+        ));
     }
     if names.contains(&tn::EXEC_COMMAND_BATCH) {
         sections.push(section(
@@ -351,6 +356,25 @@ mod tests {
         }];
         let sections = tool_sections(&tools);
         assert!(sections.iter().any(|s| s.name == "tool_exec_command"));
+        assert!(sections.iter().any(|s| s.name == "holon_cli_contract"));
+    }
+
+    #[test]
+    fn holon_cli_guidance_preserves_provenance_boundary() {
+        let tools = vec![ToolSpec {
+            name: "ExecCommand".into(),
+            description: String::new(),
+            input_schema: json!({}),
+            freeform_grammar: None,
+        }];
+        let section = tool_sections(&tools)
+            .into_iter()
+            .find(|section| section.name == "holon_cli_contract")
+            .expect("holon cli contract section");
+        assert!(section.content.contains("not authentication"));
+        assert!(section.content.contains("holon commands"));
+        assert!(section.content.contains("holon context"));
+        assert!(section.content.contains("recursive `holon run`"));
     }
 
     #[test]

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -26,6 +26,9 @@ use crate::{
         ExecCommandDuplicatePolicy, ExecCommandOutcome, ExecCommandResult, ExternalTriggerScope,
         ExternalTriggerStatus, MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority,
         TaskHandle, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, ToolArtifactRef,
+        HOLON_CALLER_AGENT_ID_ENV, HOLON_CALLER_AUTHORITY_CLASS_ENV,
+        HOLON_CALLER_SOURCE_ACTIVATION_ID_ENV, HOLON_CALLER_SOURCE_TASK_ID_ENV,
+        HOLON_CALLER_SOURCE_TURN_ID_ENV, HOLON_CALLER_SOURCE_WORK_ITEM_ID_ENV,
     },
     utf8::IncrementalUtf8LossyDecoder,
 };
@@ -519,6 +522,40 @@ impl RuntimeHandle {
                 self.agent_home().to_string_lossy().into_owned(),
             ),
         ];
+        let state = self.agent_state().await?;
+        if let Some(binding) = state.current_execution_binding.as_ref() {
+            env.push((HOLON_CALLER_AGENT_ID_ENV.to_string(), agent_id.clone()));
+            env.push((
+                HOLON_CALLER_SOURCE_TURN_ID_ENV.to_string(),
+                binding.turn_id.clone(),
+            ));
+            if let Some(work_item_id) = binding.work_item_id.as_ref() {
+                env.push((
+                    HOLON_CALLER_SOURCE_WORK_ITEM_ID_ENV.to_string(),
+                    work_item_id.clone(),
+                ));
+            }
+            if let Some(activation_id) = binding.activation_id.as_ref() {
+                env.push((
+                    HOLON_CALLER_SOURCE_ACTIVATION_ID_ENV.to_string(),
+                    activation_id.clone(),
+                ));
+            }
+            if let Some(message) = self
+                .storage()
+                .read_message_by_id(&binding.source_message_id)?
+            {
+                if let Some(task_id) = message.task_id {
+                    env.push((HOLON_CALLER_SOURCE_TASK_ID_ENV.to_string(), task_id));
+                }
+                env.push((
+                    HOLON_CALLER_AUTHORITY_CLASS_ENV.to_string(),
+                    serde_json::to_string(&message.authority_class)?
+                        .trim_matches('"')
+                        .to_string(),
+                ));
+            }
+        }
         if let Some(trigger_url) = self.command_external_trigger_url(&agent_id).await? {
             env.push(("HOLON_EXTERNAL_TRIGGER_URL".to_string(), trigger_url));
         }

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -1381,7 +1381,7 @@ async fn turn_local_continuation_recovers_by_reprojecting_recent_turns() {
         .filter(|(_, tool)| tool.name != crate::tool::names::X_SEARCH)
         .map(|(_, tool)| tool)
         .collect::<Vec<_>>();
-    let continuation_effective_budget = 12_000;
+    let continuation_effective_budget = 14_000;
     let prompt_budget_estimated_tokens = turn::estimate_tool_specs_tokens(&available_tools)
         + turn::CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS
         + continuation_effective_budget;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1380,6 +1380,107 @@ pub enum AuthorityClass {
     ExternalEvidence,
 }
 
+pub const HOLON_CALLER_AGENT_ID_ENV: &str = "HOLON_CALLER_AGENT_ID";
+pub const HOLON_CALLER_SOURCE_TASK_ID_ENV: &str = "HOLON_CALLER_SOURCE_TASK_ID";
+pub const HOLON_CALLER_SOURCE_TURN_ID_ENV: &str = "HOLON_CALLER_SOURCE_TURN_ID";
+pub const HOLON_CALLER_SOURCE_WORK_ITEM_ID_ENV: &str = "HOLON_CALLER_SOURCE_WORK_ITEM_ID";
+pub const HOLON_CALLER_SOURCE_ACTIVATION_ID_ENV: &str = "HOLON_CALLER_SOURCE_ACTIVATION_ID";
+pub const HOLON_CALLER_AUTHORITY_CLASS_ENV: &str = "HOLON_CALLER_AUTHORITY_CLASS";
+
+/// Declaration-based provenance supplied to a CLI launched by an agent.
+///
+/// These values describe the caller and its source activation, but are not
+/// authentication material. A local process can forge them.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct AgentInvocationContext {
+    pub caller_agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_activation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inherited_authority_class: Option<AuthorityClass>,
+}
+
+impl AgentInvocationContext {
+    pub fn from_env() -> Result<Option<Self>, String> {
+        let read = |name: &str| {
+            std::env::var(name)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        };
+        let caller_agent_id = read(HOLON_CALLER_AGENT_ID_ENV);
+        let any_context_field = [
+            HOLON_CALLER_SOURCE_TASK_ID_ENV,
+            HOLON_CALLER_SOURCE_TURN_ID_ENV,
+            HOLON_CALLER_SOURCE_WORK_ITEM_ID_ENV,
+            HOLON_CALLER_SOURCE_ACTIVATION_ID_ENV,
+            HOLON_CALLER_AUTHORITY_CLASS_ENV,
+        ]
+        .into_iter()
+        .any(|name| std::env::var_os(name).is_some());
+
+        Self::from_fields(
+            caller_agent_id,
+            read(HOLON_CALLER_SOURCE_TASK_ID_ENV),
+            read(HOLON_CALLER_SOURCE_TURN_ID_ENV),
+            read(HOLON_CALLER_SOURCE_WORK_ITEM_ID_ENV),
+            read(HOLON_CALLER_SOURCE_ACTIVATION_ID_ENV),
+            read(HOLON_CALLER_AUTHORITY_CLASS_ENV),
+            any_context_field,
+        )
+    }
+
+    fn from_fields(
+        caller_agent_id: Option<String>,
+        source_task_id: Option<String>,
+        source_turn_id: Option<String>,
+        source_work_item_id: Option<String>,
+        source_activation_id: Option<String>,
+        inherited_authority_class: Option<String>,
+        any_context_field: bool,
+    ) -> Result<Option<Self>, String> {
+        let Some(caller_agent_id) = caller_agent_id else {
+            if any_context_field {
+                return Err(format!(
+                    "{HOLON_CALLER_AGENT_ID_ENV} is required when caller context is present"
+                ));
+            }
+            return Ok(None);
+        };
+
+        let inherited_authority_class = inherited_authority_class
+            .map(|value| parse_agent_invocation_authority(&value))
+            .transpose()?;
+
+        Ok(Some(Self {
+            caller_agent_id,
+            source_task_id,
+            source_turn_id,
+            source_work_item_id,
+            source_activation_id,
+            inherited_authority_class,
+        }))
+    }
+}
+
+fn parse_agent_invocation_authority(value: &str) -> Result<AuthorityClass, String> {
+    match value.trim().to_ascii_lowercase().replace('-', "_").as_str() {
+        "operator_instruction" | "trusted_operator" => Ok(AuthorityClass::OperatorInstruction),
+        "runtime_instruction" | "trusted_system" => Ok(AuthorityClass::RuntimeInstruction),
+        "integration_signal" | "trusted_integration" => Ok(AuthorityClass::IntegrationSignal),
+        "external_evidence" | "untrusted_external" => Ok(AuthorityClass::ExternalEvidence),
+        _ => Err(format!(
+            "invalid {HOLON_CALLER_AUTHORITY_CLASS_ENV}: {value}"
+        )),
+    }
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct MessageEnvelope {
     pub id: String,
@@ -5326,6 +5427,57 @@ impl AgentListEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn agent_invocation_context_requires_caller_when_any_field_is_present() {
+        let error = AgentInvocationContext::from_fields(
+            None,
+            None,
+            Some("turn-1".into()),
+            None,
+            None,
+            None,
+            true,
+        )
+        .unwrap_err();
+        assert!(error.contains(HOLON_CALLER_AGENT_ID_ENV));
+    }
+
+    #[test]
+    fn agent_invocation_context_parses_declared_fields_and_authority_aliases() {
+        let context = AgentInvocationContext::from_fields(
+            Some("agent-a".into()),
+            Some("task-1".into()),
+            Some("turn-1".into()),
+            Some("work-1".into()),
+            Some("activation-1".into()),
+            Some("trusted-integration".into()),
+            true,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(context.caller_agent_id, "agent-a");
+        assert_eq!(context.source_task_id.as_deref(), Some("task-1"));
+        assert_eq!(context.source_turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(context.source_work_item_id.as_deref(), Some("work-1"));
+        assert_eq!(
+            context.source_activation_id.as_deref(),
+            Some("activation-1")
+        );
+        assert_eq!(
+            context.inherited_authority_class,
+            Some(AuthorityClass::IntegrationSignal)
+        );
+    }
+
+    #[test]
+    fn context_free_agent_invocation_context_is_operator_mode() {
+        assert_eq!(
+            AgentInvocationContext::from_fields(None, None, None, None, None, None, false).unwrap(),
+            None
+        );
+    }
 
     #[test]
     fn legacy_scheduler_contract_names_deserialize_as_current_terms() {

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -211,6 +211,12 @@
     "aliases": []
   },
   {
+    "path": "commands",
+    "positionals": [],
+    "flags": [],
+    "aliases": []
+  },
+  {
     "path": "config",
     "positionals": [],
     "flags": [],
@@ -496,6 +502,12 @@
         "required": true
       }
     ],
+    "flags": [],
+    "aliases": []
+  },
+  {
+    "path": "context",
+    "positionals": [],
     "flags": [],
     "aliases": []
   },
@@ -1894,6 +1906,27 @@
     "aliases": []
   },
   {
+    "path": "task.list",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "agent",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "limit",
+        "short": null,
+        "default_value": "50",
+        "possible_values": null,
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "task.output",
     "positionals": [
       {
@@ -2234,6 +2267,62 @@
     "aliases": []
   },
   {
+    "path": "work-item.complete",
+    "positionals": [
+      {
+        "name": "work_item_id",
+        "value_name": "WORK_ITEM_ID",
+        "index": null,
+        "required": true
+      }
+    ],
+    "flags": [
+      {
+        "long": "agent",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "report",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "report-file",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
+    "path": "work-item.create",
+    "positionals": [
+      {
+        "name": "objective",
+        "value_name": "OBJECTIVE",
+        "index": null,
+        "required": true
+      }
+    ],
+    "flags": [
+      {
+        "long": "agent",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "work-item.get",
     "positionals": [
       {
@@ -2269,6 +2358,100 @@
         "long": "limit",
         "short": null,
         "default_value": "50",
+        "possible_values": null,
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
+    "path": "work-item.pick",
+    "positionals": [
+      {
+        "name": "work_item_id",
+        "value_name": "WORK_ITEM_ID",
+        "index": null,
+        "required": true
+      }
+    ],
+    "flags": [
+      {
+        "long": "agent",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "clear-blocker",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
+        "long": "reason",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
+    "path": "work-item.update",
+    "positionals": [
+      {
+        "name": "work_item_id",
+        "value_name": "WORK_ITEM_ID",
+        "index": null,
+        "required": true
+      }
+    ],
+    "flags": [
+      {
+        "long": "agent",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "blocked-by-json",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "objective",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "plan-status",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "recheck-after",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "todo-json",
+        "short": null,
+        "default_value": null,
         "possible_values": null,
         "required": false
       }


### PR DESCRIPTION
## Summary

Closes #2416.

- Adds the `agent-aware-cli-invocation` RFC and a compact `holon_cli_contract` system-prompt section for agents with command execution.
- Adds declared command-task caller context propagation and provenance-aware CLI requests. Ordinary CLI invocations remain operator mode by default; agent context is a social/provenance contract, not an authentication or security boundary.
- Adds machine-readable `holon context` and `holon commands`, unified output/error handling, task listing, and WorkItem create/pick/update commands while reusing existing lifecycle APIs.
- Adds deterministic CLI snapshots, prompt/runtime regressions, and scripted-agent coverage; refreshes the OpenAPI snapshot.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test --test openapi_snapshot --test cli_snapshot`
- `RUSTFLAGS='-D warnings' cargo test --all-targets` (all tests passed)

## Scope note

The runtime-provided caller context identifies the intended agent caller and preserves authority/provenance semantics, but local CLI inputs and environment variables are forgeable. It must not be treated as a security restriction or as protection against a process that deliberately impersonates another caller.
