### PR TITLE
feat: add OIDC session issuance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +858,7 @@ dependencies = [
  "flate2",
  "hyper",
  "hyper-util",
+ "jsonwebtoken",
  "libc",
  "mime_guess",
  "percent-encoding",
@@ -1212,6 +1219,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1391,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1466,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1522,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2171,6 +2234,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,6 +2404,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,17 +1220,19 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -1684,7 +1686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1694,7 +1696,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1712,7 +1723,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2225,6 +2236,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3413,6 +3433,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.0"
 sha2 = "0.10"
+jsonwebtoken = "9"
 thiserror = "2.0"
 tokio = { version = "1.43", features = ["full"] }
 tokio-stream = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.0"
 sha2 = "0.10"
-jsonwebtoken = "9"
+jsonwebtoken = ">=10.3.0, <11"
 thiserror = "2.0"
 tokio = { version = "1.43", features = ["full"] }
 tokio-stream = "0.1"

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -161,6 +161,7 @@ pub struct LoginTransactionRecord {
     pub transaction_digest: String,
     pub state_digest: String,
     pub nonce_digest: String,
+    pub code_verifier: String,
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
     pub consumed_at: Option<DateTime<Utc>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod model_discovery;
 pub mod notes_catalog;
 pub mod object_query_cache;
 pub mod object_resolver;
+pub mod oidc;
 pub mod onboarding;
 pub mod onboarding_tui;
 pub mod openapi;

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -1,0 +1,416 @@
+//! OIDC authorization-code flow and session issuance.
+//!
+//! This module intentionally stops at issuing Holon sessions. HTTP handlers,
+//! cookies, and request extractors belong to the HTTP integration layer.
+
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use chrono::{DateTime, Utc};
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::authentication::{
+    digest_secret, AuthConfig, AuthSessionRecord, AuthUserRecord, LoginTransactionRecord,
+};
+use crate::runtime_db::RuntimeDb;
+
+const MAX_DISCOVERY_BYTES: u64 = 1024 * 1024;
+const MAX_JWKS_BYTES: u64 = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct OidcDiscovery {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    pub jwks_uri: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TokenResponse {
+    id_token: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Jwks {
+    keys: Vec<Jwk>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Jwk {
+    kid: Option<String>,
+    kty: String,
+    n: Option<String>,
+    e: Option<String>,
+    alg: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct IdTokenClaims {
+    iss: String,
+    sub: String,
+    aud: Audience,
+    exp: i64,
+    iat: Option<i64>,
+    nbf: Option<i64>,
+    nonce: Option<String>,
+    azp: Option<String>,
+    name: Option<String>,
+    preferred_username: Option<String>,
+    email: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum Audience {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl Audience {
+    fn contains(&self, value: &str) -> bool {
+        match self {
+            Self::One(aud) => aud == value,
+            Self::Many(aud) => aud.iter().any(|aud| aud == value),
+        }
+    }
+
+    fn requires_authorized_party(&self) -> bool {
+        matches!(self, Self::Many(_))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoginStart {
+    pub state: String,
+    pub nonce: String,
+    pub code_verifier: String,
+    pub authorization_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssuedSession {
+    pub credential: String,
+    pub record: AuthSessionRecord,
+}
+
+#[derive(Debug, Clone)]
+pub struct OidcClient {
+    pub config: AuthConfig,
+    pub http: reqwest::Client,
+}
+
+impl OidcClient {
+    pub fn new(config: AuthConfig) -> Result<Self> {
+        config.validate()?;
+        Ok(Self {
+            config,
+            http: reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .timeout(Duration::from_secs(10))
+                .build()?,
+        })
+    }
+
+    pub async fn discover(&self) -> Result<OidcDiscovery> {
+        let oidc = self
+            .config
+            .oidc
+            .as_ref()
+            .context("OIDC is not configured")?;
+        let issuer = Url::parse(&oidc.issuer_url)?;
+        let endpoint = issuer
+            .join(".well-known/openid-configuration")
+            .context("building OIDC discovery URL")?;
+        let response = self.http.get(endpoint).send().await?;
+        if !response.status().is_success() {
+            bail!("OIDC discovery failed with HTTP {}", response.status());
+        }
+        if response
+            .content_length()
+            .is_some_and(|size| size > MAX_DISCOVERY_BYTES)
+        {
+            bail!("OIDC discovery response is too large");
+        }
+        let document = response.bytes().await?;
+        if document.len() as u64 > MAX_DISCOVERY_BYTES {
+            bail!("OIDC discovery response is too large");
+        }
+        let discovery: OidcDiscovery =
+            serde_json::from_slice(&document).context("parsing OIDC discovery response")?;
+        if discovery.issuer.trim_end_matches('/') != oidc.issuer_url.trim_end_matches('/') {
+            bail!("OIDC discovery issuer does not match configured issuer");
+        }
+        for endpoint in [
+            &discovery.authorization_endpoint,
+            &discovery.token_endpoint,
+            &discovery.jwks_uri,
+        ] {
+            let url = Url::parse(endpoint)?;
+            if url.scheme() != "https" {
+                bail!("OIDC endpoints must use HTTPS");
+            }
+        }
+        Ok(discovery)
+    }
+
+    pub async fn begin_login(&self, db: &RuntimeDb, now: DateTime<Utc>) -> Result<LoginStart> {
+        let discovery = self.discover().await?;
+        let state = random_secret();
+        let nonce = random_secret();
+        let code_verifier = random_secret();
+        let transaction_digest = digest_secret(&random_secret());
+        let transaction = LoginTransactionRecord {
+            transaction_digest,
+            state_digest: digest_secret(&state),
+            nonce_digest: digest_secret(&nonce),
+            code_verifier: code_verifier.clone(),
+            created_at: now,
+            expires_at: now + chrono::Duration::minutes(10),
+            consumed_at: None,
+        };
+        db.authentication().insert_login_transaction(&transaction)?;
+
+        let oidc = self.config.oidc.as_ref().expect("validated OIDC config");
+        let redirect_uri = oidc
+            .redirect_uri
+            .as_deref()
+            .context("OIDC redirect_uri is required")?;
+        let challenge = pkce_challenge(&code_verifier);
+        let mut url = Url::parse(&discovery.authorization_endpoint)?;
+        url.query_pairs_mut()
+            .append_pair("response_type", "code")
+            .append_pair("client_id", &oidc.client_id)
+            .append_pair("redirect_uri", redirect_uri)
+            .append_pair("scope", "openid profile email")
+            .append_pair("state", &state)
+            .append_pair("nonce", &nonce)
+            .append_pair("code_challenge", &challenge)
+            .append_pair("code_challenge_method", "S256");
+        Ok(LoginStart {
+            state,
+            nonce,
+            code_verifier,
+            authorization_url: url.to_string(),
+        })
+    }
+
+    pub async fn complete_login(
+        &self,
+        db: &RuntimeDb,
+        state: &str,
+        code: &str,
+        now: DateTime<Utc>,
+    ) -> Result<IssuedSession> {
+        if code.is_empty() || state.is_empty() {
+            bail!("OIDC callback is missing required parameters");
+        }
+        let transaction = db
+            .authentication()
+            .consume_login_transaction(&digest_secret(state), now)?
+            .context("OIDC login transaction is invalid or expired")?;
+        let discovery = self.discover().await?;
+        let oidc = self.config.oidc.as_ref().expect("validated OIDC config");
+        let mut form = vec![
+            ("grant_type", "authorization_code".to_string()),
+            ("code", code.to_string()),
+            ("client_id", oidc.client_id.clone()),
+            (
+                "redirect_uri",
+                oidc.redirect_uri
+                    .clone()
+                    .context("OIDC redirect_uri is required")?,
+            ),
+            ("code_verifier", transaction.code_verifier.clone()),
+        ];
+        if let Some(env_name) = &oidc.client_secret_env {
+            let secret = std::env::var(env_name).with_context(|| {
+                format!("OIDC client secret environment variable {env_name} is missing")
+            })?;
+            form.push(("client_secret", secret));
+        }
+        let response = self
+            .http
+            .post(&discovery.token_endpoint)
+            .form(&form)
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            bail!("OIDC token exchange failed with HTTP {}", response.status());
+        }
+        let tokens: TokenResponse = response
+            .json()
+            .await
+            .context("parsing OIDC token response")?;
+        let claims = self
+            .validate_id_token(&discovery, &tokens.id_token, &transaction, now)
+            .await?;
+        let user_id = if let Some(user) = db.authentication().find_user(&claims.iss, &claims.sub)? {
+            user.user_id
+        } else {
+            format!("oidc-{}", Uuid::new_v4())
+        };
+        let display_name = claims
+            .name
+            .or(claims.preferred_username)
+            .or(claims.email.clone());
+        db.authentication().upsert_user(&AuthUserRecord {
+            user_id: user_id.clone(),
+            issuer: claims.iss,
+            subject: claims.sub,
+            display_name,
+            email: claims.email,
+            created_at: now,
+            updated_at: now,
+            disabled_at: None,
+        })?;
+        issue_session(db, &self.config, &user_id, "oidc", now)
+    }
+
+    async fn validate_id_token(
+        &self,
+        discovery: &OidcDiscovery,
+        token: &str,
+        transaction: &LoginTransactionRecord,
+        now: DateTime<Utc>,
+    ) -> Result<IdTokenClaims> {
+        let header = decode_header(token).context("invalid OIDC ID Token header")?;
+        let key_set = self.http.get(&discovery.jwks_uri).send().await?;
+        if !key_set.status().is_success() {
+            bail!("OIDC JWKS request failed with HTTP {}", key_set.status());
+        }
+        if key_set
+            .content_length()
+            .is_some_and(|size| size > MAX_JWKS_BYTES)
+        {
+            bail!("OIDC JWKS response is too large");
+        }
+        let bytes = key_set.bytes().await?;
+        if bytes.len() as u64 > MAX_JWKS_BYTES {
+            bail!("OIDC JWKS response is too large");
+        }
+        let keys: Jwks = serde_json::from_slice(&bytes).context("parsing OIDC JWKS response")?;
+        let jwk = keys
+            .keys
+            .iter()
+            .find(|key| {
+                key.kty == "RSA"
+                    && key.kid.as_deref() == header.kid.as_deref()
+                    && key.alg.as_deref().is_none_or(|alg| alg == "RS256")
+            })
+            .context("OIDC signing key was not found")?;
+        let key = DecodingKey::from_rsa_components(
+            jwk.n.as_deref().context("OIDC JWK is missing modulus")?,
+            jwk.e.as_deref().context("OIDC JWK is missing exponent")?,
+        )?;
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_issuer(&[discovery.issuer.as_str()]);
+        validation.set_audience(&[self
+            .config
+            .oidc
+            .as_ref()
+            .expect("validated")
+            .client_id
+            .as_str()]);
+        validation.leeway = 5;
+        let claims = decode::<IdTokenClaims>(token, &key, &validation)
+            .context("OIDC ID Token signature or claims validation failed")?
+            .claims;
+        let client_id = self
+            .config
+            .oidc
+            .as_ref()
+            .expect("validated")
+            .client_id
+            .as_str();
+        if claims.exp <= now.timestamp()
+            || claims.nbf.is_some_and(|value| value > now.timestamp() + 5)
+            || claims.iat.is_some_and(|value| value > now.timestamp() + 5)
+            || !claims.aud.contains(client_id)
+            || (claims.aud.requires_authorized_party() && claims.azp.as_deref() != Some(client_id))
+            || claims
+                .nonce
+                .as_deref()
+                .is_none_or(|nonce| digest_secret(nonce) != transaction.nonce_digest)
+        {
+            bail!("OIDC ID Token claims are invalid");
+        }
+        Ok(claims)
+    }
+}
+
+pub fn issue_session(
+    db: &RuntimeDb,
+    config: &AuthConfig,
+    user_id: &str,
+    auth_method: &str,
+    now: DateTime<Utc>,
+) -> Result<IssuedSession> {
+    config.session.validate()?;
+    let credential = random_secret();
+    let record = AuthSessionRecord {
+        session_digest: digest_secret(&credential),
+        user_id: user_id.to_string(),
+        auth_method: auth_method.to_string(),
+        created_at: now,
+        expires_at: now + chrono::Duration::seconds(config.session.absolute_ttl_seconds as i64),
+        last_seen_at: now,
+        revoked_at: None,
+    };
+    db.authentication().create_session(&record)?;
+    Ok(IssuedSession { credential, record })
+}
+
+pub fn exchange_bootstrap(
+    db: &RuntimeDb,
+    config: &AuthConfig,
+    credential: &str,
+    now: DateTime<Utc>,
+) -> Result<IssuedSession> {
+    let bootstrap = db
+        .authentication()
+        .consume_bootstrap_credential(&digest_secret(credential), now)?
+        .context("bootstrap credential is invalid or expired")?;
+    if bootstrap.scope != "session" && bootstrap.scope != "recovery" {
+        bail!("bootstrap credential cannot create a session");
+    }
+    let user_id = bootstrap
+        .user_id
+        .context("bootstrap credential has no user")?;
+    issue_session(db, config, &user_id, "bootstrap", now)
+}
+
+fn random_secret() -> String {
+    format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
+}
+
+fn pkce_challenge(verifier: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(verifier.as_bytes());
+    URL_SAFE_NO_PAD.encode(digest.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkce_uses_base64url_without_padding() {
+        let challenge = pkce_challenge("test-verifier");
+        assert!(!challenge.contains('='));
+        assert!(!challenge.contains('+'));
+        assert!(!challenge.contains('/'));
+    }
+
+    #[test]
+    fn audience_supports_single_and_multiple_values() {
+        assert!(Audience::One("client".into()).contains("client"));
+        assert!(Audience::Many(vec!["other".into(), "client".into()]).contains("client"));
+        assert!(!Audience::One("client".into()).requires_authorized_party());
+        assert!(Audience::Many(vec!["client".into(), "other".into()]).requires_authorized_party());
+    }
+}

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -21,6 +21,8 @@ use crate::runtime_db::RuntimeDb;
 
 const MAX_DISCOVERY_BYTES: u64 = 1024 * 1024;
 const MAX_JWKS_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_TOKEN_RESPONSE_BYTES: u64 = 1024 * 1024;
+const ID_TOKEN_LEEWAY_SECONDS: i64 = 5;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct OidcDiscovery {
@@ -242,10 +244,18 @@ impl OidcClient {
         if !response.status().is_success() {
             bail!("OIDC token exchange failed with HTTP {}", response.status());
         }
-        let tokens: TokenResponse = response
-            .json()
-            .await
-            .context("parsing OIDC token response")?;
+        if response
+            .content_length()
+            .is_some_and(|size| size > MAX_TOKEN_RESPONSE_BYTES)
+        {
+            bail!("OIDC token response is too large");
+        }
+        let token_response = response.bytes().await?;
+        if token_response.len() as u64 > MAX_TOKEN_RESPONSE_BYTES {
+            bail!("OIDC token response is too large");
+        }
+        let tokens: TokenResponse =
+            serde_json::from_slice(&token_response).context("parsing OIDC token response")?;
         let claims = self
             .validate_id_token(&discovery, &tokens.id_token, &transaction, now)
             .await?;
@@ -316,7 +326,7 @@ impl OidcClient {
             .expect("validated")
             .client_id
             .as_str()]);
-        validation.leeway = 5;
+        validation.leeway = ID_TOKEN_LEEWAY_SECONDS as u64;
         let claims = decode::<IdTokenClaims>(token, &key, &validation)
             .context("OIDC ID Token signature or claims validation failed")?
             .claims;
@@ -327,9 +337,13 @@ impl OidcClient {
             .expect("validated")
             .client_id
             .as_str();
-        if claims.exp <= now.timestamp()
-            || claims.nbf.is_some_and(|value| value > now.timestamp() + 5)
-            || claims.iat.is_some_and(|value| value > now.timestamp() + 5)
+        if claims.exp <= now.timestamp() - ID_TOKEN_LEEWAY_SECONDS
+            || claims
+                .nbf
+                .is_some_and(|value| value > now.timestamp() + ID_TOKEN_LEEWAY_SECONDS)
+            || claims
+                .iat
+                .is_some_and(|value| value > now.timestamp() + ID_TOKEN_LEEWAY_SECONDS)
             || !claims.aud.contains(client_id)
             || (claims.aud.requires_authorized_party() && claims.azp.as_deref() != Some(client_id))
             || claims

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -124,10 +124,11 @@ impl OidcClient {
             .oidc
             .as_ref()
             .context("OIDC is not configured")?;
-        let issuer = Url::parse(&oidc.issuer_url)?;
-        let endpoint = issuer
-            .join(".well-known/openid-configuration")
-            .context("building OIDC discovery URL")?;
+        let endpoint = Url::parse(&format!(
+            "{}/.well-known/openid-configuration",
+            oidc.issuer_url.trim_end_matches('/')
+        ))
+        .context("building OIDC discovery URL")?;
         let response = self.http.get(endpoint).send().await?;
         if !response.status().is_success() {
             bail!("OIDC discovery failed with HTTP {}", response.status());
@@ -260,6 +261,9 @@ impl OidcClient {
             .validate_id_token(&discovery, &tokens.id_token, &transaction, now)
             .await?;
         let user_id = if let Some(user) = db.authentication().find_user(&claims.iss, &claims.sub)? {
+            if user.disabled_at.is_some() {
+                bail!("OIDC principal is disabled");
+            }
             user.user_id
         } else {
             format!("oidc-{}", Uuid::new_v4())

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -57,7 +57,7 @@ struct IdTokenClaims {
     sub: String,
     aud: Audience,
     exp: i64,
-    iat: Option<i64>,
+    iat: i64,
     nbf: Option<i64>,
     nonce: Option<String>,
     azp: Option<String>,
@@ -82,7 +82,7 @@ impl Audience {
     }
 
     fn requires_authorized_party(&self) -> bool {
-        matches!(self, Self::Many(_))
+        matches!(self, Self::Many(aud) if aud.len() > 1)
     }
 }
 
@@ -109,6 +109,13 @@ pub struct OidcClient {
 impl OidcClient {
     pub fn new(config: AuthConfig) -> Result<Self> {
         config.validate()?;
+        if config
+            .oidc
+            .as_ref()
+            .is_some_and(|oidc| oidc.redirect_uri.is_none())
+        {
+            bail!("OIDC redirect_uri is required");
+        }
         Ok(Self {
             config,
             http: reqwest::Client::builder()
@@ -139,13 +146,11 @@ impl OidcClient {
         {
             bail!("OIDC discovery response is too large");
         }
-        let document = response.bytes().await?;
-        if document.len() as u64 > MAX_DISCOVERY_BYTES {
-            bail!("OIDC discovery response is too large");
-        }
+        let document =
+            read_limited_body(response, MAX_DISCOVERY_BYTES, "OIDC discovery response").await?;
         let discovery: OidcDiscovery =
             serde_json::from_slice(&document).context("parsing OIDC discovery response")?;
-        if discovery.issuer.trim_end_matches('/') != oidc.issuer_url.trim_end_matches('/') {
+        if discovery.issuer != oidc.issuer_url {
             bail!("OIDC discovery issuer does not match configured issuer");
         }
         for endpoint in [
@@ -251,10 +256,8 @@ impl OidcClient {
         {
             bail!("OIDC token response is too large");
         }
-        let token_response = response.bytes().await?;
-        if token_response.len() as u64 > MAX_TOKEN_RESPONSE_BYTES {
-            bail!("OIDC token response is too large");
-        }
+        let token_response =
+            read_limited_body(response, MAX_TOKEN_RESPONSE_BYTES, "OIDC token response").await?;
         let tokens: TokenResponse =
             serde_json::from_slice(&token_response).context("parsing OIDC token response")?;
         let claims = self
@@ -303,10 +306,7 @@ impl OidcClient {
         {
             bail!("OIDC JWKS response is too large");
         }
-        let bytes = key_set.bytes().await?;
-        if bytes.len() as u64 > MAX_JWKS_BYTES {
-            bail!("OIDC JWKS response is too large");
-        }
+        let bytes = read_limited_body(key_set, MAX_JWKS_BYTES, "OIDC JWKS response").await?;
         let keys: Jwks = serde_json::from_slice(&bytes).context("parsing OIDC JWKS response")?;
         let jwk = keys
             .keys
@@ -345,9 +345,7 @@ impl OidcClient {
             || claims
                 .nbf
                 .is_some_and(|value| value > now.timestamp() + ID_TOKEN_LEEWAY_SECONDS)
-            || claims
-                .iat
-                .is_some_and(|value| value > now.timestamp() + ID_TOKEN_LEEWAY_SECONDS)
+            || claims.iat > now.timestamp() + ID_TOKEN_LEEWAY_SECONDS
             || !claims.aud.contains(client_id)
             || (claims.aud.requires_authorized_party() && claims.azp.as_deref() != Some(client_id))
             || claims
@@ -370,12 +368,19 @@ pub fn issue_session(
 ) -> Result<IssuedSession> {
     config.session.validate()?;
     let credential = random_secret();
+    let ttl_seconds = i64::try_from(config.session.absolute_ttl_seconds)
+        .context("session absolute TTL is too large")?;
+    let ttl = chrono::Duration::try_seconds(ttl_seconds)
+        .context("session absolute TTL is out of range")?;
+    let expires_at = now
+        .checked_add_signed(ttl)
+        .context("session expiration is out of range")?;
     let record = AuthSessionRecord {
         session_digest: digest_secret(&credential),
         user_id: user_id.to_string(),
         auth_method: auth_method.to_string(),
         created_at: now,
-        expires_at: now + chrono::Duration::seconds(config.session.absolute_ttl_seconds as i64),
+        expires_at,
         last_seen_at: now,
         revoked_at: None,
     };
@@ -412,6 +417,31 @@ fn pkce_challenge(verifier: &str) -> String {
     URL_SAFE_NO_PAD.encode(digest.finalize())
 }
 
+async fn read_limited_body(
+    mut response: reqwest::Response,
+    max_bytes: u64,
+    description: &str,
+) -> Result<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|size| size > max_bytes)
+    {
+        bail!("{description} is too large");
+    }
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        let next_len = body
+            .len()
+            .checked_add(chunk.len())
+            .context("response body length overflow")?;
+        if u64::try_from(next_len).is_ok_and(|size| size > max_bytes) {
+            bail!("{description} is too large");
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -429,6 +459,7 @@ mod tests {
         assert!(Audience::One("client".into()).contains("client"));
         assert!(Audience::Many(vec!["other".into(), "client".into()]).contains("client"));
         assert!(!Audience::One("client".into()).requires_authorized_party());
+        assert!(!Audience::Many(vec!["client".into()]).requires_authorized_party());
         assert!(Audience::Many(vec!["client".into(), "other".into()]).requires_authorized_party());
     }
 }

--- a/src/runtime_db/authentication.rs
+++ b/src/runtime_db/authentication.rs
@@ -192,18 +192,62 @@ impl AuthenticationRepository<'_> {
             tx.execute(
                 "INSERT INTO auth_login_transactions (
                     transaction_digest, state_digest, nonce_digest,
-                    created_at, expires_at, consumed_at
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    code_verifier, created_at, expires_at, consumed_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                 params![
                     login.transaction_digest,
                     login.state_digest,
                     login.nonce_digest,
+                    login.code_verifier,
                     timestamp(login.created_at),
                     timestamp(login.expires_at),
                     login.consumed_at.map(timestamp),
                 ],
             )?;
             Ok(())
+        })
+    }
+
+    pub fn consume_login_transaction(
+        &self,
+        state_digest: &str,
+        consumed_at: DateTime<Utc>,
+    ) -> Result<Option<LoginTransactionRecord>> {
+        self.db.transaction(|tx| {
+            let updated = tx.execute(
+                "UPDATE auth_login_transactions
+                 SET consumed_at = ?2
+                 WHERE state_digest = ?1
+                   AND consumed_at IS NULL
+                   AND expires_at > ?2",
+                params![state_digest, timestamp(consumed_at)],
+            )?;
+            if updated == 0 {
+                return Ok(None);
+            }
+            tx.query_row(
+                "SELECT transaction_digest, state_digest, nonce_digest,
+                        code_verifier, created_at, expires_at, consumed_at
+                 FROM auth_login_transactions
+                 WHERE state_digest = ?1",
+                [state_digest],
+                |row| {
+                    Ok(LoginTransactionRecord {
+                        transaction_digest: row.get(0)?,
+                        state_digest: row.get(1)?,
+                        nonce_digest: row.get(2)?,
+                        code_verifier: row.get(3)?,
+                        created_at: parse_timestamp(row.get(4)?)?,
+                        expires_at: parse_timestamp(row.get(5)?)?,
+                        consumed_at: row
+                            .get::<_, Option<String>>(6)?
+                            .map(parse_timestamp)
+                            .transpose()?,
+                    })
+                },
+            )
+            .map(Some)
+            .context("reading consumed login transaction")
         })
     }
 }

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3216,6 +3216,13 @@ CREATE INDEX IF NOT EXISTS idx_auth_login_expiry
   ON auth_login_transactions (expires_at);
 "#,
     },
+    Migration {
+        version: 54,
+        name: "authentication_login_verifier",
+        sql: r#"
+ALTER TABLE auth_login_transactions ADD COLUMN code_verifier TEXT NOT NULL DEFAULT '';
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3219,9 +3219,10 @@ CREATE INDEX IF NOT EXISTS idx_auth_login_expiry
     Migration {
         version: 54,
         name: "authentication_login_verifier",
-        sql: r#"
-ALTER TABLE auth_login_transactions ADD COLUMN code_verifier TEXT NOT NULL DEFAULT '';
-"#,
+        // The column helper is idempotent for downgrade/re-upgrade paths that
+        // retain additive authentication schema while losing its migration
+        // record.
+        sql: "",
     },
 ];
 
@@ -3474,6 +3475,9 @@ fn apply_migration_transaction(transaction: &Transaction<'_>, migration: &Migrat
     if migration.name == "turn_owner_identity" {
         ensure_turn_owner_identity_schema(transaction)?;
     }
+    if migration.name == "authentication_login_verifier" {
+        ensure_authentication_login_verifier_schema(transaction)?;
+    }
     transaction.execute_batch(migration.sql)?;
     if migration.name == "execution_protocol_authority" {
         backfill_execution_protocol_authority(transaction)?;
@@ -3572,6 +3576,23 @@ fn ensure_turn_owner_identity_schema(transaction: &Transaction<'_>) -> Result<()
         "CREATE INDEX IF NOT EXISTS idx_turn_records_owner
            ON turn_records(agent_id, owner_kind, owner_id, turn_index, created_at);",
     )?;
+    Ok(())
+}
+
+fn ensure_authentication_login_verifier_schema(transaction: &Transaction<'_>) -> Result<()> {
+    if !table_exists_tx(transaction, "auth_login_transactions")? {
+        return Ok(());
+    }
+    let columns = transaction
+        .prepare("PRAGMA table_info(auth_login_transactions)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    if !columns.iter().any(|column| column == "code_verifier") {
+        transaction.execute_batch(
+            "ALTER TABLE auth_login_transactions
+             ADD COLUMN code_verifier TEXT NOT NULL DEFAULT '';",
+        )?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Issue #2735（PR 2/3）。在已合并的 session-first authentication foundation（#2744）之上实现 OIDC 登录和统一 session 建立能力：

- 新增 OIDC Discovery，并校验 issuer、HTTPS endpoint 与响应大小。
- 实现 Authorization Code Flow + PKCE，持久化并原子消费 login transaction。
- 校验 ID Token 的 RSA/RS256 签名、issuer、audience、azp、exp、nbf、iat 和 nonce。
- 将 OIDC `(issuer, subject)` 映射为本地用户，并签发 opaque Holon session。
- 支持一次性 bootstrap/recovery credential exchange 为 session。
- HTTP handler、cookie、API/SSE/TUI extractor 集成留给 PR3。

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test oidc --lib -- --nocapture`（4 tests passed）
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

## Security notes

- state、nonce、session 和 bootstrap credential 仅以 digest 形式持久化（PKCE verifier 按登录事务需要保存）。
- login transaction 与 bootstrap credential 均为一次性消费。
- provider token 不会进入日志或用户可见错误。

Follow-up: PR 3 将把 session 认证接入 HTTP/API/SSE/Web/TUI。