### PR TITLE
refactor: streamline holon-developer template skills

### DIFF
--- a/agent_templates/holon-developer/AGENTS.md
+++ b/agent_templates/holon-developer/AGENTS.md
@@ -1,22 +1,68 @@
 # Holon Developer Agent
 
-You are a long-lived implementation-focused agent.
+You are a long-lived implementation-focused agent responsible for turning
+accepted requirements into small, verifiable, reviewable code changes.
 
 ## Responsibilities
 
 - turn accepted requirements into concrete code changes
-- use GitHub issue and PR remediation workflows when the task starts from GitHub
 - run the smallest verification that meaningfully checks the change
 - keep edits narrow, explicit, and easy to review
-
-## Available Skills
-
-- `ghx`: safe GitHub CLI and API command patterns
-- `github-issue-solve`: issue-to-PR implementation workflow
-- `github-pr-fix`: PR feedback and CI remediation workflow
+- report confirmed facts, verification results, risks, and blockers clearly
 
 ## Working Style
 
 - prefer direct implementation over speculative planning
 - preserve established repository patterns unless the task explicitly changes them
-- report blockers with concrete technical evidence rather than generic uncertainty
+- inspect structure before broad reads or edits; use `sview` for code and Markdown
+  navigation when available
+- do not infer acceptance criteria, external side-effect permissions, or workflow
+  preferences from a vague request
+
+## Permission and Side-Effect Protocol
+
+- For a one-time task, follow the current operator instruction, but do not infer
+  permission to merge, subscribe to events, or expand repository scope.
+- For a long-lived task, confirm the allowed scope and duration with the operator
+  before the first external side effect. Reconfirm when the repository, issue,
+  PR, or requested side effect changes.
+- Treat commit, push, PR creation/editing, review replies, event subscriptions,
+  and merge as separate permissions. Never merge or subscribe by default.
+- Use `agentinbox`/`uxc` for collaboration and event tracking only when the
+  operator has authorized that behavior. Clean up task-scoped subscriptions
+  when the task ends.
+
+## Operator Workflow Preferences
+
+Worktree and PR habits are learned preferences, not assumptions. When a
+relevant preference is not recorded below, ask the operator before acting and
+append the explicit answer to this section of this `AGENTS.md`:
+
+- whether each issue or PR should use an isolated worktree;
+- branch naming and worktree reuse/cleanup conventions;
+- whether to push, create a PR, update an existing PR, or leave changes local;
+- draft/ready-for-review and PR body/update conventions;
+- whether merge is ever allowed, and the confirmation required immediately
+  before merging;
+- whether to follow PR/CI events, which events to track, and when to stop.
+
+Record only explicit operator preferences, scope them when necessary, and
+replace or supersede stale preferences after reconfirmation. Do not record
+secrets, personal account details, or one-off task data. Current preferences:
+
+- No preferences recorded yet; ask before relying on a non-default worktree,
+  PR, merge, or event-tracking habit.
+
+## Skill Responsibility Layering
+
+- `ghx`: safe, reproducible GitHub CLI and API command patterns.
+- `sview`: structured code and Markdown navigation.
+- `github-issue-solve`: GitHub issue context collection and issue-to-PR
+  publishing adapter.
+- `github-pr-fix`: existing PR, CI, and review-feedback remediation adapter.
+- `uxc`: remote schema interface calls used by collaboration adapters.
+- `agentinbox`: agent handoff, inbox, and event subscription lifecycle.
+
+The GitHub skills own GitHub-specific context and publishing. This template
+owns the general implementation contract, permission boundary, and learned
+workflow preferences; do not duplicate a skill's detailed procedure here.

--- a/agent_templates/holon-developer/skills.toml
+++ b/agent_templates/holon-developer/skills.toml
@@ -5,6 +5,21 @@ path = "skills/ghx"
 
 [[skills]]
 kind = "github"
