### PR TITLE
fix(queue): abort orphaned queue entries when agent is stopped or deleted

### DIFF
--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -274,6 +274,20 @@ impl RuntimeHost {
             }
         }
 
+        // Abort pending queue entries to prevent orphaned queued messages.
+        let queue_aborted = self
+            .runtime_db()
+            .queue_entries()
+            .abort_pending_for_agent(agent_id)
+            .unwrap_or(0);
+        if queue_aborted > 0 {
+            debug!(
+                agent_id,
+                count = queue_aborted,
+                "aborted pending queue entries"
+            );
+        }
+
         // Emit audit event via storage if available.
         let _ = storage.append_event(&AuditEvent::legacy(
             "deletion_quiesce",
@@ -281,6 +295,7 @@ impl RuntimeHost {
                 "agent_id": agent_id,
                 "tasks_cancelled": tasks_count,
                 "waits_cancelled": waits_count,
+                "queue_entries_aborted": queue_aborted,
             }),
         ));
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -3012,6 +3012,26 @@ impl RuntimeHost {
                 }
             }
         }
+        // Abort pending queue entries to prevent orphaned queued messages
+        // that would never be consumed after the agent is removed.
+        if let Ok(aborted_count) = self
+            .runtime_db()
+            .queue_entries()
+            .abort_pending_for_agent(agent_id)
+        {
+            if aborted_count > 0 {
+                if let Ok(storage) = self.agent_storage(agent_id) {
+                    let _ = storage.append_event(&crate::types::AuditEvent::legacy(
+                        "queue_entries_aborted",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "reason": "agent_archived",
+                            "count": aborted_count,
+                        }),
+                    ));
+                }
+            }
+        }
 
         let data_dir = self.agent_data_dir(agent_id);
         if data_dir.exists() {
@@ -3083,6 +3103,12 @@ impl RuntimeHost {
                 self.append_agent_identity(&identity)?;
             }
         }
+        // Abort pending queue entries as a safety net for agents that were
+        // stopped through a different path (e.g. data dir already removed).
+        let _ = self
+            .runtime_db()
+            .queue_entries()
+            .abort_pending_for_agent(agent_id)?;
 
         let data_dir = self.agent_data_dir(agent_id);
         if data_dir.exists() {
@@ -6804,6 +6830,138 @@ mod tests {
                 .unwrap()
                 .status,
             AgentRegistryStatus::Deleted
+        );
+    }
+
+    #[tokio::test]
+    async fn archive_private_agent_aborts_pending_queue_entries() {
+        let (_home, host) = test_host();
+        let parent_id = "archive-queue-parent";
+
+        // Create parent agent.
+        let parent = AgentIdentityRecord::new(
+            parent_id,
+            AgentKind::Default,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        );
+        host.append_agent_identity(&parent).unwrap();
+        host.runtime_db()
+            .agent_identities()
+            .upsert(&parent)
+            .unwrap();
+
+        // Create a private child with queued entries.
+        let child_id = "archive-queue-child";
+        let child = AgentIdentityRecord::new(
+            child_id,
+            AgentKind::Child,
+            AgentVisibility::Private,
+            AgentOwnership::ParentSupervised,
+            AgentProfilePreset::PrivateChild,
+            Some(parent_id.to_string()),
+            Some("task-queue-1".to_string()),
+        );
+        host.append_agent_identity(&child).unwrap();
+        host.runtime_db().agent_identities().upsert(&child).unwrap();
+
+        let now = Utc::now();
+        host.runtime_db()
+            .queue_entries()
+            .upsert(&QueueEntryRecord {
+                message_id: "msg-queued-orphan-1".into(),
+                agent_id: child_id.into(),
+                priority: Priority::Normal,
+                status: QueueEntryStatus::Queued,
+                created_at: now,
+                updated_at: now,
+            })
+            .unwrap();
+        host.runtime_db()
+            .queue_entries()
+            .upsert(&QueueEntryRecord {
+                message_id: "msg-interrupted-orphan-1".into(),
+                agent_id: child_id.into(),
+                priority: Priority::Normal,
+                status: QueueEntryStatus::Interrupted,
+                created_at: now,
+                updated_at: now,
+            })
+            .unwrap();
+
+        // Archive the private child agent.
+        host.archive_private_agent(child_id).await.unwrap();
+
+        // Verify queued entries were aborted.
+        assert_eq!(
+            host.runtime_db()
+                .queue_entries()
+                .latest("msg-queued-orphan-1")
+                .unwrap()
+                .unwrap()
+                .status,
+            QueueEntryStatus::Aborted
+        );
+        assert_eq!(
+            host.runtime_db()
+                .queue_entries()
+                .latest("msg-interrupted-orphan-1")
+                .unwrap()
+                .unwrap()
+                .status,
+            QueueEntryStatus::Aborted
+        );
+    }
+
+    #[tokio::test]
+    async fn deletion_pipeline_aborts_pending_queue_entries() {
+        let (_home, host) = test_host();
+
+        // Create a public self-owned agent with queued entries.
+        let agent = AgentIdentityRecord::new(
+            "delete-queue-me",
+            AgentKind::Default,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        );
+        host.append_agent_identity(&agent).unwrap();
+        host.runtime_db().agent_identities().upsert(&agent).unwrap();
+
+        let now = Utc::now();
+        host.runtime_db()
+            .queue_entries()
+            .upsert(&QueueEntryRecord {
+                message_id: "msg-queued-delete-1".into(),
+                agent_id: "delete-queue-me".into(),
+                priority: Priority::Normal,
+                status: QueueEntryStatus::Queued,
+                created_at: now,
+                updated_at: now,
+            })
+            .unwrap();
+
+        // Begin deletion and execute the full pipeline.
+        let (_, job, _) = host
+            .begin_public_agent_deletion("delete-queue-me", false, "operator")
+            .await
+            .unwrap();
+        host.execute_deletion_job(job).await.unwrap();
+
+        // Verify the queued entry was aborted.
+        assert_eq!(
+            host.runtime_db()
+                .queue_entries()
+                .latest("msg-queued-delete-1")
+                .unwrap()
+                .unwrap()
+                .status,
+            QueueEntryStatus::Aborted
         );
     }
 

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1641,6 +1641,23 @@ impl QueueEntryRepository<'_> {
         records.reverse();
         Ok(records)
     }
