### PR TITLE
fix(web-gui): auto-restore exact unread certainty when read marker catches up

### DIFF
--- a/docs/implementation-decisions/113-client-replay-budget.md
+++ b/docs/implementation-decisions/113-client-replay-budget.md
@@ -11,3 +11,8 @@ projection bootstrap. If replay after that snapshot also exceeds a limit, the
 Agent remains out of live state with an explicit error. A budget-driven
 bootstrap preserves the prior read marker but marks unread certainty truncated
 at the skipped snapshot boundary.
+
+That truncated generation retires itself once the read marker catches up with
+the observed head: the client acknowledges automatically at the gated head the
+marker reached, and the explicit acknowledgement stays available as an early
+confirmation.

--- a/docs/rfcs/observer-sync-agent-summary-and-read-markers.md
+++ b/docs/rfcs/observer-sync-agent-summary-and-read-markers.md
@@ -795,8 +795,9 @@ If the effective local read boundary
 retains any visible retained unread as a lower bound, changes `certainty` to
 `Truncated`, and displays a truncation indicator instead of an exact badge.
 
-The user may explicitly acknowledge the unknown history after opening and
-catching up the conversation. That action records:
+The unknown history is acknowledged in one of two ways: explicitly by the
+user, or automatically once the read marker itself reaches the observed head
+after contiguous catch-up. Either action records:
 
 ```text
 acknowledged_truncation_before_seq = current_head
@@ -810,8 +811,12 @@ lost interval.
 
 Budget-driven bootstrap does not fabricate acknowledgement. It preserves the
 prior marker where meaningful, marks unread certainty as `Truncated`, and
-records the first sequence after the snapshot boundary until explicit
-acknowledgement establishes a new exact generation.
+records the first sequence after the snapshot boundary until an
+acknowledgement establishes a new exact generation. The automatic
+acknowledgement fires only at the gated head the marker actually reached and
+never claims a boundary beyond it; the explicit acknowledgement remains the
+early-confirmation path for users who do not read through the retained
+backlog first.
 
 ### Runtime Epoch Reset
 
@@ -1159,7 +1164,8 @@ snapshot watermark is valid only with a proven consistency boundary.
 
 After a gap, the client cannot know which qualifying Brief events were deleted.
 Showing an exact count would be a false statement. Truncation must remain
-visible until the user starts a new acknowledged generation.
+visible until a new acknowledged generation starts (explicitly on request, or
+automatically when the read marker catches up with the observed head).
 
 ## Proposed Decision
 

--- a/web-gui/app/src/runtime/agent-session-repository.test.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.test.ts
@@ -435,6 +435,28 @@ describe("AgentSessionRepository ledger ingestion", () => {
     expect(acknowledged?.unreadBaselineSeq).toBe(4);
   });
 
+  it("acknowledges truncation at an explicit gated head instead of the observed head", async () => {
+    const harness = createHarness(
+      emptyAgentSession(),
+      { ledgerIngestion: ledgerIntegration() },
+    );
+    await harness.repository.initializeLedgerIngestion();
+
+    await harness.repository.ingestSessionEvents("agent-a", [
+      event(1),
+      event(2),
+      event(3),
+    ]);
+    await harness.repository.advanceReadMarker("agent-a", 3);
+
+    // The auto-restore path passes the gated head it caught up to; the
+    // acknowledgement boundary must not jump to the higher observed head.
+    const acknowledged = await harness.repository.acknowledgeReadTruncation("agent-a", 2);
+    expect(acknowledged?.certainty).toBe("exact");
+    expect(acknowledged?.unreadBaselineSeq).toBe(2);
+    expect(acknowledged?.acknowledgedTruncationBeforeSeq).toBe(2);
+  });
+
   it("returns null read-marker results when the scope is unresolved", async () => {
     const harness = createHarness(
       emptyAgentSession(),

--- a/web-gui/app/src/runtime/agent-session-repository.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.ts
@@ -601,10 +601,13 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
   /**
    * Record an explicit acknowledgement that truncated history is unknown.
    * Opens a new exact generation while preserving the recorded truncation
-   * facts. Null when unavailable; false-y records when nothing changed.
+   * facts. Null when unavailable; false-y records when nothing changed. An
+   * explicit `headSeq` acknowledges at the gated head a read marker caught
+   * up to instead of the current observed head.
    */
   async acknowledgeReadTruncation(
     agentId: string,
+    headSeq?: number,
   ): Promise<LedgerReadStateRecord | null> {
     await this.initializeLedgerIngestion();
     const pipeline = this.ledgerPipeline;
@@ -612,7 +615,7 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
       this.dependencies.ledgerIngestion?.resolveScope(agentId) ??
       this.knownLedgerScope(agentId);
     if (!pipeline || !scope) return null;
-    return pipeline.acknowledgeReadTruncation(scope);
+    return pipeline.acknowledgeReadTruncation(scope, headSeq);
   }
 
   /**

--- a/web-gui/app/src/runtime/event-ledger/index.ts
+++ b/web-gui/app/src/runtime/event-ledger/index.ts
@@ -93,6 +93,7 @@ export {
   mergeReadMarkerCandidate,
   mergeTruncationAcknowledgement,
   readMarkerBoundary,
+  shouldAutoRestoreExactCertainty,
   unreadSnapshotFromRecord,
   type LedgerUnreadSnapshot,
   type ReadCertainty,

--- a/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
+++ b/web-gui/app/src/runtime/event-ledger/ingestion-pipeline.ts
@@ -619,12 +619,16 @@ export class LedgerIngestionPipeline {
   /**
    * Record an explicit truncation acknowledgement at the current observed
    * event head. Null on memory-only durability or when no read state exists.
+   * An explicit `headSeq` (the gated head a read marker caught up to)
+   * overrides the observed head so the auto-restore path never claims a
+   * boundary beyond what the marker actually reached.
    */
   async acknowledgeReadTruncation(
     scope: LedgerScopeKey,
+    headSeq?: number,
   ): Promise<LedgerReadStateRecord | null> {
     if (!(await this.ensureExactHandle())) return null;
-    const head = this.status(scope)?.observedEventHeadSeq;
+    const head = headSeq ?? this.status(scope)?.observedEventHeadSeq;
     if (head == null) return null;
     return this.ledger!.acknowledgeReadTruncation(scope, head);
   }

--- a/web-gui/app/src/runtime/event-ledger/read-markers.test.ts
+++ b/web-gui/app/src/runtime/event-ledger/read-markers.test.ts
@@ -4,7 +4,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { EventLedger } from "./ledger";
 import type { LedgerScopeKey } from "./keys";
-import { readMarkerBoundary } from "./read-markers";
+import {
+  readMarkerBoundary,
+  shouldAutoRestoreExactCertainty,
+} from "./read-markers";
 
 function makeScope(): LedgerScopeKey {
   return {
@@ -125,6 +128,52 @@ describe("read markers", () => {
     expect(again?.acknowledgedTruncationBeforeSeq).toBe(9);
     expect(again?.unreadBaselineSeq).toBe(9);
     ledger.close();
+  });
+
+  it("auto-restores exact certainty once the marker reaches the gated head", async () => {
+    const ledger = await openLedger();
+    const scope = makeScope();
+    await seedReadState(ledger, scope, {
+      unreadBaselineSeq: 3,
+      certainty: "truncated",
+      historyTruncatedBeforeSeq: 5,
+    });
+
+    // Advancing the marker preserves the truncated certainty; the pure
+    // rule stays quiet until the marker reaches the gated head.
+    const midCatchUp = await ledger.advanceReadMarker(scope, 7);
+    expect(midCatchUp.record.certainty).toBe("truncated");
+    expect(shouldAutoRestoreExactCertainty(midCatchUp.record, 9)).toBe(false);
+
+    const caughtUp = await ledger.advanceReadMarker(scope, 9);
+    expect(caughtUp.record.certainty).toBe("truncated");
+    expect(shouldAutoRestoreExactCertainty(caughtUp.record, 9)).toBe(true);
+
+    // Acknowledging at the gated head opens the exact generation without
+    // touching the marker or the recorded truncation facts.
+    const restored = await ledger.acknowledgeReadTruncation(scope, 9);
+    expect(restored?.certainty).toBe("exact");
+    expect(restored?.unreadBaselineSeq).toBe(9);
+    expect(restored?.readThroughEventSeq).toBe(9);
+    expect(restored?.historyTruncatedBeforeSeq).toBe(5);
+    expect(shouldAutoRestoreExactCertainty(restored, 9)).toBe(false);
+    ledger.close();
+  });
+
+  it("never auto-restores without a truncated record or marker", async () => {
+    expect(shouldAutoRestoreExactCertainty(undefined, 9)).toBe(false);
+    expect(
+      shouldAutoRestoreExactCertainty(
+        { agentId: "agent-a", certainty: "exact", readThroughEventSeq: 9 } as never,
+        9,
+      ),
+    ).toBe(false);
+    expect(
+      shouldAutoRestoreExactCertainty(
+        { agentId: "agent-a", certainty: "truncated" } as never,
+        9,
+      ),
+    ).toBe(false);
   });
 
   it("acknowledging an absent read state changes nothing", async () => {

--- a/web-gui/app/src/runtime/event-ledger/read-markers.ts
+++ b/web-gui/app/src/runtime/event-ledger/read-markers.ts
@@ -16,6 +16,23 @@ export function readMarkerBoundary(record: LedgerReadStateRecord | undefined): n
   return Math.max(record.unreadBaselineSeq ?? 0, record.readThroughEventSeq ?? 0);
 }
 
+/**
+ * True when a truncated read state may retire itself into a new exact
+ * generation because the read marker caught up with the gated observed
+ * head: every event above that boundary is known from then on, so future
+ * unread counts are exact again. The explicit acknowledgement remains the
+ * early-confirmation path before the marker catches up.
+ */
+export function shouldAutoRestoreExactCertainty(
+  record: LedgerReadStateRecord | null | undefined,
+  gatedHeadSeq: number,
+): boolean {
+  return (
+    record?.certainty === "truncated" &&
+    (record.readThroughEventSeq ?? 0) >= gatedHeadSeq
+  );
+}
+
 /** True when one raw envelope qualifies as a user-facing unread brief. */
 export function isQualifyingUnreadEnvelope(envelope: unknown): boolean {
   return (

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -747,6 +747,9 @@ describe("roster activity unread state", () => {
           updatedAt: 1,
         },
       });
+    const acknowledgeReadTruncation = vi
+      .spyOn(AgentSessionRepository.prototype, "acknowledgeReadTruncation")
+      .mockResolvedValue(null);
     vi.spyOn(AgentSessionRepository.prototype, "unreadSnapshot").mockResolvedValue({
       scopeAgentId: "agent-retry",
       boundarySeq: 12,
@@ -780,7 +783,88 @@ describe("roster activity unread state", () => {
     await retryPendingReadMarker("agent-retry");
 
     expect(advanceReadMarker).toHaveBeenCalledWith("agent-retry", 12);
+    // An exact record never triggers the auto-restore acknowledgement.
+    expect(acknowledgeReadTruncation).not.toHaveBeenCalled();
     expect(useRuntimeStore.getState().ledgerUnreadByAgentId["agent-retry"]).toEqual({
+      mode: "exact",
+      count: 0,
+    });
+  });
+
+  it("auto-restores exact certainty when a sticky truncated marker already covers the head", async () => {
+    vi.stubGlobal("document", { visibilityState: "visible" });
+    let ready = false;
+    vi.spyOn(AgentSessionRepository.prototype, "sessionLedgerReadiness")
+      .mockImplementation(() => ready
+        ? { readyThroughSeq: 12, ingestedThroughSeq: 12, observedHeadSeq: 12 }
+        : null);
+    // Pre-fix durable state: the marker already reached the head, so the
+    // monotonic advance is a no-op while certainty stays truncated.
+    const advanceReadMarker = vi
+      .spyOn(AgentSessionRepository.prototype, "advanceReadMarker")
+      .mockResolvedValue({
+      advanced: false,
+      record: {
+        remoteKey: "local",
+        runtimeId: "runtime-1",
+        visibilityScopeId: "scope-1",
+        eventLogEpoch: "epoch-1",
+        agentId: "agent-auto",
+        readThroughEventSeq: 12,
+        certainty: "truncated",
+        updatedAt: 1,
+      },
+    });
+    const acknowledgeReadTruncation = vi
+      .spyOn(AgentSessionRepository.prototype, "acknowledgeReadTruncation")
+      .mockResolvedValue({
+        remoteKey: "local",
+        runtimeId: "runtime-1",
+        visibilityScopeId: "scope-1",
+        eventLogEpoch: "epoch-1",
+        agentId: "agent-auto",
+        readThroughEventSeq: 12,
+        unreadBaselineSeq: 12,
+        acknowledgedTruncationBeforeSeq: 12,
+        certainty: "exact",
+        updatedAt: 2,
+      });
+    vi.spyOn(AgentSessionRepository.prototype, "unreadSnapshot").mockResolvedValue({
+      scopeAgentId: "agent-auto",
+      boundarySeq: 12,
+      countedThroughSeq: 12,
+      certainty: "exact",
+      count: 0,
+      historyTruncatedBeforeSeq: 5,
+      acknowledgedTruncationBeforeSeq: 12,
+    });
+    useRuntimeStore.setState({
+      route: "agent",
+      selectedAgentId: "agent-auto",
+      discovery: {
+        mode: "authoritative",
+        freshness: "fresh",
+        retryAttempt: 0,
+      },
+      sessionsByAgentId: {
+        "agent-auto": sessionState(),
+      },
+      ledgerUnreadByAgentId: {
+        "agent-auto": { mode: "truncated", count: 2 },
+      },
+    });
+
+    useRuntimeStore.getState().markAgentConversationRead("agent-auto");
+    await Promise.resolve();
+    expect(advanceReadMarker).not.toHaveBeenCalled();
+
+    ready = true;
+    await retryPendingReadMarker("agent-auto");
+
+    // Auto-restore retires the truncated generation at the gated head the
+    // marker already covers, flipping the badge back to exact.
+    expect(acknowledgeReadTruncation).toHaveBeenCalledWith("agent-auto", 12);
+    expect(useRuntimeStore.getState().ledgerUnreadByAgentId["agent-auto"]).toEqual({
       mode: "exact",
       count: 0,
     });

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -47,7 +47,7 @@ import {
   type AgentRosterActivity,
   type LedgerUnreadView,
 } from "./read-state";
-import { ReadStateBus } from "./event-ledger";
+import { ReadStateBus, shouldAutoRestoreExactCertainty } from "./event-ledger";
 import {
   CACHE_SCHEMA_VERSION,
   cacheGetModelCatalog,
@@ -1324,9 +1324,21 @@ export async function retryPendingReadMarker(agentId: string): Promise<void> {
     }
     pendingReadMarkerAgentIds.delete(agentId);
     if (result.advanced) publishReadStateInvalidation(agentId);
+    // A marker that reached the gated observed head makes every event
+    // above it known from here on, so the truncated generation retires
+    // itself instead of waiting for the manual acknowledgement (RFC
+    // LocalReadState). Acknowledging at the gated candidate keeps the
+    // new boundary at what the marker actually reached.
+    const restored = shouldAutoRestoreExactCertainty(result.record, decision.candidateSeq)
+      ? await agentSessionRepository
+          .acknowledgeReadTruncation(agentId, decision.candidateSeq)
+          .catch(() => null)
+      : null;
+    if (restored) publishReadStateInvalidation(agentId);
     await refreshLedgerUnreadInView(agentId);
     span.end("ok", {
       advanced: result.advanced,
+      autoRestoreExact: Boolean(restored),
       candidateSeq: decision.candidateSeq,
     });
   } catch (error) {


### PR DESCRIPTION
## What changed

The unread badge's orange `N+` (truncated certainty) previously stuck until the user clicked "Acknowledge earlier history". This PR makes the truncated generation retire itself: once the read marker reaches the gated observed head after contiguous catch-up, every event above that boundary is known, so the client opens a new exact generation automatically — future unread counts turn blue/exact without manual action.

- `read-markers.ts`: new pure rule `shouldAutoRestoreExactCertainty(record, gatedHeadSeq)` — fires only for a `truncated` record whose `readThroughEventSeq` covers the gated head.
- `runtime-store.ts` `retryPendingReadMarker`: after a marker advance lands, apply the truncation acknowledgement transition automatically when the rule fires, then invalidate sibling tabs and refresh the unread view. This also repairs pre-existing sticky records (marker already ≥ head, `advanced: false`).
- `acknowledgeReadTruncation` (repository + pipeline) accepts an explicit `headSeq`: the auto path acknowledges at the gated head the marker actually reached, so a concurrent head move can never silently claim unread briefs beyond the marker. The manual button path is unchanged (early confirmation at the current observed head).
- RFC `observer-sync-agent-summary-and-read-markers.md` and decision note 113 updated to describe both acknowledgement paths.

## Verification

- `npm run typecheck` clean; full web-gui vitest suite: 471 passed (40 files).
- New tests: pure-rule gating + ledger-level auto-restore sequence (`read-markers.test.ts`), explicit-head acknowledgement honored over observed head (`agent-session-repository.test.ts`), sticky pre-fix record auto-restores and the badge flips to exact (`runtime-store.test.ts`); exact records never trigger the auto acknowledgement.