### PR TITLE
feat: improve login and session UX

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -18,18 +18,27 @@ Configure an OIDC provider in the runtime configuration:
       "redirect_uri": "https://holon.example/api/auth/oidc/callback"
     },
     "session": {
-      "absolute_ttl_seconds": 28800,
-      "idle_ttl_seconds": 1800
+      "absolute_ttl_seconds": null,
+      "idle_ttl_seconds": 86400
     }
   }
 }
 ```
 
+`absolute_ttl_seconds: null` disables the absolute session lifetime. The
+default idle lifetime is 86,400 seconds (24 hours), and activity refreshes the
+idle expiry. A finite absolute lifetime may still be configured; it must be
+positive and no shorter than the idle lifetime. For compatibility, persisted
+configuration using `0` for the absolute lifetime is normalized to `null`.
+
 `issuer_url` and OIDC endpoints must use HTTPS. A localhost callback may use
 HTTP for local development.
 
-Open `/api/auth/oidc/start` in a browser to begin login. The callback creates a
-session and sets the `holon_session` HttpOnly cookie before redirecting to `/`.
+Open `/login` in a browser to begin login. In OIDC mode the page provides an
+organization-login button and starts the OIDC flow after discovering the
+configured authentication mode. In local mode, enter the static control token
+on the same page; it is exchanged once for an HttpOnly `holon_session` cookie.
+The callback creates the same cookie before redirecting to `/`.
 The same session can be supplied to API clients as
 `Authorization: Bearer <session>`. `POST /api/auth/session/logout` revokes the
 current session and clears the cookie.
@@ -37,5 +46,6 @@ current session and clears the cookie.
 In OIDC mode, normal API, SSE, and Web requests require an active session.
 Missing, expired, revoked, or disabled-user sessions return HTTP `401` with the
 `auth_required` error code. Bootstrap/session exchange, OIDC callback, callback
-ingress, and webhook routes retain their separate non-session credentials and
-are not treated as browser sessions.
+ingress, `/login`, and webhook routes retain their separate non-session
+credentials and are not treated as browser sessions. The Web GUI uses the
+Holon service's same origin for all API, SSE, and login requests.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -11173,6 +11173,49 @@
         ]
       }
     },
+    "/api/auth/method": {
+      "get": {
+        "description": "Return the configured authentication mode used by the Web login page.",
+        "operationId": "authMethod",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "summary": "Authentication method",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
     "/api/auth/{provider}/device/start": {
       "post": {
         "description": "Request a provider OAuth device code and start a background job that persists the OAuth credential profile after user authorization. Supported providers include openai-codex and xai.",

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -50,26 +50,31 @@ impl OidcProviderConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionPolicy {
-    pub absolute_ttl_seconds: u64,
+    pub absolute_ttl_seconds: Option<u64>,
     pub idle_ttl_seconds: u64,
 }
 
 impl Default for SessionPolicy {
     fn default() -> Self {
         Self {
-            absolute_ttl_seconds: Duration::from_secs(8 * 60 * 60).as_secs(),
-            idle_ttl_seconds: Duration::from_secs(30 * 60).as_secs(),
+            absolute_ttl_seconds: None,
+            idle_ttl_seconds: Duration::from_secs(24 * 60 * 60).as_secs(),
         }
     }
 }
 
 impl SessionPolicy {
     pub fn validate(&self) -> Result<()> {
-        if self.absolute_ttl_seconds == 0 || self.idle_ttl_seconds == 0 {
-            bail!("session TTLs must be greater than zero");
+        if self.idle_ttl_seconds == 0 {
+            bail!("session idle TTL must be greater than zero");
         }
-        if self.idle_ttl_seconds > self.absolute_ttl_seconds {
-            bail!("session idle TTL must not exceed absolute TTL");
+        if let Some(absolute_ttl_seconds) = self.absolute_ttl_seconds {
+            if absolute_ttl_seconds == 0 {
+                bail!("session absolute TTL must be greater than zero or null for unlimited");
+            }
+            if self.idle_ttl_seconds > absolute_ttl_seconds {
+                bail!("session idle TTL must not exceed absolute TTL");
+            }
         }
         Ok(())
     }
@@ -126,7 +131,7 @@ pub struct AuthSessionRecord {
     pub user_id: String,
     pub auth_method: String,
     pub created_at: DateTime<Utc>,
-    pub expires_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
     pub last_seen_at: DateTime<Utc>,
     pub revoked_at: Option<DateTime<Utc>>,
 }
@@ -134,7 +139,7 @@ pub struct AuthSessionRecord {
 impl AuthSessionRecord {
     pub fn is_active_at(&self, now: DateTime<Utc>, idle_ttl: Duration) -> bool {
         self.revoked_at.is_none()
-            && self.expires_at > now
+            && self.expires_at.is_none_or(|expires_at| expires_at > now)
             && self.last_seen_at + chrono::Duration::from_std(idle_ttl).unwrap_or_default() > now
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -356,7 +356,8 @@ fn materialize_auth_config(file: &AuthConfigFile) -> Result<AuthConfig> {
         absolute_ttl_seconds: file
             .session
             .absolute_ttl_seconds
-            .unwrap_or(defaults.absolute_ttl_seconds),
+            .and_then(|value| (value != 0).then_some(value))
+            .or(defaults.absolute_ttl_seconds),
         idle_ttl_seconds: file
             .session
             .idle_ttl_seconds

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -10,6 +10,19 @@ pub struct ConfigSchemaEntry {
     pub allowed_values: Vec<&'static str>,
 }
 
+fn parse_optional_session_ttl(key: &str, raw_value: &str) -> Result<Option<u64>> {
+    let value = raw_value.trim();
+    if value.eq_ignore_ascii_case("null") || value == "0" {
+        return Ok(None);
+    }
+    value
+        .parse::<u64>()
+        .ok()
+        .filter(|value| *value > 0)
+        .map(Some)
+        .ok_or_else(|| anyhow!("{key} expects a positive integer or null"))
+}
+
 pub fn config_schema() -> Vec<ConfigSchemaEntry> {
     vec![
         ConfigSchemaEntry {
@@ -49,9 +62,9 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
         },
         ConfigSchemaEntry {
             key: "auth.session.absolute_ttl_seconds",
-            kind: "positive_integer",
-            description: "Absolute authentication session lifetime in seconds.",
-            default: json!(SessionPolicy::default().absolute_ttl_seconds),
+            kind: "positive_integer_or_null",
+            description: "Absolute authentication session lifetime in seconds; null means unlimited.",
+            default: Value::Null,
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
@@ -1099,7 +1112,7 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
             ensure_auth_oidc(config).redirect_uri = Some(raw_value.to_owned())
         }
         "auth.session.absolute_ttl_seconds" => {
-            config.auth.session.absolute_ttl_seconds = Some(parse_positive_u64_key(key, raw_value)?)
+            config.auth.session.absolute_ttl_seconds = parse_optional_session_ttl(key, raw_value)?
         }
         "auth.session.idle_ttl_seconds" => {
             config.auth.session.idle_ttl_seconds = Some(parse_positive_u64_key(key, raw_value)?)

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2333,7 +2333,7 @@ fn load_persisted_config_materializes_auth_settings() {
         oidc.redirect_uri.as_deref(),
         Some("http://localhost/callback")
     );
-    assert_eq!(config.auth.session.absolute_ttl_seconds, 900);
+    assert_eq!(config.auth.session.absolute_ttl_seconds, Some(900));
     assert_eq!(config.auth.session.idle_ttl_seconds, 300);
 }
 
@@ -2358,16 +2358,6 @@ fn load_persisted_config_rejects_invalid_auth_settings() {
             "OIDC mode without provider settings",
             crate::config::AuthConfigFile {
                 mode: Some(crate::authentication::AuthenticationMode::Oidc),
-                ..Default::default()
-            },
-        ),
-        (
-            "zero absolute session TTL",
-            crate::config::AuthConfigFile {
-                session: crate::config::SessionConfigFile {
-                    absolute_ttl_seconds: Some(0),
-                    idle_ttl_seconds: Some(1),
-                },
                 ..Default::default()
             },
         ),
@@ -2403,6 +2393,33 @@ fn load_persisted_config_rejects_invalid_auth_settings() {
             "{name} should be rejected"
         );
     }
+}
+
+#[test]
+fn load_persisted_config_normalizes_zero_absolute_session_ttl_to_unlimited() {
+    let home = tempdir().unwrap();
+    save_persisted_config_at(
+        &persisted_config_path(home.path()),
+        &HolonConfigFile {
+            auth: crate::config::AuthConfigFile {
+                session: crate::config::SessionConfigFile {
+                    absolute_ttl_seconds: Some(0),
+                    idle_ttl_seconds: Some(1),
+                },
+                ..Default::default()
+            },
+            model: ModelConfigFile {
+                default: Some("anthropic/claude-sonnet-4-6".into()),
+                ..ModelConfigFile::default()
+            },
+            ..HolonConfigFile::default()
+        },
+    )
+    .unwrap();
+
+    let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+    assert_eq!(config.auth.session.absolute_ttl_seconds, None);
+    assert_eq!(config.auth.session.idle_ttl_seconds, 1);
 }
 
 #[test]

--- a/src/http/auth.rs
+++ b/src/http/auth.rs
@@ -15,8 +15,19 @@ pub struct SessionExchangeRequest {
 #[derive(Debug, Serialize)]
 pub struct SessionResponse {
     ok: bool,
-    expires_at: chrono::DateTime<Utc>,
+    expires_at: Option<chrono::DateTime<Utc>>,
     user_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuthMethodResponse {
+    mode: crate::authentication::AuthenticationMode,
+}
+
+pub async fn auth_method(State(state): State<Arc<AppState>>) -> Json<AuthMethodResponse> {
+    Json(AuthMethodResponse {
+        mode: state.host.config().auth.mode,
+    })
 }
 
 fn session_cookie(state: &AppState, credential: &str) -> String {
@@ -86,13 +97,49 @@ pub async fn exchange_session(
     if request.credential.trim().is_empty() {
         return Err(bad_request("credential must not be empty"));
     }
-    let session = crate::oidc::exchange_bootstrap(
-        state.host.runtime_db(),
-        &state.host.config().auth,
-        &request.credential,
-        Utc::now(),
-    )
-    .map_err(error_response)?;
+    let config = state.host.config();
+    let now = Utc::now();
+    let session = if config.auth.mode == crate::authentication::AuthenticationMode::Local {
+        let expected = config
+            .control_token
+            .as_deref()
+            .ok_or_else(|| bad_request("static token authentication is not configured"))?;
+        if request.credential != expected {
+            return Err(auth_required("invalid static token"));
+        }
+        let user_id = "local-static-token";
+        state
+            .host
+            .runtime_db()
+            .authentication()
+            .upsert_user(&crate::authentication::AuthUserRecord {
+                user_id: user_id.to_string(),
+                issuer: "local".to_string(),
+                subject: "static-token".to_string(),
+                display_name: Some("Local token user".to_string()),
+                email: None,
+                created_at: now,
+                updated_at: now,
+                disabled_at: None,
+            })
+            .map_err(error_response)?;
+        crate::oidc::issue_session(
+            state.host.runtime_db(),
+            &config.auth,
+            user_id,
+            "static_token",
+            now,
+        )
+        .map_err(error_response)?
+    } else {
+        crate::oidc::exchange_bootstrap(
+            state.host.runtime_db(),
+            &config.auth,
+            &request.credential,
+            now,
+        )
+        .map_err(error_response)?
+    };
     let cookie = session_cookie(&state, &session.credential);
     Ok((
         StatusCode::OK,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -551,6 +551,7 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/auth/oidc/start", get(auth::start_oidc_login))
         .route("/auth/oidc/callback", get(auth::complete_oidc_login))
+        .route("/auth/method", get(auth::auth_method))
         .route("/auth/session/exchange", post(auth::exchange_session))
         .route("/auth/session/logout", post(auth::logout))
         .route(
@@ -882,6 +883,9 @@ pub(crate) fn authorize_control(headers: &HeaderMap, state: &AppState) -> Result
     if state.host.config().auth.mode == crate::authentication::AuthenticationMode::Oidc {
         return authenticate_session(headers, state).map(|_| ());
     }
+    if session_credential(headers).is_some_and(|_| authenticate_session(headers, state).is_ok()) {
+        return Ok(());
+    }
     if !state.require_control_token {
         return Ok(());
     }
@@ -985,7 +989,11 @@ async fn session_auth_middleware(
     let api_path = path.strip_prefix("/api").unwrap_or(path);
     let anonymous = matches!(
         api_path,
-        "/auth/oidc/start" | "/auth/oidc/callback" | "/auth/session/exchange"
+        "/auth/oidc/start"
+            | "/auth/oidc/callback"
+            | "/auth/method"
+            | "/auth/session/exchange"
+            | "/login"
     ) || api_path.starts_with("/callbacks/")
         || api_path.starts_with("/webhooks/");
 
@@ -1512,6 +1520,7 @@ mod tests {
         assert_eq!(body["code"], "auth_required");
 
         let web_response = app
+            .clone()
             .oneshot(
                 Request::builder()
                     .method("GET")
@@ -1523,10 +1532,20 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(web_response.status(), StatusCode::FOUND);
-        assert_eq!(
-            web_response.headers()[header::LOCATION],
-            "/api/auth/oidc/start"
-        );
+        assert_eq!(web_response.headers()[header::LOCATION], "/login");
+
+        let login_response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/login")
+                    .header(header::ACCEPT, "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(login_response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/src/http/web.rs
+++ b/src/http/web.rs
@@ -9,6 +9,12 @@ pub async fn web_or_not_found_handler(
     if matches!(method, Method::GET | Method::HEAD) {
         let head_only = method == Method::HEAD;
         let request_path = uri.path().trim_start_matches('/');
+        if request_path == "login" {
+            if let Some(response) = web_asset_response(&state, "index.html", head_only).await {
+                return response;
+            }
+            return login_page_response(head_only);
+        }
         if !request_path.is_empty() {
             if let Some(response) = web_asset_response(&state, request_path, head_only).await {
                 return response;
@@ -20,7 +26,7 @@ pub async fn web_or_not_found_handler(
             {
                 return (
                     StatusCode::FOUND,
-                    [(LOCATION, HeaderValue::from_static("/api/auth/oidc/start"))],
+                    [(LOCATION, HeaderValue::from_static("/login"))],
                 )
                     .into_response();
             }
@@ -30,6 +36,33 @@ pub async fn web_or_not_found_handler(
         }
     }
     not_found("Not Found").into_response()
+}
+
+fn login_page_response(head_only: bool) -> AxumResponse {
+    let body = r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Holon login</title>
+  <style>body{font-family:system-ui,sans-serif;max-width:32rem;margin:12vh auto;padding:1.5rem;line-height:1.5}a{display:inline-block;background:#111;color:#fff;padding:.65rem 1rem;border-radius:.5rem;text-decoration:none}.hint{color:#666}</style>
+</head>
+<body>
+  <h1>Sign in to Holon</h1>
+  <p class="hint">Continue with the configured Holon authentication method.</p>
+  <p><a href="/api/auth/oidc/start">Continue with organization login</a></p>
+</body>
+</html>"#;
+    let body = if head_only {
+        Body::empty()
+    } else {
+        Body::from(body)
+    };
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "text/html; charset=utf-8")
+        .body(body)
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
 }
 
 pub(crate) fn accepts_html(headers: &HeaderMap) -> bool {

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -368,13 +368,18 @@ pub fn issue_session(
 ) -> Result<IssuedSession> {
     config.session.validate()?;
     let credential = random_secret();
-    let ttl_seconds = i64::try_from(config.session.absolute_ttl_seconds)
-        .context("session absolute TTL is too large")?;
-    let ttl = chrono::Duration::try_seconds(ttl_seconds)
-        .context("session absolute TTL is out of range")?;
-    let expires_at = now
-        .checked_add_signed(ttl)
-        .context("session expiration is out of range")?;
+    let expires_at = config
+        .session
+        .absolute_ttl_seconds
+        .map(|ttl_seconds| {
+            let ttl_seconds =
+                i64::try_from(ttl_seconds).context("session absolute TTL is too large")?;
+            let ttl = chrono::Duration::try_seconds(ttl_seconds)
+                .context("session absolute TTL is out of range")?;
+            now.checked_add_signed(ttl)
+                .context("session expiration is out of range")
+        })
+        .transpose()?;
     let record = AuthSessionRecord {
         session_digest: digest_secret(&credential),
         user_id: user_id.to_string(),

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -158,6 +158,7 @@ const ROUTES: &[RouteSpec] = &[
     route("delete", "/control/runtime/credentials/{profile}", "deleteRuntimeCredential", "runtime", "Delete runtime credential", "Remove a credential profile from the runtime credential store.", None, AuthKind::Control),
     route("post", "/auth/codex/device/start", "startCodexDeviceLogin", "auth", "Start Codex device login", "Request an OpenAI Codex device code and start a background job that persists the OAuth credential profile after user authorization.", None, AuthKind::Control),
     route("post", "/auth/{provider}/device/start", "startOAuthDeviceLogin", "auth", "Start OAuth device login", "Request a provider OAuth device code and start a background job that persists the OAuth credential profile after user authorization. Supported providers include openai-codex and xai.", None, AuthKind::Control),
+    route("get", "/auth/method", "authMethod", "auth", "Authentication method", "Return the configured authentication mode used by the Web login page.", None, AuthKind::None),
     route("post", "/control/runtime/shutdown", "runtimeShutdown", "runtime", "Runtime shutdown", "Request graceful runtime shutdown.", None, AuthKind::Control),
     route("post", "/control/agents/{agent_id}/debug-prompt", "debugPrompt", "control", "Debug prompt", "Render a diagnostic prompt preview.", Some("DebugPromptRequest"), AuthKind::Control),
     route("post", "/control/agents/{agent_id}/wake", "controlWake", "control", "Wake agent", "Submit a trusted wake hint.", Some("ControlWakeRequest"), AuthKind::Control),

--- a/src/runtime_db/authentication.rs
+++ b/src/runtime_db/authentication.rs
@@ -98,7 +98,7 @@ impl AuthenticationRepository<'_> {
                     session.user_id,
                     session.auth_method,
                     timestamp(session.created_at),
-                    timestamp(session.expires_at),
+                    session.expires_at.map(timestamp),
                     timestamp(session.last_seen_at),
                     session.revoked_at.map(timestamp),
                 ],
@@ -128,7 +128,7 @@ impl AuthenticationRepository<'_> {
                  SET last_seen_at = ?2
                  WHERE session_digest = ?1
                    AND revoked_at IS NULL
-                   AND expires_at > ?2
+                    AND (expires_at IS NULL OR expires_at > ?2)
                    AND last_seen_at <= ?2",
                 params![session_digest, timestamp(last_seen_at)],
             )? == 1)
@@ -304,7 +304,10 @@ fn row_to_session(row: &rusqlite::Row<'_>) -> rusqlite::Result<AuthSessionRecord
         user_id: row.get(1)?,
         auth_method: row.get(2)?,
         created_at: parse_timestamp(row.get(3)?)?,
-        expires_at: parse_timestamp(row.get(4)?)?,
+        expires_at: row
+            .get::<_, Option<String>>(4)?
+            .map(parse_timestamp)
+            .transpose()?,
         last_seen_at: parse_timestamp(row.get(5)?)?,
         revoked_at: row
             .get::<_, Option<String>>(6)?
@@ -390,7 +393,7 @@ mod tests {
             user_id: "user".into(),
             auth_method: "local".into(),
             created_at: now,
-            expires_at: now + chrono::Duration::hours(1),
+            expires_at: Some(now + chrono::Duration::hours(1)),
             last_seen_at: now + chrono::Duration::minutes(5),
             revoked_at: None,
         })?;

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3224,6 +3224,40 @@ CREATE INDEX IF NOT EXISTS idx_auth_login_expiry
         // record.
         sql: "",
     },
+    Migration {
+        version: 55,
+        name: "authentication_unlimited_sessions",
+        sql: r#"
+ALTER TABLE auth_sessions RENAME TO auth_sessions_previous;
+
+CREATE TABLE auth_sessions (
+  session_digest TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES auth_users(user_id),
+  auth_method TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  expires_at TEXT,
+  last_seen_at TEXT NOT NULL,
+  revoked_at TEXT
+);
+
+INSERT INTO auth_sessions (
+  session_digest, user_id, auth_method, created_at, expires_at,
+  last_seen_at, revoked_at
+)
+SELECT
+  session_digest, user_id, auth_method, created_at, expires_at,
+  last_seen_at, revoked_at
+FROM auth_sessions_previous;
+
+DROP TABLE auth_sessions_previous;
+
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_user
+  ON auth_sessions (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_expiry
+  ON auth_sessions (expires_at);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -93,7 +93,7 @@ fn render_live_inventory() -> String {
             route
         })
         .collect();
-    assert_eq!(routes.len(), 108, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 109, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -622,6 +622,20 @@
   },
   {
     "method": "get",
+    "path": "/api/auth/method",
+    "handler": "auth_method",
+    "operation_id": "authMethod",
+    "tag": "auth",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": []
+  },
+  {
+    "method": "get",
     "path": "/api/briefs",
     "handler": "briefs_default",
     "operation_id": "defaultBriefs",

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -24,6 +24,7 @@ import type { ComponentType } from "react";
 
 import holonMarkUrl from "../assets/holon-mark.png";
 import { AgentPage } from "../features/agent/AgentPage";
+import { LoginPage } from "../features/auth/LoginPage";
 import { Button } from "../components/ui/Button";
 import { EmptyState } from "../components/ui/EmptyState";
 import { SegmentedControl, SegmentedControlButton } from "../components/ui/SegmentedControl";
@@ -486,6 +487,9 @@ export function App() {
 
   if (isInitialBootstrapping) {
     return <BootstrappingPage connection={bootstrap.connection} onSetConnection={setRuntimeConnection} />;
+  }
+  if (bootstrap.connection.authRequired) {
+    return <LoginPage />;
   }
 
   return (

--- a/web-gui/app/src/features/auth/LoginPage.tsx
+++ b/web-gui/app/src/features/auth/LoginPage.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+
+export function LoginPage() {
+  const [token, setToken] = useState("");
+  const [error, setError] = useState<string>();
+  const [busy, setBusy] = useState(false);
+  const [oidc, setOidc] = useState<boolean>();
+  const returnTo = useMemo(() => {
+    const requested = new URLSearchParams(window.location.search).get("return_to");
+    return requested?.startsWith("/") && !requested.startsWith("//")
+      ? requested
+      : window.location.pathname === "/login"
+        ? "/"
+        : `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  }, []);
+
+  useEffect(() => {
+    void fetch("/api/auth/method", {
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Unable to discover authentication method.");
+        const body = (await response.json()) as { mode?: string };
+        setOidc(body.mode === "oidc");
+      })
+      .catch(() => setOidc(true));
+  }, []);
+
+  useEffect(() => {
+    if (oidc !== true) return;
+    window.location.replace(oidcStart);
+  }, [oidc]);
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    setBusy(true);
+    setError(undefined);
+    try {
+      const response = await fetch("/api/auth/session/exchange", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ credential: token }),
+      });
+      if (!response.ok) throw new Error("The token could not be exchanged.");
+      window.location.replace(returnTo || "/");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Login failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const oidcStart = `/api/auth/oidc/start?return_to=${encodeURIComponent(returnTo || "/")}`;
+  return (
+    <main className="login-page">
+      <section className="login-card" aria-labelledby="login-title">
+        <h1 id="login-title">Sign in to Holon</h1>
+        <p>
+          {oidc === false
+            ? "Enter a static token to create a session."
+            : "Continue with organization login."}
+        </p>
+        {oidc === true ? (
+          <a className="button button-primary" href={oidcStart}>
+            Continue with organization login
+          </a>
+        ) : null}
+        {oidc === false ? (
+          <form onSubmit={submit}>
+            <label htmlFor="login-token">Static token</label>
+            <input
+              id="login-token"
+              type="password"
+              value={token}
+              onChange={(event) => setToken(event.target.value)}
+              autoComplete="current-password"
+            />
+            <button className="button" type="submit" disabled={busy || !token.trim()}>
+              {busy ? "Signing in…" : "Sign in with token"}
+            </button>
+            {error ? <p role="alert">{error}</p> : null}
+          </form>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -681,7 +681,9 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
   const connectionMode = options.mode ?? (options.baseUrl ? "remote" : "local");
   const defaultBaseUrl = connectionMode === "local" ? DEFAULT_DEV_API_BASE : undefined;
   const baseUrl = normalizeBaseUrl(options.baseUrl ?? import.meta.env.VITE_HOLON_API_BASE ?? defaultBaseUrl);
-  const fetchImpl = options.fetchImpl ?? fetch;
+  const rawFetchImpl = options.fetchImpl ?? fetch;
+  const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
+    rawFetchImpl(input, { ...init, credentials: "include" })) as typeof fetch;
   const requestHeaders = authorizationHeaders(options.token);
   const hasToken = Boolean(options.token?.trim());
 

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -601,6 +601,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Authentication method
+         * @description Return the configured authentication mode used by the Web login page.
+         */
+        get: operations["authMethod"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/{provider}/device/start": {
         parameters: {
             query?: never;
@@ -2769,6 +2789,21 @@ export interface components {
         CompleteWorkItemRequest: {
             /** @enum {string|null} */
             authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
+            /**
+             * @description Declaration-based provenance supplied to a CLI launched by an agent.
+             *
+             *      These values describe the caller and its source activation, but are not
+             *      authentication material. A local process can forge them.
+             */
+            invocation_context?: {
+                caller_agent_id: string;
+                /** @enum {string|null} */
+                inherited_authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
+                source_activation_id?: string | null;
+                source_task_id?: string | null;
+                source_turn_id?: string | null;
+                source_work_item_id?: string | null;
+            } | null;
             report_text: string;
         };
         /** @description Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize. */
@@ -3152,6 +3187,21 @@ export interface components {
             authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
             /** @default false */
             clear_blocker: boolean;
+            /**
+             * @description Declaration-based provenance supplied to a CLI launched by an agent.
+             *
+             *      These values describe the caller and its source activation, but are not
+             *      authentication material. A local process can forge them.
+             */
+            invocation_context?: {
+                caller_agent_id: string;
+                /** @enum {string|null} */
+                inherited_authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
+                source_activation_id?: string | null;
+                source_task_id?: string | null;
+                source_turn_id?: string | null;
+                source_work_item_id?: string | null;
+            } | null;
             reason?: string | null;
         };
         /** PickWorkItemResponse */
@@ -4365,6 +4415,21 @@ export interface components {
             /** @enum {string|null} */
             authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
             blocked_by?: unknown;
+            /**
+             * @description Declaration-based provenance supplied to a CLI launched by an agent.
+             *
+             *      These values describe the caller and its source activation, but are not
+             *      authentication material. A local process can forge them.
+             */
+            invocation_context?: {
+                caller_agent_id: string;
+                /** @enum {string|null} */
+                inherited_authority_class?: "operator_instruction" | "runtime_instruction" | "integration_signal" | "external_evidence" | null;
+                source_activation_id?: string | null;
+                source_task_id?: string | null;
+                source_turn_id?: string | null;
+                source_work_item_id?: string | null;
+            } | null;
             objective?: string | null;
             /** @enum {string|null} */
             plan_status?: "draft" | "ready" | "needs_input" | null;
@@ -5676,6 +5741,44 @@ export interface operations {
         };
     };
     startCodexDeviceLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JsonValue"];
+                };
+            };
+            /** @description Client error JSON response. */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error JSON response. */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    authMethod: {
         parameters: {
             query?: never;
             header?: never;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -6759,6 +6759,35 @@ code {
   font-size: 10px;
 }
 
+.login-page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  background: var(--color-bg, #f6f7f9);
+}
+
+.login-card {
+  width: min(100%, 28rem);
+  display: grid;
+  gap: 1rem;
+  padding: 2rem;
+  border: 1px solid var(--color-border, #d9dde5);
+  border-radius: 1rem;
+  background: var(--color-surface, #fff);
+  box-shadow: 0 1rem 3rem rgb(15 23 42 / 10%);
+}
+
+.login-card form {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.login-card input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
 @media (max-width: 980px) {
   .timeline-events-toolbar,
   .timeline-events-workspace {


### PR DESCRIPTION
## 概要

- 将默认 session idle TTL 调整为 24 小时，并支持 `absolute_ttl_seconds = null` 表示无绝对过期上限；旧值 `0` 兼容归一化为 unlimited。
- 新增统一 Web `/login` 页面：OIDC 未认证访问先进入 `/login`，静态 token 也从该页面输入并交换 session。
- Web GUI 仅使用服务同源 API；补齐匿名路由、同源 `return_to` 校验、OpenAPI/路由快照、配置与认证文档。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test --all-targets`
- Node `22.12.0` / npm `10.9.0` 下 `npm run typecheck && npm run build`
- `git diff --check`

以上检查均通过；前端构建仅保留既有的大 chunk warning。
