### PR TITLE
fix: reconcile execution root registry after migration

### DIFF
--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -1283,6 +1283,28 @@ fn prepare_runtime_storage(
             queued_messages: queue.len(),
         },
     );
+    if let Some(active) = state.active_workspace_entry.as_ref() {
+        let existing = runtime_db
+            .execution_root_entries()
+            .get(&active.execution_root_id)?;
+        let entry = workspace::execution_root_entry_from_active(
+            active,
+            existing
+                .as_ref()
+                .map(|entry| entry.created_at)
+                .unwrap_or_else(chrono::Utc::now),
+            existing.and_then(|entry| entry.worktree),
+        );
+        if let Err(error) = runtime_db.execution_root_entries().upsert(&entry) {
+            tracing::warn!(
+                agent_id = %agent_id,
+                execution_root_id = %entry.execution_root_id,
+                workspace_id = %entry.workspace_id,
+                error = %error,
+                "failed to reconcile active execution root registry entry during bootstrap"
+            );
+        }
+    }
     storage.write_agent(&state)?;
     storage
         .legacy_importer()

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -12,8 +12,8 @@ use crate::{
         WorkspaceAccessMode, WorkspaceProjectionKind, WorkspaceView,
     },
     types::{
-        agent_home_workspace_id, ActiveWorkspaceEntry, AgentState, WorkspaceEntry,
-        AGENT_HOME_WORKSPACE_ID,
+        agent_home_workspace_id, ActiveWorkspaceEntry, AgentState, ExecutionRootEntry,
+        WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
     },
 };
 
