### PR TITLE
fix: fall back to session cookie when bearer credential is stale

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -43,6 +43,12 @@ The same session can be supplied to API clients as
 `Authorization: Bearer <session>`. `POST /api/auth/session/logout` revokes the
 current session and clears the cookie.
 
+When a request presents both a Bearer session credential and a session cookie,
+the runtime tries the Bearer credential first and falls back to the cookie. A
+stale Bearer token (for example a static control token cached by a browser
+before the deployment switched to OIDC) therefore cannot mask a valid session
+cookie.
+
 In OIDC mode, normal API, SSE, and Web requests require an active session.
 Missing, expired, revoked, or disabled-user sessions return HTTP `401` with the
 `auth_required` error code. Bootstrap/session exchange, OIDC callback, callback

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -917,23 +917,25 @@ pub(crate) fn authorize_remote_access(headers: &HeaderMap, state: &AppState) -> 
     Ok(())
 }
 
-pub(crate) fn session_credential(headers: &HeaderMap) -> Option<String> {
-    if let Some(value) = headers
+fn bearer_session_credential(headers: &HeaderMap) -> Option<String> {
+    let value = headers
         .get(AUTHORIZATION)
-        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.to_str().ok())?;
+    let mut parts = value.split_whitespace();
+    if !parts
+        .next()
+        .is_some_and(|scheme| scheme.eq_ignore_ascii_case("Bearer"))
     {
-        let mut parts = value.split_whitespace();
-        if parts
-            .next()
-            .is_some_and(|scheme| scheme.eq_ignore_ascii_case("Bearer"))
-        {
-            if let Some(token) = parts.next().filter(|token| !token.is_empty()) {
-                if parts.next().is_none() {
-                    return Some(token.to_string());
-                }
-            }
-        }
+        return None;
     }
+    let token = parts.next().filter(|token| !token.is_empty())?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(token.to_string())
+}
+
+fn cookie_session_credential(headers: &HeaderMap) -> Option<String> {
     headers
         .get(COOKIE)
         .and_then(|value| value.to_str().ok())
@@ -945,13 +947,40 @@ pub(crate) fn session_credential(headers: &HeaderMap) -> Option<String> {
         })
 }
 
