### PR TITLE
fix: retain worktree branch when merge proof fails

### DIFF
--- a/src/runtime/tests/workspace_control.rs
+++ b/src/runtime/tests/workspace_control.rs
@@ -330,6 +330,55 @@ async fn remove_worktree_retains_dirty_then_removes_clean_without_deleting_branc
 }
 
 #[tokio::test]
+async fn remove_worktree_keeps_branch_when_merge_reachability_check_fails() {
+    let (_home, _host, runtime) = host_backed_test_runtime().await;
+    let repo = init_git_repo();
+    let workspace = runtime
+        .attach_workspace_path(repo.path().to_path_buf())
+        .await
+        .unwrap()
+        .workspace;
+    let created = runtime
+        .create_worktree_for_workspace(
+            &workspace.workspace_id,
+            "feature/not-merged",
+            "main",
+            None,
+            false,
+            ExistingWorktreePolicy::Reuse,
+        )
+        .await
+        .unwrap();
+    let execution_root_id = created.execution_root_id.unwrap();
+    let worktree_path = created.worktree_path.unwrap();
+
+    git(repo.path(), &["branch", "unrelated", "main"]);
+    std::fs::write(worktree_path.join("feature.txt"), "feature\n").unwrap();
+    git(&worktree_path, &["add", "."]);
+    git(&worktree_path, &["commit", "-m", "feature commit"]);
+
+    let removed = runtime
+        .remove_registered_worktree(
+            &execution_root_id,
+            None,
+            WorktreeBranchPolicy::DeleteIfMerged,
+            Some("unrelated"),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(removed.disposition, "removed_branch_retained");
+    assert!(removed.removed);
+    assert!(!removed.branch_deleted);
+    assert_eq!(
+        removed.branch_retained_reason.as_deref(),
+        Some("not_ancestor_of_merged_into")
+    );
+    assert!(!worktree_path.exists());
+    assert!(!git(repo.path(), &["branch", "--list", "feature/not-merged"]).is_empty());
+}
+
+#[tokio::test]
 async fn active_dirty_remove_preflight_does_not_switch_workspace() {
     let (_home, _host, runtime) = host_backed_test_runtime().await;
     let repo = init_git_repo();

--- a/src/runtime/workspace_control.rs
+++ b/src/runtime/workspace_control.rs
@@ -775,6 +775,7 @@ impl RuntimeHandle {
                     .and_then(|worktree| worktree.head_commit.clone()),
                 changed_files: Vec::new(),
                 error: None,
+                branch_retained_reason: None,
                 summary_text: Some("worktree was already removed".into()),
             });
         }
@@ -923,12 +924,14 @@ impl RuntimeHandle {
                 branch_tip: record.head,
                 changed_files,
                 error: None,
+                branch_retained_reason: None,
                 summary_text: Some("dirty worktree retained".into()),
             });
         }
 
         let branch = record.branch_ref.as_deref().and_then(short_branch_name);
         let tip = record.head.clone();
+        let mut branch_retained_reason = None;
         if record.detached && merged_into.is_none() {
             return Err(anyhow!(
                 "detached HEAD removal requires `merged_into` reachability proof"
@@ -947,9 +950,12 @@ impl RuntimeHandle {
                 )
                 .await?
             {
-                return Err(anyhow!(
-                    "worktree HEAD is not merged into `{merged_into}`; artifact retained"
-                ));
+                if record.detached {
+                    return Err(anyhow!(
+                        "worktree HEAD is not merged into `{merged_into}`; artifact retained"
+                    ));
+                }
+                branch_retained_reason = Some("not_ancestor_of_merged_into".to_string());
             }
         }
 
@@ -999,6 +1005,7 @@ impl RuntimeHandle {
                 branch_tip: tip,
                 changed_files: Vec::new(),
                 error: Some(remove.stderr),
+                branch_retained_reason: None,
                 summary_text: Some("git refused worktree removal; artifact retained".into()),
             });
         }
@@ -1008,7 +1015,8 @@ impl RuntimeHandle {
             .execution_root_entries()
             .mark_removed(execution_root_id)?;
         let mut branch_deleted = false;
-        if branch_policy == WorktreeBranchPolicy::DeleteIfMerged {
+        if branch_policy == WorktreeBranchPolicy::DeleteIfMerged && branch_retained_reason.is_none()
+        {
             if let (Some(branch_ref), Some(tip)) = (record.branch_ref.as_deref(), tip.as_deref()) {
                 let delete = self
                     .run_git(
@@ -1033,6 +1041,7 @@ impl RuntimeHandle {
                         branch_tip: Some(tip.to_string()),
                         changed_files: Vec::new(),
                         error: Some(delete.stderr),
+                        branch_retained_reason: Some("branch_deletion_failed".into()),
                         summary_text: Some(
                             "worktree removed but branch deletion failed safely".into(),
                         ),
@@ -1047,11 +1056,17 @@ impl RuntimeHandle {
                 "execution_root_id": execution_root_id,
                 "branch": branch,
                 "branch_deleted": branch_deleted,
+                "branch_retained_reason": branch_retained_reason,
             }),
         )?;
+        let branch_retained = branch_retained_reason.is_some();
         Ok(RemoveWorktreeResult {
             execution_root_id: execution_root_id.into(),
-            disposition: "removed".into(),
+            disposition: if branch_retained {
+                "removed_branch_retained".into()
+            } else {
+                "removed".into()
+            },
             switched,
             removed: true,
             branch_deleted,
@@ -1059,7 +1074,13 @@ impl RuntimeHandle {
             branch_tip: tip,
             changed_files: Vec::new(),
             error: None,
-            summary_text: Some("worktree removed safely".into()),
+            branch_retained_reason,
+            summary_text: Some(if branch_retained {
+                "worktree removed; branch retained because merge reachability could not be proven"
+                    .into()
+            } else {
+                "worktree removed safely".into()
+            }),
         })
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3875,6 +3875,8 @@ pub struct RemoveWorktreeResult {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_retained_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary_text: Option<String>,
 }
 


### PR DESCRIPTION
Closes #2412\n\n## Summary\n- remove the registered worktree even when delete_if_merged cannot prove ancestry\n- retain the branch and return structured branch_retained_reason warning\n- preserve detached HEAD safety rejection and add regression coverage\n\n## Verification\n- cargo fmt --all -- --check\n- cargo test runtime::tests::workspace_control -- --nocapture\n- RUSTFLAGS="-D warnings" cargo check --all-targets