### PR TITLE
refactor: unify wait/wake resume authorization

### DIFF
--- a/docs/rfcs/wake-authority.md
+++ b/docs/rfcs/wake-authority.md
@@ -1,0 +1,64 @@
+---
+title: RFC: Wake Authority And Resume Authorization
+date: 2026-09-02
+status: draft
+---
+
+# RFC: Wake Authority And Resume Authorization
+
+## Summary
+
+Holon has two related but different contracts:
+
+1. **Explicit sleep requires durable intent.** When `WaitFor` puts an agent
+   into a blocked posture, the wait condition (or an equivalent durable
+   continuation) must be persisted atomically with that posture.
+2. **Every model re-entry requires verifiable authorization.** A missing wait
+   condition does not by itself prohibit re-entry when a runtime-owned event,
+   such as a terminal task result, independently proves that re-entry is
+   authorized.
+
+The wait registry is therefore authoritative for matching explicit waits, but
+it is not the sole authority for every wake. Resume authorization is classified
+explicitly as:
+
+- `ExpectedWait`: the trigger matches the persisted waiting reason and carries
+  the content required by that wait;
+- `RuntimeEventReentry`: a runtime-owned terminal event is correlated to the
+  same work item and is allowed to re-enter even when the prior closure summary
+  is incomplete or polluted;
+- `Override`: an authenticated operator input intentionally supersedes the
+  current wait;
+- `LocalContinuation`: a non-waiting runtime continuation such as an internal
+  follow-up or a valid local timer/external continuation;
+- `LivenessOnly`: the runtime should reconsider scheduling, but must not invoke
+  the model.
+
+## Invariants
+
+- A `WaitFor` sleep must never rely on an in-memory promise alone.
+- A terminal `TaskResult` may re-enter without a matching wait when task
+  terminality, work-item ownership, and correlation evidence are present.
+- A non-terminal or mismatched task result is liveness-only.
+- A wake hint without content is liveness-only; contentful external/system
+  delivery may re-enter when its waiting contract matches.
+- Authorization classification is centralized in one resolver rather than
+  duplicated in trigger-specific continuation branches.
+- Observability may report a suspicious sleep posture, but Phase 0 does not
+  change scheduling behavior.
+
+## Phase 0 And Phase 1
+
+Phase 0 documents the dual authorization contract and records an audit event
+when an indefinite sleep has no currently visible wake source. This is a
+diagnostic guardrail, not a new wake policy. The observation is intentionally
+conservative: it considers queue entries, runnable work, active waits, active
+tasks, timers, pending wake hints, and interrupted replay.
+
+Phase 1 centralizes the existing behavior in the
+`resolve_resume_authorization` decision function. The migration preserves the
+existing continuation classes and trigger behavior while making the source of
+authorization visible in evidence.
+
+Later phases may move more state transitions to an explicit authorization
+record, but are out of scope for this RFC's initial implementation.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -26,6 +26,7 @@ mod test_util;
 mod turn;
 mod unsettled_claim;
 mod waiting;
+mod wake_matching;
 pub(crate) mod workspace;
 pub(crate) mod workspace_control;
 mod worktree;

--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -1,3 +1,4 @@
+use super::wake_matching::{resolve_resume_authorization, ResumeAuthorization};
 use crate::types::{
     admission_trigger_kind_for_message_kind, ClosureDecision, ClosureOutcome, ContinuationClass,
     ContinuationResolution, ContinuationTriggerKind, MessageBody, MessageEnvelope, MessageKind,
@@ -116,6 +117,14 @@ pub(super) fn resolve_continuation(
         }
         (Some(t), Some(a)) => t == a,
     };
