### PR TITLE
fix: align E2E auth status expectation with session-first 401 response

### DIFF
--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -2225,7 +2225,7 @@ def run_runtime_case(harness: CaseHarness, case: dict[str, Any]) -> None:
     unauthorized = harness.request(
         "GET",
         "/api/control/runtime/readiness",
-        expected_status=403,
+        expected_status=401,
         authenticated=False,
     )
     write_json(harness.evidence / "unauthorized-readiness.json", unauthorized)


### PR DESCRIPTION
## Summary

The `runtime-auth-model-delivery` Docker E2E case expected HTTP **403** for unauthenticated `/api/control/runtime/readiness` requests. PR #2758 (session-first authentication) correctly changed the auth middleware to return **401** (UNAUTHORIZED) with code `auth_required` for missing credentials — the HTTP-spec-correct status.

The unit tests in `src/http/mod.rs` already assert 401 and `auth_required` for unauthenticated requests. This PR updates the stale Docker E2E expectation from 403 to 401 so the black-box case passes.

## Changed behavior

- `scripts/docker_e2e/runner.py`: `expected_status=403` → `expected_status=401` for the unauthenticated readiness probe in `run_runtime_case`.

## Verification

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✓
- `python3 scripts/docker-e2e.py --case runtime-auth-model-delivery --skip-build --timeout 900` → **PASS**

## Related

- Discovered during Issue #2735 acceptance verification.
- Root cause: PR #2758 session-first auth migration; the E2E expectation was not updated.