+pub(crate) fn session_credential(headers: &HeaderMap) -> Option<String> {
+    bearer_session_credential(headers).or_else(|| cookie_session_credential(headers))
+}
+
+/// Authenticate a request by trying each presented session credential in
+/// priority order: the `Authorization: Bearer` session first, then the
+/// `holon_session` cookie. Browsers upgrading from a static-token deployment
+/// may keep sending a stale Bearer token; it must not mask a valid session
+/// cookie, or OIDC logins loop between the callback and the login page.
 pub(crate) fn authenticate_session(
     headers: &HeaderMap,
     state: &AppState,
 ) -> Result<crate::authentication::AuthSessionRecord> {
-    let credential =
-        session_credential(headers).ok_or_else(|| anyhow!("missing session credential"))?;
-    let digest = crate::authentication::digest_secret(&credential);
+    let mut last_error = anyhow!("missing session credential");
+    for credential in [
+        bearer_session_credential(headers),
+        cookie_session_credential(headers),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        match authenticate_session_credential(&credential, state) {
+            Ok(session) => return Ok(session),
+            Err(error) => last_error = error,
+        }
+    }
+    Err(last_error)
+}
+
+fn authenticate_session_credential(
+    credential: &str,
+    state: &AppState,
+) -> Result<crate::authentication::AuthSessionRecord> {
+    let digest = crate::authentication::digest_secret(credential);
     let session = state
         .host
         .runtime_db()
@@ -1449,8 +1478,8 @@ pub async fn serve_unix(
 #[cfg(test)]
 mod tests {
     use super::{
-        error_response, projection_gate_error_response, router, session_credential, AppState,
-        ProjectionGate, ProjectionGateError,
+        authenticate_session, error_response, projection_gate_error_response, router,
+        session_credential, AppState, ProjectionGate, ProjectionGateError,
     };
     use crate::{
         config::AppConfig,
@@ -1539,6 +1568,89 @@ mod tests {
             HeaderValue::from_static("holon_session=; theme=dark"),
         );
         assert!(session_credential(&headers).is_none());
+    }
+
+    fn oidc_test_host_with_session() -> (tempfile::TempDir, RuntimeHost, String) {
+        let (home, host) = oidc_test_host();
+        let now = chrono::Utc::now();
+        let authentication = host.runtime_db().authentication();
+        authentication
+            .upsert_user(&crate::authentication::AuthUserRecord {
+                user_id: "user-1".to_string(),
+                issuer: "https://issuer.example".to_string(),
+                subject: "subject-1".to_string(),
+                display_name: None,
+                email: None,
+                created_at: now,
+                updated_at: now,
+                disabled_at: None,
+            })
+            .unwrap();
+        let session_secret = "cookie-session-secret".to_string();
+        authentication
+            .create_session(&crate::authentication::AuthSessionRecord {
+                session_digest: crate::authentication::digest_secret(&session_secret),
+                user_id: "user-1".to_string(),
+                auth_method: "oidc".to_string(),
+                created_at: now,
+                expires_at: None,
+                last_seen_at: now,
+                revoked_at: None,
+            })
+            .unwrap();
+        (home, host, session_secret)
+    }
+
+    #[test]
+    fn authenticate_session_falls_back_to_cookie_when_bearer_is_stale() {
+        let (_home, host, session_secret) = oidc_test_host_with_session();
+        let app = AppState::for_tcp(host);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer stale-static-token"),
+        );
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_str(&format!("theme=dark; holon_session={session_secret}")).unwrap(),
+        );
+        let session = authenticate_session(&headers, &app)
+            .expect("valid cookie should authenticate when the bearer token is stale");
+        assert_eq!(session.user_id, "user-1");
+    }
+
+    #[test]
+    fn authenticate_session_keeps_bearer_priority_and_rejects_stale_credentials() {
+        let (_home, host, session_secret) = oidc_test_host_with_session();
+        let app = AppState::for_tcp(host);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {session_secret}")).unwrap(),
+        );
+        assert!(authenticate_session(&headers, &app).is_ok());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer stale-static-token"),
+        );
+        assert!(authenticate_session(&headers, &app).is_err());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer stale-static-token"),
+        );
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_static("holon_session=wrong-cookie"),
+        );
+        assert!(authenticate_session(&headers, &app).is_err());
+
+        let headers = HeaderMap::new();
+        assert!(authenticate_session(&headers, &app).is_err());
     }
 
     #[tokio::test]

--- a/web-gui/app/src/features/auth/LoginPage.tsx
+++ b/web-gui/app/src/features/auth/LoginPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import holonMarkUrl from "../../assets/holon-mark.png";
 import { Button } from "../../components/ui/Button";
+import { clearStoredRuntimeConnectionToken } from "../../runtime/runtime-store";
 
 export function LoginPage() {
   const { t } = useTranslation();
@@ -28,6 +29,11 @@ export function LoginPage() {
       .then(async (response) => {
         if (!response.ok) throw new Error(t("auth.authMethodError"));
         const body = (await response.json()) as { mode?: string };
+        if (body.mode === "oidc") {
+          // OIDC runtimes authenticate via the session cookie; a stored
+          // static token would be sent as a stale Bearer header and mask it.
+          clearStoredRuntimeConnectionToken();
+        }
         setOidc(body.mode === "oidc");
       })
       .catch(() => setOidc(true));

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -16,6 +16,7 @@ import {
   modelCatalogCacheKey,
   missingBriefIdsForHydration,
   observerSyncDiagnostics,
+  clearStoredRuntimeConnectionToken,
   readStoredRemoteConnectionProfiles,
   retryPendingReadMarker,
   resetSessionsForResume,
@@ -648,6 +649,37 @@ describe("runtime connection storage", () => {
 
     expect(readStoredRuntimeConnectionConfig()).toEqual({ mode: "local" });
     expect(readStoredRemoteConnectionProfiles()).toEqual([]);
+  });
+
+  it("clears stale stored tokens once an oidc runtime is confirmed", () => {
+    const sharedLocalStorage = new MemoryStorage();
+    const windowSession = new MemoryStorage();
+
+    installWindow(sharedLocalStorage, windowSession);
+    writeStoredRuntimeConnectionConfig({
+      mode: "remote",
+      baseUrl: "https://holon.example",
+      token: "stale-static-token",
+    });
+    expect(readStoredRuntimeConnectionConfig()).toEqual({
+      mode: "remote",
+      baseUrl: "https://holon.example",
+      token: "stale-static-token",
+    });
+
+    clearStoredRuntimeConnectionToken();
+
+    expect(readStoredRuntimeConnectionConfig()).toEqual({
+      mode: "remote",
+      baseUrl: "https://holon.example",
+    });
+
+    // A fresh window session must not rehydrate the stale profile token.
+    installWindow(sharedLocalStorage, new MemoryStorage());
+    expect(readStoredRuntimeConnectionConfig()).toEqual({ mode: "local" });
+    expect(readStoredRemoteConnectionProfiles()).toEqual([
+      { baseUrl: "https://holon.example", hasToken: false },
+    ]);
   });
 });
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -828,6 +828,34 @@ function writeStoredRemoteProfile(config: RuntimeConnectionConfig): void {
   }
 }
 