+    let authorization = resolve_resume_authorization(
+        prior.outcome,
+        prior_waiting_reason,
+        trigger.kind,
+        trigger.contentful,
+        trigger.task_result_outcome,
+        same_work_item,
+    );
     let mut evidence = Vec::new();
     evidence.push(format!("trigger_kind={}", enum_label(trigger.kind)));
     if trigger.contentful {
@@ -130,49 +139,49 @@ pub(super) fn resolve_continuation(
     if trigger.exact_task_wait {
         evidence.push("exact_task_wait".to_string());
     }
+    if authorization.matched_waiting_reason {
+        evidence.push("matches_waiting_reason".to_string());
+    } else {
+        evidence.push("does_not_satisfy_waiting_reason".to_string());
+    }
     if let Some(source) = trigger.wake_hint_source.as_ref() {
         evidence.push(format!("wake_hint_source={source}"));
     }
-
-    let prior_closure_outcome = prior.outcome;
-
-    if prior.outcome == ClosureOutcome::Waiting {
-        return resolve_waiting(
-            prior_waiting_reason,
-            prior_closure_outcome,
-            trigger,
-            same_work_item,
-            evidence,
-        );
+    match authorization.authorization {
+        ResumeAuthorization::ExpectedWait => {
+            evidence.push("resume_authorization=expected_wait".into())
+        }
+        ResumeAuthorization::RuntimeEventReentry => {
+            evidence.push("resume_authorization=runtime_event_reentry".into())
+        }
+        ResumeAuthorization::Override => evidence.push("resume_authorization=override".into()),
+        ResumeAuthorization::LocalContinuation => {
+            evidence.push("resume_authorization=local_continuation".into())
+        }
+        ResumeAuthorization::LivenessOnly => {
+            evidence.push("resume_authorization=liveness_only".into())
+        }
     }
-
-    let terminal_task_result = trigger.kind == ContinuationTriggerKind::TaskResult
-        && trigger.task_result_outcome.is_some()
-        && same_work_item;
-    let model_reentry = terminal_task_result
-        || matches!(
-            trigger.kind,
-            ContinuationTriggerKind::OperatorInput
-                | ContinuationTriggerKind::TimerFire
-                | ContinuationTriggerKind::InternalFollowup
-        )
-        || ((trigger.kind == ContinuationTriggerKind::ExternalEvent
-            || trigger.kind == ContinuationTriggerKind::SystemTick)
-            && trigger.contentful);
-    let class = if terminal_task_result {
-        ContinuationClass::TaskResultReentry
-    } else if model_reentry {
-        ContinuationClass::LocalContinuation
-    } else {
-        ContinuationClass::LivenessOnly
+    let class = match authorization.authorization {
+        ResumeAuthorization::ExpectedWait => ContinuationClass::ResumeExpectedWait,
+        ResumeAuthorization::RuntimeEventReentry => {
+            if prior.outcome == ClosureOutcome::Waiting {
+                ContinuationClass::ResumeOverride
+            } else {
+                ContinuationClass::TaskResultReentry
+            }
+        }
+        ResumeAuthorization::Override => ContinuationClass::ResumeOverride,
+        ResumeAuthorization::LocalContinuation => ContinuationClass::LocalContinuation,
+        ResumeAuthorization::LivenessOnly => ContinuationClass::LivenessOnly,
     };
     ContinuationResolution {
         trigger_kind: trigger.kind,
         class,
-        model_reentry,
-        prior_closure_outcome,
+        model_reentry: authorization.model_reentry,
+        prior_closure_outcome: prior.outcome,
         prior_waiting_reason,
-        matched_waiting_reason: false,
+        matched_waiting_reason: authorization.matched_waiting_reason,
         evidence,
     }
 }
@@ -182,120 +191,6 @@ fn enum_label<T: serde::Serialize + std::fmt::Debug>(value: T) -> String {
         .ok()
         .and_then(|value| value.as_str().map(ToString::to_string))
         .unwrap_or_else(|| format!("{value:?}").to_lowercase())
-}
-
-fn resolve_waiting(
-    prior_waiting_reason: Option<WaitingReason>,
-    prior_closure_outcome: ClosureOutcome,
-    trigger: &ContinuationTrigger,
-    same_work_item: bool,
-    mut evidence: Vec<String>,
-) -> ContinuationResolution {
-    let reason = prior_waiting_reason;
-    let expected = matches!(
-        (reason, trigger.kind),
-        (
-            Some(WaitingReason::AwaitingOperatorInput),
-            ContinuationTriggerKind::OperatorInput
-        ) | (
-            Some(WaitingReason::AwaitingTaskResult),
-            ContinuationTriggerKind::TaskResult
-        ) | (
-            Some(WaitingReason::AwaitingExternalChange),
-            ContinuationTriggerKind::ExternalEvent
-        ) | (
-            Some(WaitingReason::AwaitingExternalChange),
-            ContinuationTriggerKind::SystemTick
-        ) | (
-            Some(WaitingReason::AwaitingTimer),
-            ContinuationTriggerKind::TimerFire
-        )
-    );
-    let override_allowed = trigger.kind == ContinuationTriggerKind::OperatorInput;
-    if expected {
-        let model_reentry = match trigger.kind {
-            ContinuationTriggerKind::TaskResult => {
-                trigger.task_result_outcome.is_some() && same_work_item
-            }
-            ContinuationTriggerKind::ExternalEvent => trigger.contentful,
-            ContinuationTriggerKind::SystemTick => trigger.contentful,
-            _ => true,
-        };
-        evidence.push("matches_waiting_reason".to_string());
-        return ContinuationResolution {
-            trigger_kind: trigger.kind,
-            class: if model_reentry {
-                ContinuationClass::ResumeExpectedWait
-            } else {
-                ContinuationClass::LivenessOnly
-            },
-            model_reentry,
-            prior_closure_outcome,
-            prior_waiting_reason,
-            matched_waiting_reason: true,
-            evidence,
-        };
-    }
-
-    if override_allowed {
-        evidence.push("override_waiting_reason".to_string());
-        return ContinuationResolution {
-            trigger_kind: trigger.kind,
-            class: ContinuationClass::ResumeOverride,
-            model_reentry: true,
-            prior_closure_outcome,
-            prior_waiting_reason,
-            matched_waiting_reason: false,
-            evidence,
-        };
-    }
-
-    if trigger.kind == ContinuationTriggerKind::SystemTick && trigger.contentful {
-        evidence.push("contentful_system_tick_expected_external_recheck".to_string());
-        let matched_waiting_reason = reason == Some(WaitingReason::AwaitingExternalChange);
-        return ContinuationResolution {
-            trigger_kind: trigger.kind,
-            class: if matched_waiting_reason {
-                ContinuationClass::ResumeExpectedWait
-            } else {
-                ContinuationClass::LivenessOnly
-            },
-            model_reentry: matched_waiting_reason,
-            prior_closure_outcome,
-            prior_waiting_reason,
-            matched_waiting_reason,
-            evidence,
-        };
-    }
-
-    if trigger.kind == ContinuationTriggerKind::TaskResult
-        && trigger.task_result_outcome.is_some()
-        && same_work_item
-    {
-        // Terminal task state is persisted before TaskResult enqueue, so
-        // resuming here cannot reopen the stale active-task wait that just ended.
-        evidence.push("terminal_task_result".to_string());
-        return ContinuationResolution {
-            trigger_kind: trigger.kind,
-            class: ContinuationClass::ResumeOverride,
-            model_reentry: true,
-            prior_closure_outcome,
-            prior_waiting_reason,
-            matched_waiting_reason: false,
-            evidence,
-        };
-    }
-
-    evidence.push("does_not_satisfy_waiting_reason".to_string());
-    ContinuationResolution {
-        trigger_kind: trigger.kind,
-        class: ContinuationClass::LivenessOnly,
-        model_reentry: false,
-        prior_closure_outcome,
-        prior_waiting_reason,
-        matched_waiting_reason: false,
-        evidence,
-    }
 }
 
 fn body_is_contentful(body: &MessageBody) -> bool {

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1787,9 +1787,50 @@ impl RuntimeHandle {
             )
             .await?;
         self.append_state_changed_events(&state)?;
+        if sleeping_until.is_none() {
+            self.observe_indefinite_sleep_without_wake_source(&state)?;
+        }
         if let (Some(duration_ms), Some(sleeping_until)) = (duration_ms, sleeping_until) {
             self.spawn_session_sleep_wake(duration_ms, sleeping_until);
         }
+        Ok(())
+    }
+
+    fn observe_indefinite_sleep_without_wake_source(&self, state: &AgentState) -> Result<()> {
+        let projection = scheduler::SchedulerProjection::from_state(&self.inner.storage, state)?;
+        let has_runnable_work = projection.work_reactivation_signal().is_some();
+        let has_queue_entries = projection.queue_len > 0 || projection.queued_work_items > 0;
+        let has_pending_task = !projection.active_tasks.is_empty();
+        let has_wake_source = has_queue_entries
+            || has_runnable_work
+            || projection.active_waiting_intents > 0
+            || has_pending_task
+            || projection.active_timers > 0
+            || projection.pending_wake_hint
+            || projection.has_interrupted_replay;
+        if state.status != AgentStatus::Asleep || state.sleeping_until.is_some() || has_wake_source
+        {
+            return Ok(());
+        }
+
+        self.inner.storage.append_event(&AuditEvent::legacy(
+            "orphan_sleep_observed",
+            serde_json::json!({
+                "agent_id": state.id,
+                "sleeping_until": state.sleeping_until,
+                "evidence": [
+                    "indefinite_sleep".to_string(),
+                    "queue_len=0".to_string(),
+                    "queued_work_items=0".to_string(),
+                    "active_waiting_intents=0".to_string(),
+                    "active_tasks=0".to_string(),
+                    "active_timers=0".to_string(),
+                    "pending_wake_hint=false".to_string(),
+                    "has_interrupted_replay=false".to_string(),
+                ],
+                "severity": "warning",
+            }),
+        ))?;
         Ok(())
     }
 

--- a/src/runtime/wake_matching.rs
+++ b/src/runtime/wake_matching.rs
@@ -1,0 +1,222 @@
+use crate::types::{ClosureOutcome, ContinuationTriggerKind, TaskResultOutcome, WaitingReason};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ResumeAuthorization {
+    ExpectedWait,
+    RuntimeEventReentry,
+    Override,
+    LocalContinuation,
+    LivenessOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ResumeDecision {
+    pub(super) authorization: ResumeAuthorization,
+    pub(super) model_reentry: bool,
+    pub(super) matched_waiting_reason: bool,
+}
+
+pub(super) fn resolve_resume_authorization(
+    prior_outcome: ClosureOutcome,
+    prior_waiting_reason: Option<WaitingReason>,
+    trigger_kind: ContinuationTriggerKind,
+    contentful: bool,
+    task_result_outcome: Option<TaskResultOutcome>,
+    same_work_item: bool,
+) -> ResumeDecision {
+    let terminal_task_result =
+        trigger_kind == ContinuationTriggerKind::TaskResult && task_result_outcome.is_some();
+    let expected = waiting_reason_matches(prior_waiting_reason, trigger_kind);
+
+    if prior_outcome == ClosureOutcome::Waiting {
+        if expected {
+            let model_reentry = match trigger_kind {
+                ContinuationTriggerKind::TaskResult => terminal_task_result && same_work_item,
+                ContinuationTriggerKind::ExternalEvent | ContinuationTriggerKind::SystemTick => {
+                    contentful
+                }
+                _ => true,
+            };
+            return ResumeDecision {
+                authorization: if model_reentry {
+                    ResumeAuthorization::ExpectedWait
+                } else {
+                    ResumeAuthorization::LivenessOnly
+                },
+                model_reentry,
+                matched_waiting_reason: true,
+            };
+        }
+
+        if trigger_kind == ContinuationTriggerKind::OperatorInput {
+            return ResumeDecision {
+                authorization: ResumeAuthorization::Override,
+                model_reentry: true,
+                matched_waiting_reason: false,
+            };
+        }
+
+        if terminal_task_result && same_work_item {
+            return ResumeDecision {
+                authorization: ResumeAuthorization::RuntimeEventReentry,
+                model_reentry: true,
+                matched_waiting_reason: false,
+            };
+        }
+
+        return ResumeDecision {
+            authorization: ResumeAuthorization::LivenessOnly,
+            model_reentry: false,
+            matched_waiting_reason: false,
+        };
+    }
+
+    let runtime_event_reentry = terminal_task_result && same_work_item;
+    let local_continuation = matches!(
+        trigger_kind,
+        ContinuationTriggerKind::OperatorInput
+            | ContinuationTriggerKind::TimerFire
+            | ContinuationTriggerKind::InternalFollowup
+    ) || matches!(
+        trigger_kind,
+        ContinuationTriggerKind::ExternalEvent | ContinuationTriggerKind::SystemTick
+    ) && contentful;
+
+    let authorization = if runtime_event_reentry {
+        ResumeAuthorization::RuntimeEventReentry
+    } else if local_continuation {
+        ResumeAuthorization::LocalContinuation
+    } else {
+        ResumeAuthorization::LivenessOnly
+    };
+    ResumeDecision {
+        model_reentry: authorization != ResumeAuthorization::LivenessOnly,
+        authorization,
+        matched_waiting_reason: false,
+    }
+}
+
+fn waiting_reason_matches(
+    reason: Option<WaitingReason>,
+    trigger_kind: ContinuationTriggerKind,
+) -> bool {
+    matches!(
+        (reason, trigger_kind),
+        (
+            Some(WaitingReason::AwaitingOperatorInput),
+            ContinuationTriggerKind::OperatorInput
+        ) | (
+            Some(WaitingReason::AwaitingTaskResult),
+            ContinuationTriggerKind::TaskResult
+        ) | (
+            Some(WaitingReason::AwaitingExternalChange),
+            ContinuationTriggerKind::ExternalEvent
+        ) | (
+            Some(WaitingReason::AwaitingExternalChange),
+            ContinuationTriggerKind::SystemTick
+        ) | (
+            Some(WaitingReason::AwaitingTimer),
+            ContinuationTriggerKind::TimerFire
+        )
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn decision(
+        outcome: ClosureOutcome,
+        reason: Option<WaitingReason>,
+        kind: ContinuationTriggerKind,
+        contentful: bool,
+        task_result_outcome: Option<TaskResultOutcome>,
+        same_work_item: bool,
+    ) -> ResumeDecision {
+        resolve_resume_authorization(
+            outcome,
+            reason,
+            kind,
+            contentful,
+            task_result_outcome,
+            same_work_item,
+        )
+    }
+
+    #[test]
+    fn classifies_the_four_authorization_sources() {
+        assert_eq!(
+            decision(
+                ClosureOutcome::Waiting,
+                Some(WaitingReason::AwaitingTimer),
+                ContinuationTriggerKind::TimerFire,
+                false,
+                None,
+                false,
+            )
+            .authorization,
+            ResumeAuthorization::ExpectedWait
+        );
+        assert_eq!(
+            decision(
+                ClosureOutcome::Waiting,
+                Some(WaitingReason::AwaitingTimer),
+                ContinuationTriggerKind::TaskResult,
+                true,
+                Some(TaskResultOutcome::Succeeded),
+                true,
+            )
+            .authorization,
+            ResumeAuthorization::RuntimeEventReentry
+        );
+        assert_eq!(
+            decision(
+                ClosureOutcome::Waiting,
+                Some(WaitingReason::AwaitingTimer),
+                ContinuationTriggerKind::OperatorInput,
+                true,
+                None,
+                false,
+            )
+            .authorization,
+            ResumeAuthorization::Override
+        );
+        assert_eq!(
+            decision(
+                ClosureOutcome::Continuable,
+                None,
+                ContinuationTriggerKind::ExternalEvent,
+                false,
+                None,
+                false,
+            )
+            .authorization,
+            ResumeAuthorization::LivenessOnly
+        );
+    }
+
+    #[test]
+    fn does_not_authorize_unbound_or_non_terminal_task_results() {
+        let unbound = decision(
+            ClosureOutcome::Waiting,
+            Some(WaitingReason::AwaitingTimer),
+            ContinuationTriggerKind::TaskResult,
+            true,
+            Some(TaskResultOutcome::Succeeded),
+            false,
+        );
+        assert_eq!(unbound.authorization, ResumeAuthorization::LivenessOnly);
+        assert!(!unbound.model_reentry);
+
+        let active = decision(
+            ClosureOutcome::Waiting,
+            Some(WaitingReason::AwaitingTaskResult),
+            ContinuationTriggerKind::TaskResult,
+            true,
+            None,
+            true,
+        );
+        assert_eq!(active.authorization, ResumeAuthorization::LivenessOnly);
+        assert!(active.matched_waiting_reason);
+    }
+}

--- a/tests/support/runtime_workspace_worktree.rs
+++ b/tests/support/runtime_workspace_worktree.rs
@@ -150,7 +150,7 @@ pub async fn enter_worktree_tool_switches_workspace_and_restores_on_reload() -> 
         branch_name
     );
 
-    let events = runtime.recent_events(20).await?;
+    let events = runtime.recent_events(40).await?;
     assert!(events.iter().any(|event| event.kind == "workspace_entered"));
 
     let restarted_host =


### PR DESCRIPTION
## 关联 issue

Closes #2747

## 变更摘要

实施 wait/wake 恢复授权重构的 Phase 0 + Phase 1：

- 新增 `docs/rfcs/wake-authority.md`，固化显式等待授权与 runtime 任务终态重入授权的双重契约。
- 新增统一的 resume authorization 判定器，区分 `ExpectedWait`、`RuntimeEventReentry`、`Override` 与 `LivenessOnly`。
- 将现有 continuation/lifecycle/wake matching 路径接入统一判定器，移除分散的手工特判。
- 增加孤儿睡眠观测护栏：保持现有唤醒行为不变，同时暴露缺少可恢复授权的异常状态。
- 补齐行为等价测试，覆盖 task result、timer、external ingress 以及 override/liveness-only 场景。

## 设计边界

本 PR 不要求所有唤醒都先登记 `WaitFor`：

1. 显式 `WaitFor` 睡眠必须原子持久化等待承诺或等价 continuation 授权。
2. runtime-owned 的任务终态事件可依据任务归属与终态证据独立授权模型重入。

Phase 2/3（更广泛的调度与协议调整）不在本 PR 范围内。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib`
- `git diff --check`
