### PR TITLE
fix: accept conversation binding in interrupted-schema47 E2E poll

### DIFF
--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -2474,6 +2474,7 @@ def run_runtime_upgrade_interrupted_schema47_case(
     deadline = time.monotonic() + harness.timeout_seconds
     old_live: dict[str, Any] | None = None
     matching: list[dict[str, Any]] = []
+    prompt_binding: dict[str, Any] = {}
     while time.monotonic() < deadline:
         old_live = harness.runtime_db_snapshot("upgrade-schema47-open-attempt")
         matching = [
@@ -2481,21 +2482,30 @@ def run_runtime_upgrade_interrupted_schema47_case(
             for row in old_live["execution_protocol_attempts"]
             if row["lifecycle_state"] == "open"
         ]
+        prompt_binding = {
+            row["agent_id"]: json.loads(row["payload_json"]).get("binding")
+            for row in matching
+        }
         binding_kinds = {
             json.loads(row["payload_json"]).get("binding", {}).get("kind")
             for row in matching
         }
         matching_agents = {row["agent_id"] for row in matching}
-        if {"agent_lifecycle", "work_item"}.issubset(binding_kinds) and {
-            lifecycle_agent,
-            work_item_agent,
-        }.issubset(matching_agents):
+        # Previous releases since v0.35.0 bind HTTP-control operator prompts
+        # to their conversation interaction instead of the bare agent
+        # lifecycle, so accept either binding for the interrupted prompt.
+        if (
+            "work_item" in binding_kinds
+            and binding_kinds & {"agent_lifecycle", "conversation"}
+            and {lifecycle_agent, work_item_agent}.issubset(matching_agents)
+        ):
             break
         matching = []
         time.sleep(0.5)
     require(
         matching,
-        "previous image did not retain open agent-lifecycle and WorkItem attempts",
+        "previous image did not retain open agent-lifecycle/conversation and "
+        f"WorkItem attempts: {prompt_binding}",
     )
     harness.crash()
     prompt_thread.join(timeout=35)


### PR DESCRIPTION
## Root cause (fixes the release v0.36.0 E2E blocker, refs #2778)

`runtime-upgrade-interrupted-schema47` failed **deterministically** in the v0.36.0 release E2E (runs 33780990403 and 33782733113, both with `previous_ref=v0.35.0`):

```
FAIL runtime-upgrade-interrupted-schema47: previous image did not retain open agent-lifecycle and WorkItem attempts
```

This is not the timing flake suspected in #2778. Reproduced locally (previous image built from the v0.35.0 release tarball, candidate at 9303080e). The last poll snapshot shows:

- the interrupted operator prompt on `main` is open with binding kind **`conversation`** (`interaction1_...`), not `agent_lifecycle`;
- the WorkItem activation on the worker agent is open with binding kind `work_item` (as required).

The case poll required open `agent_lifecycle` + `work_item` bindings simultaneously. Since v0.35.0, HTTP-control operator prompts get a trusted interaction id (`HttpControlPrompt`/`ControlAuthenticated`) and `unbound_execution_binding` maps them to `ExecutionBinding::Conversation`, so the poll can never succeed with a v0.35.0+ previous image. On 9/2 the same case passed with `previous=v0.34.0`, which masked the issue during the v0.35.0 release.

## Change

- Accept either `agent_lifecycle` (older previous images) or `conversation` (v0.35.0+) as the interrupted prompt binding; still require the `work_item` binding and both agents.
- Include the observed open bindings per agent in the failure message (the diagnostic #2778 asked for).

All later stages of the case (crash, offline `scheduler-recovery --all-affected`, schema migration attestation, fixed point) are binding-agnostic and unchanged.

## Verification

- `python3 -m pytest tests/test_docker_e2e_runner.py` — 85 passed.
- Local Docker E2E, single case, previous image built from v0.35.0 release assets + candidate image built at 9303080e:
  - before fix: `FAIL ... did not retain open agent-lifecycle and WorkItem attempts` (reproduced);
  - after fix: `PASS runtime-upgrade-interrupted-schema47`, attestation: prev schema 52 → candidate schema 55, affected agents `main` + worker, fixed point reached with no open attempts.