+repo = "holon-run/sview"
+path = "skills/sview"
+
+[[skills]]
+kind = "github"
+repo = "holon-run/uxc"
+path = "skills/uxc"
+
+[[skills]]
+kind = "github"
+repo = "holon-run/agentinbox"
+path = "skills/agentinbox"
+
+[[skills]]
+kind = "github"
 repo = "holon-run/holon"
 path = "skills/github-issue-solve"
 

--- a/agent_templates/holon-reviewer/AGENTS.md
+++ b/agent_templates/holon-reviewer/AGENTS.md
@@ -1,21 +1,77 @@
 # Holon Reviewer Agent
 
-You are a long-lived review-focused agent.
+You are a long-lived code review agent responsible for code review, PR
+lifecycle tracking, and merge decisions.
 
-## Responsibilities
+## Permission Confirmation Protocol
 
-- inspect pull requests for correctness, regressions, and contract drift
-- use the GitHub review workflow when publishing PR reviews
-- prioritize concrete findings with clear severity and file references
-- keep summaries short after findings are stated
+For **non-one-time** review work, confirm the following with the operator
+before starting, then record the confirmed scope in your agent-local
+AGENTS.md:
 
-## Available Skills
+- whether you may merge PRs
+- whether you should subscribe to PR events via `agentinbox` follow
+- whether you may approve PRs
+- whether you may fix code on behalf of the author
 
-- `github-review`: structured PR review workflow and publish contract
-- `ghx`: safe GitHub CLI and API command patterns
+One-time review tasks (a single PR review with no ongoing tracking) do not
+require this protocol — proceed directly with the review.
 
-## Working Style
+## Skill Responsibility Layering
 
-- prefer code-reading and verification over surface-level commentary
-- distinguish proven issues from open questions
-- avoid requesting changes without a concrete behavioral reason
+Each skill owns a distinct layer. Do not duplicate one skill's methodology
+in another's scope.
+
+- `code-review`: platform-neutral review process — scope, evidence,
+  finding classification, verification, and coverage summary. This skill
+  defines *how* to review; defer to it for review methodology.
+- `github-review`: GitHub PR adapter — collect PR context, deduplicate
+  against prior review comments, and optionally publish a review.
+- `ghx`: safe, reproducible GitHub CLI and API command patterns.
+- `sview`: structured code and Markdown navigation to reduce broad reads
+  during review.
+- `uxc`: remote schema interface calls; runtime dependency for
+  `agentinbox` adapters.
+- `agentinbox`: event-driven PR/CI/issue subscription, inbox batch
+  read-and-ack, timer management, and subscription cleanup.
+
+## Event-Driven PR Lifecycle
+
+When tracking a PR beyond a single review:
+
+1. Create a WorkItem to anchor the review lifecycle.
+2. Use `agentinbox` follow to subscribe to PR events (new commits, CI
+   status, review comments). Use `WaitFor` only as a timed fallback.
+3. On new head commits, re-verify previously raised findings against the
+   updated diff before re-stating them.
+4. After merge or close, complete the WorkItem and clean up task-scoped
+   subscriptions.
+
+## Merge Gate
+
+A PR is merge-ready when:
+
+- all required CI checks pass on the final head commit;
+- no blocking findings remain unresolved;
+- non-blocking suggestions are not misclassified as blocking;
+- platform limitations are respected (e.g., cannot approve your own PR —
+  post a comment instead).
+
+## Authority Boundary
+
+- Default scope: review, comment, and merge (when authorized). Do not
+  actively fix code for the author unless the operator or permission
+  protocol explicitly grants it.
+- Escalate to the operator for large-scale refactors, breaking API
+  changes, or security-sensitive modifications.
+- Never hardcode personal accounts, PR numbers, file paths, or capability
+  secrets into template-level files.
+
+## Output Principle
+
+- Present blocking findings first, then non-blocking, then verdict.
+- Do not produce fixed artifact files unless a consumer needs them.
+- Keep summaries short after findings are stated.
+- For review methodology (evidence requirements, finding schema,
+  confidence levels, coverage summary), follow `code-review` rather than
+  restating its rules here.

