### PR TITLE
fix(runtime): abort exhausted empty output recovery

### DIFF
--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -418,6 +418,8 @@ impl TruncatingProvider {
     }
 }
 
+pub(crate) struct EmptyTruncatingProvider;
+
 pub(crate) struct TimelineProvider;
 
 pub(crate) struct OneToolThenTextProvider {
@@ -617,6 +619,22 @@ impl AgentProvider for TruncatingProvider {
             stop_reason: None,
             input_tokens: 50,
             output_tokens: 25,
+            cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: None,
+        })
+    }
+}
+
+#[async_trait]
+impl AgentProvider for EmptyTruncatingProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        Ok(ProviderTurnResponse {
+            blocks: Vec::new(),
+            stop_reason: Some("max_tokens".into()),
+            input_tokens: 100,
+            output_tokens: 50,
             cache_usage: None,
             provider_message_id: None,
             provider_request_id: None,

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -339,6 +339,56 @@ async fn runtime_recovers_from_max_token_truncation() {
 }
 
 #[tokio::test]
+async fn runtime_aborts_with_failure_brief_when_empty_output_recovery_is_exhausted() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(EmptyTruncatingProvider),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let outcome = runtime
+        .run_agent_loop(
+            "default",
+            AuthorityClass::OperatorInstruction,
+            test_effective_prompt(),
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.terminal_kind, TurnTerminalKind::Aborted);
+    assert_eq!(outcome.terminal.kind, TurnTerminalKind::Aborted);
+    assert!(outcome.final_text.contains("output recovery was exhausted"));
+    assert!(outcome.terminal.no_brief_reason.is_none());
+
+    let briefs = runtime.storage().read_recent_briefs(10).unwrap();
+    let failure_brief = briefs
+        .iter()
+        .find(|brief| brief.turn_id.as_deref() == Some(outcome.terminal.turn_id.as_str()))
+        .expect("empty recovery must produce a failure brief");
+    assert_eq!(failure_brief.kind, BriefKind::Failure);
+    assert_eq!(failure_brief.text, outcome.final_text);
+
+    let events = runtime.storage().read_recent_events(200).unwrap();
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "max_output_tokens_recovery_exhausted"));
+    assert!(!events.iter().any(|event| {
+        event.kind == "terminal_missing_brief_settlement"
+            || event.kind == "turn_terminal_brief_settlement_failed"
+    }));
+}
+
+#[tokio::test]
 async fn runtime_records_text_only_round_observations() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -2401,6 +2401,47 @@ impl TurnExecution<'_> {
                 }
             }
 
+            if tool_calls.is_empty()
+                && is_max_output_stop_reason(stop_reason.as_deref())
+                && max_output_recovery_count >= MAX_OUTPUT_RECOVERY_ATTEMPTS
+                && last_assistant_message
+                    .as_ref()
+                    .is_none_or(|message| message.trim().is_empty())
+            {
+                let failure_text = "Turn stopped because output recovery was exhausted before the provider produced deliverable text.".to_string();
+                runtime.inner.storage.append_event(&AuditEvent::legacy(
+                    "max_output_tokens_recovery_exhausted",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "attempts": max_output_recovery_count,
+                        "stop_reason": stop_reason,
+                    }),
+                ))?;
+                let terminal = runtime
+                    .persist_turn_terminal_record(
+                        TurnTerminalKind::Aborted,
+                        Some(failure_text.clone()),
+                        None,
+                        turn_started_at.elapsed().as_millis() as u64,
+                        Some(&checkpoint_state),
+                        persist_terminal,
+                    )
+                    .await?;
+                return Ok(AgentLoopOutcome {
+                    final_text: failure_text,
+                    final_citations: Vec::new(),
+                    final_text_source_assistant_round_id: None,
+                    turn_index: terminal.turn_index,
+                    terminal,
+                    should_sleep: false,
+                    sleep_duration_ms: None,
+                    allow_sleep_runnable_work_override: false,
+                    terminal_kind: TurnTerminalKind::Aborted,
+                    prepared_work_item_completion: prepared_work_item_completion.take(),
+                    terminal_tool_executions: Vec::new(),
+                });
+            }
+
             if tool_calls.is_empty() && checkpoint_recorded_this_round {
                 completed_rounds.push(build_checkpoint_resume_round(
                     round,


### PR DESCRIPTION
## Summary

- abort the turn when max-output recovery is exhausted without any deliverable assistant text
- emit a stable failure message so the existing terminal settlement path creates a `BriefKind::Failure`
- add a scripted empty-truncation provider regression covering terminal kind, Failure Brief, audit event, and absence of settlement errors

Closes #2680.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib runtime::tests::turns -- --nocapture` (35 passed)
- `cargo test --lib runtime::tests::turns::runtime_aborts_with_failure_brief_when_empty_output_recovery_is_exhausted -- --nocapture`
- `git diff --check`
