### PR TITLE
feat: add opt-in WorkItem-scoped provider context projection

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -142,6 +142,35 @@ pub(crate) fn reproject_recent_turns(
     .map(|content| turn_section("recent_turns", content))
 }
 
+pub(crate) fn reproject_work_item_scoped(
+    storage: &AppStorage,
+    reprojection: &RecentTurnsReprojection,
+    budget: usize,
+) -> Option<PromptSection> {
+    let work_item_id = reprojection.current_work_item.as_ref()?.id.as_str();
+    let turn_records = reprojection
+        .turn_records
+        .iter()
+        .filter(|record| record.effective_owner().work_item_id() == Some(work_item_id))
+        .cloned()
+        .collect::<Vec<_>>();
+    if turn_records.is_empty() {
+        return None;
+    }
+    render_turn_records_with_budget(
+        storage,
+        &turn_records,
+        &reprojection.messages,
+        &reprojection.briefs,
+        &reprojection.tools,
+        &reprojection.transcript,
+        &reprojection.current_message,
+        reprojection.current_work_item.as_ref(),
+        budget,
+    )
+    .map(|content| turn_section("recent_turns", content))
+}
+
 pub fn build_context(
     storage: &AppStorage,
     agent: &AgentState,

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -17,8 +17,9 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     context::{
-        build_context_with_default_external_ingress, reproject_recent_turns, BuiltContext,
-        ContextConfig, ContextPlanEvidence, RecentTurnsReprojection,
+        build_context_with_default_external_ingress, reproject_recent_turns,
+        reproject_work_item_scoped, BuiltContext, ContextConfig, ContextPlanEvidence,
+        RecentTurnsReprojection,
     },
     projection_eval::{
         compare_prompt_history_selectors, manifest_from_effective_prompt,
@@ -110,6 +111,58 @@ impl EffectivePrompt {
 
     pub fn compare_history_selectors(&self) -> serde_json::Result<ProjectionScorecard> {
         compare_prompt_history_selectors(self)
+    }
+
+    pub(crate) fn reproject_for_history_selector(
+        &self,
+        storage: &AppStorage,
+        budget: usize,
+        available_tools: &[ToolSpec],
+        selector: HistorySelector,
+    ) -> Option<Self> {
+        let reprojection = self.recent_turns_reprojection.as_ref()?;
+        let replacement = match selector {
+            HistorySelector::RecentTurns => reproject_recent_turns(storage, reprojection, budget),
+            HistorySelector::WorkItemScoped => {
+                reproject_work_item_scoped(storage, reprojection, budget)
+            }
+        };
+        // An unavailable scoped projection must fall back at the request
+        // boundary; it must never become an empty history section.
+        let replacement = replacement?;
+        let replacement_for_evidence = replacement.clone();
+        let mut context_sections = self
+            .context_sections
+            .iter()
+            .filter(|section| section.name != "recent_turns")
+            .cloned()
+            .collect::<Vec<_>>();
+        let insertion_index = self
+            .context_sections
+            .iter()
+            .position(|section| section.name == "recent_turns")
+            .unwrap_or(context_sections.len())
+            .min(context_sections.len());
+        context_sections.insert(insertion_index, replacement);
+        let rendered_context_attachment = render_sections(&context_sections);
+        if rendered_context_attachment == self.rendered_context_attachment {
+            return None;
+        }
+        let context_fingerprint = reprojected_context_fingerprint(
+            &self.cache_identity,
+            &self.execution,
+            &self.system_sections,
+            &context_sections,
+            available_tools,
+        );
+        let mut prompt = self.clone();
+        prompt.context_sections = context_sections;
+        prompt.rendered_context_attachment = rendered_context_attachment;
+        prompt.cache_identity.context_fingerprint = context_fingerprint;
+        prompt
+            .context_plan_evidence
+            .record_reprojection("recent_turns", Some(&replacement_for_evidence));
+        Some(prompt)
     }
 
     pub(crate) fn recent_turns_initial_budget(&self) -> Option<usize> {

--- a/src/runtime/turn/context_management.rs
+++ b/src/runtime/turn/context_management.rs
@@ -1,9 +1,111 @@
 //! Context management eligibility diagnostics for tool results.
 
+use crate::config::ModelRouteRef;
+use crate::projection_eval::{HistorySelector, ProjectionDiagnostics};
 use crate::provider::{
-    AgentProvider, ConversationMessage, ModelBlock, ProviderTurnRequest, ToolResultBlock,
+    AgentProvider, ConversationMessage, ModelBlock, ProviderPromptCapability, ProviderTurnRequest,
+    ToolResultBlock,
 };
 use serde_json::Value;
+
+pub(super) fn configured_history_selector(
+    agent_id: &str,
+    model: &ModelRouteRef,
+) -> HistorySelector {
+    configured_history_selector_with_lookup(agent_id, model, |key| std::env::var(key).ok())
+}
+
+pub(super) fn projection_fallback_reason(
+    provider: &dyn AgentProvider,
+    selector: HistorySelector,
+) -> Option<&'static str> {
+    if selector == HistorySelector::RecentTurns {
+        return None;
+    }
+    let capabilities = provider.prompt_capabilities();
+    if capabilities.contains(&ProviderPromptCapability::FullRequestOnly)
+        || capabilities.contains(&ProviderPromptCapability::PromptCacheKey)
+        || capabilities.contains(&ProviderPromptCapability::PromptCacheBlocks)
+    {
+        None
+    } else {
+        Some("provider_projection_capability_unavailable")
+    }
+}
+
+fn configured_history_selector_with_lookup(
+    agent_id: &str,
+    model: &ModelRouteRef,
+    mut lookup: impl FnMut(&str) -> Option<String>,
+) -> HistorySelector {
+    let model_ref = format!(
+        "{}@{}/{}",
+        model.provider.as_str(),
+        model.endpoint.as_str(),
+        model.model
+    );
+    let keys = [
+        format!(
+            "HOLON_CONTEXT_HISTORY_SELECTOR_AGENT_{}",
+            selector_env_component(agent_id)
+        ),
+        format!(
+            "HOLON_CONTEXT_HISTORY_SELECTOR_MODEL_{}",
+            selector_env_component(&model_ref)
+        ),
+        format!(
+            "HOLON_CONTEXT_HISTORY_SELECTOR_PROVIDER_{}",
+            selector_env_component(model.provider.as_str())
+        ),
+        "HOLON_CONTEXT_HISTORY_SELECTOR".to_string(),
+    ];
+    keys.iter()
+        .find_map(|key| lookup(key).and_then(|value| parse_configured_history_selector(&value)))
+        .unwrap_or(HistorySelector::RecentTurns)
+}
+
+fn selector_env_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn parse_configured_history_selector(value: &str) -> Option<HistorySelector> {
+    match value.trim() {
+        "work_item_scoped" => Some(HistorySelector::WorkItemScoped),
+        "recent_turns" => Some(HistorySelector::RecentTurns),
+        _ => None,
+    }
+}
+
+pub(super) fn projection_diagnostic(
+    prompt: &crate::prompt::EffectivePrompt,
+    selector: HistorySelector,
+    fallback_reason: Option<&str>,
+) -> Value {
+    let mut diagnostic = prompt
+        .projection_manifest_for_selector(selector)
+        .diagnostics
+        .unwrap_or_else(|| {
+            ProjectionDiagnostics::new(selector, "request_scoped_projection", None, 0, 0, 0)
+        });
+    if let Some(reason) = fallback_reason {
+        diagnostic = diagnostic.with_fallback_reason(reason);
+    }
+    serde_json::to_value(diagnostic).unwrap_or_else(|_| {
+        serde_json::json!({
+            "history_selector": selector.as_str(),
+            "fallback_reason": fallback_reason,
+        })
+    })
+}
 
 pub(super) fn context_management_diagnostic(
     provider: &dyn AgentProvider,
@@ -97,4 +199,107 @@ pub(super) fn estimate_context_management_eligible_tool_results(
 
 pub(super) fn is_context_management_excluded_tool(tool_name: Option<&str>) -> bool {
     matches!(tool_name, Some(crate::tool::names::APPLY_PATCH))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::{
+        config::ModelRouteRef,
+        provider::{
+            AgentProvider, ProviderPromptCapability, ProviderTurnRequest, ProviderTurnResponse,
+        },
+    };
+    use async_trait::async_trait;
+
+    use super::{
+        configured_history_selector_with_lookup, parse_configured_history_selector, HistorySelector,
+    };
+
+    #[test]
+    fn history_selector_defaults_to_recent_turns() {
+        assert_eq!(parse_configured_history_selector("unknown"), None);
+        assert_eq!(
+            parse_configured_history_selector(" work_item_scoped "),
+            Some(HistorySelector::WorkItemScoped)
+        );
+    }
+
+    #[test]
+    fn history_selector_prefers_agent_then_model_then_provider_then_global() {
+        let model = ModelRouteRef::parse("openai@default/gpt-5").unwrap();
+        let mut values = BTreeMap::from([
+            (
+                "HOLON_CONTEXT_HISTORY_SELECTOR".to_string(),
+                "work_item_scoped".to_string(),
+            ),
+            (
+                "HOLON_CONTEXT_HISTORY_SELECTOR_PROVIDER_OPENAI".to_string(),
+                "recent_turns".to_string(),
+            ),
+            (
+                "HOLON_CONTEXT_HISTORY_SELECTOR_MODEL_OPENAI_DEFAULT_GPT_5".to_string(),
+                "work_item_scoped".to_string(),
+            ),
+            (
+                "HOLON_CONTEXT_HISTORY_SELECTOR_AGENT_AGENT_1".to_string(),
+                "recent_turns".to_string(),
+            ),
+        ]);
+        let lookup = |key: &str| values.remove(key);
+        assert_eq!(
+            configured_history_selector_with_lookup("agent-1", &model, lookup),
+            HistorySelector::RecentTurns
+        );
+    }
+
+    #[test]
+    fn invalid_higher_priority_selector_falls_back_to_valid_lower_priority_value() {
+        let model = ModelRouteRef::parse("openai@default/gpt-5").unwrap();
+        let values = BTreeMap::from([
+            (
+                "HOLON_CONTEXT_HISTORY_SELECTOR_AGENT_AGENT_1".to_string(),
+                "typo".to_string(),
+            ),
+            (
+                "HOLON_CONTEXT_HISTORY_SELECTOR".to_string(),
+                "work_item_scoped".to_string(),
+            ),
+        ]);
+        let lookup = |key: &str| values.get(key).cloned();
+        assert_eq!(
+            configured_history_selector_with_lookup("agent-1", &model, lookup),
+            HistorySelector::WorkItemScoped
+        );
+    }
+
+    struct NoPromptProjectionProvider;
+
+    #[async_trait]
+    impl AgentProvider for NoPromptProjectionProvider {
+        async fn complete_turn(
+            &self,
+            _request: ProviderTurnRequest,
+        ) -> anyhow::Result<ProviderTurnResponse> {
+            Err(anyhow::anyhow!("test provider must not be called"))
+        }
+
+        fn prompt_capabilities(&self) -> Vec<ProviderPromptCapability> {
+            Vec::new()
+        }
+    }
+
+    #[test]
+    fn scoped_projection_requires_a_provider_request_capability() {
+        let provider = NoPromptProjectionProvider;
+        assert_eq!(
+            super::projection_fallback_reason(&provider, HistorySelector::WorkItemScoped),
+            Some("provider_projection_capability_unavailable")
+        );
+        assert_eq!(
+            super::projection_fallback_reason(&provider, HistorySelector::RecentTurns),
+            None
+        );
+    }
 }

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -41,7 +41,10 @@ use super::completion::{
     exec_command_disposition_field, exec_command_exit_status_field, exec_command_task_handle_field,
     rejects_truncated_mutation_tool_call, result_work_item_id, truncated_mutation_recovery_hint,
 };
-use super::context_management::context_management_diagnostic;
+use super::context_management::{
+    configured_history_selector, context_management_diagnostic, projection_diagnostic,
+    projection_fallback_reason as provider_projection_fallback_reason,
+};
 use super::projection::{
     build_round_estimated_tokens, build_turn_local_projection_with_runtime_reminder,
     normalize_provider_attempt_timing, provider_attempt_model_state, TurnLocalProjectionOutcome,
@@ -1144,6 +1147,31 @@ impl TurnExecution<'_> {
         ) = runtime
             .provider_tool_selection_for_turn(&identity, model_selection.fallback_model())
             .await?;
+        let configured_selector =
+            configured_history_selector(agent_id, &turn_model_state.effective_model);
+        let mut projection_selector = configured_selector;
+        let mut projection_fallback_reason =
+            provider_projection_fallback_reason(provider.as_ref(), configured_selector);
+        if configured_selector == crate::projection_eval::HistorySelector::WorkItemScoped {
+            if projection_fallback_reason.is_none() {
+                let context_config = runtime.current_context_config().await;
+                if effective_prompt
+                    .reproject_for_history_selector(
+                        &runtime.inner.storage,
+                        context_config.turn_projection_budget(),
+                        &available_tools,
+                        configured_selector,
+                    )
+                    .map(|projected| effective_prompt = projected)
+                    .is_none()
+                {
+                    projection_fallback_reason = Some("work_item_scoped_projection_unavailable");
+                }
+            }
+            if projection_fallback_reason.is_some() {
+                projection_selector = crate::projection_eval::HistorySelector::RecentTurns;
+            }
+        }
         let allowed_tool_names = available_tools
             .iter()
             .map(|tool| tool.name.clone())
@@ -1255,7 +1283,13 @@ impl TurnExecution<'_> {
                     native_web_search.clone(),
                 );
                 crate::diagnostics::record_provider_request_build(request_build_started.elapsed());
-                let context_management = context_management_diagnostic(provider.as_ref(), &request);
+                let mut context_management =
+                    context_management_diagnostic(provider.as_ref(), &request);
+                context_management["history_projection"] = projection_diagnostic(
+                    &effective_prompt,
+                    projection_selector,
+                    projection_fallback_reason,
+                );
                 let context_build_ms = context_build_started.elapsed().as_millis() as u64;
                 let (result, provider_started_at, provider_completed_at, provider_round_ms) =
                     runtime
@@ -1644,7 +1678,13 @@ impl TurnExecution<'_> {
                     available_tools.clone(),
                     native_web_search.clone(),
                 );
-                let context_management = context_management_diagnostic(provider.as_ref(), &request);
+                let mut context_management =
+                    context_management_diagnostic(provider.as_ref(), &request);
+                context_management["history_projection"] = projection_diagnostic(
+                    &effective_prompt,
+                    projection_selector,
+                    projection_fallback_reason,
+                );
                 let context_build_ms = context_build_started.elapsed().as_millis() as u64;
                 let (result, provider_started_at, provider_completed_at, provider_round_ms) =
                     runtime

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -212,6 +212,12 @@ fn isolated_holon_command() -> (Command, tempfile::TempDir) {
             "HOLON_SOCKET_PATH",
             home.path().join("run").join("missing.sock"),
         )
+        .env_remove("HOLON_CALLER_AGENT_ID")
+        .env_remove("HOLON_CALLER_SOURCE_TASK_ID")
+        .env_remove("HOLON_CALLER_SOURCE_TURN_ID")
+        .env_remove("HOLON_CALLER_SOURCE_WORK_ITEM_ID")
+        .env_remove("HOLON_CALLER_SOURCE_ACTIVATION_ID")
+        .env_remove("HOLON_CALLER_AUTHORITY_CLASS")
         .env_remove("HOLON_CONTROL_TOKEN")
         .env_remove("HOLON_CONTROL_AUTH_MODE")
         .env_remove("RUST_LOG");


### PR DESCRIPTION
## Summary

Part of #2768. This PR wires the existing context projection into the production provider request path while preserving baseline behavior by default.

- Adds an explicit request-boundary projection using the canonical turn/work-item context.
- Keeps `recent_turns` as the default selector; `work_item_scoped` is explicit opt-in via `HOLON_CONTEXT_HISTORY_SELECTOR=work_item_scoped`.
- Adds provider capability/cache compatibility checks and deterministic baseline fallback for missing work-item anchors, projection failures, or unsupported providers.
- Records projection diagnostics without persisting or rewriting canonical transcript history and without changing scheduler, replay, retry, settlement, or provider call-count semantics.
- Adds isolated environment/config coverage and regression tests.

## Default decision

The hard enablement gate is not met in this PR: no new real-provider telemetry is available from the test environment. Therefore the default remains baseline (`recent_turns`), with the scoped projection available for explicit opt-in evaluation.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test --all-targets`
- `git diff --check`

All passed. Live-provider tests remain ignored unless provider credentials and network access are configured.