--- a/agent_templates/holon-reviewer/skills.toml
+++ b/agent_templates/holon-reviewer/skills.toml
@@ -5,6 +5,26 @@ path = "skills/ghx"
 
 [[skills]]
 kind = "github"
+repo = "holon-run/sview"
+path = "skills/sview"
+
+[[skills]]
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/code-review"
+
+[[skills]]
+kind = "github"
 repo = "holon-run/holon"
 path = "skills/github-review"
+
+[[skills]]
+kind = "github"
+repo = "holon-run/uxc"
+path = "skills/uxc"
+
+[[skills]]
+kind = "github"
+repo = "holon-run/agentinbox"
+path = "skills/agentinbox"
 

--- a/agent_templates/holon-reviewer/template.toml
+++ b/agent_templates/holon-reviewer/template.toml
@@ -1,7 +1,7 @@
 schema = "holon.agent_template.v1"
 id = "holon-reviewer"
 name = "Holon Reviewer"
-summary = "You are a long-lived review-focused agent."
+summary = "You are a long-lived code review agent that tracks PR lifecycles, evaluates merge readiness, and manages event-driven review subscriptions."
 
 [compatibility]
 holon = ">=0.1.0"

--- a/skills/github-issue-solve/SKILL.md
+++ b/skills/github-issue-solve/SKILL.md
@@ -28,8 +28,10 @@ Use this skill when you need to turn a GitHub issue into a concrete code change 
 
 ## Runtime Paths
 
-- `GITHUB_OUTPUT_DIR`: output artifacts directory (caller-provided preferred; otherwise temp dir).
+- `GITHUB_OUTPUT_DIR`: optional caller-provided output artifacts directory.
 - `GITHUB_CONTEXT_DIR`: context directory (default `${GITHUB_OUTPUT_DIR}/github-context`).
+- Do not create fixed output files unless the caller or an integration explicitly
+  requires them.
 
 ## Inputs (Manifest-First)
 
@@ -60,7 +62,8 @@ Resolve usable inputs from `manifest.artifacts[]` by `id`/`path`/`status`/`descr
 
 - Extract acceptance criteria and constraints from issue metadata and discussion.
 - Implement minimal complete changes for the requested outcome.
-- Use deterministic branch naming (`feature/issue-<number>` or `fix/issue-<number>`).
+- Follow the developer agent's recorded worktree, branch, and PR preferences;
+  ask the operator when a relevant preference is not recorded.
 - Run relevant verification commands before publish.
 
 ### 3. Commit and push
@@ -70,20 +73,21 @@ Resolve usable inputs from `manifest.artifacts[]` by `id`/`path`/`status`/`descr
 
 ### 4. Publish PR
 
-Use raw `gh` commands with `--body-file`:
+Use raw `gh` commands. Pass the PR body directly, or use a caller-requested
+body file when the integration needs one:
 
 ```bash
-gh pr create --repo <owner/repo> --title "<title>" --body-file <summary.md> --head <branch> --base <base>
-gh pr edit <pr_number> --repo <owner/repo> --title "<title>" --body-file <summary.md>
+gh pr create --repo <owner/repo> --title "<title>" --body "<body>" --head <branch> --base <base>
+gh pr edit <pr_number> --repo <owner/repo> --title "<title>" --body "<body>"
 ```
 
 Publish completion is mandatory; do not report success without a real PR side effect.
 
-### 5. Finalize outputs
+### 5. Finalize delivery
 
-Required outputs under `${GITHUB_OUTPUT_DIR}`:
-- `summary.md`
-- `manifest.json`
+Report the result in the normal agent delivery. If a caller explicitly requires
+machine-readable output, write only the requested artifacts under
+`${GITHUB_OUTPUT_DIR}` and include their paths in the delivery.
 
 ## Delivery Standards
 
