### PR TITLE
feat: unify HTTP session-first authentication

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,41 @@
+# HTTP authentication
+
+Holon supports local control-token authentication and session-first OIDC
+authentication for its HTTP surface.
+
+## OIDC mode
+
+Configure an OIDC provider in the runtime configuration:
+
+```json
+{
+  "auth": {
+    "mode": "oidc",
+    "oidc": {
+      "issuer_url": "https://id.example.com",
+      "client_id": "holon",
+      "client_secret_env": "HOLON_OIDC_CLIENT_SECRET",
+      "redirect_uri": "https://holon.example/api/auth/oidc/callback"
+    },
+    "session": {
+      "absolute_ttl_seconds": 28800,
+      "idle_ttl_seconds": 1800
+    }
+  }
+}
+```
+
+`issuer_url` and OIDC endpoints must use HTTPS. A localhost callback may use
+HTTP for local development.
+
+Open `/api/auth/oidc/start` in a browser to begin login. The callback creates a
+session and sets the `holon_session` HttpOnly cookie before redirecting to `/`.
+The same session can be supplied to API clients as
+`Authorization: Bearer <session>`. `POST /api/auth/session/logout` revokes the
+current session and clears the cookie.
+
+In OIDC mode, normal API, SSE, and Web requests require an active session.
+Missing, expired, revoked, or disabled-user sessions return HTTP `401` with the
+`auth_required` error code. Bootstrap/session exchange, OIDC callback, callback
+ingress, and webhook routes retain their separate non-session credentials and
+are not treated as browser sessions.

--- a/src/http/auth.rs
+++ b/src/http/auth.rs
@@ -1,5 +1,123 @@
 use super::*;
 
