### PR TITLE
fix: make daemon startup readiness explicit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ axum = { version = "0.8", features = ["json"] }
 base64 = "0.22"
 arc-swap = "1.7"
 chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 crossterm = "0.28"
 encoding_rs = "0.8"
 hyper = { version = "1.5", features = ["server", "http1", "http2"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -317,6 +317,8 @@ pub enum DaemonCommands {
     Start {
         #[command(flatten)]
         options: ServeOptions,
+        #[arg(long, env = "HOLON_DAEMON_START_TIMEOUT_SECS", value_parser = clap::value_parser!(u64).range(1..=86400))]
+        start_timeout: Option<u64>,
     },
     Stop,
     #[command(hide = true)]
@@ -325,6 +327,8 @@ pub enum DaemonCommands {
     Restart {
         #[command(flatten)]
         options: ServeOptions,
+        #[arg(long, env = "HOLON_DAEMON_START_TIMEOUT_SECS", value_parser = clap::value_parser!(u64).range(1..=86400))]
+        start_timeout: Option<u64>,
     },
     Logs {
         #[arg(long, default_value_t = 80)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6,9 +6,10 @@ mod state;
 mod tests;
 
 pub use lifecycle::{
-    daemon_prepare_update, daemon_restart, daemon_start, daemon_status, daemon_stop,
-    ensure_serve_preflight, graceful_runtime_shutdown, prepare_runtime_before_server,
-    DAEMON_SERVE_ARGS_ENV, PRE_SERVER_PREPARED_ENV,
+    daemon_prepare_update, daemon_restart, daemon_restart_with_timeout, daemon_start,
+    daemon_start_with_timeout, daemon_status, daemon_stop, ensure_serve_preflight,
+    graceful_runtime_shutdown, prepare_runtime_before_server, DAEMON_SERVE_ARGS_ENV,
+    PRE_SERVER_PREPARED_ENV,
 };
 pub(crate) use service::runtime_activity_message;
 pub use service::{

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     ffi::{OsStr, OsString},
     fs,
     future::Future,
@@ -32,12 +33,14 @@ use super::{
     RuntimeServiceMetadata, RuntimeStatusResponse, DAEMON_CONTROL_PROTOCOL_VERSION,
 };
 
-const START_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_START_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_START_TIMEOUT_SECS: u64 = 24 * 60 * 60;
 const START_STABILITY_WINDOW: Duration = Duration::from_secs(2);
 const STOP_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 pub const PRE_SERVER_PREPARED_ENV: &str = "HOLON_PRE_SERVER_RUNTIME_PREPARED";
 pub const DAEMON_SERVE_ARGS_ENV: &str = "HOLON_DAEMON_SERVE_ARGS";
+pub const DAEMON_START_TIMEOUT_ENV: &str = "HOLON_DAEMON_START_TIMEOUT_SECS";
 const UNIX_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub(crate) fn web_url(http_addr: &str) -> String {
@@ -201,9 +204,20 @@ pub async fn daemon_start(
     serve_args: &[OsString],
     control_token_env: Option<&str>,
 ) -> Result<DaemonLifecycleResult> {
+    daemon_start_with_timeout(config, serve_args, control_token_env, None).await
+}
+
+pub async fn daemon_start_with_timeout(
+    config: &AppConfig,
+    serve_args: &[OsString],
+    control_token_env: Option<&str>,
+    start_timeout_secs: Option<u64>,
+) -> Result<DaemonLifecycleResult> {
     let _lock = lifecycle_lock(config).await?;
     persist_daemon_desired_running(config, true)?;
-    let mut result = daemon_start_unlocked(config, serve_args, control_token_env).await?;
+    let start_timeout = resolve_start_timeout(start_timeout_secs)?;
+    let mut result =
+        daemon_start_unlocked(config, serve_args, control_token_env, start_timeout).await?;
     result.status.desired_running = true;
     Ok(result)
 }
@@ -212,6 +226,7 @@ async fn daemon_start_unlocked(
     config: &AppConfig,
     serve_args: &[OsString],
     control_token_env: Option<&str>,
+    start_timeout: Duration,
 ) -> Result<DaemonLifecycleResult> {
     let current_fingerprint = config_fingerprint(config)?;
     match probe_runtime(config).await {
@@ -290,10 +305,10 @@ async fn daemon_start_unlocked(
     command.env(PRE_SERVER_PREPARED_ENV, "1");
     let mut child = command.spawn().context("failed to spawn 'holon serve'")?;
 
-    let deadline = tokio::time::Instant::now() + START_TIMEOUT;
+    let deadline = tokio::time::Instant::now() + start_timeout;
     loop {
         match probe_runtime(config).await {
-            ProbeRuntime::Running(status) => {
+            ProbeRuntime::Running(status) if status.healthy => {
                 if status.config_fingerprint != current_fingerprint {
                     let details = effective_config_mismatch_summary(config, &status);
                     best_effort_cleanup_spawned_start(config, &mut child).await;
@@ -343,6 +358,7 @@ async fn daemon_start_unlocked(
                     status: daemon_status(config).await?,
                 });
             }
+            ProbeRuntime::Running(_) => {}
             ProbeRuntime::Stopped { .. } => {}
             ProbeRuntime::Incompatible { details } => {
                 best_effort_cleanup_spawned_start(config, &mut child).await;
@@ -390,8 +406,9 @@ async fn daemon_start_unlocked(
                 &RuntimeFailureSummary {
                     occurred_at: Utc::now(),
                     summary: format!(
-                        "timed out waiting for runtime on {}",
-                        config.socket_path.display()
+                        "timed out waiting for healthy runtime on {} after {}s",
+                        config.socket_path.display(),
+                        start_timeout.as_secs()
                     ),
                     phase: RuntimeFailurePhase::Startup,
                     detail_hint: Some(daemon_log_hint()),
@@ -399,13 +416,30 @@ async fn daemon_start_unlocked(
                 },
             );
             return Err(anyhow!(
-                "timed out waiting for runtime on {}; {}",
+                "timed out waiting for healthy runtime on {} after {}s; {}",
                 config.socket_path.display(),
+                start_timeout.as_secs(),
                 daemon_log_hint()
             ));
         }
         tokio::time::sleep(POLL_INTERVAL).await;
     }
+}
+
+fn resolve_start_timeout(explicit_secs: Option<u64>) -> Result<Duration> {
+    let secs = explicit_secs
+        .or_else(|| {
+            env::var(DAEMON_START_TIMEOUT_ENV)
+                .ok()
+                .and_then(|value| value.parse().ok())
+        })
+        .unwrap_or(DEFAULT_START_TIMEOUT.as_secs());
+    if secs == 0 || secs > MAX_START_TIMEOUT_SECS {
+        return Err(anyhow!(
+            "daemon start timeout must be between 1 and {MAX_START_TIMEOUT_SECS} seconds"
+        ));
+    }
+    Ok(Duration::from_secs(secs))
 }
 
 pub fn prepare_runtime_before_server(config: &AppConfig) -> Result<()> {
@@ -617,6 +651,15 @@ pub async fn daemon_restart(
     serve_args: &[OsString],
     control_token_env: Option<&str>,
 ) -> Result<DaemonLifecycleResult> {
+    daemon_restart_with_timeout(config, serve_args, control_token_env, None).await
+}
+
+pub async fn daemon_restart_with_timeout(
+    config: &AppConfig,
+    serve_args: &[OsString],
+    control_token_env: Option<&str>,
+    start_timeout_secs: Option<u64>,
+) -> Result<DaemonLifecycleResult> {
     let _lock = lifecycle_lock(config).await?;
     persist_daemon_desired_running(config, true)?;
     match probe_runtime(config).await {
@@ -627,7 +670,9 @@ pub async fn daemon_restart(
             let _ = daemon_stop_unlocked(config).await?;
         }
     }
-    let mut started = daemon_start_unlocked(config, serve_args, control_token_env).await?;
+    let start_timeout = resolve_start_timeout(start_timeout_secs)?;
+    let mut started =
+        daemon_start_unlocked(config, serve_args, control_token_env, start_timeout).await?;
     started.status.desired_running = true;
     Ok(DaemonLifecycleResult {
         ok: true,

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -1,4 +1,11 @@
-use std::{env, fs, path::PathBuf, sync::Arc};
+use std::{
+    env, fs,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
@@ -282,10 +289,19 @@ pub struct RuntimeServiceHandle {
 struct RuntimeServiceInner {
     metadata: RuntimeServiceMetadata,
     shutdown_tx: watch::Sender<bool>,
+    healthy: AtomicBool,
 }
 
 impl RuntimeServiceHandle {
     pub fn new(config: &AppConfig) -> Result<Self> {
+        Self::new_with_health(config, true)
+    }
+
+    pub fn new_starting(config: &AppConfig) -> Result<Self> {
+        Self::new_with_health(config, false)
+    }
+
+    fn new_with_health(config: &AppConfig, healthy: bool) -> Result<Self> {
         let (shutdown_tx, _) = watch::channel(false);
         Ok(Self {
             inner: Arc::new(RuntimeServiceInner {
@@ -308,8 +324,13 @@ impl RuntimeServiceHandle {
                     control_token_env_configured: env::var_os("HOLON_CONTROL_TOKEN").is_some(),
                 },
                 shutdown_tx,
+                healthy: AtomicBool::new(healthy),
             }),
         })
+    }
+
+    pub fn mark_healthy(&self) {
+        self.inner.healthy.store(true, Ordering::Release);
     }
 
     pub fn status_response(
@@ -321,7 +342,7 @@ impl RuntimeServiceHandle {
     ) -> RuntimeStatusResponse {
         RuntimeStatusResponse {
             ok: true,
-            healthy: true,
+            healthy: self.inner.healthy.load(Ordering::Acquire),
             pid: self.inner.metadata.pid,
             home_dir: self.inner.metadata.home_dir.clone(),
             socket_path: self.inner.metadata.socket_path.clone(),
@@ -346,7 +367,7 @@ impl RuntimeServiceHandle {
     ) -> RuntimeStatusResponse {
         RuntimeStatusResponse {
             ok: true,
-            healthy: true,
+            healthy: self.inner.healthy.load(Ordering::Acquire),
             pid: self.inner.metadata.pid,
             home_dir: self.inner.metadata.home_dir.clone(),
             socket_path: self.inner.metadata.socket_path.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,9 +24,9 @@ use holon::{
     },
     config::{AgentTemplateRemoteSourceConfigFile, AgentTemplatesConfigFile},
     daemon::{
-        daemon_logs, daemon_prepare_update, daemon_restart, daemon_start, daemon_status,
-        daemon_stop, ensure_serve_preflight, prepare_runtime_before_server, RuntimeServiceHandle,
-        DAEMON_SERVE_ARGS_ENV, PRE_SERVER_PREPARED_ENV,
+        daemon_logs, daemon_prepare_update, daemon_restart_with_timeout, daemon_start_with_timeout,
+        daemon_status, daemon_stop, ensure_serve_preflight, prepare_runtime_before_server,
+        RuntimeServiceHandle, DAEMON_SERVE_ARGS_ENV, PRE_SERVER_PREPARED_ENV,
     },
     fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
     host::RuntimeHost,
@@ -865,6 +865,25 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
     }
 
     let host = RuntimeHost::new(config.clone())?;
+    let runtime_service = RuntimeServiceHandle::new_starting(&config)?;
+    #[cfg(unix)]
+    let unix_server = {
+        ensure_socket_parent(&config.socket_path)?;
+        let unix_listener = tokio::net::UnixListener::bind(&config.socket_path)
+            .with_context(|| format!("failed to bind {}", config.socket_path.display()))?;
+        runtime_service.write_state_files(&config)?;
+        println!("Holon control socket on {}", config.socket_path.display());
+        let unix_router = http::router(
+            AppState::for_unix_with_runtime_service(host.clone(), Some(runtime_service.clone()))
+                .with_web_dist(web_dist.clone()),
+        );
+        Some(tokio::spawn(http::serve_unix(
+            unix_listener,
+            unix_router,
+            runtime_service.shutdown_signal(),
+        )))
+    };
+
     host.recover_orphaned_queue_claims_at_startup().await?;
     let runtime = host.default_runtime().await?;
     host.spawn_daemon_memory_indexer();
@@ -872,7 +891,7 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
     host.spawn_daemon_deletion_coordinator();
     spawn_stale_agent_template_remote_source_sync(&config, &host);
     emit_first_run_intro(&config, &runtime).await;
-    let runtime_service = RuntimeServiceHandle::new(&config)?;
+    runtime_service.mark_healthy();
 
     let tcp_router = http::router(
         AppState::for_tcp_with_runtime_service(host.clone(), Some(runtime_service.clone()))
@@ -909,30 +928,34 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
 
     #[cfg(unix)]
     {
-        ensure_socket_parent(&config.socket_path)?;
-        let unix_listener = tokio::net::UnixListener::bind(&config.socket_path)
-            .with_context(|| format!("failed to bind {}", config.socket_path.display()))?;
-        runtime_service.write_state_files(&config)?;
-        println!("Holon control socket on {}", config.socket_path.display());
-        let unix_router = http::router(
-            AppState::for_unix_with_runtime_service(host.clone(), Some(runtime_service.clone()))
-                .with_web_dist(web_dist.clone()),
-        );
-        let tcp_server = axum::serve(listener, tcp_router)
-            .with_graceful_shutdown(wait_for_shutdown(runtime_service.shutdown_signal()));
-        let unix_server = http::serve_unix(
-            unix_listener,
-            unix_router,
-            runtime_service.shutdown_signal(),
-        );
+        let tcp_server = async {
+            axum::serve(listener, tcp_router)
+                .with_graceful_shutdown(wait_for_shutdown(runtime_service.shutdown_signal()))
+                .await
+                .context("TCP server failed")?;
+            Ok::<(), anyhow::Error>(())
+        };
+        let unix_server =
+            unix_server.expect("unix control server was initialized before runtime recovery");
+        let unix_server = async {
+            unix_server
+                .await
+                .context("unix control server task failed")??;
+            Ok::<(), anyhow::Error>(())
+        };
         let result = if let Some(local) = local_listener {
             let local_router = http::router(
                 AppState::for_tcp_with_runtime_service(host.clone(), Some(runtime_service.clone()))
                     .with_advertise_url(advertise_url.clone())
                     .with_web_dist(web_dist.clone()),
             );
-            let local_server = axum::serve(local, local_router)
-                .with_graceful_shutdown(wait_for_shutdown(runtime_service.shutdown_signal()));
+            let local_server = async {
+                axum::serve(local, local_router)
+                    .with_graceful_shutdown(wait_for_shutdown(runtime_service.shutdown_signal()))
+                    .await
+                    .context("localhost server failed")?;
+                Ok::<(), anyhow::Error>(())
+            };
             tokio::try_join!(tcp_server, unix_server, local_server)
                 .map(|_| ())
                 .context("runtime servers failed")
@@ -1231,7 +1254,7 @@ mod tests {
             "/tmp/holon.token",
         ]);
         let Commands::Daemon {
-            command: DaemonCommands::Start { options },
+            command: DaemonCommands::Start { options, .. },
         } = cli.command
         else {
             panic!("expected daemon start command");
@@ -3988,15 +4011,19 @@ fn format_duration_ms(duration_ms: u64) -> String {
 
 async fn handle_daemon_command(config: AppConfig, command: DaemonCommands) -> Result<()> {
     let value = match command {
-        DaemonCommands::Start { options } => {
+        DaemonCommands::Start {
+            options,
+            start_timeout,
+        } => {
             let mut config = config;
             let serve_launch = serve_args_for_options(&options);
             apply_serve_options(&mut config, options)?;
             serde_json::to_value(
-                daemon_start(
+                daemon_start_with_timeout(
                     &config,
                     &serve_launch.args,
                     serve_launch.control_token_env.as_deref(),
+                    start_timeout,
                 )
                 .await?,
             )?
@@ -4006,16 +4033,20 @@ async fn handle_daemon_command(config: AppConfig, command: DaemonCommands) -> Re
             serde_json::to_value(daemon_prepare_update(&config).await?)?
         }
         DaemonCommands::Status => serde_json::to_value(daemon_status(&config).await?)?,
-        DaemonCommands::Restart { options } => {
+        DaemonCommands::Restart {
+            options,
+            start_timeout,
+        } => {
             let mut config = config;
             let metadata = holon::daemon::load_daemon_metadata(&config)?;
             let serve_launch =
                 restart_serve_launch_options(&mut config, options, metadata.as_ref())?;
             serde_json::to_value(
-                daemon_restart(
+                daemon_restart_with_timeout(
                     &config,
                     &serve_launch.args,
                     serve_launch.control_token_env.as_deref(),
+                    start_timeout,
                 )
                 .await?,
             )?

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -108,17 +108,12 @@ fn spawn_local_serve(home: &tempfile::TempDir) -> (ServeChild, String) {
                             .trim_start_matches("Holon listening on ")
                             .to_string(),
                     );
-                } else if line.starts_with("Holon control socket on ") {
-                    let addr = addr.expect("serve should print TCP listener before control socket");
-                    return (ServeChild { child }, addr);
                 }
                 if line.starts_with("Holon listening on ") && addr.is_some() {
                     let Some(addr) = addr.clone() else {
                         unreachable!("addr should be set")
                     };
-                    if !cfg!(unix) {
-                        return (ServeChild { child }, addr);
-                    }
+                    return (ServeChild { child }, addr);
                 }
             }
             Ok(Err(error)) => panic!("read serve stdout: {error}"),

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -603,6 +603,13 @@
         "required": false
       },
       {
+        "long": "start-timeout",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
         "long": "token",
         "short": null,
         "default_value": null,
@@ -665,6 +672,13 @@
       },
       {
         "long": "port",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "start-timeout",
         "short": null,
         "default_value": null,
         "possible_values": null,


### PR DESCRIPTION
## Summary

Fixes #2754.

`daemon start` no longer treats the absence of a fully initialized runtime as a dead serve process. The control socket is exposed during startup, readiness reports `healthy=false` until recovery completes, and the CLI waits for the real healthy transition.

## Changes

- Expose the control service and PID/metadata before runtime recovery finishes.
- Add explicit startup state handling for readiness/status responses.
- Make daemon start timeout configurable via `--start-timeout` and `HOLON_DAEMON_START_TIMEOUT_SECS`.
- Keep startup probing alive while the daemon reports a starting/degraded state, and clean up only on an actual timeout or process failure.
- Update CLI contract tests and the command-tree snapshot.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `RUSTFLAGS="-D warnings" cargo test --all-targets`

All passed.