@@ -92,26 +96,6 @@ Required outputs under `${GITHUB_OUTPUT_DIR}`:
 - Include concrete verification results (commands + outcomes).
 - If full verification is impossible, report what was attempted and why it is incomplete.
 
-## Output Contract
-
-### `summary.md`
-
-Must include:
-- issue reference and interpreted requirements
-- key code changes
-- verification performed and outcomes
-- PR publish result (`pr_number`, `pr_url`, branch)
-- explicit blockers or follow-ups (if any)
-
-### `manifest.json`
-
-Execution metadata for this skill, including:
-- `provider: "github-issue-solve"`
-- issue reference
-- branch
-- publish result fields (`pr_number`, `pr_url`)
-- `status` (`completed|failed`)
-
 ## Failure Rules
 
 Mark run as failed if any of the following is true:
@@ -119,4 +103,5 @@ Mark run as failed if any of the following is true:
 - commit/push was not completed
 - PR create/update failed or PR URL cannot be verified
 
-Do not report success from artifacts alone.
+Do not report success from artifacts alone. A summary or manifest is optional
+evidence, not a substitute for the actual commit, push, or PR side effect.

--- a/skills/github-issue-solve/references/issue-solve-workflow.md
+++ b/skills/github-issue-solve/references/issue-solve-workflow.md
@@ -13,7 +13,8 @@ Detailed execution workflow for `github-issue-solve`.
    - `gh issue view <issue_number> --repo <owner/repo> --json ...`
    - `gh api repos/<owner>/<repo>/issues/<issue_number>/comments --paginate`
 
-If required context is missing, record explicit limitations in `summary.md`.
+If required context is missing, record explicit limitations in the agent
+delivery or in a caller-requested output artifact.
 
 ## 2) Solution planning
 
@@ -23,7 +24,8 @@ If required context is missing, record explicit limitations in `summary.md`.
 
 ## 3) Implementation and verification
 
-1. Create/switch branch (`feature/issue-<number>` or `fix/issue-<number>`).
+1. Create or switch the branch according to the developer agent's recorded
+   worktree and branch preferences; ask the operator when they are unknown.
 2. Implement code changes.
 3. Run relevant validation commands.
 4. Commit and push.
@@ -33,8 +35,8 @@ Never claim success without commit and push.
 ## 4) PR publish
 
 Publish with direct `gh` commands:
-- `gh pr create --body-file`
-- `gh pr edit --body-file`
+- `gh pr create --body` (or a caller-requested `--body-file`)
+- `gh pr edit --body` (or a caller-requested `--body-file`)
 
 After publish, verify PR identity:
 - `pr_number`
@@ -42,9 +44,9 @@ After publish, verify PR identity:
 
 ## 5) Output finalization
 
-Write/update:
-- `${GITHUB_OUTPUT_DIR}/summary.md`
-- `${GITHUB_OUTPUT_DIR}/manifest.json`
+Use the normal agent delivery for the result. Only write
+`${GITHUB_OUTPUT_DIR}/summary.md`, `${GITHUB_OUTPUT_DIR}/manifest.json`, or
+other artifacts when the caller or an integration explicitly requests them.
 
 ## Completion criteria
 
@@ -52,4 +54,4 @@ The run is complete only when:
 1. Code changes are implemented for issue intent.
 2. Changes are committed and pushed.
 3. A PR was created or updated and can be verified (`pr_number`, `pr_url`).
-4. Outputs include verification details and final status.
+4. The delivery includes verification details and final status.

--- a/skills/github-pr-fix/SKILL.md
+++ b/skills/github-pr-fix/SKILL.md
@@ -28,8 +28,10 @@ Use this skill when you need to remediate an existing pull request: diagnose wha
 
 ## Runtime Paths
 
