### PR TITLE
test: cover multiple execution roots for workspace links

### DIFF
--- a/tests/http_workspace.rs
+++ b/tests/http_workspace.rs
@@ -21,6 +21,7 @@ http_async_tests!(
     workspace_files_path_traversal_rejected,
     workspace_files_symlink_escape_rejected,
     workspace_files_execution_root_id_resolves_registered_root,
+    workspace_files_distinguishes_multiple_execution_roots,
     workspace_files_returns_404_for_missing_file,
     workspace_files_metadata_only,
     workspace_files_unknown_workspace_404,

--- a/tests/support/http_workspace.rs
+++ b/tests/support/http_workspace.rs
@@ -382,3 +382,50 @@ pub async fn workspace_files_execution_root_id_resolves_registered_root() -> Res
     server.abort();
     Ok(())
 }
+
+pub async fn workspace_files_distinguishes_multiple_execution_roots() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let client = reqwest::Client::new();
+
+    let workspace_id = "agent_home:default";
+    let first_root_id = "test-worktree-root-first";
+    let second_root_id = "test-worktree-root-second";
+    let first_root = tempdir()?;
+    let second_root = tempdir()?;
+    std::fs::write(first_root.path().join("same-path.txt"), "first root")?;
+    std::fs::write(second_root.path().join("same-path.txt"), "second root")?;
+
+    for (execution_root_id, filesystem_path) in [
+        (first_root_id, first_root.path()),
+        (second_root_id, second_root.path()),
+    ] {
+        host.runtime_db()
+            .execution_root_entries()
+            .upsert(&ExecutionRootEntry {
+                execution_root_id: execution_root_id.into(),
+                workspace_id: workspace_id.into(),
+                filesystem_path: filesystem_path.to_path_buf(),
+                root_kind: WorkspaceProjectionKind::GitWorktreeRoot,
+                worktree: None,
+                created_at: Utc::now(),
+                removed_at: None,
+            })?;
+    }
+
+    for (execution_root_id, expected_contents) in [
+        (first_root_id, "first root"),
+        (second_root_id, "second root"),
+    ] {
+        let response = client
+            .get(format!(
+                "{base}/api/workspaces/{workspace_id}/files/same-path.txt?root={execution_root_id}"
+            ))
+            .send()
+            .await?;
+        assert_eq!(response.status(), 200, "{}", response.text().await?);
+        assert_eq!(response.text().await?, expected_contents);
+    }
+
+    server.abort();
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- add an HTTP workspace regression test covering two registered execution roots under the same workspace
- verify identical relative paths resolve to the content from the selected opaque `root` ID
- close the remaining acceptance-evidence gap for execution-root file links

The durable registry implementation and security/lifecycle behavior are already provided by PR #2241, with worktree registration and recovery completed by PR #2792 for issue #2299.

Closes #2238

## Verification

- `cargo fmt --all -- --check`
- `cargo test --test http_workspace` (13 passed)
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