@@ -157,6 +157,22 @@ pub(crate) fn canonical_agent_home_active_entry(
 
 pub(crate) fn detached_execution_root(storage: &AppStorage) -> PathBuf {
     storage.data_dir().to_path_buf()
+}
+
+pub(crate) fn execution_root_entry_from_active(
+    active: &ActiveWorkspaceEntry,
+    created_at: chrono::DateTime<chrono::Utc>,
+    worktree: Option<crate::types::WorktreeArtifactMetadata>,
+) -> ExecutionRootEntry {
+    ExecutionRootEntry {
+        execution_root_id: active.execution_root_id.clone(),
+        workspace_id: active.workspace_id.clone(),
+        filesystem_path: active.execution_root.clone(),
+        root_kind: active.projection_kind,
+        worktree,
+        created_at,
+        removed_at: None,
+    }
 }
 
 impl ActiveWorkspaceEntry {

--- a/src/runtime/worktree.rs
+++ b/src/runtime/worktree.rs
@@ -213,6 +213,38 @@ impl RuntimeHandle {
             guard.state.worktree_session = Some(worktree_session.clone());
             guard.persist_state(&self.inner.storage)?;
         }
+        let active = self
+            .agent_state()
+            .await?
+            .active_workspace_entry
+            .ok_or_else(|| anyhow!("managed worktree entry disappeared after persistence"))?;
+        let existing = self
+            .inner
+            .runtime_db
+            .execution_root_entries()
+            .get(&active.execution_root_id)?;
+        let entry = crate::runtime::workspace::execution_root_entry_from_active(
+            &active,
+            existing
+                .as_ref()
+                .map(|entry| entry.created_at)
+                .unwrap_or_else(chrono::Utc::now),
+            existing.and_then(|entry| entry.worktree),
+        );
+        if let Err(error) = self
+            .inner
+            .runtime_db
+            .execution_root_entries()
+            .upsert(&entry)
+        {
+            tracing::warn!(
+                agent_id = %agent_id,
+                execution_root_id = %entry.execution_root_id,
+                workspace_id = %entry.workspace_id,
+                error = %error,
+                "failed to register managed worktree execution root"
+            );
+        }
 
         let boundary = crate::system::HostLocalBoundary::from_parts(
             &self.agent_state().await?.execution_profile,

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -14,13 +14,16 @@ use crate::domain::{
     },
     scheduler::SchedulerOwner,
 };
-use crate::runtime_db::evidence::content_hash;
+use crate::runtime_db::evidence::{content_hash, upsert_execution_root_entry_tx};
 use crate::runtime_db::legacy_scheduler_wire::{
     ActivationBinding, ActivationCause, ActivationOrigin, ActivationPriority, ActivationTrust,
     AdmitActivationCommand, WorkDemand,
 };
 use crate::runtime_db::retired_scheduler_cleanup::retired_scheduler_cleanup_inventory;
-use crate::types::{AgentState, MessageEnvelope, TaskRecord, WaitConditionRecord, WorkItemRecord};
+use crate::types::{
+    AgentState, ExecutionRootEntry, MessageEnvelope, TaskRecord, WaitConditionRecord,
+    WorkItemRecord,
+};
 
 pub struct Migration {
     pub version: i64,
@@ -3258,6 +3261,11 @@ CREATE INDEX IF NOT EXISTS idx_auth_sessions_expiry
   ON auth_sessions (expires_at);
 "#,
     },
+    Migration {
+        version: 56,
+        name: "execution_root_registry_backfill",
+        sql: "",
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {
@@ -3512,6 +3520,9 @@ fn apply_migration_transaction(transaction: &Transaction<'_>, migration: &Migrat
     if migration.name == "authentication_login_verifier" {
         ensure_authentication_login_verifier_schema(transaction)?;
     }
+    if migration.name == "execution_root_registry_backfill" {
+        backfill_execution_root_entries(transaction)?;
+    }
     transaction.execute_batch(migration.sql)?;
     if migration.name == "execution_protocol_authority" {
         backfill_execution_protocol_authority(transaction)?;
@@ -3539,6 +3550,64 @@ fn apply_migration_transaction(transaction: &Transaction<'_>, migration: &Migrat
             Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         ),
     )?;
+    Ok(())
+}
+
+fn backfill_execution_root_entries(transaction: &Transaction<'_>) -> Result<()> {
+    if !table_exists_tx(transaction, "execution_root_entries")?
+        || !table_exists_tx(transaction, "agent_states")?
+    {
+        return Ok(());
+    }
+    let mut statement = transaction.prepare(
+        "SELECT payload_json FROM agent_states
+         WHERE payload_json IS NOT NULL
+         ORDER BY agent_id ASC",
+    )?;
+    let payloads = statement
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    for payload in payloads {
+        let state: AgentState = match serde_json::from_str(&payload) {
+            Ok(state) => state,
+            Err(error) => {
+                tracing::warn!(%error, "skipping invalid agent state during execution root backfill");
+                continue;
+            }
+        };
+        let Some(active) = state.active_workspace_entry else {
+            continue;
+        };
+        let existing: Option<(String, String)> = transaction
+            .query_row(
+                "SELECT created_at, payload_json
+                 FROM execution_root_entries
+                 WHERE execution_root_id = ?1",
+                [&active.execution_root_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        let created_at = existing
+            .as_ref()
+            .map(|(created_at, _)| created_at.clone())
+            .and_then(|value| chrono::DateTime::parse_from_rfc3339(&value).ok())
+            .map(|value| value.with_timezone(&Utc))
+            .unwrap_or_else(Utc::now);
+        let worktree = existing
+            .and_then(|(_, payload)| serde_json::from_str::<ExecutionRootEntry>(&payload).ok())
+            .and_then(|entry| entry.worktree);
+        let entry = ExecutionRootEntry {
+            execution_root_id: active.execution_root_id,
+            workspace_id: active.workspace_id,
+            filesystem_path: active.execution_root,
+            root_kind: active.projection_kind,
+            worktree,
+            created_at,
+            removed_at: None,
+        };
+        upsert_execution_root_entry_tx(transaction, &entry)?;
+    }
     Ok(())
 }
 

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -2,9 +2,9 @@
 #[cfg(test)]
 use crate::runtime_db::connection::{is_retryable_db_error, open_connection};
 #[cfg(test)]
-use crate::runtime_db::evidence::content_hash;
-#[cfg(test)]
 use crate::runtime_db::evidence::insert_audit_event_tx;
+#[cfg(test)]
+use crate::runtime_db::evidence::{content_hash, upsert_execution_root_entry_tx};
 #[cfg(test)]
 use crate::runtime_db::migrations::{
     apply_migration, apply_release_baseline, backfill_wait_condition_payload_columns,
@@ -100,10 +100,10 @@ mod tests {
             AgentStateMutation, QueueHeadNoProgressCommand, QueueHeadNoProgressOutcome,
             TransitionFaultPoint,
         },
-        system::WorkspaceAccessMode,
+        system::{WorkspaceAccessMode, WorkspaceProjectionKind},
         types::{
-            AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentStatus,
-            AgentVisibility, BriefKind,
+            ActiveWorkspaceEntry, AgentKind, AgentOwnership, AgentProfilePreset,
+            AgentRegistryStatus, AgentStatus, AgentVisibility, BriefKind,
         },
     };
     use rusqlite::OptionalExtension;
@@ -6142,6 +6142,107 @@ CREATE TABLE working_memory_deltas (
 
         let result = repo.get("nonexistent")?;
         assert!(result.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn execution_root_registry_backfill_recovers_legacy_agent_state_idempotently() -> Result<()> {
+        let (_temp_dir, db_path, _lock_path) = temp_paths()?;
+        std::fs::create_dir_all(db_path.parent().unwrap())?;
+        let mut connection = open_connection(&db_path)?;
+        migrate_through(&mut connection, 55)?;
+
+        let execution_root_id = "git_worktree_root:ws_legacy:/tmp/restored-worktree";
+        let mut state = AgentState::new("agent-backfill");
+        state.active_workspace_entry = Some(ActiveWorkspaceEntry {
+            workspace_id: "ws_legacy".into(),
+            workspace_anchor: PathBuf::from("/tmp/repository"),
+            execution_root_id: execution_root_id.into(),
+            execution_root: PathBuf::from("/tmp/restored-worktree"),
+            projection_kind: WorkspaceProjectionKind::GitWorktreeRoot,
+            access_mode: WorkspaceAccessMode::ExclusiveWrite,
+            cwd: PathBuf::from("/tmp/restored-worktree"),
+            occupancy_id: None,
+            projection_metadata: None,
+        });
+        let state_payload = serde_json::to_string(&state)?;
+
+        let existing_created_at = Utc::now() - chrono::Duration::hours(1);
+        let existing = ExecutionRootEntry {
+            execution_root_id: execution_root_id.into(),
+            workspace_id: "ws_legacy".into(),
+            filesystem_path: PathBuf::from("/tmp/old-worktree-path"),
+            root_kind: WorkspaceProjectionKind::GitWorktreeRoot,
+            worktree: Some(crate::types::WorktreeArtifactMetadata {
+                provenance: crate::types::WorktreeProvenance::Discovered,
+                registered_by_agent_id: Some("agent-backfill".into()),
+                authorized_agent_ids: vec!["agent-backfill".into()],
+                branch: Some("legacy-branch".into()),
+                branch_ref: None,
+                head_commit: None,
+                detached: false,
+                requested_base_ref: None,
+                resolved_base_commit: None,
+                git_common_dir: None,
+                git_dir: None,
+                last_cleanup: None,
+            }),
+            created_at: existing_created_at,
+            removed_at: None,
+        };
+
+        connection.execute(
+            "INSERT INTO agent_states (
+                agent_id, status, turn_index, current_run_id, current_work_item_id,
+                active_workspace_id, updated_at, payload_json, control_revision
+             ) VALUES (?1, ?2, 0, NULL, NULL, ?3, ?4, ?5, 1)",
+            (
+                state.id.as_str(),
+                enum_string(&state.status)?,
+                "ws_legacy",
+                timestamp(Utc::now()),
+                state_payload,
+            ),
+        )?;
+        {
+            let transaction = connection.transaction()?;
+            upsert_execution_root_entry_tx(&transaction, &existing)?;
+            transaction.commit()?;
+        }
+
+        let migration = MIGRATIONS
+            .iter()
+            .find(|migration| migration.version == 56)
+            .expect("execution root backfill migration");
+        apply_migration(&mut connection, migration)?;
+
+        let payload: String = connection.query_row(
+            "SELECT payload_json FROM execution_root_entries WHERE execution_root_id = ?1",
+            [execution_root_id],
+            |row| row.get(0),
+        )?;
+        let recovered: ExecutionRootEntry = serde_json::from_str(&payload)?;
+        assert_eq!(
+            recovered.filesystem_path,
+            PathBuf::from("/tmp/restored-worktree")
+        );
+        assert_eq!(
+            timestamp(recovered.created_at),
+            timestamp(existing_created_at)
+        );
+        assert_eq!(recovered.worktree, existing.worktree);
+
+        connection.execute(
+            "DELETE FROM schema_migrations WHERE version = ?1",
+            [migration.version],
+        )?;
+        apply_migration(&mut connection, migration)?;
+        let count: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM execution_root_entries WHERE execution_root_id = ?1",
+            [execution_root_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 1);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Fixes #2299.

- Add migration v56 to idempotently backfill active `execution_root_entries` from persisted agent state left by pre-v56 databases.
- Reconcile the active execution-root registry during bootstrap recovery.
- Register managed worktrees when entering through `worktree::enter_worktree`.
- Preserve existing registry metadata and avoid reviving released/tombstoned roots.
- Add regression coverage for legacy state backfill and idempotency. Bootstrap recovery, managed worktree entry, and file-browser resolution are covered by the implementation review and existing surrounding tests, but are not each represented by a new dedicated regression test in this PR.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib` (2994 passed, 0 failed, 2 ignored)
- `git diff --check`