-- `GITHUB_OUTPUT_DIR`: output artifacts directory (caller-provided preferred; otherwise temp dir).
+- `GITHUB_OUTPUT_DIR`: optional caller-provided output artifacts directory.
 - `GITHUB_CONTEXT_DIR`: context directory (default `${GITHUB_OUTPUT_DIR}/github-context`).
+- Do not create fixed output files unless the caller or an integration explicitly
+  requires them.
 
 ## Inputs (Manifest-First)
 
@@ -86,6 +88,8 @@ Use existing review threads/comments to avoid duplicate or stale responses.
 ### 3. Implement fixes
 
 - Apply minimal targeted fixes for blocking issues first.
+- Follow the developer agent's recorded worktree, branch, and PR preferences;
+  ask the operator when a relevant preference is not recorded.
 - Run relevant verification commands.
 - Commit and push before posting review replies.
 
@@ -100,11 +104,11 @@ gh api repos/<owner>/<repo>/pulls/<pr_number>/comments \
   -f body='Thanks, fixed in the latest commit.'
 ```
 
-### 5. Finalize outputs
+### 5. Finalize delivery
 
-Required outputs under `${GITHUB_OUTPUT_DIR}`:
-- `summary.md`
-- `manifest.json`
+Report the result in the normal agent delivery. If a caller explicitly requires
+machine-readable output, write only the requested artifacts under
+`${GITHUB_OUTPUT_DIR}` and include their paths in the delivery.
 
 ## Remediation Standards
 
@@ -113,30 +117,12 @@ Required outputs under `${GITHUB_OUTPUT_DIR}`:
 - Defer non-blocking large refactors with explicit rationale.
 - Keep review replies concrete: what changed, where, and any remaining risk.
 
-## Output Contract
-
-### `summary.md`
-
-Must include:
-- PR reference and diagnosis summary
-- fixes applied
-- verification commands and outcomes
-- reply publish result summary
-- deferred/follow-up items
-
-### `manifest.json`
-
-Execution metadata for this skill, including:
-- `provider: "github-pr-fix"`
-- PR reference
-- fix/reply counters
-- `status` (`completed|partial|failed`)
-
 ## Completion Criteria
 
 A successful run requires all of the following:
 1. Blocking fixes are committed and pushed to the PR branch.
 2. Replies planned for this run are published successfully.
-3. `summary.md` records what changed, which replies were posted, and any remaining risks.
+3. The agent delivery records what changed, which replies were posted, and any
+   remaining risks.
 
 If replies are planned but not published, the run is not successful.

--- a/skills/github-pr-fix/references/pr-fix-workflow.md
+++ b/skills/github-pr-fix/references/pr-fix-workflow.md
@@ -39,15 +39,15 @@ Do not publish replies before push completes.
 
 Use direct `gh api` reply operations for review-thread replies and related comments.
 
-## 5) Finalize outputs
+## 5) Finalize delivery
 
-Write/update:
-- `${GITHUB_OUTPUT_DIR}/summary.md`
-- `${GITHUB_OUTPUT_DIR}/manifest.json`
+Use the normal agent delivery for the result. Only write
+`${GITHUB_OUTPUT_DIR}/summary.md`, `${GITHUB_OUTPUT_DIR}/manifest.json`, or
+other artifacts when the caller or an integration explicitly requests them.
 
 ## Completion criteria
 
 Run is successful only when:
 1. Required fixes are committed and pushed.
 2. Replies planned for this run are published.
-3. `summary.md` records the replies that were posted and any residual risks.
+3. The delivery records the replies that were posted and any residual risks.


### PR DESCRIPTION
## Summary
- streamline the holon-developer template contract and add sview, uxc, and agentinbox
- remove mandatory summary/manifest artifact output from GitHub solve/fix skills
- preserve operator preferences for worktrees, PRs, merges, and event tracking in agent guidance

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test --all-targets checked_in_templates
- RUSTFLAGS="-D warnings" cargo check --all-targets