+
+    /// Abort all pending (Queued or Interrupted) queue entries for an agent.
+    ///
+    /// Used during agent stop/deletion to prevent orphaned entries that would
+    /// never be consumed. Returns the number of entries aborted.
+    pub fn abort_pending_for_agent(&self, agent_id: &str) -> Result<usize> {
+        let entries = self.queued_for_agent(agent_id)?;
+        let now = chrono::Utc::now();
+        let mut count = 0;
+        for mut entry in entries {
+            entry.status = QueueEntryStatus::Aborted;
+            entry.updated_at = now;
+            self.upsert(&entry)?;
+            count += 1;
+        }
+        Ok(count)
+    }
 }
 
 impl TimerRepository<'_> {

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -4516,6 +4516,70 @@ CREATE TABLE working_memory_deltas (
     }
 
     #[test]
+    fn abort_pending_for_agent_aborts_queued_and_interrupted_entries() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+
+        let queued_entry = QueueEntryRecord {
+            message_id: "msg-queued-abort".into(),
+            agent_id: "agent-abort".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        let interrupted_entry = QueueEntryRecord {
+            message_id: "msg-interrupted-abort".into(),
+            agent_id: "agent-abort".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Interrupted,
+            created_at: now,
+            updated_at: now,
+        };
+        let processed_entry = QueueEntryRecord {
+            message_id: "msg-processed-keep".into(),
+            agent_id: "agent-abort".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Processed,
+            created_at: now,
+            updated_at: now,
+        };
+
+        db.queue_entries().upsert(&queued_entry)?;
+        db.queue_entries().upsert(&interrupted_entry)?;
+        db.queue_entries().upsert(&processed_entry)?;
+
+        let count = db.queue_entries().abort_pending_for_agent("agent-abort")?;
+        assert_eq!(count, 2, "should abort queued and interrupted entries");
+
+        assert_eq!(
+            db.queue_entries()
+                .latest("msg-queued-abort")?
+                .unwrap()
+                .status,
+            QueueEntryStatus::Aborted
+        );
+        assert_eq!(
+            db.queue_entries()
+                .latest("msg-interrupted-abort")?
+                .unwrap()
+                .status,
+            QueueEntryStatus::Aborted
+        );
+        // Processed entries should be untouched.
+        assert_eq!(
+            db.queue_entries()
+                .latest("msg-processed-keep")?
+                .unwrap()
+                .status,
+            QueueEntryStatus::Processed
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn recovery_candidate_agent_ids_include_dequeued_and_interrupted_entries() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;


### PR DESCRIPTION
## Summary

When a `tmp_child` agent is stopped/archived or a public agent is deleted, its `queue_entries` with `status='queued'` or `status='interrupted'` were left orphaned — never consumed, aborted, or cleaned up. The scheduler only processes entries for active agents, so these entries leaked indefinitely (confirmed 2 cases stuck 3h+ with no self-healing).

## Root cause

Both the agent stop path (`archive_private_agent` in `src/host.rs`) and the deletion pipeline (`deletion_phase_quiesce` in `src/deletion.rs`) already terminalize tasks, wait conditions, and timers — but **neither aborts queue entries**. The scheduler recovery path (`recovery_candidate_agent_ids`) only considers agents with `Dequeued`/`Interrupted` entries AND `active` identity status, so stopped/deleted agents are skipped entirely.

## Fix

Add `QueueEntryRepository::abort_pending_for_agent()` that transitions `Queued`/`Interrupted` entries to `Aborted`, mirroring how tasks, waits, and timers are already terminalized. Call it in three lifecycle paths:

1. **`archive_private_agent`** (`src/host.rs`) — main stop path for private child agents
2. **`archive_private_agent_identity_record`** (`src/host.rs`) — convergence safety net for agents stopped through other paths
3. **`deletion_phase_quiesce`** (`src/deletion.rs`) — public agent deletion pipeline (also covers cascaded private children)

## Tests

- `abort_pending_for_agent_aborts_queued_and_interrupted_entries` — repository-level: verifies Queued and Interrupted entries are aborted, Processed entries untouched
- `archive_private_agent_aborts_pending_queue_entries` — integration: verifies entries are aborted when a private child is archived
- `deletion_pipeline_aborts_pending_queue_entries` — integration: verifies entries are aborted through the full deletion pipeline

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib queue` — 122 passed, 0 failed ✅
- `cargo test --lib deletion` — 9 passed, 0 failed ✅

Closes #2638