### PR TITLE
fix: preserve repeating timer schedule sequence

### DIFF
--- a/src/runtime/tests/timers.rs
+++ b/src/runtime/tests/timers.rs
@@ -109,6 +109,71 @@ async fn runtime_recovers_active_timer_without_next_fire_at() {
     runtime_task.abort();
 }
 
+#[tokio::test(start_paused = true)]
+async fn runtime_recovers_overdue_repeating_timer_on_original_schedule() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let clock = controlled_clock();
+    let now = clock.now();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let scheduled_fire_at = now - chrono::Duration::seconds(5);
+    storage
+        .append_timer(&TimerRecord {
+            id: "timer-recover-repeat".into(),
+            agent_id: "default".into(),
+            created_at: scheduled_fire_at - chrono::Duration::seconds(1),
+            duration_ms: 1_000,
+            interval_ms: Some(1_000),
+            repeat: true,
+            status: TimerStatus::Active,
+            summary: Some("repeating timer recovered".into()),
+            next_fire_at: Some(scheduled_fire_at),
+            last_fired_at: None,
+            fire_count: 0,
+        })
+        .unwrap();
+
+    let runtime = RuntimeHandle::new_with_clock(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("timer done")),
+        "default".into(),
+        context_config(),
+        clock,
+    )
+    .unwrap();
+    let runtime_task = tokio::spawn(runtime.clone().run());
+    wait_for_audit_events(
+        &runtime,
+        100,
+        |events| {
+            events.iter().any(|event| {
+                event.kind == "timer_fired"
+                    && event
+                        .data
+                        .get("timer_id")
+                        .and_then(serde_json::Value::as_str)
+                        == Some("timer-recover-repeat")
+            })
+        },
+        "recovered overdue repeating timer",
+    )
+    .await;
+
+    let timer = runtime
+        .recent_timers(10)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|timer| timer.id == "timer-recover-repeat" && timer.fire_count == 1)
+        .unwrap();
+    assert_eq!(timer.status, TimerStatus::Active);
+    assert_eq!(timer.next_fire_at, Some(now + chrono::Duration::seconds(1)));
+    runtime_task.abort();
+}
+
 #[tokio::test]
 async fn schedule_timer_rejects_unrepresentable_duration() {
     let dir = tempdir().unwrap();

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -1289,6 +1289,7 @@ impl RuntimeHandle {
             }
         }
 
+        let scheduled_fire_at = timer.next_fire_at;
         let work_item_id = self
             .wait_condition_work_item_id_for_timer(&timer.id)
             .await?;
@@ -1325,7 +1326,11 @@ impl RuntimeHandle {
         timer.fire_count += 1;
         if let Some(interval_ms) = timer.interval_ms {
             timer.status = TimerStatus::Active;
-            timer.next_fire_at = Some(advance_time(fired_at, interval_ms)?);
+            timer.next_fire_at = Some(next_repeating_fire_at(
+                scheduled_fire_at.unwrap_or(fired_at),
+                fired_at,
+                interval_ms,
+            )?);
         } else {
             timer.status = TimerStatus::Completed;
             timer.next_fire_at = None;
@@ -2018,7 +2023,42 @@ fn advance_time(base: chrono::DateTime<Utc>, delta_ms: u64) -> Result<chrono::Da
     let delta_ms = i64::try_from(delta_ms).context("duration_ms exceeds supported timer range")?;
     let delta = chrono::Duration::try_milliseconds(delta_ms)
         .ok_or_else(|| anyhow!("duration_ms exceeds supported timer range"))?;
-    Ok(base + delta)
+    base.checked_add_signed(delta)
+        .ok_or_else(|| anyhow!("timer deadline exceeds supported date range"))
+}
+
+fn next_repeating_fire_at(
+    scheduled_fire_at: DateTime<Utc>,
+    fired_at: DateTime<Utc>,
+    interval_ms: u64,
+) -> Result<DateTime<Utc>> {
+    let interval_ms =
+        i64::try_from(interval_ms).context("duration_ms exceeds supported timer range")?;
+    anyhow::ensure!(
+        interval_ms > 0,
+        "repeating timer interval must be greater than zero"
+    );
+
+    let first_next_fire_at = advance_time(scheduled_fire_at, interval_ms as u64)?;
+    if first_next_fire_at > fired_at {
+        return Ok(first_next_fire_at);
+    }
+
+    let elapsed_ms = fired_at
+        .signed_duration_since(scheduled_fire_at)
+        .num_milliseconds();
+    let periods = elapsed_ms
+        .checked_div(interval_ms)
+        .and_then(|periods| periods.checked_add(1))
+        .context("repeating timer schedule exceeds supported timer range")?;
+    let next_delta_ms = interval_ms
+        .checked_mul(periods)
+        .context("repeating timer schedule exceeds supported timer range")?;
+    advance_time(
+        scheduled_fire_at,
+        u64::try_from(next_delta_ms)
+            .context("repeating timer schedule exceeds supported timer range")?,
+    )
 }
 
 fn normalize_recovered_timer(mut timer: TimerRecord, now: DateTime<Utc>) -> TimerRecord {


### PR DESCRIPTION
## Issue
Fixes holon-run/holon#2786.

## Summary
- Preserve `next_fire_at` as the repeating timer's planned schedule sequence instead of re-anchoring it to the actual firing time.
- When delayed or recovered overdue timers fire, advance from the scheduled slot and skip missed slots until the next slot is strictly in the future.
- Keep `last_fired_at` tied to the actual firing time and preserve one-shot completion behavior.
- Add a regression test covering recovery of an overdue repeating timer.

## Verification
- `cargo fmt --all -- --check` — passed.
- `cargo test --lib runtime::tests::timers -- --nocapture` — passed.
- `RUSTFLAGS="-D warnings" cargo check --all-targets` — passed.
- `git diff --check` — passed.