+/**
+ * Drop any stored static control token for the active connection and its
+ * remote profile. OIDC runtimes authenticate through the session cookie; a
+ * stale static token kept from an earlier local-mode deployment would still
+ * be sent as a Bearer header and mask the fresh cookie, looping the login
+ * flow between the callback and the login page.
+ */
+export function clearStoredRuntimeConnectionToken(): void {
+  if (typeof window === "undefined") return;
+  const activeConfig = coerceRuntimeConnectionConfig(
+    readStoredJson(window.sessionStorage, ACTIVE_RUNTIME_CONNECTION_STORAGE_KEY),
+  );
+  if (activeConfig?.token) {
+    writeActiveRuntimeConnectionConfig({ ...activeConfig, token: undefined });
+  }
+  if (activeConfig?.mode !== "remote" || !activeConfig.baseUrl) return;
+  const profiles = readStoredRemoteProfiles();
+  const key = remoteProfileKey(activeConfig.baseUrl);
+  const profile = profiles[key];
+  if (!profile?.token) return;
+  profiles[key] = { ...profile, token: undefined };
+  try {
+    window.localStorage.setItem(RUNTIME_CONNECTION_PROFILES_STORAGE_KEY, JSON.stringify(profiles));
+  } catch {
+    // Ignore storage failures; the in-memory connection still applies.
+  }
+}
+
 export function readStoredRemoteConnectionProfiles(): RuntimeConnectionProfile[] {
   if (!canUseRemoteRuntimeConnections()) return [];
   return Object.values(readStoredRemoteProfiles())


### PR DESCRIPTION
## Summary

Fixes an OIDC login loop: after a deployment switches from static-token (local) mode to OIDC, browsers that still carry the old static control token send it as `Authorization: Bearer` on every request. Session authentication preferred the Bearer header and never fell back to the `holon_session` cookie, so the stale header masked the freshly issued session cookie — every API request returned 401 and the web GUI looped between the OIDC callback and `/login`.

## Changes

- **Server (`src/http/mod.rs`)**: `authenticate_session` now tries each presented credential in priority order (Bearer first, then the session cookie) and accepts the first valid session. Credential priority is unchanged; only failed lookups now fall back instead of failing the whole request.
- **Web GUI**: `clearStoredRuntimeConnectionToken()` drops stored static connection tokens (active config + remote profile) once the login page confirms the runtime is in OIDC mode, so stale tokens stop shadowing the cookie.
- **Docs**: `docs/authentication.md` documents the credential fallback.

## Test evidence

- New unit tests: `authenticate_session_falls_back_to_cookie_when_bearer_is_stale`, `authenticate_session_keeps_bearer_priority_and_rejects_stale_credentials` — `cargo test --lib http::tests` 10/10 pass.
- New web-gui test: `clears stale stored tokens once an oidc runtime is confirmed` — full suite `vitest run` 479/479 pass, `tsc --noEmit` clean.
- `cargo fmt --check` clean; `cargo clippy --lib` no new warnings for touched files.

## Compatibility

- No protocol/API changes; Bearer keeps priority, valid static-token (local mode) flows are untouched (`authorize_control` still falls back to the configured control token after session checks).
- Requests with no valid credential still return the same `auth_required` 401.