### PR TITLE
fix: address settings review follow-ups

### DIFF
--- a/web-gui/app/src/features/settings/SettingsPage.test.ts
+++ b/web-gui/app/src/features/settings/SettingsPage.test.ts
@@ -5,7 +5,9 @@ import {
   buildSearchProviderConfigUpdates,
   buildStandardSearchProviderDefinitions,
   buildVisionConfigUpdates,
+  filterFallbackSuggestions,
   providerCredentialReady,
+  reorderModelFallbacks,
   sortProvidersForSettings,
   sortSearchProvidersForSettings,
 } from "./SettingsPage";
@@ -144,6 +146,52 @@ describe("buildImageGenerationConfigUpdates", () => {
 
   it("unsets image generation default when left empty for auto-selection", () => {
     expect(buildImageGenerationConfigUpdates("   ")).toEqual([{ key: "image_generation.default", unset: true }]);
+  });
+});
+
+describe("fallback model settings helpers", () => {
+  it("reorders fallback models without mutating the input", () => {
+    const models = ["a", "b", "c"];
+
+    expect(reorderModelFallbacks(models, 0, 2)).toEqual(["b", "c", "a"]);
+    expect(models).toEqual(["a", "b", "c"]);
+    expect(reorderModelFallbacks(models, 1, 1)).toBe(models);
+  });
+
+  it("filters fallback suggestions using route and display names", () => {
+    const models = [
+      {
+        model: "gpt-5",
+        routeRef: "openai/default/gpt-5",
+        provider: "openai",
+        providerFamily: "openai",
+        endpoint: "default",
+        routeProvider: "openai",
+        displayName: "GPT-5",
+        available: true,
+        supportsImageInput: false,
+        supportsImageGeneration: false,
+        supportsReasoningEffort: false,
+        reasoningEffortOptions: [],
+      },
+      {
+        model: "claude-sonnet",
+        routeRef: "anthropic/default/claude-sonnet",
+        provider: "anthropic",
+        providerFamily: "anthropic",
+        endpoint: "default",
+        routeProvider: "anthropic",
+        displayName: "Sonnet",
+        available: true,
+        supportsImageInput: false,
+        supportsImageGeneration: false,
+        supportsReasoningEffort: false,
+        reasoningEffortOptions: [],
+      },
+    ];
+
+    expect(filterFallbackSuggestions(models, "son", [])).toEqual([models[1]]);
+    expect(filterFallbackSuggestions(models, "gpt", [models[0].routeRef])).toEqual([]);
   });
 });
 

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -811,7 +811,7 @@ export function SettingsPage({
                 </label>
                 <details className="settings-advanced">
                   <summary>{t("settings.tabAdvanced")}</summary>
-                  <div>
+                  <div className="settings-form-field">
                     <label htmlFor="settings-fallback-model-input">{t("settings.fallbackModels")}</label>
                    <div className="settings-chip-input">
                      {modelFallbacks.map((model, index) => (

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { ArrowRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -74,6 +74,46 @@ export function buildVisionConfigUpdates(visionDefault: string): Array<{ key: st
 export function buildImageGenerationConfigUpdates(imageGenDefault: string): Array<{ key: string; value?: unknown; unset?: boolean }> {
   const trimmed = imageGenDefault.trim();
   return [trimmed ? { key: "image_generation.default", value: trimmed } : { key: "image_generation.default", unset: true }];
+}
+
+export function reorderModelFallbacks(
+  models: string[],
+  fromIndex: number,
+  toIndex: number,
+): string[] {
+  if (
+    fromIndex === toIndex
+    || fromIndex < 0
+    || toIndex < 0
+    || fromIndex >= models.length
+    || toIndex >= models.length
+  ) {
+    return models;
+  }
+  const next = [...models];
+  const [moved] = next.splice(fromIndex, 1);
+  if (moved === undefined) return models;
+  next.splice(toIndex, 0, moved);
+  return next;
+}
+
+export function filterFallbackSuggestions(
+  availableModels: readonly RuntimeModelOption[],
+  input: string,
+  selectedModels: readonly string[],
+): RuntimeModelOption[] {
+  const query = input.trim().toLowerCase();
+  if (!query) return [];
+  const selected = new Set(selectedModels);
+  return availableModels
+    .filter((model) =>
+      !selected.has(model.routeRef)
+      && (
+        model.model.toLowerCase().includes(query)
+        || model.routeRef.toLowerCase().includes(query)
+        || model.displayName.toLowerCase().includes(query)
+      ))
+    .slice(0, 10);
 }
 type ProviderDraft = Pick<
   RuntimeProviderSummary,
@@ -180,6 +220,7 @@ export function SettingsPage({
   const [modelFallbacks, setModelFallbacks] = useState<string[]>([]);
   const [fallbackInput, setFallbackInput] = useState("");
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const draggedIndexRef = useRef<number | null>(null);
   const [visionDefault, setVisionDefault] = useState("");
   const [imageGenDefault, setImageGenDefault] = useState("");
   const [defaultToolOutputTokens, setDefaultToolOutputTokens] = useState("");
@@ -211,6 +252,10 @@ export function SettingsPage({
   const availableModels = useMemo(() => modelCatalog.options.filter((model) => model.available), [modelCatalog.options]);
   const visionModels = useMemo(() => modelCatalog.options.filter((model) => model.available && model.supportsImageInput), [modelCatalog.options]);
   const imageGenModels = useMemo(() => modelCatalog.options.filter((model) => model.available && model.supportsImageGeneration), [modelCatalog.options]);
+  const fallbackSuggestions = useMemo(
+    () => filterFallbackSuggestions(availableModels, fallbackInput, modelFallbacks),
+    [availableModels, fallbackInput, modelFallbacks],
+  );
   const providersWithModels = useMemo(
     () => new Set(modelCatalog.options.map((model) => model.routeProvider)),
     [modelCatalog.options],
@@ -766,25 +811,30 @@ export function SettingsPage({
                 </label>
                 <details className="settings-advanced">
                   <summary>{t("settings.tabAdvanced")}</summary>
-                  <label>
-                    <span>{t("settings.fallbackModels")}</span>
+                  <div>
+                    <label htmlFor="settings-fallback-model-input">{t("settings.fallbackModels")}</label>
                    <div className="settings-chip-input">
                      {modelFallbacks.map((model, index) => (
                        <span
                          key={model}
                          className={`settings-chip${draggedIndex === index ? " dragging" : ""}`}
                          draggable
-                         onDragStart={() => setDraggedIndex(index)}
+                         onDragStart={() => {
+                           draggedIndexRef.current = index;
+                           setDraggedIndex(index);
+                         }}
                          onDragOver={(e) => {
                            e.preventDefault();
-                           if (draggedIndex === null || draggedIndex === index) return;
-                           const next = [...modelFallbacks];
-                           const [moved] = next.splice(draggedIndex, 1);
-                           next.splice(index, 0, moved);
+                           const fromIndex = draggedIndexRef.current;
+                           if (fromIndex === null || fromIndex === index) return;
+                           draggedIndexRef.current = index;
                            setDraggedIndex(index);
-                           setModelFallbacks(next);
+                           setModelFallbacks((current) => reorderModelFallbacks(current, fromIndex, index));
                          }}
-                         onDragEnd={() => setDraggedIndex(null)}
+                         onDragEnd={() => {
+                           draggedIndexRef.current = null;
+                           setDraggedIndex(null);
+                         }}
                        >
                          <span className="settings-chip-grip" aria-hidden="true">⠿</span>
                          {model}
@@ -798,6 +848,7 @@ export function SettingsPage({
                        </span>
                      ))}
                      <input
+                       id="settings-fallback-model-input"
                        value={fallbackInput}
                        onChange={(e) => setFallbackInput(e.target.value)}
                        onKeyDown={(e) => {
@@ -814,16 +865,9 @@ export function SettingsPage({
                        }}
                          placeholder={modelFallbacks.length === 0 ? "provider@endpoint/model" : ""}
                      />
-                     {fallbackInput && (
-                       availableModels
-                        .filter((m) => (m.model.toLowerCase().includes(fallbackInput.toLowerCase()) || m.routeRef.toLowerCase().includes(fallbackInput.toLowerCase()) || m.displayName.toLowerCase().includes(fallbackInput.toLowerCase())) && !modelFallbacks.includes(m.routeRef))
-                         .slice(0, 10)
-                         .length > 0 && (
+                     {fallbackSuggestions.length > 0 && (
                          <div className="settings-chip-suggestions">
-                           {availableModels
-                            .filter((m) => (m.model.toLowerCase().includes(fallbackInput.toLowerCase()) || m.routeRef.toLowerCase().includes(fallbackInput.toLowerCase()) || m.displayName.toLowerCase().includes(fallbackInput.toLowerCase())) && !modelFallbacks.includes(m.routeRef))
-                             .slice(0, 10)
-                             .map((model) => (
+                           {fallbackSuggestions.map((model) => (
                                <button
                                  key={model.routeRef}
                                  type="button"
@@ -840,10 +884,9 @@ export function SettingsPage({
                                </button>
                              ))}
                          </div>
-                       )
                      )}
                    </div>
-                  </label>
+                  </div>
                   <div className="settings-form-row">
                     <label>
                       <span>{t("settings.defaultToolOutputTokens")}</span>

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3295,6 +3295,11 @@ code {
   text-transform: uppercase;
 }
 
+.settings-form-field {
+  display: grid;
+  gap: 6px;
+}
+
 .settings-form input:not([type="checkbox"]),
 .settings-form select {
   width: 100%;


### PR DESCRIPTION
## Summary

Implements the actionable Settings follow-ups from the canonical checklist in #2761, consolidating the overlapping items from #2174-9, #2174-10, #2174-12 and #2184-6, #2184-9, #2184-11.

## Changes

- Avoid repeated drag reorder work by tracking the active drag index in a ref and updating state only when the target index changes.
- Extract fallback-model suggestion filtering into a memoized helper, preserving case-insensitive matching, selected-model exclusion, ordering, and the ten-item cap.
- Replace the interactive-chip-inside-label structure with an explicit `htmlFor`/`id` relationship.
- Add focused helper tests for reorder immutability and suggestion filtering.

## Verification

- `npm run typecheck` — passed.
- `git diff --check` — passed.
- `npm test -- --run src/features/settings/SettingsPage.test.ts` — blocked by the local Node.js runtime: installed Node.js is `v18.20.8`, while the current Vitest/Rolldown dependency requires Node.js 20+ (`node:util` does not export `styleText` on Node 18).

Closes #2761
