### PR TITLE
feat: models.dev supplemental catalog — auto-draft new models for supported providers

### DIFF
--- a/.github/workflows/models-dev-refresh.yml
+++ b/.github/workflows/models-dev-refresh.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          if git diff --exit-code -- models.dev/; then
+          if [ -z "$(git status --porcelain -- models.dev/)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/models-dev-refresh.yml
+++ b/.github/workflows/models-dev-refresh.yml
@@ -38,18 +38,28 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Compose PR body from refresh summary
+        if: steps.diff.outputs.changed == 'true'
+        id: pr_body
+        run: |
+          {
+            echo 'body<<SUMMARY_EOF'
+            cat models.dev/refresh-summary.md
+            echo ''
+            echo '---'
+            echo 'Automated models.dev snapshot/artifact/supplement refresh. Supplement'
+            echo 'entries join the built-in catalog when this PR merges; provider'
+            echo 'enablement, routes, and credentials are unchanged.'
+            echo 'SUMMARY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create or update PR
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: models-dev-refresh
-          title: "chore: refresh models.dev snapshot and artifact"
-          body: |
-            Automated models.dev snapshot refresh.
-
-            - Snapshot and artifact regenerated from `https://models.dev/api.json`.
-            - Review the provider mapping audit output.
-            - No provider enablement or route changes.
-          commit-message: "chore: refresh models.dev snapshot and artifact"
+          title: "chore: refresh models.dev snapshot, artifact, and supplement"
+          body: ${{ steps.pr_body.outputs.body }}
+          commit-message: "chore: refresh models.dev snapshot, artifact, and supplement"
           labels: models-dev

--- a/.github/workflows/models-dev-validate.yml
+++ b/.github/workflows/models-dev-validate.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - "models.dev/**"
+      - "src/model_catalog.rs"
+      - "src/model_catalog/snapshot.rs"
       - "src/model_catalog/models_dev/**"
       - "src/provider/registry/providers.rs"
       - "tests/models_dev_adapter.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "holon"
 version = "0.35.0"
 edition = "2021"
+default-run = "holon"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"
 license = "Apache-2.0"

--- a/docs/implementation-decisions/119-models-dev-supplemental-catalog.md
+++ b/docs/implementation-decisions/119-models-dev-supplemental-catalog.md
@@ -20,6 +20,10 @@ Decision:
 - the refresh PR body is generated from `models.dev/refresh-summary.md`
   (drafted/retained/removed/deferred lists); merge review is the admission
   gate
+- `holon models-dev` commands are pure data utilities and load config in
+  inspection mode, so the refresh workflow runs on credential-less CI
+  runners; refresh change detection uses `git status --porcelain` because
+  the first refresh run creates previously untracked files
 
 Reason:
 

--- a/docs/implementation-decisions/119-models-dev-supplemental-catalog.md
+++ b/docs/implementation-decisions/119-models-dev-supplemental-catalog.md
@@ -1,0 +1,45 @@
+# models.dev Supplemental Catalog
+
+Decision:
+
+- upgrade the weekly models.dev refresh from discovery-only to a
+  review-gated supply line: `holon models-dev refresh` drafts new catalog
+  entries into the checked-in `models.dev/supplemental_catalog.json`
+- auto-draft only for a curated provider allowlist
+  (`AUTO_SUPPLEMENT_PROVIDERS`); aggregators and gateways (openrouter,
+  huggingface, nvidia, venice, nearai, together, fireworks, chutes, arcee)
+  stay out because their catalogs mirror other providers
+- a candidate must be missing from the compiled-in catalog, emit text
+  output, and carry an upstream release date inside a 120-day window; the
+  window gates entry only, retention is sticky (entries stay while they
+  exist upstream and are not promoted into the compiled-in catalog)
+- the runtime merges the checked-in supplement into the built-in catalog at
+  startup (`src/model_catalog/snapshot.rs`): metadata plus a
+  default-endpoint route per entry, never overriding compiled-in entries,
+  aliases, routes, credentials, or preferred models
+- the refresh PR body is generated from `models.dev/refresh-summary.md`
+  (drafted/retained/removed/deferred lists); merge review is the admission
+  gate
+
+Reason:
+
+Discovery-only refresh produced information but no capability: new models
+(for example `xai/grok-4.6`) were visible in the snapshot yet unusable
+until someone hand-edited the Rust catalog. Full automation over all mapped
+providers would import the entire models.dev archive (870+ models
+including dated snapshots and aggregator mirrors). The allowlist plus
+recency gate keeps drafts small and current-generational, while sticky
+retention keeps the catalog stable across weekly refreshes.
+
+Preserved boundary / tradeoff:
+
+- supplement entries are metadata only; a model still needs provider
+  credentials and endpoint configuration to be callable
+- curated defaults still belong in the compiled-in catalog; promoting a
+  supplement entry to `builtin_snapshot_v1.json` removes it from the
+  supplement automatically on the next refresh
+- aggregators and unmapped providers remain audit data; adding a provider
+  to the allowlist is a code change with review
+- upstream metadata corrections ride along automatically with retained
+  entries; deliberate Holon-specific overrides must be promoted to the
+  compiled-in catalog

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -115,3 +115,4 @@ Current decision notes:
 - [115 macOS Menu App Keeps Standalone Daemon](./115-macos-menu-app-keeps-standalone-daemon.md)
 - [116 Universal macOS App DMG](./116-universal-macos-app-dmg.md)
 - [118 Explicit models.dev Provider Mapping](./118-explicit-models-dev-provider-mapping.md)
+- [119 models.dev Supplemental Catalog](./119-models-dev-supplemental-catalog.md)

--- a/docs/rfcs/models-dev-adapter.md
+++ b/docs/rfcs/models-dev-adapter.md
@@ -13,7 +13,10 @@ issue:
 This RFC defines Phase 2A+2B of the models.dev integration: a CI-time
 adapter that reads a pinned `models.dev` snapshot, projects it into Holon's
 canonical model registry format, and emits an immutable artifact with
-provenance metadata. The runtime does not consume `models.dev` directly.
+provenance metadata. The runtime never fetches `models.dev` at run time; the
+reviewed supplemental catalog (`models.dev/supplemental_catalog.json`, see
+[119 models.dev Supplemental Catalog](../implementation-decisions/119-models-dev-supplemental-catalog.md))
+merges into the built-in catalog only through PR review and merge.
 
 This RFC builds on the accepted [Versioned Model Registry Snapshot][snap-rfc]
 and its four fact layers: `ModelDefinition`, `ProviderOffering`,
@@ -130,7 +133,9 @@ and default selections are Holon-controlled and not derivable from
 
 The artifact is a CI intermediate. After review and merge, selected model
 entries are integrated into the next built-in snapshot revision. The
-runtime does not load the artifact directly in this phase.
+runtime does not load the artifact directly in this phase; the supplemental
+catalog is the only reviewed channel through which models.dev metadata joins
+the built-in catalog.
 
 ### Artifact validation
 

--- a/models.dev/README.md
+++ b/models.dev/README.md
@@ -10,6 +10,11 @@ artifact generated from it.
 - `artifact.json` — Holon canonical model metadata projected from the
   snapshot using the explicit provider mapping in
   `src/model_catalog/models_dev/projection.rs`.
+- `supplemental_catalog.json` — auto-drafted catalog entries for
+  already-supported providers (see below). The runtime merges it into the
+  built-in catalog after review.
+- `refresh-summary.md` — human-readable summary of the latest refresh:
+  drafted, retained, removed, and deferred models.
 
 ## Refresh
 
@@ -17,10 +22,11 @@ artifact generated from it.
 cargo run -- models-dev refresh
 ```
 
-This fetches the live `models.dev` snapshot, regenerates the artifact, and
-prints a provider mapping audit summary. The GitHub Actions workflow
-`models-dev-refresh.yml` runs this weekly and opens a PR when the snapshot
-or artifact changes.
+This fetches the live `models.dev` snapshot, regenerates the artifact,
+drafts the supplemental catalog, and prints a provider mapping audit
+summary. The GitHub Actions workflow `models-dev-refresh.yml` runs this
+weekly and opens a PR (with the refresh summary as the PR body) when
+anything under `models.dev/` changes.
 
 ## Validate
 

--- a/models.dev/supplemental_catalog.json
+++ b/models.dev/supplemental_catalog.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "upstream_revision": "",
+  "adapter_version": "",
+  "models": []
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,7 @@ fn runtime_command_uses_config_inspection(command: &Commands) -> bool {
             command: DebugCommands::SchedulerRecovery { .. }
                 | DebugCommands::SchedulerRecoveryFixture { .. }
                 | DebugCommands::SchedulerRestartFixture { .. }
-        }
+        } | Commands::ModelsDev { .. }
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3011,13 +3011,15 @@ async fn handle_models_dev_command(command: ModelsDevCommands) -> Result<()> {
     match command {
         ModelsDevCommands::Refresh { url, output_dir } => {
             println!("Fetching models.dev snapshot from {url} …");
-            let response = reqwest::blocking::get(&url)
+            let response = reqwest::get(&url)
+                .await
                 .map_err(|e| anyhow!("failed to fetch models.dev snapshot: {e}"))?;
             if !response.status().is_success() {
                 anyhow::bail!("models.dev fetch returned status {}", response.status());
             }
             let raw_json = response
                 .text()
+                .await
                 .map_err(|e| anyhow!("failed to read models.dev response: {e}"))?;
             let fetched_at = chrono::Utc::now().to_rfc3339();
             let sha = sha2::Sha256::digest(raw_json.as_bytes());
@@ -3045,10 +3047,47 @@ async fn handle_models_dev_command(command: ModelsDevCommands) -> Result<()> {
             std::fs::write(&artifact_path, &artifact_json)
                 .map_err(|e| anyhow!("failed to write artifact: {e}"))?;
 
-            let report = audit_mappings(
-                &parse_snapshot(&raw_json).map_err(|e| anyhow!("parse error: {e}"))?,
-                &ProviderMapping::default_mappings(),
-            );
+            let parsed_snapshot =
+                parse_snapshot(&raw_json).map_err(|e| anyhow!("parse error: {e}"))?;
+            let report = audit_mappings(&parsed_snapshot, &ProviderMapping::default_mappings());
+
+            // Draft the supplemental catalog for allowlisted providers.
+            let supplement_path = output_dir.join("supplemental_catalog.json");
+            let previous_supplement = match std::fs::read_to_string(&supplement_path) {
+                Ok(raw) => Some(
+                    holon::model_catalog::models_dev::ModelsDevSupplement::parse(&raw)
+                        .map_err(|e| anyhow!("previous supplement invalid: {e}"))?,
+                ),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+                Err(err) => {
+                    return Err(anyhow!("failed to read previous supplement: {err}"));
+                }
+            };
+            let legacy = holon::model_catalog::legacy_builtin_catalog()
+                .map_err(|e| anyhow!("built-in catalog invalid: {e}"))?;
+            let cutoff = (chrono::Utc::now().date_naive()
+                - chrono::Duration::days(holon::model_catalog::models_dev::RECENCY_WINDOW_DAYS))
+            .format("%Y-%m-%d")
+            .to_string();
+            let update = holon::model_catalog::models_dev::supplement::generate(
+                &parsed_snapshot,
+                previous_supplement.as_ref(),
+                &legacy,
+                &cutoff,
+                &upstream_revision,
+                env!("HOLON_VERSION"),
+            )
+            .map_err(|e| anyhow!("supplement generation failed: {e}"))?;
+            let supplement_json = update
+                .supplement
+                .to_json()
+                .map_err(|e| anyhow!("failed to serialize supplement: {e}"))?;
+            std::fs::write(&supplement_path, format!("{supplement_json}\n"))
+                .map_err(|e| anyhow!("failed to write supplement: {e}"))?;
+            let summary = holon::model_catalog::models_dev::render_summary_markdown(&update);
+            let summary_path = output_dir.join("refresh-summary.md");
+            std::fs::write(&summary_path, &summary)
+                .map_err(|e| anyhow!("failed to write refresh summary: {e}"))?;
 
             println!("Snapshot  → {}", snapshot_path.display());
             println!(
@@ -3062,6 +3101,16 @@ async fn handle_models_dev_command(command: ModelsDevCommands) -> Result<()> {
                 report.unmapped_upstream.len()
             );
             println!("Stale     → {} Holon mappings", report.stale_holon.len());
+            println!(
+                "Supplement→ {} ({} models: {} drafted, {} retained, {} removed, {} deferred)",
+                supplement_path.display(),
+                update.supplement.models.len(),
+                update.drafted.len(),
+                update.retained.len(),
+                update.removed.len(),
+                update.deferred.len()
+            );
+            println!("Summary   → {}", summary_path.display());
             if !report.stale_holon.is_empty() {
                 eprintln!("WARNING: stale mappings (models.dev ID not in snapshot):");
                 for entry in &report.stale_holon {
@@ -3098,6 +3147,20 @@ async fn handle_models_dev_command(command: ModelsDevCommands) -> Result<()> {
                     "WARNING: {} stale mapping(s) need attention",
                     report.stale_holon.len()
                 );
+            }
+            let supplement_path = input_dir.join("supplemental_catalog.json");
+            if supplement_path.exists() {
+                let raw = std::fs::read_to_string(&supplement_path)
+                    .map_err(|e| anyhow!("failed to read supplement: {e}"))?;
+                let supplement = holon::model_catalog::models_dev::ModelsDevSupplement::parse(&raw)
+                    .map_err(|e| anyhow!("supplement validation failed: {e}"))?;
+                let legacy = holon::model_catalog::legacy_builtin_catalog()
+                    .map_err(|e| anyhow!("built-in catalog invalid: {e}"))?;
+                let mut catalog = legacy.clone();
+                supplement
+                    .apply_to(&mut catalog)
+                    .map_err(|e| anyhow!("supplement validation failed: {e}"))?;
+                println!("Supplement valid ({} models)", supplement.models.len());
             }
             Ok(())
         }

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -22,6 +22,10 @@ pub enum ModelMetadataSource {
     ConservativeBuiltin,
     ConfigOverride,
     RemoteDiscovered,
+    /// Checked-in `models.dev/supplemental_catalog.json` entry, drafted by
+    /// `holon models-dev refresh` for already-supported providers and
+    /// admitted through PR review.
+    ModelsDevSupplement,
     UnknownFallback,
 }
 
@@ -573,9 +577,9 @@ impl BuiltInModelCatalog {
 
     #[cfg(test)]
     fn from_legacy_definitions() -> Self {
+        let mut route_entries = HashMap::new();
         let mut entries = HashMap::new();
         let mut preferred_models = HashMap::new();
-        let mut route_entries = HashMap::new();
         let mut preferred_routes = HashMap::new();
         let mut preferred_routes_by_model = HashMap::new();
         let mut aliases = Self::legacy_aliases();
@@ -1532,6 +1536,14 @@ impl BuiltInModelCatalog {
     }
 }
 
+/// The compiled-in built-in catalog without the models.dev supplemental
+/// entries. This is the drafting baseline for
+/// `models_dev::supplement::generate` and the collision-check base for
+/// `holon models-dev validate`.
+pub fn legacy_builtin_catalog() -> Result<BuiltInModelCatalog, String> {
+    snapshot::legacy_catalog()
+}
+
 impl Default for BuiltInModelCatalog {
     fn default() -> Self {
         Self::new()
@@ -1725,6 +1737,13 @@ fn default_verbosity_for_model(model_ref: &ModelRef) -> Option<ModelVerbosity> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn curated_catalog() -> BuiltInModelCatalog {
+        // Curation-tracking tests document the compiled-in Rust catalog;
+        // models.dev supplement entries are a separate reviewed data layer.
+        legacy_builtin_catalog().expect("legacy catalog must be valid")
+    }
+
     use crate::provider::{provider_definitions, ProviderCatalogPolicy, ProviderMaterializer};
 
     fn base_context() -> ContextConfig {
@@ -1803,7 +1822,7 @@ mod tests {
 
     #[test]
     fn arcee_catalog_tracks_current_hosted_models_conservatively() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let arcee = ProviderId::parse("arcee").unwrap();
         let models = catalog
             .list()
@@ -1847,7 +1866,7 @@ mod tests {
 
     #[test]
     fn anthropic_catalog_tracks_current_generally_available_models() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let expected = [
             ("claude-fable-5", 1_000_000, 128_000),
             ("claude-opus-4-8", 1_000_000, 128_000),
@@ -1890,7 +1909,7 @@ mod tests {
 
     #[test]
     fn gemini_catalog_tracks_current_generate_content_models() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let expected = [
             "gemini-3.5-flash",
             "gemini-3.1-pro-preview",
@@ -1929,7 +1948,7 @@ mod tests {
 
     #[test]
     fn xai_catalog_tracks_current_recommended_models() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let expected = [
             (
                 "grok-4.3",
@@ -1980,7 +1999,7 @@ mod tests {
 
     #[test]
     fn deepseek_catalog_tracks_current_api_models() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
 
         for model in ["deepseek-v4-flash", "deepseek-v4-pro"] {
             let metadata = catalog
@@ -2160,7 +2179,7 @@ mod tests {
 
     #[test]
     fn resolves_anthropic_compatible_provider_model_policy() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
 
         let deepseek = catalog.resolve_policy(
             &ModelRef::parse("deepseek/deepseek-v4-flash").unwrap(),
@@ -2423,7 +2442,7 @@ mod tests {
 
     #[test]
     fn dashscope_catalog_tracks_current_modalities_and_reasoning() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let expected = [
             ("qwen3.5-plus", 1_000_000, true, true),
             ("qwen3.8-max-preview", 1_000_000, true, true),
@@ -2472,7 +2491,7 @@ mod tests {
 
     #[test]
     fn chutes_catalog_tracks_the_public_live_model_directory() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let expected = [
             ("moonshotai/Kimi-K2.6-TEE", 262_144, Some(65_535), true),
             ("zai-org/GLM-5.2-TEE", 1_048_576, Some(65_535), false),
@@ -2528,7 +2547,7 @@ mod tests {
 
     #[test]
     fn fireworks_catalog_tracks_current_serverless_chat_models() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let expected = [
             (
                 "accounts/fireworks/models/deepseek-v4-flash",
@@ -2603,7 +2622,7 @@ mod tests {
 
     #[test]
     fn nvidia_catalog_tracks_the_public_hosted_model_directory() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let expected = [
             ("nvidia/nemotron-3-super-120b-a12b", 1_000_000, false),
             ("moonshotai/kimi-k2.6", 262_144, true),
@@ -2643,7 +2662,7 @@ mod tests {
 
     #[test]
     fn together_catalog_tracks_current_serverless_chat_models() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let expected = [
             ("MiniMaxAI/MiniMax-M3", 524_288, false, true),
             ("MiniMaxAI/MiniMax-M2.7", 202_752, true, false),
@@ -2758,7 +2777,7 @@ mod tests {
 
     #[test]
     fn kilocode_catalog_tracks_the_current_auto_virtual_models() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let expected = [
             ("kilo-auto/frontier", 1_000_000, 128_000, true),
             ("kilo-auto/balanced", 1_000_000, 65_536, true),
@@ -2786,7 +2805,7 @@ mod tests {
 
     #[test]
     fn synthetic_catalog_tracks_current_always_on_models() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let synthetic = ProviderId::parse("synthetic").unwrap();
         let models = catalog
             .list()
@@ -2839,7 +2858,7 @@ mod tests {
 
     #[test]
     fn vercel_ai_gateway_catalog_tracks_current_picker_defaults() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let expected = [
             ("anthropic/claude-opus-4.6", 1_000_000, 128_000),
             ("openai/gpt-5.4", 1_050_000, 128_000),
@@ -2880,7 +2899,7 @@ mod tests {
 
     #[test]
     fn stepfun_catalog_tracks_current_chat_models_and_reasoning_controls() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let expected = [
             ("step-3.7-flash", true, &["low", "medium", "high"][..]),
             ("step-3.5-flash-2603", false, &["low", "high"][..]),
@@ -2988,7 +3007,7 @@ mod tests {
 
     #[test]
     fn minimax_catalog_tracks_current_anthropic_models_and_modalities() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let minimax = ProviderId::parse("minimax").unwrap();
         let models = catalog
             .list()
@@ -3034,7 +3053,7 @@ mod tests {
 
     #[test]
     fn qianfan_catalog_tracks_current_v2_models_limits_and_modalities() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let qianfan = ProviderId::parse("qianfan").unwrap();
         let models = catalog
             .list()
@@ -3740,7 +3759,7 @@ mod tests {
 
     #[test]
     fn moonshot_catalog_tracks_current_models_and_retirements() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let moonshot = ProviderId::parse("moonshot").unwrap();
         let models = catalog
             .list()
@@ -3816,7 +3835,7 @@ mod tests {
 
     #[test]
     fn mistral_catalog_tracks_current_models_and_retirements() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let mistral = ProviderId::parse("mistral").unwrap();
         let models = catalog
             .list()
@@ -3900,7 +3919,7 @@ mod tests {
 
     #[test]
     fn opencode_go_catalog_tracks_the_current_dual_transport_model_table() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let provider = provider_id("opencode-go");
         let models = catalog
             .list()
@@ -3979,7 +3998,7 @@ mod tests {
 
     #[test]
     fn tencent_tokenhub_catalog_tracks_current_language_and_image_understanding_models() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let provider = provider_id("tencent-tokenhub");
         let models = catalog
             .list()
@@ -4043,7 +4062,7 @@ mod tests {
 
     #[test]
     fn venice_catalog_tracks_stable_trait_defaults() {
-        let catalog = BuiltInModelCatalog::new();
+        let catalog = curated_catalog();
         let provider = provider_id("venice");
         let models = catalog
             .list()

--- a/src/model_catalog/models_dev/dto.rs
+++ b/src/model_catalog/models_dev/dto.rs
@@ -118,8 +118,18 @@ pub struct ModelsDevModel {
 pub struct ModelsDevReasoningOption {
     #[serde(default)]
     pub r#type: Option<String>,
-    #[serde(default)]
+    /// Null entries appear upstream (e.g. sarvam models) and are dropped.
+    #[serde(default, deserialize_with = "deserialize_reasoning_values")]
     pub values: Vec<String>,
+}
+
+/// Deserializes `Vec<String>` while dropping upstream `null` entries.
+fn deserialize_reasoning_values<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Vec::<Option<String>>::deserialize(deserializer)?;
+    Ok(raw.into_iter().flatten().collect())
 }
 
 /// Input and output modalities.
@@ -156,10 +166,40 @@ pub struct ModelsDevCost {
 }
 
 /// Interleaved reasoning content configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+///
+/// The live `models.dev` API encodes this either as a boolean flag or as an
+/// object carrying the interleaved field name; both shapes deserialize into
+/// this struct (`enabled` records the boolean form).
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct ModelsDevInterleaved {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for ModelsDevInterleaved {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Raw {
+            Boolean(bool),
+            Object { field: Option<String> },
+        }
+        Ok(match Raw::deserialize(deserializer)? {
+            Raw::Boolean(enabled) => Self {
+                enabled: Some(enabled),
+                field: None,
+            },
+            Raw::Object { field } => Self {
+                enabled: None,
+                field,
+            },
+        })
+    }
 }
 
 #[cfg(test)]
@@ -236,6 +276,39 @@ mod tests {
         assert_eq!(
             model.modalities.as_ref().unwrap().input,
             vec!["text", "image"]
+        );
+    }
+
+    #[test]
+    fn parses_both_interleaved_shapes() {
+        let json = r#"{
+            "bool-provider": {
+                "id": "bool-provider",
+                "models": {
+                    "m": {"id": "m", "interleaved": true}
+                }
+            },
+            "obj-provider": {
+                "id": "obj-provider",
+                "models": {
+                    "m": {"id": "m", "interleaved": {"field": "reasoning_content"}}
+                }
+            }
+        }"#;
+        let snapshot: ModelsDevSnapshot = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            snapshot.providers["bool-provider"].models["m"].interleaved,
+            Some(ModelsDevInterleaved {
+                enabled: Some(true),
+                field: None
+            })
+        );
+        assert_eq!(
+            snapshot.providers["obj-provider"].models["m"].interleaved,
+            Some(ModelsDevInterleaved {
+                enabled: None,
+                field: Some("reasoning_content".to_string())
+            })
         );
     }
 

--- a/src/model_catalog/models_dev/mod.rs
+++ b/src/model_catalog/models_dev/mod.rs
@@ -15,20 +15,23 @@
 //!   (upstream revision, content SHA-256, adapter version).
 //! - [`mapping`] defines the versioned, Holon-owned provider mapping manifest
 //!   schema that connects `models.dev` provider IDs to Holon route identities.
+//! - [`supplement`] drafts new models for already-supported providers into a
+//!   checked-in supplemental catalog that the runtime merges after review.
 //! - [`validation`] validates a manifest against Holon's built-in provider
 //!   definitions and optionally a `models.dev` snapshot, producing a
 //!   deterministic report with rejection diagnostics.
 //! - [`audit_mappings`] compares provider mappings against a live snapshot
 //!   to surface unmapped upstream providers and stale Holon mappings.
 //!
-//! The runtime does not consume `models.dev` directly. CI uses this module
-//! to generate an immutable artifact that enters Holon through review and
-//! merge.
+//! The runtime never fetches `models.dev` at run time. CI uses this module
+//! to generate an immutable artifact and a supplemental catalog draft; both
+//! enter Holon through review and merge.
 
 pub mod artifact;
 pub mod dto;
 pub mod mapping;
 pub mod projection;
+pub mod supplement;
 pub mod validation;
 
 pub use artifact::{
@@ -45,6 +48,10 @@ pub use mapping::{
     MAPPING_SCHEMA_VERSION,
 };
 pub use projection::{ProjectedModel, ProjectionResult, Projector, ProviderMapping, UnmappedModel};
+pub use supplement::{
+    render_summary_markdown, DeferredModel, DeferredReason, ModelsDevSupplement, RemovalReason,
+    RemovedModel, SupplementUpdate, AUTO_SUPPLEMENT_PROVIDERS, RECENCY_WINDOW_DAYS,
+};
 pub use validation::{ValidationEngine, ValidationEntry, ValidationReport, ValidationSeverity};
 
 /// Parses a `models.dev` JSON snapshot from raw bytes.

--- a/src/model_catalog/models_dev/projection.rs
+++ b/src/model_catalog/models_dev/projection.rs
@@ -193,15 +193,28 @@ impl Default for Projector {
     }
 }
 
-fn project_model(model_ref: &ModelRef, model: &ModelsDevModel) -> BuiltInModelMetadata {
+/// Projects one upstream model into Holon metadata using the shared
+/// conservative projection rules. Also used by the supplemental catalog
+/// generator, which overrides the provenance source afterwards.
+pub(super) fn project_model(model_ref: &ModelRef, model: &ModelsDevModel) -> BuiltInModelMetadata {
     let display_name = model.name.clone().unwrap_or_else(|| model.id.clone());
     let description = model
         .description
         .clone()
         .unwrap_or_else(|| format!("Holon projected metadata for {}.", model.id));
 
-    let context_window_tokens = model.limit.as_ref().and_then(|l| l.context);
-    let default_max_output_tokens = model.limit.as_ref().and_then(|l| l.output);
+    // Upstream reports `0` limits for some models; treat them as unknown
+    // instead of projecting invalid token limits.
+    let context_window_tokens = model
+        .limit
+        .as_ref()
+        .and_then(|l| l.context)
+        .filter(|v| *v > 0);
+    let default_max_output_tokens = model
+        .limit
+        .as_ref()
+        .and_then(|l| l.output)
+        .filter(|v| *v > 0);
     let max_output_tokens_upper_limit = default_max_output_tokens;
 
     let auto_compact_token_limit = context_window_tokens

--- a/src/model_catalog/models_dev/supplement.rs
+++ b/src/model_catalog/models_dev/supplement.rs
@@ -1,0 +1,726 @@
+//! Supplemental catalog drafting from `models.dev`.
+//!
+//! The supplement turns the weekly refresh from a passive radar into a
+//! review-gated supply line for already-supported providers:
+//!
+//! - Only providers on [`AUTO_SUPPLEMENT_PROVIDERS`] get auto-drafted.
+//!   Aggregators and gateways stay out; their offerings remain audit data.
+//! - Only models missing from the compiled-in legacy catalog are drafted;
+//!   existing Holon entries are never overridden by upstream metadata.
+//! - A model must emit `text` output and carry a `release_date` (or
+//!   `last_updated`) inside [`RECENCY_WINDOW_DAYS`] to be drafted. The
+//!   window gates entry only: admitted entries are retained while they
+//!   remain in the upstream snapshot, so the catalog does not flap.
+//! - Generation is incremental: the previous checked-in supplement is the
+//!   retention baseline; entries disappear only when the model vanishes
+//!   upstream or is promoted into the legacy catalog.
+//!
+//! The runtime merges the checked-in supplement into the built-in catalog
+//! (see `model_catalog::snapshot`). Nothing becomes callable without PR
+//! review and merge; the supplement never changes routes, credentials, or
+//! provider enablement.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::{ModelRef, ModelRouteRef, ProviderEndpointId};
+use crate::model_catalog::{
+    BuiltInModelCatalog, BuiltInModelMetadata, BuiltInModelRoutePolicy, ModelMetadataSource,
+};
+
+use super::dto::{ModelsDevModel, ModelsDevSnapshot};
+use super::projection::{project_model, ProviderMapping};
+
+pub const SUPPLEMENT_SCHEMA_VERSION: u32 = 1;
+
+/// models.dev provider IDs whose new models are auto-drafted into the
+/// supplemental catalog. Curated first-party and primary-hosted providers
+/// only; aggregators (openrouter, huggingface, nvidia, venice, nearai,
+/// together, fireworks, chutes, arcee) deliberately stay out because their
+/// catalogs mirror other providers and would flood review with duplicates.
+pub const AUTO_SUPPLEMENT_PROVIDERS: &[&str] = &[
+    "anthropic",
+    "openai",
+    "google",
+    "xai",
+    "deepseek",
+    "moonshotai",
+    "zhipuai",
+    "zai",
+    "minimax",
+    "alibaba",
+    "xiaomi",
+    "stepfun",
+    "volcengine",
+    "mistral",
+];
+
+/// How many days back a model's upstream release date may lie and still be
+/// auto-drafted. Gates entry only; retention is sticky.
+pub const RECENCY_WINDOW_DAYS: i64 = 120;
+
+/// The checked-in supplemental catalog DTO.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ModelsDevSupplement {
+    pub schema_version: u32,
+    /// SHA-256 of the `models.dev/api.json` payload this supplement was
+    /// generated from.
+    #[serde(default)]
+    pub upstream_revision: String,
+    /// Holon crate version of the generator.
+    #[serde(default)]
+    pub adapter_version: String,
+    pub models: Vec<BuiltInModelMetadata>,
+}
+
+impl ModelsDevSupplement {
+    /// The bootstrap supplement: valid, empty, no provenance.
+    pub fn empty() -> Self {
+        Self {
+            schema_version: SUPPLEMENT_SCHEMA_VERSION,
+            upstream_revision: String::new(),
+            adapter_version: String::new(),
+            models: Vec::new(),
+        }
+    }
+
+    /// Parses and structurally validates a supplement JSON document.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        let supplement = serde_json::from_str::<ModelsDevSupplement>(raw)
+            .map_err(|error| format!("failed to parse models.dev supplement: {error}"))?;
+        supplement.validate()?;
+        Ok(supplement)
+    }
+
+    /// Serializes deterministically (models sorted by model ref).
+    pub fn to_json(&self) -> Result<String, String> {
+        let mut sorted = self.clone();
+        sorted
+            .models
+            .sort_by_key(|model| model.model_ref.as_string());
+        serde_json::to_string_pretty(&sorted)
+            .map_err(|error| format!("failed to serialize models.dev supplement: {error}"))
+    }
+
+    /// Structural validation independent of the legacy catalog.
+    pub fn validate(&self) -> Result<(), String> {
+        for model in &self.models {
+            crate::model_catalog::snapshot::validate_model_entry(model)?;
+        }
+        if self.schema_version != SUPPLEMENT_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported supplement schema version {}; expected {SUPPLEMENT_SCHEMA_VERSION}",
+                self.schema_version
+            ));
+        }
+        if self.models.is_empty() {
+            return Ok(());
+        }
+        if self.upstream_revision.trim().is_empty() {
+            return Err("non-empty supplement must record upstream_revision".to_string());
+        }
+        if self.adapter_version.trim().is_empty() {
+            return Err("non-empty supplement must record adapter_version".to_string());
+        }
+        let mut seen = HashSet::new();
+        for model in &self.models {
+            if model.source != ModelMetadataSource::ModelsDevSupplement {
+                return Err(format!(
+                    "supplement model {} must declare source models_dev_supplement",
+                    model.model_ref.as_string()
+                ));
+            }
+            if model.endpoint.is_some() {
+                return Err(format!(
+                    "supplement model {} must not declare an endpoint",
+                    model.model_ref.as_string()
+                ));
+            }
+            if !seen.insert(model.model_ref.clone()) {
+                return Err(format!(
+                    "duplicate supplement model {}",
+                    model.model_ref.as_string()
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Validates this supplement against the compiled-in legacy catalog and
+    /// merges its entries (plus default-endpoint routes) into `catalog`.
+    pub fn apply_to(&self, catalog: &mut BuiltInModelCatalog) -> Result<(), String> {
+        self.validate()?;
+        for model in &self.models {
+            if catalog.entries.contains_key(&model.model_ref) {
+                return Err(format!(
+                    "supplement model {} collides with the built-in catalog",
+                    model.model_ref.as_string()
+                ));
+            }
+            if catalog.aliases.contains_key(&model.model_ref) {
+                return Err(format!(
+                    "supplement model {} collides with a built-in alias",
+                    model.model_ref.as_string()
+                ));
+            }
+        }
+        for model in &self.models {
+            let route_ref = ModelRouteRef::new(
+                model.model_ref.provider.clone(),
+                ProviderEndpointId::default_endpoint(),
+                model.model_ref.model.clone(),
+            );
+            catalog
+                .entries
+                .insert(model.model_ref.clone(), model.clone());
+            catalog
+                .route_entries
+                .entry(route_ref)
+                .or_insert_with(BuiltInModelRoutePolicy::default);
+        }
+        Ok(())
+    }
+}
+
+/// Why a candidate model was not auto-drafted.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeferredReason {
+    /// Output modalities do not include text (image/audio/embedding-only).
+    NotTextOutput,
+    /// Release date is older than the recency window.
+    ReleaseOutsideWindow,
+    /// No usable release date upstream; needs a human decision.
+    NoReleaseDate,
+    /// The model ref is a legacy alias key and cannot be shadowed.
+    LegacyAliasConflict,
+    /// The provider/model id pair cannot form a valid model ref.
+    InvalidModelRef,
+}
+
+/// Why a previous supplement entry disappeared from the new supplement.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RemovalReason {
+    /// The model was promoted into the compiled-in legacy catalog.
+    PromotedToLegacy,
+    /// The model vanished from the upstream snapshot.
+    MissingUpstream,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeferredModel {
+    pub model_ref: String,
+    pub reason: DeferredReason,
+    pub release_date: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemovedModel {
+    pub model_ref: String,
+    pub reason: RemovalReason,
+}
+
+/// The outcome of supplement generation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SupplementUpdate {
+    /// The complete regenerated supplement to check in.
+    pub supplement: ModelsDevSupplement,
+    /// Models drafted in this run (new since the previous supplement).
+    pub drafted: Vec<BuiltInModelMetadata>,
+    /// Model refs retained from the previous supplement.
+    pub retained: Vec<String>,
+    /// Model refs dropped from the previous supplement, with reasons.
+    pub removed: Vec<RemovedModel>,
+    /// Allowlisted candidates that were not drafted, with reasons.
+    pub deferred: Vec<DeferredModel>,
+    /// Mapped models.dev providers that are not on the supplement allowlist.
+    pub providers_not_allowlisted: Vec<String>,
+}
+
+/// Generates the next supplement from a snapshot and the previous state.
+///
+/// `cutoff` is the earliest `YYYY-MM-DD` release date still inside the
+/// recency window (ISO dates compare correctly as strings).
+pub fn generate(
+    snapshot: &ModelsDevSnapshot,
+    previous: Option<&ModelsDevSupplement>,
+    legacy: &BuiltInModelCatalog,
+    cutoff: &str,
+    upstream_revision: &str,
+    adapter_version: &str,
+) -> Result<SupplementUpdate, String> {
+    let default_mappings = ProviderMapping::default_mappings();
+    let mappings: BTreeMap<&str, &ProviderMapping> = default_mappings
+        .iter()
+        .map(|mapping| (mapping.models_dev_id.as_str(), mapping))
+        .collect();
+    let allowlist: BTreeSet<&str> = AUTO_SUPPLEMENT_PROVIDERS.iter().copied().collect();
+
+    let previous_entries: BTreeMap<String, &BuiltInModelMetadata> = previous
+        .map(|supplement| {
+            supplement
+                .models
+                .iter()
+                .map(|model| (model.model_ref.as_string(), model))
+                .collect()
+        })
+        .unwrap_or_default();
+    let mut remaining_previous: BTreeSet<String> = previous_entries.keys().cloned().collect();
+
+    let mut drafted: Vec<BuiltInModelMetadata> = Vec::new();
+    let mut retained: Vec<String> = Vec::new();
+    let mut deferred: Vec<DeferredModel> = Vec::new();
+    let mut promoted: Vec<String> = Vec::new();
+    let mut providers_not_allowlisted: Vec<String> = Vec::new();
+
+    for (md_provider_id, provider) in &snapshot.providers {
+        let Some(mapping) = mappings.get(md_provider_id.as_str()) else {
+            continue;
+        };
+        if !allowlist.contains(md_provider_id.as_str()) {
+            providers_not_allowlisted.push(md_provider_id.clone());
+            continue;
+        }
+        let holon_provider_id = mapping.holon_provider_id.clone();
+        for (md_model_id, model) in &provider.models {
+            let Ok(model_ref) =
+                ModelRef::parse(format!("{holon_provider_id}/{md_model_id}").as_str())
+            else {
+                deferred.push(DeferredModel {
+                    model_ref: format!("{holon_provider_id}/{md_model_id}"),
+                    reason: DeferredReason::InvalidModelRef,
+                    release_date: None,
+                });
+                continue;
+            };
+            let model_ref_string = model_ref.as_string();
+            if legacy.entries.contains_key(&model_ref) {
+                if remaining_previous.remove(&model_ref_string) {
+                    promoted.push(model_ref_string);
+                }
+                continue;
+            }
+            if legacy.aliases.contains_key(&model_ref) {
+                deferred.push(DeferredModel {
+                    model_ref: model_ref_string,
+                    reason: DeferredReason::LegacyAliasConflict,
+                    release_date: release_date_key(model).map(str::to_string),
+                });
+                continue;
+            }
+            if remaining_previous.remove(&model_ref_string) {
+                // Retained: refresh metadata from the current snapshot but
+                // keep the entry admitted.
+                retained.push(model_ref_string);
+                continue;
+            }
+            let Some(modalities) = model.modalities.as_ref() else {
+                deferred.push(DeferredModel {
+                    model_ref: model_ref_string,
+                    reason: DeferredReason::NotTextOutput,
+                    release_date: release_date_key(model).map(str::to_string),
+                });
+                continue;
+            };
+            if !modalities.output.iter().any(|m| m == "text") {
+                deferred.push(DeferredModel {
+                    model_ref: model_ref_string,
+                    reason: DeferredReason::NotTextOutput,
+                    release_date: release_date_key(model).map(str::to_string),
+                });
+                continue;
+            }
+            let Some(date_key) = release_date_key(model) else {
+                deferred.push(DeferredModel {
+                    model_ref: model_ref_string,
+                    reason: DeferredReason::NoReleaseDate,
+                    release_date: None,
+                });
+                continue;
+            };
+            if date_key < cutoff {
+                deferred.push(DeferredModel {
+                    model_ref: model_ref_string,
+                    reason: DeferredReason::ReleaseOutsideWindow,
+                    release_date: Some(date_key.to_string()),
+                });
+                continue;
+            }
+            let mut metadata = project_model(&model_ref, model);
+            metadata.source = ModelMetadataSource::ModelsDevSupplement;
+            metadata.endpoint = None;
+            drafted.push(metadata);
+        }
+    }
+
+    // Retained entries need re-projection from the current snapshot; collect
+    // them from the snapshot loop above is awkward, so rebuild here from the
+    // retained ref list.
+    let mut models: Vec<BuiltInModelMetadata> = drafted.clone();
+    for model_ref_string in &retained {
+        let model_ref = ModelRef::parse(model_ref_string)
+            .map_err(|error| format!("invalid retained model ref {model_ref_string}: {error}"))?;
+        let md_provider_id = mappings
+            .iter()
+            .find(|(_, mapping)| mapping.holon_provider_id == model_ref.provider.as_str())
+            .map(|(md_id, _)| md_id.to_string())
+            .ok_or_else(|| format!("retained model {model_ref_string} has no provider mapping"))?;
+        let provider = snapshot.providers.get(&md_provider_id).ok_or_else(|| {
+            format!("retained model {model_ref_string} lost its upstream provider")
+        })?;
+        let model = provider
+            .models
+            .get(model_ref.model.as_str())
+            .ok_or_else(|| format!("retained model {model_ref_string} lost its upstream entry"))?;
+        let mut metadata = project_model(&model_ref, model);
+        metadata.source = ModelMetadataSource::ModelsDevSupplement;
+        metadata.endpoint = None;
+        models.push(metadata);
+    }
+
+    let mut removed = remaining_previous
+        .into_iter()
+        .map(|model_ref_string| {
+            let is_promoted = ModelRef::parse(&model_ref_string)
+                .map(|model_ref| legacy.entries.contains_key(&model_ref))
+                .unwrap_or(false);
+            RemovedModel {
+                reason: if is_promoted {
+                    RemovalReason::PromotedToLegacy
+                } else {
+                    RemovalReason::MissingUpstream
+                },
+                model_ref: model_ref_string,
+            }
+        })
+        .collect::<Vec<_>>();
+    removed.extend(promoted.into_iter().map(|model_ref| RemovedModel {
+        model_ref,
+        reason: RemovalReason::PromotedToLegacy,
+    }));
+
+    models.sort_by_key(|model| model.model_ref.as_string());
+    retained.sort();
+    deferred.sort_by(|a, b| a.model_ref.cmp(&b.model_ref));
+    removed.sort_by(|a, b| a.model_ref.cmp(&b.model_ref));
+    providers_not_allowlisted.sort();
+
+    Ok(SupplementUpdate {
+        supplement: ModelsDevSupplement {
+            schema_version: SUPPLEMENT_SCHEMA_VERSION,
+            upstream_revision: upstream_revision.to_string(),
+            adapter_version: adapter_version.to_string(),
+            models,
+        },
+        drafted,
+        retained,
+        removed,
+        deferred,
+        providers_not_allowlisted,
+    })
+}
+
+fn release_date_key(model: &ModelsDevModel) -> Option<&str> {
+    model
+        .release_date
+        .as_deref()
+        .or(model.last_updated.as_deref())
+        .filter(|value| !value.trim().is_empty())
+}
+
+/// Renders the refresh PR summary markdown for a supplement update.
+pub fn render_summary_markdown(update: &SupplementUpdate) -> String {
+    const LIST_CAP: usize = 40;
+    let mut out = String::new();
+    out.push_str("# models.dev refresh summary\n\n");
+    out.push_str(&format!(
+        "- Supplement models: {} (drafted this run: {}, retained: {}, removed: {})\n",
+        update.supplement.models.len(),
+        update.drafted.len(),
+        update.retained.len(),
+        update.removed.len()
+    ));
+    out.push_str(&format!(
+        "- Deferred candidates: {} (not auto-drafted; see below)\n",
+        update.deferred.len()
+    ));
+    out.push_str(&format!(
+        "- Mapped providers without auto-supplement (aggregators etc.): {}\n",
+        update.providers_not_allowlisted.len()
+    ));
+
+    out.push_str("\n## Auto-drafted supplement models\n\n");
+    if update.drafted.is_empty() {
+        out.push_str("(none this run)\n");
+    } else {
+        for model in &update.drafted {
+            out.push_str(&format!(
+                "- `{}` — {} (context {}, reasoning {}, image input {})\n",
+                model.model_ref.as_string(),
+                model.display_name,
+                model
+                    .context_window_tokens
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "unknown".into()),
+                model.capabilities.supports_reasoning,
+                model.capabilities.image_input
+            ));
+        }
+    }
+
+    if !update.removed.is_empty() {
+        out.push_str("\n## Removed from previous supplement\n\n");
+        for removed in update.removed.iter().take(LIST_CAP) {
+            out.push_str(&format!(
+                "- `{}` — {:?}\n",
+                removed.model_ref, removed.reason
+            ));
+        }
+        if update.removed.len() > LIST_CAP {
+            out.push_str(&format!(
+                "- … and {} more\n",
+                update.removed.len() - LIST_CAP
+            ));
+        }
+    }
+
+    out.push_str("\n## Deferred (needs human decision or outside policy)\n\n");
+    if update.deferred.is_empty() {
+        out.push_str("(none)\n");
+    } else {
+        for deferred in update.deferred.iter().take(LIST_CAP) {
+            out.push_str(&format!(
+                "- `{}` — {:?} (release {})\n",
+                deferred.model_ref,
+                deferred.reason,
+                deferred.release_date.as_deref().unwrap_or("unknown")
+            ));
+        }
+        if update.deferred.len() > LIST_CAP {
+            out.push_str(&format!(
+                "- … and {} more (see `holon models-dev audit`)\n",
+                update.deferred.len() - LIST_CAP
+            ));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_catalog::snapshot;
+
+    fn snapshot_json() -> String {
+        r#"{
+            "mistral": {
+                "id": "mistral",
+                "models": {
+                    "magistral-small": {"id": "magistral-small", "release_date": "2026-08-30",
+                        "modalities": {"input": ["text"], "output": ["text"]}}
+                }
+            },
+            "xai": {
+                "id": "xai",
+                "models": {
+                    "grok-4.3": {"id": "grok-4.3", "name": "Grok 4.3", "release_date": "2026-01-10",
+                        "modalities": {"input": ["text"], "output": ["text"]}},
+                    "grok-new-9": {"id": "grok-new-9", "name": "Grok New 9", "release_date": "2026-08-30",
+                        "modalities": {"input": ["text", "image"], "output": ["text"]},
+                        "limit": {"context": 400000, "output": 64000}, "reasoning": true},
+                    "grok-old-1": {"id": "grok-old-1", "name": "Grok Old 1", "release_date": "2024-01-01",
+                        "modalities": {"input": ["text"], "output": ["text"]}},
+                    "grok-nodate": {"id": "grok-nodate", "name": "Grok No Date",
+                        "modalities": {"input": ["text"], "output": ["text"]}},
+                    "grok-image": {"id": "grok-image", "release_date": "2026-08-30",
+                        "modalities": {"input": ["text"], "output": ["image"]}},
+                    "grok-retained": {"id": "grok-retained", "name": "Grok Retained", "release_date": "2026-01-05",
+                        "modalities": {"input": ["text"], "output": ["text"]}}
+                }
+            },
+            "openrouter": {
+                "id": "openrouter",
+                "models": {
+                    "some/model": {"id": "some/model", "release_date": "2026-08-30",
+                        "modalities": {"input": ["text"], "output": ["text"]}}
+                }
+            }
+        }"#
+        .to_string()
+    }
+
+    fn legacy() -> BuiltInModelCatalog {
+        snapshot::legacy_catalog().expect("legacy catalog must parse")
+    }
+
+    fn supplement_metadata(model_ref: &str, display_name: &str) -> BuiltInModelMetadata {
+        BuiltInModelMetadata {
+            model_ref: ModelRef::parse(model_ref).unwrap(),
+            display_name: display_name.to_string(),
+            description: "supplement test entry".to_string(),
+            context_window_tokens: None,
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: None,
+            tool_output_truncation_estimated_tokens: Some(2_500),
+            capabilities: Default::default(),
+            reasoning_effort_options: Vec::new(),
+            source: ModelMetadataSource::ModelsDevSupplement,
+            endpoint: None,
+        }
+    }
+
+    fn previous() -> ModelsDevSupplement {
+        let metadata = supplement_metadata("xai/grok-retained", "Grok Retained");
+        let vanished = supplement_metadata("xai/grok-vanished", "Grok Vanished");
+        ModelsDevSupplement {
+            schema_version: SUPPLEMENT_SCHEMA_VERSION,
+            upstream_revision: "abc".into(),
+            adapter_version: "test".into(),
+            models: vec![metadata, vanished],
+        }
+    }
+
+    #[test]
+    fn drafts_only_recent_text_models_of_allowlisted_providers() {
+        let parsed: ModelsDevSnapshot = serde_json::from_str(&snapshot_json()).unwrap();
+        let update = generate(&parsed, None, &legacy(), "2026-05-05", "rev", "ver").unwrap();
+
+        let drafted_refs: Vec<String> = update
+            .drafted
+            .iter()
+            .map(|model| model.model_ref.as_string())
+            .collect();
+        assert_eq!(drafted_refs, vec!["xai/grok-new-9".to_string()]);
+        let drafted_model = &update.drafted[0];
+        assert_eq!(
+            drafted_model.source,
+            ModelMetadataSource::ModelsDevSupplement
+        );
+        assert_eq!(drafted_model.context_window_tokens, Some(400_000));
+        assert!(drafted_model.capabilities.supports_reasoning);
+        assert!(drafted_model.capabilities.image_input);
+
+        let deferred: Vec<(&str, DeferredReason)> = update
+            .deferred
+            .iter()
+            .map(|d| (d.model_ref.as_str(), d.reason))
+            .collect();
+        assert!(deferred.contains(&("xai/grok-old-1", DeferredReason::ReleaseOutsideWindow)));
+        assert!(deferred.contains(&("xai/grok-nodate", DeferredReason::NoReleaseDate)));
+        assert!(deferred.contains(&("xai/grok-image", DeferredReason::NotTextOutput)));
+        assert_eq!(
+            update.providers_not_allowlisted,
+            vec!["openrouter".to_string()]
+        );
+    }
+
+    #[test]
+    fn retains_sticky_entries_and_removes_missing_ones() {
+        let parsed: ModelsDevSnapshot = serde_json::from_str(&snapshot_json()).unwrap();
+        let prev = previous();
+        let update = generate(&parsed, Some(&prev), &legacy(), "2026-05-05", "rev", "ver").unwrap();
+
+        assert_eq!(update.retained, vec!["xai/grok-retained".to_string()]);
+        assert_eq!(update.drafted.len(), 1);
+        let refs: Vec<String> = update
+            .supplement
+            .models
+            .iter()
+            .map(|model| model.model_ref.as_string())
+            .collect();
+        assert_eq!(
+            refs,
+            vec![
+                "xai/grok-new-9".to_string(),
+                "xai/grok-retained".to_string()
+            ]
+        );
+        assert_eq!(
+            update.removed,
+            vec![RemovedModel {
+                model_ref: "xai/grok-vanished".into(),
+                reason: RemovalReason::MissingUpstream,
+            }]
+        );
+    }
+
+    #[test]
+    fn promotes_to_legacy_when_model_enters_builtin_catalog() {
+        let parsed: ModelsDevSnapshot = serde_json::from_str(&snapshot_json()).unwrap();
+        let mut prev = previous();
+        let metadata = supplement_metadata("xai/grok-4.3", "Grok 4.3");
+        prev.models.push(metadata);
+        let update = generate(&parsed, Some(&prev), &legacy(), "2026-05-05", "rev", "ver").unwrap();
+        assert!(update.removed.iter().any(|removed| {
+            removed.model_ref == "xai/grok-4.3" && removed.reason == RemovalReason::PromotedToLegacy
+        }));
+        assert!(!update
+            .supplement
+            .models
+            .iter()
+            .any(|model| model.model_ref.as_string() == "xai/grok-4.3"));
+    }
+
+    #[test]
+    fn defers_models_that_shadow_legacy_aliases() {
+        let parsed: ModelsDevSnapshot = serde_json::from_str(&snapshot_json()).unwrap();
+        let update = generate(&parsed, None, &legacy(), "2026-05-05", "rev", "ver").unwrap();
+        // mistral/magistral-small is a legacy alias; the snapshot lists it
+        // under xai here as an unmapped id, so only the alias path matters.
+        assert!(update
+            .deferred
+            .iter()
+            .any(|deferred| { deferred.reason == DeferredReason::LegacyAliasConflict }));
+    }
+
+    #[test]
+    fn supplement_round_trips_through_json() {
+        let parsed: ModelsDevSnapshot = serde_json::from_str(&snapshot_json()).unwrap();
+        let update = generate(
+            &parsed,
+            Some(&previous()),
+            &legacy(),
+            "2026-05-05",
+            "rev",
+            "ver",
+        )
+        .unwrap();
+        let json = update.supplement.to_json().unwrap();
+        let parsed_back = ModelsDevSupplement::parse(&json).unwrap();
+        assert_eq!(parsed_back, update.supplement);
+    }
+
+    #[test]
+    fn apply_to_rejects_collisions_and_inserts_routes() {
+        let parsed: ModelsDevSnapshot = serde_json::from_str(&snapshot_json()).unwrap();
+        let update = generate(&parsed, None, &legacy(), "2026-05-05", "rev", "ver").unwrap();
+        let mut catalog = legacy();
+        update.supplement.apply_to(&mut catalog).unwrap();
+        let model_ref = ModelRef::parse("xai/grok-new-9").unwrap();
+        assert!(catalog.get(&model_ref).is_some());
+        let route = catalog.get_route(&ModelRouteRef::parse("xai@default/grok-new-9").unwrap());
+        assert!(route.is_some());
+
+        // Collision: force the supplement to claim a legacy model.
+        let mut colliding = update.supplement.clone();
+        let metadata = supplement_metadata("xai/grok-4.3", "Grok 4.3");
+        colliding.models.push(metadata);
+        let error = colliding.apply_to(&mut legacy()).unwrap_err();
+        assert!(error.contains("collides with the built-in catalog"));
+    }
+
+    #[test]
+    fn empty_bootstrap_parses_and_applies() {
+        let json = serde_json::to_string_pretty(&ModelsDevSupplement::empty()).unwrap();
+        let parsed = ModelsDevSupplement::parse(&json).unwrap();
+        let mut catalog = legacy();
+        parsed.apply_to(&mut catalog).unwrap();
+        assert_eq!(catalog.list().len(), legacy().list().len());
+    }
+}

--- a/src/model_catalog/snapshot.rs
+++ b/src/model_catalog/snapshot.rs
@@ -9,6 +9,10 @@ use super::{
 
 const SCHEMA_VERSION: u32 = 1;
 const BUILT_IN_SNAPSHOT: &str = include_str!("builtin_snapshot_v1.json");
+/// Checked-in `models.dev` supplemental catalog. Drafted by
+/// `holon models-dev refresh` for allowlisted providers and admitted through
+/// PR review; the runtime merges it into the built-in catalog.
+const MODELS_DEV_SUPPLEMENT: &str = include_str!("../../models.dev/supplemental_catalog.json");
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -59,7 +63,20 @@ struct SnapshotPreferredModelRoute {
 }
 
 pub(super) fn built_in_catalog() -> Result<BuiltInModelCatalog, String> {
+    let mut catalog = legacy_catalog()?;
+    apply_models_dev_supplement(&mut catalog, MODELS_DEV_SUPPLEMENT)?;
+    Ok(catalog)
+}
+
+/// The compiled-in built-in snapshot without the models.dev supplement.
+/// Used as the drafting baseline by supplement generation and tests.
+pub(super) fn legacy_catalog() -> Result<BuiltInModelCatalog, String> {
     parse_and_validate(BUILT_IN_SNAPSHOT)
+}
+
+fn apply_models_dev_supplement(catalog: &mut BuiltInModelCatalog, raw: &str) -> Result<(), String> {
+    let supplement = crate::model_catalog::models_dev::supplement::ModelsDevSupplement::parse(raw)?;
+    supplement.apply_to(catalog)
 }
 
 fn parse_and_validate(raw: &str) -> Result<BuiltInModelCatalog, String> {
@@ -83,59 +100,7 @@ impl RegistrySnapshot {
 
         let mut models = HashMap::new();
         for model in &self.models {
-            if model.model_ref.model.trim().is_empty() {
-                return Err("model id must not be empty".to_string());
-            }
-            if model.endpoint.is_some() {
-                return Err(format!(
-                    "canonical model {} must not declare an endpoint",
-                    model.model_ref.as_string()
-                ));
-            }
-            if model.effective_context_window_percent == 0
-                || model.effective_context_window_percent > 100
-            {
-                return Err(format!(
-                    "model {} has invalid effective context window percent {}",
-                    model.model_ref.as_string(),
-                    model.effective_context_window_percent
-                ));
-            }
-            if model.context_window_tokens.is_some_and(|value| value == 0)
-                || model
-                    .default_max_output_tokens
-                    .is_some_and(|value| value == 0)
-                || model
-                    .max_output_tokens_upper_limit
-                    .is_some_and(|value| value == 0)
-            {
-                return Err(format!(
-                    "model {} token limits must be positive",
-                    model.model_ref.as_string()
-                ));
-            }
-            if let (Some(default), Some(upper)) = (
-                model.default_max_output_tokens,
-                model.max_output_tokens_upper_limit,
-            ) {
-                if default > upper {
-                    return Err(format!(
-                        "model {} default max output {default} exceeds upper limit {upper}",
-                        model.model_ref.as_string()
-                    ));
-                }
-            }
-            let mut reasoning_options = HashSet::new();
-            if model
-                .reasoning_effort_options
-                .iter()
-                .any(|option| !reasoning_options.insert(option))
-            {
-                return Err(format!(
-                    "model {} has duplicate reasoning effort options",
-                    model.model_ref.as_string()
-                ));
-            }
+            validate_model_entry(model)?;
             if models.insert(model.model_ref.clone(), model).is_some() {
                 return Err(format!("duplicate model {}", model.model_ref.as_string()));
             }
@@ -367,6 +332,63 @@ fn validate_preferred_routes(
     Ok(())
 }
 
+/// Per-model invariants shared by the built-in snapshot and the models.dev
+/// supplemental catalog.
+pub(super) fn validate_model_entry(model: &BuiltInModelMetadata) -> Result<(), String> {
+    if model.model_ref.model.trim().is_empty() {
+        return Err("model id must not be empty".to_string());
+    }
+    if model.endpoint.is_some() {
+        return Err(format!(
+            "canonical model {} must not declare an endpoint",
+            model.model_ref.as_string()
+        ));
+    }
+    if model.effective_context_window_percent == 0 || model.effective_context_window_percent > 100 {
+        return Err(format!(
+            "model {} has invalid effective context window percent {}",
+            model.model_ref.as_string(),
+            model.effective_context_window_percent
+        ));
+    }
+    if model.context_window_tokens.is_some_and(|value| value == 0)
+        || model
+            .default_max_output_tokens
+            .is_some_and(|value| value == 0)
+        || model
+            .max_output_tokens_upper_limit
+            .is_some_and(|value| value == 0)
+    {
+        return Err(format!(
+            "model {} token limits must be positive",
+            model.model_ref.as_string()
+        ));
+    }
+    if let (Some(default), Some(upper)) = (
+        model.default_max_output_tokens,
+        model.max_output_tokens_upper_limit,
+    ) {
+        if default > upper {
+            return Err(format!(
+                "model {} default max output {default} exceeds upper limit {upper}",
+                model.model_ref.as_string()
+            ));
+        }
+    }
+    let mut reasoning_options = HashSet::new();
+    if model
+        .reasoning_effort_options
+        .iter()
+        .any(|option| !reasoning_options.insert(option))
+    {
+        return Err(format!(
+            "model {} has duplicate reasoning effort options",
+            model.model_ref.as_string()
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -389,9 +411,40 @@ mod tests {
 
     #[test]
     fn built_in_snapshot_matches_legacy_catalog() {
-        let snapshot = built_in_catalog().expect("built-in snapshot must be valid");
+        let snapshot = legacy_catalog().expect("built-in snapshot must be valid");
         let legacy = BuiltInModelCatalog::from_legacy_definitions();
         assert_eq!(snapshot, legacy);
+    }
+
+    #[test]
+    fn built_in_catalog_includes_checked_in_supplement() {
+        let catalog = built_in_catalog().expect("built-in snapshot must be valid");
+        let supplement = crate::model_catalog::models_dev::supplement::ModelsDevSupplement::parse(
+            MODELS_DEV_SUPPLEMENT,
+        )
+        .expect("checked-in supplement must parse");
+        for model in &supplement.models {
+            let entry = catalog.get(&model.model_ref).unwrap_or_else(|| {
+                panic!(
+                    "supplement model {} must merge",
+                    model.model_ref.as_string()
+                )
+            });
+            assert_eq!(
+                entry.source,
+                crate::model_catalog::ModelMetadataSource::ModelsDevSupplement
+            );
+            let route = ModelRouteRef::new(
+                model.model_ref.provider.clone(),
+                crate::config::ProviderEndpointId::default_endpoint(),
+                model.model_ref.model.clone(),
+            );
+            assert!(
+                catalog.get_route(&route).is_some(),
+                "supplement model {} must have a default route",
+                model.model_ref.as_string()
+            );
+        }
     }
 
     #[test]

--- a/tests/models_dev_adapter.rs
+++ b/tests/models_dev_adapter.rs
@@ -130,13 +130,13 @@ fn artifact_json_roundtrips_through_serde() {
 }
 
 #[test]
-fn artifact_rejects_zero_context_window() {
+fn artifact_treats_zero_upstream_limits_as_unknown() {
     let json = r#"{
         "openai": {
             "id": "openai",
             "models": {
-                "bad-model": {
-                    "id": "bad-model",
+                "zero-limits-model": {
+                    "id": "zero-limits-model",
                     "limit": {"context": 0, "output": 128000}
                 }
             }
@@ -144,9 +144,16 @@ fn artifact_rejects_zero_context_window() {
     }"#;
     let snapshot = parse_snapshot(json).unwrap();
     let result = Projector::new().project(&snapshot).unwrap();
+    let model = result
+        .projected
+        .iter()
+        .find(|m| m.models_dev_model_id == "zero-limits-model")
+        .unwrap();
+    // Upstream reports 0 limits for some models; projection must treat them
+    // as unknown rather than emitting invalid token limits.
+    assert_eq!(model.metadata.context_window_tokens, None);
     let artifact = ArtifactBuilder::new("rev", "ts", b"raw", "v").build(&result);
-    // The artifact validate should catch zero context window.
-    assert!(artifact.validate().is_err());
+    assert!(artifact.validate().is_ok());
 }
 
 #[test]


### PR DESCRIPTION
## What changes

Turns the weekly models.dev refresh from discovery-only into a **review-gated supply line** for already-supported providers (proposal from the discussion in #2731 follow-up):

- `holon models-dev refresh` now regenerates `models.dev/supplemental_catalog.json`: for providers on a curated allowlist (`AUTO_SUPPLEMENT_PROVIDERS`, 14 first-party providers; aggregators like openrouter/huggingface/nvidia deliberately excluded), new upstream models are auto-drafted **only when** they are missing from the built-in catalog, emit text output, and were released inside a 120-day recency window. The window gates entry only — retention is sticky (entries stay while present upstream; dropped only when promoted into `builtin_snapshot_v1.json` or removed upstream).
- The runtime merges the checked-in supplement into the built-in catalog at startup: metadata plus one default-endpoint route per entry, `source = models_dev_supplement`, never overriding compiled-in entries, aliases, routes, credentials, or preferred models.
- The refresh PR body is now generated from `models.dev/refresh-summary.md` (drafted / retained / removed / deferred lists), so the audit summary is on the PR instead of only in workflow logs.
- Decision record: `docs/implementation-decisions/119-models-dev-supplemental-catalog.md`.

Expected first refresh run (validated locally against live `api.json`): **24 drafted models** including `xai/grok-4.6`, `anthropic/claude-opus-5`, `anthropic/claude-fable-5-1`, `gemini/gemini-3.6-flash`, `openai/gpt-5.6`, `volcengine/doubao-seed-2-1-*`; 172 deferred (dated snapshots / image-only / alias conflicts) stay listed for human decision.

## Latent bugs fixed (found while testing the chain end to end)

1. `models-dev refresh` used `reqwest::blocking` inside the async CLI handler → panicked ("Cannot drop a runtime…") on every invocation. Switched to the async client.
2. `cargo run -- models-dev …` could not pick a binary (`holon` vs `holon-docgen`) → both models.dev workflows would fail on first run. Added `default-run = "holon"`.
3. Live `api.json` parsing: `interleaved` arrives as bool *or* object; `reasoning_options[].values` can contain `null` (sarvam); zero token limits (336 models) must project as unknown instead of failing artifact validation.

## Runtime concept

Model metadata provenance gains a new `ModelMetadataSource::ModelsDevSupplement` layer between curated built-ins and runtime discovery: upstream data still never becomes callable config without PR review and merge; supplement entries carry no routes/credentials and only attach to already-supported providers.

## Verification

- `cargo fmt --all -- --check`, `RUSTFLAGS="-D warnings" cargo check --all-targets` — clean.
- `cargo test --lib models_dev`, `model_catalog`, `model_catalog::snapshot`, `cargo test --test models_dev_adapter` — pass (117 + 54 + 6 + 11).
- End-to-end local run: served live `api.json` over localhost, ran refresh into a scratch dir — 24 drafts, `grok-4.6` present with context 500k / reasoning / image-input / effort options; second run is idempotent (24 retained, 0 drafted/removed, byte-identical models).
- Runtime merge exercised with the real 24-model supplement checked in temporarily: all `model_catalog` tests pass; curation-tracking tests now assert against the legacy (curated) catalog via `curated_catalog()` so future refresh PRs don't break them.

## After merge

Dispatch `models.dev refresh` manually to validate the automated path end to end; the resulting PR should carry grok-4.6 and the other 23 drafts for review.