+#[derive(Debug, Deserialize)]
+pub struct OidcCallbackQuery {
+    pub state: String,
+    pub code: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SessionExchangeRequest {
+    pub credential: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionResponse {
+    ok: bool,
+    expires_at: chrono::DateTime<Utc>,
+    user_id: String,
+}
+
+pub async fn start_oidc_login(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let config = state.host.config().auth.clone();
+    let client = crate::oidc::OidcClient::new(config).map_err(error_response)?;
+    let login = client
+        .begin_login(state.host.runtime_db(), Utc::now())
+        .await
+        .map_err(error_response)?;
+    let location = HeaderValue::from_str(&login.authorization_url)
+        .map_err(|error| error_response(anyhow!("invalid OIDC authorization URL: {error}")))?;
+    Ok((StatusCode::FOUND, [(LOCATION, location)]))
+}
+
+pub async fn complete_oidc_login(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<OidcCallbackQuery>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let config = state.host.config().auth.clone();
+    let client = crate::oidc::OidcClient::new(config).map_err(error_response)?;
+    let session = client
+        .complete_login(
+            state.host.runtime_db(),
+            &query.state,
+            &query.code,
+            Utc::now(),
+        )
+        .await
+        .map_err(error_response)?;
+    let cookie = format!(
+        "{}={}; Path=/; HttpOnly; SameSite=Lax",
+        SESSION_COOKIE_NAME, session.credential
+    );
+    Ok((
+        StatusCode::FOUND,
+        [
+            (LOCATION, HeaderValue::from_static("/")),
+            (
+                SET_COOKIE,
+                HeaderValue::from_str(&cookie)
+                    .map_err(|error| error_response(anyhow!("invalid session cookie: {error}")))?,
+            ),
+        ],
+    ))
+}
+
+pub async fn exchange_session(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<SessionExchangeRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    if request.credential.trim().is_empty() {
+        return Err(bad_request("credential must not be empty"));
+    }
+    let session = crate::oidc::exchange_bootstrap(
+        state.host.runtime_db(),
+        &state.host.config().auth,
+        &request.credential,
+        Utc::now(),
+    )
+    .map_err(error_response)?;
+    let cookie = format!(
+        "{}={}; Path=/; HttpOnly; SameSite=Lax",
+        SESSION_COOKIE_NAME, session.credential
+    );
+    Ok((
+        StatusCode::OK,
+        [(
+            SET_COOKIE,
+            HeaderValue::from_str(&cookie)
+                .map_err(|error| error_response(anyhow!("invalid session cookie: {error}")))?,
+        )],
+        Json(SessionResponse {
+            ok: true,
+            expires_at: session.record.expires_at,
+            user_id: session.record.user_id,
+        }),
+    ))
+}
+
+pub async fn logout(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let session =
+        authenticate_session(&headers, &state).map_err(|error| auth_required(error.to_string()))?;
+    state
+        .host
+        .runtime_db()
+        .authentication()
+        .revoke_session(&session.session_digest, Utc::now())
+        .map_err(error_response)?;
+    Ok((
+        StatusCode::NO_CONTENT,
+        [(
+            SET_COOKIE,
+            HeaderValue::from_static("holon_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax"),
+        )],
+    ))
+}
+
 #[derive(Debug, Serialize)]
 struct OAuthDeviceStartResponse {
     ok: bool,

--- a/src/http/auth.rs
+++ b/src/http/auth.rs
@@ -1,4 +1,5 @@
 use super::*;
+use url::Url;
 
 #[derive(Debug, Deserialize)]
 pub struct OidcCallbackQuery {
@@ -16,6 +17,23 @@ pub struct SessionResponse {
     ok: bool,
     expires_at: chrono::DateTime<Utc>,
     user_id: String,
+}
+
+fn session_cookie(state: &AppState, credential: &str) -> String {
+    let secure = state
+        .host
+        .config()
+        .auth
+        .oidc
+        .as_ref()
+        .and_then(|oidc| oidc.redirect_uri.as_deref())
+        .and_then(|redirect_uri| Url::parse(redirect_uri).ok())
+        .is_some_and(|redirect_uri| redirect_uri.scheme() == "https");
+    let secure_attribute = if secure { "; Secure" } else { "" };
+    format!(
+        "{}={}; Path=/; HttpOnly; SameSite=Lax{}",
+        SESSION_COOKIE_NAME, credential, secure_attribute
+    )
 }
 
 pub async fn start_oidc_login(
@@ -47,10 +65,7 @@ pub async fn complete_oidc_login(
         )
         .await
         .map_err(error_response)?;
-    let cookie = format!(
-        "{}={}; Path=/; HttpOnly; SameSite=Lax",
-        SESSION_COOKIE_NAME, session.credential
-    );
+    let cookie = session_cookie(&state, &session.credential);
     Ok((
         StatusCode::FOUND,
         [
@@ -78,10 +93,7 @@ pub async fn exchange_session(
         Utc::now(),
     )
     .map_err(error_response)?;
-    let cookie = format!(
-        "{}={}; Path=/; HttpOnly; SameSite=Lax",
-        SESSION_COOKIE_NAME, session.credential
-    );
+    let cookie = session_cookie(&state, &session.credential);
     Ok((
         StatusCode::OK,
         [(

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -12,10 +12,11 @@ pub(crate) use axum::{
     body::{Body, Bytes},
     extract::{DefaultBodyLimit, MatchedPath, Path, Query, State},
     http::{
-        header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE},
+        header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, COOKIE, LOCATION, SET_COOKIE},
         HeaderMap, HeaderName, HeaderValue, Method, Request as AxumRequest, Response, StatusCode,
         Uri,
     },
+    middleware::{from_fn_with_state, Next},
     response::{
         sse::{Event, KeepAlive, Sse},
         IntoResponse, Response as AxumResponse,
@@ -280,6 +281,7 @@ pub(crate) const CONTROL_PROMPT_BODY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
 pub(crate) const DEFAULT_EVENT_STREAM_WINDOW: usize = 128;
 pub const MAX_EVENT_STREAM_WINDOW: usize = 512;
 pub(crate) const EVENT_STREAM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+pub(crate) const SESSION_COOKIE_NAME: &str = "holon_session";
 
 impl AppState {
     pub fn for_tcp(host: RuntimeHost) -> Self {
@@ -547,6 +549,10 @@ pub fn router(state: AppState) -> Router {
             "/auth/{provider}/device/start",
             post(auth::start_oauth_device_login),
         )
+        .route("/auth/oidc/start", get(auth::start_oidc_login))
+        .route("/auth/oidc/callback", get(auth::complete_oidc_login))
+        .route("/auth/session/exchange", post(auth::exchange_session))
+        .route("/auth/session/logout", post(auth::logout))
         .route(
             "/control/runtime/credentials",
             get(control::list_credentials),
@@ -660,6 +666,10 @@ pub fn router(state: AppState) -> Router {
     let api_routes = api_routes
         .route("/search", post(agents::search))
         .route("/memory/get", post(agents::memory_get));
+    let api_routes = api_routes.layer(from_fn_with_state(
+        Arc::new(state.clone()),
+        session_auth_middleware,
+    ));
 
     Router::new()
         .nest("/api", api_routes)
@@ -869,6 +879,9 @@ pub(crate) fn projection_gate_error_response(error: ProjectionGateError) -> Axum
     }
 }
 pub(crate) fn authorize_control(headers: &HeaderMap, state: &AppState) -> Result<()> {
+    if state.host.config().auth.mode == crate::authentication::AuthenticationMode::Oidc {
+        return authenticate_session(headers, state).map(|_| ());
+    }
     if !state.require_control_token {
         return Ok(());
     }
@@ -881,11 +894,9 @@ pub(crate) fn authorize_control(headers: &HeaderMap, state: &AppState) -> Result
         .get(AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
         .ok_or_else(|| anyhow!("missing Authorization header"))?;
-    let prefix = "Bearer ";
-    if !provided.starts_with(prefix) {
-        return Err(anyhow!("invalid Authorization scheme"));
-    }
-    let token = &provided[prefix.len()..];
+    let token = provided
+        .strip_prefix("Bearer ")
+        .ok_or_else(|| anyhow!("invalid Authorization scheme"))?;
     if token != expected_token {
         return Err(anyhow!("invalid control token"));
     }
@@ -893,10 +904,100 @@ pub(crate) fn authorize_control(headers: &HeaderMap, state: &AppState) -> Result
 }
 
 pub(crate) fn authorize_remote_access(headers: &HeaderMap, state: &AppState) -> Result<()> {
-    if state.require_control_token {
+    if state.require_control_token
+        || state.host.config().auth.mode == crate::authentication::AuthenticationMode::Oidc
+    {
         authorize_control(headers, state)?;
     }
     Ok(())
+}
+
+pub(crate) fn session_credential(headers: &HeaderMap) -> Option<String> {
+    if let Some(value) = headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+    {
+        let mut parts = value.split_whitespace();
+        if parts
+            .next()
+            .is_some_and(|scheme| scheme.eq_ignore_ascii_case("Bearer"))
+        {
+            if let Some(token) = parts.next().filter(|token| !token.is_empty()) {
+                if parts.next().is_none() {
+                    return Some(token.to_string());
+                }
+            }
+        }
+    }
+    headers
+        .get(COOKIE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| {
+            value.split(';').find_map(|part| {
+                let (name, value) = part.trim().split_once('=')?;
+                (name == SESSION_COOKIE_NAME && !value.is_empty()).then(|| value.to_string())
+            })
+        })
+}
+
+pub(crate) fn authenticate_session(
+    headers: &HeaderMap,
+    state: &AppState,
+) -> Result<crate::authentication::AuthSessionRecord> {
+    let credential =
+        session_credential(headers).ok_or_else(|| anyhow!("missing session credential"))?;
+    let digest = crate::authentication::digest_secret(&credential);
+    let session = state
+        .host
+        .runtime_db()
+        .authentication()
+        .find_session(&digest)?
+        .ok_or_else(|| anyhow!("invalid or expired session"))?;
+    let config = state.host.config();
+    let now = Utc::now();
+    let idle_ttl = std::time::Duration::from_secs(config.auth.session.idle_ttl_seconds);
+    if !session.is_active_at(now, idle_ttl) {
+        return Err(anyhow!("session is expired or revoked"));
+    }
+    if state
+        .host
+        .runtime_db()
+        .authentication()
+        .find_user_by_id(&session.user_id)?
+        .is_some_and(|user| user.disabled_at.is_some())
+    {
+        return Err(anyhow!("session user is disabled"));
+    }
+    state
+        .host
+        .runtime_db()
+        .authentication()
+        .touch_session(&session.session_digest, now)?;
+    Ok(session)
+}
+
+async fn session_auth_middleware(
+    State(state): State<Arc<AppState>>,
+    request: AxumRequest<Body>,
+    next: Next,
+) -> AxumResponse {
+    let path = request.uri().path();
+    let api_path = path.strip_prefix("/api").unwrap_or(path);
+    let anonymous = matches!(
+        api_path,
+        "/auth/oidc/start" | "/auth/oidc/callback" | "/auth/session/exchange"
+    ) || api_path.starts_with("/callbacks/")
+        || api_path.starts_with("/webhooks/");
+
+    if state.host.config().auth.mode == crate::authentication::AuthenticationMode::Oidc
+        && !anonymous
+    {
+        if let Err(error) = authenticate_session(request.headers(), &state) {
+            return auth_required(error.to_string()).into_response();
+        }
+    }
+
+    next.run(request).await
 }
 
 pub(crate) fn into_origin(origin: IncomingOrigin) -> MessageOrigin {
@@ -977,10 +1078,10 @@ pub(crate) fn forbidden(reason: impl Into<String>) -> (StatusCode, Json<Value>) 
 
 pub(crate) fn auth_required(reason: impl Into<String>) -> (StatusCode, Json<Value>) {
     http_error(
-        StatusCode::FORBIDDEN,
+        StatusCode::UNAUTHORIZED,
         HttpErrorEnvelope::new(reason)
             .code("auth_required")
-            .hint("retry with an Authorization: Bearer <token> header"),
+            .hint("retry with an Authorization: Bearer <session> header or session cookie"),
     )
 }
 
@@ -1269,8 +1370,8 @@ pub async fn serve_unix(
 #[cfg(test)]
 mod tests {
     use super::{
-        error_response, projection_gate_error_response, router, AppState, ProjectionGate,
-        ProjectionGateError,
+        error_response, projection_gate_error_response, router, session_credential, AppState,
+        ProjectionGate, ProjectionGateError,
     };
     use crate::{
         config::AppConfig,
@@ -1280,7 +1381,7 @@ mod tests {
     };
     use axum::{
         body::{to_bytes, Body},
-        http::{header, Request, StatusCode},
+        http::{header, HeaderMap, HeaderValue, Request, StatusCode},
     };
     use std::{fs, sync::Arc, time::Duration};
     use tempfile::tempdir;
@@ -1297,6 +1398,68 @@ mod tests {
         let host =
             RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
         (home, host)
+    }
+
+    fn oidc_test_host() -> (tempfile::TempDir, RuntimeHost) {
+        let home = tempdir().unwrap();
+        fs::write(
+            home.path().join("config.json"),
+            r#"{
+                "auth": {
+                    "mode": "oidc",
+                    "oidc": {
+                        "issuer_url": "https://issuer.example",
+                        "client_id": "holon-test",
+                        "redirect_uri": "https://holon.example/api/auth/oidc/callback"
+                    }
+                },
+                "model": {"default": "openai/gpt-5.4"}
+            }"#,
+        )
+        .unwrap();
+        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let host =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
+        (home, host)
+    }
+
+    #[test]
+    fn session_credential_accepts_bearer_or_session_cookie() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer session-secret"),
+        );
+        assert_eq!(
+            session_credential(&headers).as_deref(),
+            Some("session-secret")
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_static("theme=dark; holon_session=cookie-secret"),
+        );
+        assert_eq!(
+            session_credential(&headers).as_deref(),
+            Some("cookie-secret")
+        );
+    }
+
+    #[test]
+    fn session_credential_rejects_empty_or_wrong_credentials() {
+        for value in ["Bearer ", "Basic session-secret"] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::AUTHORIZATION, HeaderValue::from_static(value));
+            assert!(session_credential(&headers).is_none(), "{value}");
+        }
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_static("holon_session=; theme=dark"),
+        );
+        assert!(session_credential(&headers).is_none());
     }
 
     #[tokio::test]
@@ -1321,6 +1484,49 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert_eq!(&body[..], b"<html>holon ui</html>");
+    }
+
+    #[tokio::test]
+    async fn oidc_routes_require_session_and_web_redirects_to_login() {
+        let (_home, host) = oidc_test_host();
+        let app = router(AppState::for_tcp(host));
+
+        let api_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(api_response.status(), StatusCode::UNAUTHORIZED);
+        let body: serde_json::Value = serde_json::from_slice(
+            &to_bytes(api_response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["code"], "auth_required");
+
+        let web_response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/")
+                    .header(header::ACCEPT, "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(web_response.status(), StatusCode::FOUND);
+        assert_eq!(
+            web_response.headers()[header::LOCATION],
+            "/api/auth/oidc/start"
+        );
     }
 
     #[tokio::test]
@@ -1357,7 +1563,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(response.status(), StatusCode::FORBIDDEN, "{uri}");
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{uri}");
             assert!(
                 !response.headers().contains_key(header::RETRY_AFTER),
                 "{uri}"

--- a/src/http/observer_sync.rs
+++ b/src/http/observer_sync.rs
@@ -874,7 +874,7 @@ mod tests {
             let mut state = AppState::for_tcp(host);
             state.require_control_token = true;
             let (status, body) = get_snapshot(state).await;
-            assert_eq!(status, StatusCode::FORBIDDEN);
+            assert_eq!(status, StatusCode::UNAUTHORIZED);
             assert_eq!(body["code"], "auth_required");
             assert!(body.get("agents").is_none());
         }
@@ -1225,7 +1225,7 @@ mod tests {
             let mut state = AppState::for_tcp(host);
             state.require_control_token = true;
             let (status, body) = get_projection_snapshot(state, "web").await;
-            assert_eq!(status, StatusCode::FORBIDDEN);
+            assert_eq!(status, StatusCode::UNAUTHORIZED);
             assert_eq!(body["code"], "auth_required");
             assert!(body.get("projection").is_none());
             assert!(body.get("runtime_id").is_none());

--- a/src/http/web.rs
+++ b/src/http/web.rs
@@ -15,6 +15,15 @@ pub async fn web_or_not_found_handler(
             }
         }
         if accepts_html(&headers) {
+            if state.host.config().auth.mode == crate::authentication::AuthenticationMode::Oidc
+                && super::authenticate_session(&headers, &state).is_err()
+            {
+                return (
+                    StatusCode::FOUND,
+                    [(LOCATION, HeaderValue::from_static("/api/auth/oidc/start"))],
+                )
+                    .into_response();
+            }
             if let Some(response) = web_asset_response(&state, "index.html", head_only).await {
                 return response;
             }

--- a/src/runtime_db/authentication.rs
+++ b/src/runtime_db/authentication.rs
@@ -72,6 +72,20 @@ impl AuthenticationRepository<'_> {
             .context("looking up authenticated user")
     }
 
+    pub fn find_user_by_id(&self, user_id: &str) -> Result<Option<AuthUserRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT user_id, issuer, subject, display_name, email,
+                        created_at, updated_at, disabled_at
+                 FROM auth_users WHERE user_id = ?1",
+                [user_id],
+                row_to_user,
+            )
+            .optional()
+            .context("looking up authenticated user by id")
+    }
+
     pub fn create_session(&self, session: &AuthSessionRecord) -> Result<()> {
         self.db.transaction(|tx| {
             tx.execute(

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -21,7 +21,14 @@ struct HttpRoute {
 }
 
 fn is_openapi_route(route: &HttpRoute) -> bool {
-    route.handler != "web_or_not_found_handler"
+    !matches!(
+        route.handler.as_str(),
+        "web_or_not_found_handler"
+            | "start_oidc_login"
+            | "complete_oidc_login"
+            | "exchange_session"
+            | "logout"
+    )
 }
 
 #[derive(Debug, Serialize)]
@@ -86,7 +93,7 @@ fn render_live_inventory() -> String {
             route
         })
         .collect();
-    assert_eq!(routes.len(), 104, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 108, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1627,7 +1627,7 @@ pub async fn control_prompt_requires_bearer_token_when_required() -> Result<()> 
         .json(&serde_json::json!({ "text": "hello" }))
         .send()
         .await?;
-    assert_eq!(denied.status(), reqwest::StatusCode::FORBIDDEN);
+    assert_eq!(denied.status(), reqwest::StatusCode::UNAUTHORIZED);
     let allowed = client
         .post(format!("{base}/api/control/agents/default/prompt"))
         .bearer_auth("secret")
@@ -1783,7 +1783,7 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         let denied = client.get(format!("{base}{path}")).send().await?;
         assert_eq!(
             denied.status(),
-            reqwest::StatusCode::FORBIDDEN,
+            reqwest::StatusCode::UNAUTHORIZED,
             "{path} should require bearer auth"
         );
         let body: serde_json::Value = denied.json().await?;
@@ -1829,7 +1829,7 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         .await?;
     assert_eq!(
         invalid_runtime_status.status(),
-        reqwest::StatusCode::FORBIDDEN
+        reqwest::StatusCode::UNAUTHORIZED
     );
     let invalid_body: serde_json::Value = invalid_runtime_status.json().await?;
     assert_eq!(invalid_body["ok"], false);
@@ -1850,7 +1850,7 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         .json(&serde_json::json!({ "text": "hello" }))
         .send()
         .await?;
-    assert_eq!(denied_enqueue.status(), reqwest::StatusCode::FORBIDDEN);
+    assert_eq!(denied_enqueue.status(), reqwest::StatusCode::UNAUTHORIZED);
     let denied_enqueue_body: serde_json::Value = denied_enqueue.json().await?;
     assert_eq!(denied_enqueue_body["ok"], false);
     assert!(denied_enqueue_body["error"].is_string());
@@ -1927,7 +1927,7 @@ pub async fn control_prompt_requires_bearer_token_for_non_loopback_auto() -> Res
         .json(&serde_json::json!({ "text": "hello" }))
         .send()
         .await?;
-    assert_eq!(denied.status(), reqwest::StatusCode::FORBIDDEN);
+    assert_eq!(denied.status(), reqwest::StatusCode::UNAUTHORIZED);
 
     let allowed = client
         .post(format!("{base}/api/control/agents/default/prompt"))

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -1145,7 +1145,7 @@ pub async fn events_stream_requires_control_auth_when_configured() -> Result<()>
         .get(format!("{base}/api/agents/default/events/stream"))
         .send()
         .await?;
-    assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
 
     server.abort();
     Ok(())

--- a/tests/support/http_ingress.rs
+++ b/tests/support/http_ingress.rs
@@ -327,7 +327,7 @@ pub async fn generic_webhook_requires_bearer_token_when_configured() -> Result<(
         .json(&serde_json::json!({ "status": "opened" }))
         .send()
         .await?;
-    assert_eq!(denied.status(), reqwest::StatusCode::FORBIDDEN);
+    assert_eq!(denied.status(), reqwest::StatusCode::UNAUTHORIZED);
     let denied_payload: serde_json::Value = denied.json().await?;
     assert_eq!(denied_payload["ok"], false);
     assert!(runtime.storage().read_recent_messages(10)?.is_empty());

--- a/tests/support/http_operator_ingress.rs
+++ b/tests/support/http_operator_ingress.rs
@@ -227,7 +227,7 @@ pub async fn operator_ingress_requires_control_auth() -> Result<()> {
         }))
         .send()
         .await?;
-    assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
 
     server.abort();
     Ok(())


### PR DESCRIPTION
## Summary

Part 3 of #2735: migrate interactive HTTP/API/SSE/Web/TUI access to the unified session-first authentication layer.

- Route ordinary interactive requests through the shared session authentication middleware.
- Preserve bootstrap/recovery, health, OIDC callback, and machine-credential boundaries.
- Add session credential handling, Web login redirects, and consistent unauthorized responses.
- Add integration coverage for session authentication and document the user-facing behavior.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test http --lib`
