### PR TITLE
docs: update guides and reference for v0.30.0–v0.35.0

### DIFF
--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -40,6 +40,9 @@ holon --help
 
 Or download binaries from [GitHub Releases](https://github.com/holon-run/holon/releases/latest).
 
+macOS 13 or later users can install the universal `Holon-<version>.dmg` from
+the same release page for a native menu bar app with launch-at-login support.
+
 ### Configure a provider
 
 ```bash

--- a/docs/website/guides/tui.md
+++ b/docs/website/guides/tui.md
@@ -70,6 +70,7 @@ and `Enter` to select. Press `Esc` to dismiss.
 | `/agent create <name>` | Create a new agent |
 | `/agent start [id]` | Start an agent |
 | `/agent stop [id]` | Stop an agent |
+| `/agent delete [id]` | Delete an agent (optionally `--cascade-private-children`) |
 | `/model` | Open model picker for selected agent |
 | `/state` | Open agent state overlay |
 | `/abort` | Abort current agent run |

--- a/docs/website/guides/web-gui.md
+++ b/docs/website/guides/web-gui.md
@@ -39,6 +39,9 @@ The Dashboard provides a runtime overview:
   command, workdir, and output. Task events (creation, status updates,
   completion) refresh the list in real time.
 - **Quick actions** — create agents, attach workspaces, and view agent detail.
+- **Agent lifecycle** — start, stop, and delete agents directly from the
+  dashboard. Deleting an agent permanently removes it and its data, with an
+  option to also remove its private child agents.
 
 ### Agent Conversation
 
@@ -184,6 +187,8 @@ Configure Holon from the browser:
   automatically determines the right credential method for each provider
   (API key input for api_key providers, device login link for OAuth
   providers like Codex).
+- **Ollama discovery** — a locally running Ollama server is discovered
+  automatically with no API key; its models appear in the model selectors.
 - **Language** — switch the Web GUI display language. Supported languages are
   English (EN) and Simplified Chinese (ZH-CN). All UI text — navigation,
   buttons, labels, and status messages — updates in real time without a
@@ -227,6 +232,10 @@ When viewing an agent or the Dashboard, the right panel shows:
 The right panel also hosts contextual detail views. For example, clicking
 a task in the Dashboard opens a **Task Detail** panel showing status,
 kind, command, workdir, and output right alongside the main view.
+
+The right panel supports an expanded fullscreen mode, and the model menu
+renders through a fixed-position portal so it is never clipped by layout
+overflow.
 
 ## Remote Access
 

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -16,7 +16,7 @@ For scripting guidance, stability levels, and support policy, see
 ## Command Tree
 
 ```
-holon (v0.30.0)
+holon (v0.35.0)
 ├── serve        Start HTTP control plane server
 ├── onboard      Interactive setup wizard or secret-safe diagnostics
 ├── daemon       Background daemon lifecycle
@@ -39,8 +39,10 @@ holon (v0.30.0)
 │   │   ├── set    Store a credential
 │   │   ├── list   List stored credentials
 │   │   └── remove Remove a credential
-│   ├── models  Model catalog
-│   │   └── list List available models
+│   ├── models  Model catalog and discovery
+│   │   ├── list    List available models
+│   │   └── refresh Refresh discovered models for a provider
+│   ├── migrate-model-routes  Inspect/rewrite legacy model selections
 │   ├── list     List all current config
 │   ├── schema   Show all config keys with types and defaults
 │   └── doctor   Full system health check
@@ -66,6 +68,7 @@ holon (v0.30.0)
 │   ├── create   Create a new agent
 │   ├── start    Start an agent
 │   ├── stop     Stop an agent
+│   ├── delete   Permanently delete an agent and its data
 │   ├── abort    Abort current run
 │   └── model    Per-agent model configuration
 │       ├── get  Get agent model override
@@ -104,9 +107,16 @@ holon (v0.30.0)
 ├── memory-index Memory indexing management
 │   ├── status   Show indexing status
 │   └── rebuild  Rebuild the memory search index
+├── models-dev   models.dev snapshot refresh, validation, and audit
+│   ├── refresh  Fetch the snapshot and regenerate the artifact
+│   ├── validate Validate the checked-in snapshot and artifact
+│   └── audit    Audit provider mappings against a snapshot
 ├── debug        Debug utilities
 │   ├── prompt   Debug-mode prompt
 │   ├── latency  Show latency metrics
+│   ├── performance  Show performance metrics
+│   ├── runtime-db   Runtime database audit and retention
+│   ├── scheduler-recovery  Inspect/apply scheduler recovery
 │   └── scheduler-fixture Generate scheduler fixture data
 └── help         Print help
 ```
@@ -139,6 +149,7 @@ holon run --agent reviewer "Review src/runtime/turn.rs"
 holon agent start reviewer
 holon agent stop reviewer
 holon agent abort reviewer
+holon agent delete reviewer --yes
 ```
 
 > **Deprecated:** The `holon control` command has been replaced by
@@ -146,6 +157,11 @@ holon agent abort reviewer
 > The old `control` command is kept for backward compatibility only; see
 > [CLI stability policy](./cli-stability-policy.md#deprecated-holon-control)
 > for the compatibility and removal criteria.
+
+`holon agent delete` permanently removes an agent and its associated data.
+Pass `--cascade-private-children` to also remove its private child agents and
+`--wait` to block until the deletion job completes. It requires `--yes` in
+non-interactive mode.
 
 ### Model selection
 
@@ -164,6 +180,24 @@ accepted. Inspect or rewrite persisted legacy values with:
 holon config migrate-model-routes          # dry-run
 holon config migrate-model-routes --write  # validated canonical rewrite
 ```
+
+### models.dev provider mapping
+
+Holon ships a checked-in [models.dev](https://models.dev) snapshot and a
+versioned provider mapping manifest that reconciles upstream model metadata
+with Holon provider/route identities. The `holon models-dev` subcommands
+audit, validate, and refresh this snapshot:
+
+```bash
+holon models-dev validate        # validate the checked-in snapshot and artifact
+holon models-dev audit           # audit provider mappings against the snapshot
+holon models-dev audit --json    # machine-readable mapping audit report
+holon models-dev refresh         # fetch upstream and regenerate the artifact
+```
+
+`refresh` and `validate` target the repository's checked-in `models.dev/`
+files and are intended for Holon development and release automation. See
+[Supported Models](./models.md) for the runtime model catalog.
 
 ### Daemon management
 

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -199,6 +199,25 @@ holon config providers list
 
 Each provider entry shows its transport protocol (`anthropic_messages`, `openai_chat_completions`, etc.), base URL, and credential requirement.
 
+### Ollama (local)
+
+Holon includes a built-in [`ollama`](./models.md) provider for running models
+locally with [Ollama](https://ollama.com). It requires no API key and targets
+a local Ollama server at `http://127.0.0.1:11434` over the Anthropic Messages
+transport.
+
+1. Install and start Ollama, then pull a model, for example
+   `ollama pull qwen3.8:latest`.
+2. Select Ollama during `holon onboard`, or set it directly:
+
+```bash
+holon config set model.default "ollama/qwen3.8:latest"
+```
+
+The Web GUI discovers locally running Ollama models without any credential
+configuration, and `ViewImage` automatically discovers Ollama vision models
+for image analysis.
+
 ### Adding a Custom Provider
 
 ```bash

--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -7,7 +7,7 @@ generated: auto-generated from holon source — do not edit directly
 # Supported Models
 
 Holon includes built-in configuration for **34 provider accounts**
-across **43 endpoints** and **264 models**.
+across **43 endpoints** and **267 models**.
 
 This page is auto-generated from the Holon source code
 ([`src/model_catalog.rs`](../../../src/model_catalog.rs) and
@@ -103,6 +103,7 @@ and capabilities.
 | `bigmodel` | `glm-5.1` | `bigmodel/glm-5.1` | 204800 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5.2` | `bigmodel/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5.3` | `bigmodel/glm-5.3` | 1000000 | 131072 | ✅ | — |
+| `bigmodel` | `glm-5.3-flash` | `bigmodel/glm-5.3-flash` | 1000000 | 131072 | ✅ | ✅ |
 | `bigmodel` | `glm-5v-turbo` | `bigmodel/glm-5v-turbo` | 204800 | 131072 | ✅ | ✅ |
 | `chutes` | `MiniMaxAI/MiniMax-M2.5-TEE` | `chutes/MiniMaxAI/MiniMax-M2.5-TEE` | 196608 | 65536 | ✅ | — |
 | `chutes` | `Qwen/Qwen3-235B-A22B-Thinking-2507-TEE` | `chutes/Qwen/Qwen3-235B-A22B-Thinking-2507-TEE` | 262144 | 262144 | ✅ | — |
@@ -146,6 +147,7 @@ and capabilities.
 | `dashscope` | `qwen3.7-max-2026-06-08` | `dashscope/qwen3.7-max-2026-06-08` | 1000000 | 65536 | ✅ | — |
 | `dashscope` | `qwen3.7-plus` | `dashscope/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope` | `qwen3.7-plus-2026-05-26` | `dashscope/qwen3.7-plus-2026-05-26` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope` | `qwen3.8-flash` | `dashscope/qwen3.8-flash` | 1000000 | 131072 | ✅ | ✅ |
 | `dashscope` | `qwen3.8-max` | `dashscope/qwen3.8-max` | 1000000 | 131072 | ✅ | ✅ |
 | `dashscope` | `qwen3.8-max-preview` | `dashscope/qwen3.8-max-preview` | 1000000 | 65536 | ✅ | ✅ |
 | `deepseek` | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
@@ -340,4 +342,5 @@ and capabilities.
 | `zai` | `glm-5.1` | `zai/glm-5.1` | 202800 | 131072 | ✅ | — |
 | `zai` | `glm-5.2` | `zai/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `zai` | `glm-5.3` | `zai/glm-5.3` | 1000000 | 131072 | ✅ | — |
+| `zai` | `glm-5.3-flash` | `zai/glm-5.3-flash` | 1000000 | 131072 | ✅ | ✅ |
 | `zai` | `glm-5v-turbo` | `zai/glm-5v-turbo` | 202800 | 131072 | ✅ | ✅ |


### PR DESCRIPTION
## 概述

覆盖已发布版本 v0.30.0 → v0.35.0（当前稳定版 v0.35.0）的用户可见特性文档更新。`main` 上尚未 release 的特性（agent-aware CLI、session-first auth、models.dev supplemental catalog 等）未纳入本次。

## 变更（6 files, +73/-4）

| 文件 | 变更 |
|------|------|
| `reference/models.md` | 重生成：补 `glm-5.3-flash` / `qwen3.8-flash`（264 → 267 模型） |
| `reference/cli.md` | 命令树同步到 v0.35.0；新增 `holon agent delete`、`holon models-dev`（refresh/validate/audit）、`config models refresh`、`config migrate-model-routes`、`debug runtime-db / scheduler-recovery / performance` |
| `reference/configuration.md` | 新增一等 Ollama provider 小节（本地、免凭据、127.0.0.1:11434） |
| `guides/web-gui.md` | Agent 生命周期控制（stop/start/delete）、Settings 中 Ollama 免凭据发现、右面板全屏模式 + 模型菜单 portal |
| `guides/tui.md` | `/agent delete [id] [--cascade-private-children]` |
| `website/README.md` | macOS 菜单栏应用 DMG 安装方式（与根 README 对齐） |

## 说明

- `models.md` 通过 `cargo run --bin holon-docgen -- models` 重生成（基于 v0.35.0 的目录，未包含 main 上未发布的新模型）。
- v0.32.0 的 legacy scheduler 移除与数据库迁移在 `configuration.md` 的 Scheduler 节已覆盖，无需额外改动。