### PR TITLE
feat: add agent names and canonical detail API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "twox-hash",
+ "unicode-casefold",
  "unicode-width 0.2.0",
  "url",
  "uuid",
@@ -3100,6 +3101,12 @@ name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-casefold"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f66b1c8f8caa2ab31dc6d3f35386f16efdab89668f93411e565ac368908e8f"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ tower-http = { version = "0.6.8", features = ["compression-gzip", "cors", "trace
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 unicode-width = "0.2"
+unicode-casefold = "0.2"
 url = "2.5"
 uuid = { version = "1.11", features = ["serde", "v4"] }
 twox-hash = { version = "2.1.2", features = ["std"] }

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -186,6 +186,12 @@
                   "null"
                 ]
               },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "ownership": {
                 "enum": [
                   "parent_supervised",
@@ -358,6 +364,12 @@
                   "null"
                 ]
               },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "ownership": {
                 "enum": [
                   "parent_supervised",
@@ -495,6 +507,201 @@
           "identity"
         ],
         "title": "AgentDeletionStatusResponse",
+        "type": "object"
+      },
+      "AgentDetail": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "deletion": {
+            "properties": {
+              "agent_id": {
+                "type": "string"
+              },
+              "attempts": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "cascade_private_children": {
+                "type": "boolean"
+              },
+              "completed_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "created_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "deletion_id": {
+                "type": "string"
+              },
+              "expected_identity_revision": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "last_error": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "phase": {
+                "enum": [
+                  "fence",
+                  "quiesce",
+                  "ingress",
+                  "scheduler",
+                  "workspace",
+                  "index",
+                  "home",
+                  "finalize"
+                ],
+                "type": "string"
+              },
+              "requested_by": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "pending",
+                  "running",
+                  "retryable_failed",
+                  "completed"
+                ],
+                "type": "string"
+              },
+              "updated_at": {
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "required": [
+              "deletion_id",
+              "agent_id",
+              "status",
+              "phase",
+              "requested_by",
+              "expected_identity_revision",
+              "cascade_private_children",
+              "attempts",
+              "created_at",
+              "updated_at"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "identity": {
+            "properties": {
+              "agent_id": {
+                "type": "string"
+              },
+              "delegated_from_task_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_default_agent": {
+                "type": "boolean"
+              },
+              "kind": {
+                "enum": [
+                  "default",
+                  "named",
+                  "child"
+                ],
+                "type": "string"
+              },
+              "lineage_parent_agent_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ownership": {
+                "enum": [
+                  "parent_supervised",
+                  "self_owned"
+                ],
+                "type": "string"
+              },
+              "parent_agent_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "profile_preset": {
+                "enum": [
+                  "private_child",
+                  "public_named"
+                ],
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "active",
+                  "deleting",
+                  "deleted"
+                ],
+                "type": "string"
+              },
+              "visibility": {
+                "enum": [
+                  "public",
+                  "private"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "agent_id",
+              "kind",
+              "visibility",
+              "ownership",
+              "profile_preset",
+              "status",
+              "is_default_agent"
+            ],
+            "type": "object"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "identity",
+          "display_name",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "AgentDetail",
         "type": "object"
       },
       "AgentEventWindow": {
@@ -740,6 +947,12 @@
                           "type": "string"
                         },
                         "lineage_parent_agent_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
                           "type": [
                             "string",
                             "null"
@@ -1449,6 +1662,12 @@
                     "type": "string"
                   },
                   "lineage_parent_agent_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
                     "type": [
                       "string",
                       "null"
@@ -4756,6 +4975,11 @@
         "type": "object"
       },
       "RemoveTemplateRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "RenameAgentRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
         "type": "object"
@@ -11889,6 +12113,64 @@
         ]
       }
     },
+    "/api/control/agents/{agent_id}/detail": {
+      "get": {
+        "description": "Return the canonical Agent identity, lifecycle, profile, and deletion detail.",
+        "operationId": "agentDetail",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDetail"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Agent detail",
+        "tags": [
+          "control"
+        ]
+      }
+    },
     "/api/control/agents/{agent_id}/model": {
       "post": {
         "description": "Set an agent model override and optional reasoning effort.",
@@ -12020,6 +12302,74 @@
           }
         ],
         "summary": "Clear agent model override",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/api/control/agents/{agent_id}/name": {
+      "patch": {
+        "description": "Update the public display name without changing the technical agent identity or lifecycle target.",
+        "operationId": "renameAgent",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameAgentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDetail"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Rename agent",
         "tags": [
           "control"
         ]

--- a/src/client.rs
+++ b/src/client.rs
@@ -734,6 +734,7 @@ impl LocalClient {
             &format!("/control/agents/{agent_id}/create"),
             &CreateAgentRequest {
                 authority_class: Some(AuthorityClass::OperatorInstruction),
+                name: None,
                 template,
             },
         )

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -4490,6 +4490,7 @@ mod tests {
         );
         let identity = AgentIdentityView {
             agent_id: "default".into(),
+            name: None,
             kind: AgentKind::Default,
             visibility: AgentVisibility::Public,
             ownership: AgentOwnership::SelfOwned,

--- a/src/host.rs
+++ b/src/host.rs
@@ -51,13 +51,13 @@ use crate::{
     },
     tool::{apply_patch::ApplyPatchSurface, ToolError, ToolRegistry},
     types::{
-        AdmissionContext, AgentCreateReceipt, AgentCreateResult, AgentCreateStage,
-        AgentDeletionJob, AgentDurability, AgentIdentityRecord, AgentIdentityView, AgentKind,
-        AgentLifecycleHint, AgentListEntry, AgentOwnership, AgentProfilePreset,
-        AgentRegistryStatus, AgentState, AgentStatus, AgentSummary, AgentTokenUsageSummary,
-        AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord,
-        ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMdView, MessageBody,
-        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
+        normalize_agent_name, AdmissionContext, AgentCreateReceipt, AgentCreateResult,
+        AgentCreateStage, AgentDeletionJob, AgentDetail, AgentDurability, AgentIdentityRecord,
+        AgentIdentityView, AgentKind, AgentLifecycleHint, AgentListEntry, AgentOwnership,
+        AgentProfilePreset, AgentRegistryStatus, AgentState, AgentStatus, AgentSummary,
+        AgentTokenUsageSummary, AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome,
+        ExternalTriggerRecord, ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMdView,
+        MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
         OperatorNotificationRecord, Priority, QueueEntryStatus, RuntimeFailureSummary,
         SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, TaskKind, TaskRecord,
         TaskStatus, TimerRecord, TokenUsage, TranscriptEntry, TranscriptEntryKind,
@@ -226,6 +226,8 @@ pub enum PublicAgentError {
     Deleting { agent_id: String },
     Deleted { agent_id: String },
     DeleteForbidden { agent_id: String, reason: String },
+    InvalidName { agent_id: String, reason: String },
+    NameConflict { agent_id: String, name: String },
     Private { agent_id: String },
     Stopped { agent_id: String },
     ShuttingDown,
@@ -243,6 +245,16 @@ impl std::fmt::Display for PublicAgentError {
             Self::Deleted { agent_id } => write!(f, "agent {} was deleted", agent_id),
             Self::DeleteForbidden { agent_id, reason } => {
                 write!(f, "agent {} cannot be deleted: {}", agent_id, reason)
+            }
+            Self::InvalidName { agent_id, reason } => {
+                write!(f, "agent {} has an invalid name: {}", agent_id, reason)
+            }
+            Self::NameConflict { agent_id, name } => {
+                write!(
+                    f,
+                    "agent {} cannot use name {:?}: name is already in use",
+                    agent_id, name
+                )
             }
             Self::Private { agent_id } => write!(f, "agent {} is private", agent_id),
             Self::Stopped { agent_id } => {
@@ -412,6 +424,22 @@ fn named_agent_already_exists_error(agent_id: &str) -> anyhow::Error {
         .with_recovery_hint(
             "use an explicit agent invocation or enqueue operation to deliver work to an existing agent",
         ),
+    )
+}
+
+fn named_agent_name_already_exists_error(agent_id: &str, name: &str) -> anyhow::Error {
+    anyhow::Error::from(
+        ToolError::new(
+            "already_exists",
+            format!("public named agent name {name:?} is already in use"),
+        )
+        .with_domain(crate::runtime_error::RuntimeErrorDomain::Conflict)
+        .with_details(json!({
+            "agent_id": agent_id,
+            "name": name,
+            "preset": AgentProfilePreset::PublicNamed,
+        }))
+        .with_recovery_hint("choose a different name for the new public named agent"),
     )
 }
 
@@ -1758,6 +1786,114 @@ impl RuntimeHost {
         Ok((identity, job))
     }
 
+    pub fn public_agent_detail(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<AgentDetail, PublicAgentError> {
+        self.validate_agent_id(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        let identity = self
+            .agent_identity_record(agent_id)
+            .map_err(PublicAgentError::Runtime)?
+            .ok_or_else(|| PublicAgentError::NotFound {
+                agent_id: agent_id.to_string(),
+            })?;
+        if identity.visibility != AgentVisibility::Public
+            || identity.ownership() != AgentOwnership::SelfOwned
+        {
+            return Err(PublicAgentError::Private {
+                agent_id: agent_id.to_string(),
+            });
+        }
+        let deletion = self
+            .runtime_db()
+            .agent_deletions()
+            .latest_for_agent(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        Ok(AgentDetail {
+            display_name: identity.display_name(),
+            name: identity.name.clone(),
+            created_at: identity.created_at,
+            updated_at: identity.updated_at,
+            identity: AgentIdentityView::from_record(&identity, &self.config().default_agent_id),
+            deletion,
+        })
+    }
+
+    pub fn rename_public_agent(
+        &self,
+        agent_id: &str,
+        requested_name: &str,
+        actor: &str,
+    ) -> std::result::Result<AgentDetail, PublicAgentError> {
+        let existing_identity = self
+            .agent_identity_record(agent_id)
+            .map_err(PublicAgentError::Runtime)?
+            .ok_or_else(|| PublicAgentError::NotFound {
+                agent_id: agent_id.to_string(),
+            })?;
+        if existing_identity.visibility != AgentVisibility::Public
+            || existing_identity.ownership() != AgentOwnership::SelfOwned
+        {
+            return Err(PublicAgentError::Private {
+                agent_id: agent_id.to_string(),
+            });
+        }
+        if agent_id == self.config().default_agent_id {
+            return Err(PublicAgentError::DeleteForbidden {
+                agent_id: agent_id.to_string(),
+                reason: "the configured default agent cannot be renamed".into(),
+            });
+        }
+        normalize_agent_name(requested_name).map_err(|error| PublicAgentError::InvalidName {
+            agent_id: agent_id.to_string(),
+            reason: error.to_string(),
+        })?;
+        let identity = self
+            .runtime_db()
+            .agent_identities()
+            .rename(agent_id, requested_name, actor)
+            .map_err(|error| {
+                if error.to_string().contains("agent_name_conflict")
+                    || error.to_string().contains("UNIQUE constraint failed")
+                {
+                    PublicAgentError::NameConflict {
+                        agent_id: agent_id.to_string(),
+                        name: requested_name.trim().to_string(),
+                    }
+                } else if error.to_string().contains("cannot be renamed while it is") {
+                    match existing_identity.status {
+                        AgentRegistryStatus::Deleting => PublicAgentError::Deleting {
+                            agent_id: agent_id.to_string(),
+                        },
+                        AgentRegistryStatus::Deleted => PublicAgentError::Deleted {
+                            agent_id: agent_id.to_string(),
+                        },
+                        AgentRegistryStatus::Active => PublicAgentError::Runtime(error),
+                    }
+                } else {
+                    PublicAgentError::Runtime(error)
+                }
+            })?;
+        self.inner
+            .registry
+            .cache_agent_identity(&identity)
+            .map_err(PublicAgentError::Runtime)?;
+        let deletion = self
+            .runtime_db()
+            .agent_deletions()
+            .latest_for_agent(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        Ok(AgentDetail {
+            display_name: identity.display_name(),
+            name: identity.name.clone(),
+            created_at: identity.created_at,
+            updated_at: identity.updated_at,
+            identity: AgentIdentityView::from_record(&identity, &self.config().default_agent_id),
+            deletion,
+        })
+    }
+
     pub(crate) async fn public_agent_state_projection(
         &self,
         agent_id: &str,
@@ -1999,6 +2135,7 @@ impl RuntimeHost {
             None,
             None,
             NamedAgentExistingBehavior::Reuse,
+            None,
         )
         .await
         .map(|(record, _)| record)
@@ -2011,6 +2148,24 @@ impl RuntimeHost {
         lineage_parent_agent_id: Option<&str>,
         catalog_agent_home: Option<&Path>,
     ) -> Result<AgentCreateResult> {
+        self.create_public_named_agent_with_name(
+            agent_id,
+            template,
+            lineage_parent_agent_id,
+            catalog_agent_home,
+            None,
+        )
+        .await
+    }
+
+    pub async fn create_public_named_agent_with_name(
+        &self,
+        agent_id: &str,
+        template: Option<&str>,
+        lineage_parent_agent_id: Option<&str>,
+        catalog_agent_home: Option<&Path>,
+        requested_name: Option<&str>,
+    ) -> Result<AgentCreateResult> {
         let (identity, created) = self
             .ensure_named_agent(
                 agent_id,
@@ -2018,12 +2173,15 @@ impl RuntimeHost {
                 lineage_parent_agent_id,
                 catalog_agent_home,
                 NamedAgentExistingBehavior::Reject,
+                requested_name,
             )
             .await?;
         Ok(AgentCreateResult {
             receipt: AgentCreateReceipt {
                 receipt_id: ids::runtime_id("agent_create"),
                 agent_id: identity.agent_id.clone(),
+                name: identity.name.clone(),
+                display_name: identity.display_name(),
                 preset: AgentProfilePreset::PublicNamed,
                 stage: AgentCreateStage::Bootstrapped,
                 lifecycle: identity.status,
@@ -2040,6 +2198,7 @@ impl RuntimeHost {
         lineage_parent_agent_id: Option<&str>,
         catalog_agent_home: Option<&Path>,
         existing_behavior: NamedAgentExistingBehavior,
+        requested_name: Option<&str>,
     ) -> Result<(AgentIdentityRecord, bool)> {
         self.validate_agent_id(agent_id)?;
         if agent_id == self.config().default_agent_id {
@@ -2090,6 +2249,7 @@ impl RuntimeHost {
             }
             return Ok((existing, false));
         }
+        let normalized_name = requested_name.map(normalize_agent_name).transpose()?;
         if let Some(template) = template {
             let agent_home = self.agent_data_dir(agent_id);
             let user_home = self.config().home_dir.clone();
@@ -2119,7 +2279,7 @@ impl RuntimeHost {
                 named_agent_create_failed_error(agent_id, AgentCreateStage::Profiled, error)
             })?;
         }
-        let record = AgentIdentityRecord::new(
+        let mut record = AgentIdentityRecord::new(
             agent_id,
             AgentKind::Named,
             AgentVisibility::Public,
@@ -2129,7 +2289,16 @@ impl RuntimeHost {
             None,
         )
         .with_lineage_parent_agent_id(lineage_parent_agent_id.map(ToString::to_string));
+        record.name = normalized_name;
         self.append_agent_identity(&record).map_err(|error| {
+            if let Some(name) = record.name.as_deref() {
+                if error
+                    .to_string()
+                    .contains("UNIQUE constraint failed: agent_identities.name_key")
+                {
+                    return named_agent_name_already_exists_error(agent_id, name);
+                }
+            }
             named_agent_create_failed_error(agent_id, AgentCreateStage::Reserved, error)
         })?;
         self.activate_agent(agent_id, RuntimeActivationReason::AgentLifecycle)
@@ -4572,16 +4741,71 @@ mod tests {
         let (_home, host) = test_host();
 
         let created = host
-            .create_public_named_agent("receipt-bot", None, None, None)
+            .create_public_named_agent_with_name(
+                "receipt-bot",
+                None,
+                None,
+                None,
+                Some("Receipt Bot"),
+            )
             .await
             .unwrap();
         assert_eq!(created.identity.agent_id, "receipt-bot");
+        assert_eq!(created.identity.name.as_deref(), Some("Receipt Bot"));
+        assert_eq!(created.receipt.name.as_deref(), Some("Receipt Bot"));
+        assert_eq!(created.receipt.display_name, "Receipt Bot");
         assert_eq!(created.receipt.agent_id, "receipt-bot");
         assert_eq!(created.receipt.preset, AgentProfilePreset::PublicNamed);
         assert_eq!(created.receipt.stage, AgentCreateStage::Bootstrapped);
         assert_eq!(created.receipt.lifecycle, AgentRegistryStatus::Active);
         assert!(created.receipt.created);
         assert!(!created.receipt.receipt_id.is_empty());
+
+        let detail = host.public_agent_detail("receipt-bot").unwrap();
+        assert_eq!(detail.display_name, "Receipt Bot");
+        assert_eq!(detail.name.as_deref(), Some("Receipt Bot"));
+
+        let renamed = host
+            .rename_public_agent("receipt-bot", "Receipt Worker", "test-operator")
+            .unwrap();
+        assert_eq!(renamed.identity.agent_id, "receipt-bot");
+        assert_eq!(renamed.name.as_deref(), Some("Receipt Worker"));
+        assert_eq!(renamed.display_name, "Receipt Worker");
+        assert_eq!(
+            host.agent_identity_record("receipt-bot")
+                .unwrap()
+                .unwrap()
+                .name
+                .as_deref(),
+            Some("Receipt Worker")
+        );
+
+        let duplicate = host
+            .create_public_named_agent_with_name(
+                "other-receipt-bot",
+                None,
+                None,
+                None,
+                Some("Receipt Worker"),
+            )
+            .await
+            .expect_err("duplicate display names must fail closed");
+        assert!(duplicate.to_string().contains("already_exists"));
+
+        host.create_public_named_agent_with_name("unicode-name", None, None, None, Some("Straße"))
+            .await
+            .unwrap();
+        let unicode_duplicate = host
+            .create_public_named_agent_with_name(
+                "other-unicode-name",
+                None,
+                None,
+                None,
+                Some("STRASSE"),
+            )
+            .await
+            .expect_err("Unicode-equivalent display names must fail closed");
+        assert!(unicode_duplicate.to_string().contains("already_exists"));
 
         let error = host
             .create_public_named_agent("receipt-bot", None, None, None)
@@ -4593,6 +4817,57 @@ mod tests {
             tool_error.domain,
             Some(crate::runtime_error::RuntimeErrorDomain::Conflict)
         );
+    }
+
+    #[tokio::test]
+    async fn deleted_public_agent_detail_retains_name_and_rename_is_rejected() {
+        let (_home, host) = test_host();
+        let _created = host
+            .create_public_named_agent_with_name(
+                "delete-named",
+                None,
+                None,
+                None,
+                Some("Retained Name"),
+            )
+            .await
+            .unwrap();
+
+        let (_identity, job, created_deletion) = host
+            .begin_public_agent_deletion("delete-named", false, "test-operator")
+            .await
+            .unwrap();
+        assert!(created_deletion);
+
+        let deleting_detail = host.public_agent_detail("delete-named").unwrap();
+        assert_eq!(deleting_detail.name.as_deref(), Some("Retained Name"));
+        assert_eq!(deleting_detail.display_name, "Retained Name");
+        assert!(deleting_detail.deletion.is_some());
+
+        let rename_error = host
+            .rename_public_agent("delete-named", "New Name", "test-operator")
+            .expect_err("deleting agent must not be renamed");
+        assert!(matches!(
+            rename_error,
+            PublicAgentError::Deleting { ref agent_id } if agent_id == "delete-named"
+        ));
+
+        host.execute_deletion_job(job).await.unwrap();
+        let deleted_detail = host.public_agent_detail("delete-named").unwrap();
+        assert_eq!(deleted_detail.name.as_deref(), Some("Retained Name"));
+        assert_eq!(deleted_detail.display_name, "Retained Name");
+        assert!(matches!(
+            deleted_detail.identity.status,
+            AgentRegistryStatus::Deleted
+        ));
+
+        let rename_error = host
+            .rename_public_agent("delete-named", "New Name", "test-operator")
+            .expect_err("deleted agent must not be renamed");
+        assert!(matches!(
+            rename_error,
+            PublicAgentError::Deleted { ref agent_id } if agent_id == "delete-named"
+        ));
     }
 
     #[tokio::test]

--- a/src/host_registry.rs
+++ b/src/host_registry.rs
@@ -96,6 +96,10 @@ impl RuntimeRegistry {
 
     pub(crate) fn append_agent_identity(&self, record: &AgentIdentityRecord) -> Result<()> {
         self.inner.host_storage.append_agent_identity(record)?;
+        self.cache_agent_identity(record)
+    }
+
+    pub(crate) fn cache_agent_identity(&self, record: &AgentIdentityRecord) -> Result<()> {
         self.inner
             .agent_identities
             .write()

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -470,7 +470,13 @@ pub async fn create_agent(
     let provided_trust = request.authority_class;
     let created = state
         .host
-        .create_public_named_agent(&agent_id, request.template.as_deref(), None, None)
+        .create_public_named_agent_with_name(
+            &agent_id,
+            request.template.as_deref(),
+            None,
+            None,
+            request.name.as_deref(),
+        )
         .await
         .map_err(error_response)?;
     let runtime = state
@@ -493,6 +499,33 @@ pub async fn create_agent(
         )
         .map_err(error_response)?;
     Ok(Json(created))
+}
+
+pub async fn agent_detail(
+    Path(agent_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    let detail = state
+        .host
+        .public_agent_detail(&agent_id)
+        .map_err(agent_access_error)?;
+    Ok(Json(detail))
+}
+
+pub async fn rename_agent(
+    Path(agent_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<RenameAgentRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    let detail = state
+        .host
+        .rename_public_agent(&agent_id, &request.name, "authenticated_operator_control")
+        .map_err(agent_access_error)?;
+    Ok(Json(detail))
 }
 
 pub async fn delete_agent(

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -475,6 +475,14 @@ pub fn router(state: AppState) -> Router {
             "/control/agents/{agent_id}/create",
             post(control::create_agent),
         )
+        .route(
+            "/control/agents/{agent_id}/detail",
+            get(control::agent_detail),
+        )
+        .route(
+            "/control/agents/{agent_id}/name",
+            patch(control::rename_agent),
+        )
         .route("/control/agents/{agent_id}", delete(control::delete_agent))
         .route(
             "/control/agents/{agent_id}/delete-status",
@@ -1286,6 +1294,19 @@ pub(crate) fn agent_access_error(error: PublicAgentError) -> (StatusCode, Json<V
             HttpErrorEnvelope::new(reason)
                 .code("agent_delete_forbidden")
                 .extension("agent_id", agent_id),
+        ),
+        PublicAgentError::InvalidName { agent_id, reason } => http_error(
+            StatusCode::BAD_REQUEST,
+            HttpErrorEnvelope::new(reason)
+                .code("agent_name_invalid")
+                .extension("agent_id", agent_id),
+        ),
+        PublicAgentError::NameConflict { agent_id, name } => http_error(
+            StatusCode::CONFLICT,
+            HttpErrorEnvelope::new(format!("agent name {:?} is already in use", name))
+                .code("agent_name_conflict")
+                .extension("agent_id", agent_id)
+                .extension("name", name),
         ),
         PublicAgentError::Stopped { agent_id } => stopped_agent_conflict(
             format!("agent {} is stopped; start first", agent_id),

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -15,6 +15,12 @@ pub struct SearchRequest {
     pub types: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RenameAgentRequest {
+    pub name: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DeleteAgentRequest {
@@ -479,4 +485,6 @@ pub struct ClearAgentModelRequest {
 pub struct CreateAgentRequest {
     pub authority_class: Option<AuthorityClass>,
     pub template: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4418,6 +4418,7 @@ async fn handle_agent_command(config: &AppConfig, command: Option<AgentCommands>
                 &format!("/control/agents/{agent_id}/create"),
                 &http::CreateAgentRequest {
                     authority_class: Some(AuthorityClass::OperatorInstruction),
+                    name: None,
                     template,
                 },
             )

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -134,6 +134,8 @@ const ROUTES: &[RouteSpec] = &[
     route_with_response("post", "/control/agents/{agent_id}/timers", "createTimer", "control", "Create timer", "Schedule a timer for an agent.", Some("CreateTimerRequest"), "TimerRecord", AuthKind::Control),
     route_with_response("post", "/control/agents/{agent_id}/timers/{timer_id}/cancel", "cancelTimer", "control", "Cancel timer", "Cancel an active timer. Cancellation is idempotent for already-cancelled timers; completed or missing timers return a shared error envelope.", Some("CancelTimerRequest"), "TimerRecord", AuthKind::Control),
     route("post", "/control/agents/{agent_id}/create", "createAgent", "control", "Create named agent", "Create a public named agent, optionally from a template.", Some("CreateAgentRequest"), AuthKind::Control),
+    route_with_response("get", "/control/agents/{agent_id}/detail", "agentDetail", "control", "Agent detail", "Return the canonical Agent identity, lifecycle, profile, and deletion detail.", None, "AgentDetail", AuthKind::Control),
+    route_with_response("patch", "/control/agents/{agent_id}/name", "renameAgent", "control", "Rename agent", "Update the public display name without changing the technical agent identity or lifecycle target.", Some("RenameAgentRequest"), "AgentDetail", AuthKind::Control),
     route_with_response("delete", "/control/agents/{agent_id}", "deleteAgent", "control", "Delete agent", "Fence a public self-owned agent and create or return its durable deletion job.", Some("DeleteAgentRequest"), "AgentDeletionResponse", AuthKind::Control),
     route_with_response("get", "/control/agents/{agent_id}/delete-status", "agentDeleteStatus", "control", "Agent deletion status", "Return the identity tombstone and current or completed deletion job.", None, "AgentDeletionStatusResponse", AuthKind::Control),
     route("post", "/control/agents/{agent_id}/reset-callback", "resetCallback", "control", "Reset external trigger callback", "Revoke the current external trigger and provision a fresh one with a new token.", None, AuthKind::Control),
@@ -694,6 +696,10 @@ fn component_schemas() -> Value {
         component_schema::<AgentDeletionStatusResponse>(),
     );
     schemas.insert(
+        "AgentDetail".into(),
+        component_schema::<crate::types::AgentDetail>(),
+    );
+    schemas.insert(
         "PickWorkItemRequest".into(),
         component_schema::<PickWorkItemRequest>(),
     );
@@ -1044,6 +1050,7 @@ fn component_schemas() -> Value {
         "TaskStopRequest",
         "CreateWorkItemRequest",
         "CreateAgentRequest",
+        "RenameAgentRequest",
         "AttachWorkspaceRequest",
         "ExitWorkspaceRequest",
         "DetachWorkspaceRequest",

--- a/src/projection_eval/baseline.rs
+++ b/src/projection_eval/baseline.rs
@@ -109,6 +109,7 @@ fn reason_for(outcome: ContextPlanOutcome) -> ContextPlanReason {
 fn baseline_identity() -> AgentIdentityView {
     AgentIdentityView {
         agent_id: "baseline-agent".into(),
+        name: None,
         kind: AgentKind::Default,
         visibility: AgentVisibility::Public,
         ownership: AgentOwnership::SelfOwned,

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -1215,6 +1215,7 @@ mod tests {
     fn sample_identity() -> AgentIdentityView {
         AgentIdentityView {
             agent_id: "default".into(),
+            name: None,
             kind: AgentKind::Default,
             visibility: AgentVisibility::Public,
             ownership: AgentOwnership::SelfOwned,
@@ -1230,6 +1231,7 @@ mod tests {
     fn sample_child_identity() -> AgentIdentityView {
         AgentIdentityView {
             agent_id: "child_test".into(),
+            name: None,
             kind: AgentKind::Child,
             visibility: AgentVisibility::Private,
             ownership: AgentOwnership::ParentSupervised,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3072,6 +3072,7 @@ impl RuntimeHandle {
         };
         AgentIdentityView {
             agent_id: agent_id.to_string(),
+            name: None,
             kind,
             visibility: crate::types::AgentVisibility::Public,
             ownership: crate::types::AgentOwnership::SelfOwned,

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -393,8 +393,16 @@ impl RuntimeHandle {
             .storage
             .read_agent()?
             .unwrap_or_else(|| AgentState::new(agent_id.to_string()));
+        let name = match self.inner.host_bridge.as_ref() {
+            Some(bridge) => bridge
+                .identity_for_agent(agent_id)
+                .await?
+                .and_then(|identity| identity.name),
+            None => None,
+        };
         let identity = AgentIdentityView {
             agent_id: agent_id.to_string(),
+            name,
             kind: AgentKind::Child,
             visibility: crate::types::AgentVisibility::Private,
             ownership: crate::types::AgentOwnership::ParentSupervised,

--- a/src/runtime/provider_turn.rs
+++ b/src/runtime/provider_turn.rs
@@ -699,6 +699,7 @@ mod tests {
         EffectivePrompt {
             identity: AgentIdentityView {
                 agent_id: "default".into(),
+                name: None,
                 kind: AgentKind::Default,
                 visibility: AgentVisibility::Public,
                 ownership: AgentOwnership::SelfOwned,
@@ -757,6 +758,7 @@ mod tests {
         let effective_prompt = EffectivePrompt {
             identity: AgentIdentityView {
                 agent_id: "default".into(),
+                name: None,
                 kind: AgentKind::Default,
                 visibility: AgentVisibility::Public,
                 ownership: AgentOwnership::SelfOwned,

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -1306,6 +1306,7 @@ fn current_input_summary_extracts_body_from_context_section() {
     let prompt = EffectivePrompt {
         identity: AgentIdentityView {
             agent_id: "default".into(),
+            name: None,
             kind: AgentKind::Default,
             visibility: AgentVisibility::Public,
             ownership: AgentOwnership::SelfOwned,

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -170,6 +170,7 @@ pub(crate) async fn host_backed_test_runtime() -> (TempDir, RuntimeHost, Runtime
 pub(crate) fn private_child_identity(agent_id: &str) -> AgentIdentityView {
     AgentIdentityView {
         agent_id: agent_id.into(),
+        name: None,
         kind: AgentKind::Child,
         visibility: AgentVisibility::Private,
         ownership: AgentOwnership::ParentSupervised,
@@ -186,6 +187,7 @@ pub(crate) fn test_effective_prompt() -> EffectivePrompt {
     EffectivePrompt {
         identity: AgentIdentityView {
             agent_id: "default".into(),
+            name: None,
             kind: AgentKind::Default,
             visibility: AgentVisibility::Public,
             ownership: AgentOwnership::SelfOwned,

--- a/src/runtime/tests/tui_pipeline_e2e.rs
+++ b/src/runtime/tests/tui_pipeline_e2e.rs
@@ -27,6 +27,7 @@ fn minimal_agent_summary(agent_id: &str) -> AgentSummary {
     AgentSummary {
         identity: AgentIdentityView {
             agent_id: agent_id.into(),
+            name: None,
             kind: AgentKind::Default,
             visibility: AgentVisibility::Public,
             ownership: AgentOwnership::SelfOwned,

--- a/src/runtime_db/evidence.rs
+++ b/src/runtime_db/evidence.rs
@@ -426,6 +426,7 @@ pub(crate) fn upsert_agent_identity_tx(
     // can never regain availability, not even through a stale replay.
     reserve_agent_identity_tx(tx, record)?;
     let payload_json = serde_json::to_string(record)?;
+    let name_key = record.name.as_deref().map(crate::types::agent_name_key);
     let kind = enum_string(&record.kind)?;
     let visibility = enum_string(&record.visibility)?;
     let ownership = record.ownership.as_ref().map(enum_string).transpose()?;
@@ -437,11 +438,13 @@ pub(crate) fn upsert_agent_identity_tx(
     let status = enum_string(&record.status)?;
     tx.execute(
         "INSERT INTO agent_identities (
-            agent_id, kind, visibility, ownership, profile_preset, status,
+            agent_id, name, name_key, kind, visibility, ownership, profile_preset, status,
             parent_agent_id, lineage_parent_agent_id, delegated_from_task_id,
             created_at, updated_at, archived_at, payload_json
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
          ON CONFLICT(agent_id) DO UPDATE SET
+            name = excluded.name,
+            name_key = excluded.name_key,
             kind = excluded.kind,
             visibility = excluded.visibility,
             ownership = excluded.ownership,
@@ -457,6 +460,8 @@ pub(crate) fn upsert_agent_identity_tx(
          WHERE excluded.updated_at >= agent_identities.updated_at",
         params![
             record.agent_id,
+            record.name,
+            name_key,
             kind,
             visibility,
             ownership,

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3266,6 +3266,11 @@ CREATE INDEX IF NOT EXISTS idx_auth_sessions_expiry
         name: "execution_root_registry_backfill",
         sql: "",
     },
+    Migration {
+        version: 57,
+        name: "agent_display_names",
+        sql: "",
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {
@@ -3542,6 +3547,9 @@ fn apply_migration_transaction(transaction: &Transaction<'_>, migration: &Migrat
     if migration.name == "brief_created_event_linkage" {
         backfill_brief_created_event_linkage(transaction)?;
     }
+    if migration.name == "agent_display_names" {
+        ensure_agent_display_names_schema(transaction)?;
+    }
     transaction.execute(
         "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
         (
@@ -3631,6 +3639,29 @@ fn table_exists_tx(transaction: &Transaction<'_>, table: &str) -> Result<bool> {
         |row| row.get(0),
     )?;
     Ok(count == 1)
+}
+
+fn ensure_agent_display_names_schema(transaction: &Transaction<'_>) -> Result<()> {
+    if !table_exists_tx(transaction, "agent_identities")? {
+        return Ok(());
+    }
+    let columns = transaction
+        .prepare("PRAGMA table_info(agent_identities)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    for (column, definition) in [("name", "name TEXT"), ("name_key", "name_key TEXT")] {
+        if !columns.iter().any(|existing| existing == column) {
+            transaction.execute_batch(&format!(
+                "ALTER TABLE agent_identities ADD COLUMN {definition};"
+            ))?;
+        }
+    }
+    transaction.execute_batch(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_identities_name_unique
+           ON agent_identities(name_key)
+           WHERE name_key IS NOT NULL;",
+    )?;
+    Ok(())
 }
 
 /// Adds the immutable `created_event_seq` linkage column and its uniqueness

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -418,6 +418,65 @@ impl AgentIdentityRepository<'_> {
             .map(|payload| decode_agent_identity_payload(&payload))
             .transpose()
     }
+
+    pub fn rename(
+        &self,
+        agent_id: &str,
+        requested_name: &str,
+        actor: &str,
+    ) -> Result<AgentIdentityRecord> {
+        let name = normalize_agent_name(requested_name)?;
+        let name_key = agent_name_key(&name);
+        self.db.transaction(|tx| {
+            let payload = tx
+                .query_row(
+                    "SELECT payload_json FROM agent_identities WHERE agent_id = ?1",
+                    [agent_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .ok_or_else(|| anyhow!("agent {agent_id} not found"))?;
+            let mut identity = decode_agent_identity_payload(&payload)?;
+            anyhow::ensure!(
+                identity.status == AgentRegistryStatus::Active,
+                "agent {agent_id} cannot be renamed while it is {:?}",
+                identity.status
+            );
+            let conflict = tx
+                .query_row(
+                    "SELECT agent_id FROM agent_identities
+                     WHERE name_key = ?1 AND agent_id <> ?2",
+                    params![name_key, agent_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            if let Some(conflict) = conflict {
+                return Err(anyhow!(
+                    "agent_name_conflict: name {name:?} is already used by agent {conflict}"
+                ));
+            }
+            let previous_name = identity.name.clone();
+            let now = std::cmp::max(
+                Utc::now(),
+                identity.updated_at + chrono::Duration::nanoseconds(1),
+            );
+            identity.name = Some(name.clone());
+            identity.revision = identity.revision.saturating_add(1);
+            identity.updated_at = now;
+            upsert_agent_identity_tx(tx, &identity)?;
+            let event = AuditEvent::legacy(
+                "agent_renamed",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "actor": actor,
+                    "previous_name": previous_name,
+                    "name": identity.name,
+                }),
+            );
+            append_audit_event_tx(tx, Some(agent_id), &event)?;
+            Ok(identity)
+        })
+    }
 }
 
 impl AgentDeletionRepository<'_> {

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -1223,6 +1223,7 @@ mod tests {
         AgentSummary {
             identity: AgentIdentityView {
                 agent_id: "default".into(),
+                name: None,
                 kind: AgentKind::Default,
                 visibility: AgentVisibility::Public,
                 ownership: AgentOwnership::SelfOwned,

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -314,6 +314,7 @@ mod tests {
         AgentSummary {
             identity: AgentIdentityView {
                 agent_id: "default".into(),
+                name: None,
                 kind: AgentKind::Default,
                 visibility: AgentVisibility::Public,
                 ownership: AgentOwnership::SelfOwned,

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -3786,6 +3786,7 @@ mod tests {
         AgentSummary {
             identity: AgentIdentityView {
                 agent_id: "default".into(),
+                name: None,
                 kind: AgentKind::Default,
                 visibility: AgentVisibility::Public,
                 ownership: AgentOwnership::SelfOwned,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -922,7 +922,11 @@ pub(super) fn render_model_status(agent: &AgentSummary) -> String {
 
 pub(super) fn render_summary(agent: &AgentSummary) -> String {
     let mut lines = vec![
-        format!("Agent: {}", agent.identity.agent_id),
+        format!(
+            "Agent: {} ({})",
+            agent.identity.display_name(),
+            agent.identity.agent_id
+        ),
         format!("Kind: {:?}", agent.identity.kind),
         format!("Identity contract: {}", agent.identity.contract_badge()),
         format!("Contract summary: {}", agent.identity.contract_summary()),
@@ -1009,7 +1013,8 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
                 .iter()
                 .map(|child| {
                     format!(
-                        "{}:{:?}[{}]",
+                        "{}:{}:{:?}[{}]",
+                        child.identity.display_name(),
                         child.identity.agent_id,
                         child.status,
                         child.identity.contract_badge()
@@ -1076,6 +1081,7 @@ mod tests {
         AgentSummary {
             identity: AgentIdentityView {
                 agent_id: "default".into(),
+                name: None,
                 kind: AgentKind::Default,
                 visibility: AgentVisibility::Public,
                 ownership: AgentOwnership::SelfOwned,
@@ -1155,6 +1161,7 @@ mod tests {
             active_children: vec![ChildAgentSummary {
                 identity: AgentIdentityView {
                     agent_id: "child_1".into(),
+                    name: None,
                     kind: AgentKind::Child,
                     visibility: AgentVisibility::Private,
                     ownership: AgentOwnership::ParentSupervised,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -190,6 +190,7 @@ fn sample_agent_summary(agent_id: &str) -> AgentSummary {
     AgentSummary {
         identity: AgentIdentityView {
             agent_id: agent_id.into(),
+            name: None,
             kind: AgentKind::Default,
             visibility: AgentVisibility::Public,
             ownership: AgentOwnership::SelfOwned,

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -40,7 +40,11 @@ impl StatusbarViewModel {
 }
 
 pub(super) fn render_header_line(agent: &AgentSummary) -> String {
-    format!("{}  {}", agent.identity.agent_id, agent_status_label(agent))
+    format!(
+        "{}  {}",
+        agent.identity.display_name(),
+        agent_status_label(agent)
+    )
 }
 
 fn agent_status_label(agent: &AgentSummary) -> &'static str {

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@ use serde::{de, Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use unicode_casefold::UnicodeCaseFold;
 
 use crate::config::ModelRouteRef;
 use crate::domain::scheduler::{ScenarioMode, SchedulerScenarioClass};
@@ -419,6 +420,8 @@ pub enum AgentRegistryStatus {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct AgentIdentityRecord {
     pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     pub kind: AgentKind,
     pub visibility: AgentVisibility,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -459,6 +462,9 @@ pub enum AgentCreateStage {
 pub struct AgentCreateReceipt {
     pub receipt_id: String,
     pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub display_name: String,
     pub preset: AgentProfilePreset,
     pub stage: AgentCreateStage,
     pub lifecycle: AgentRegistryStatus,
@@ -469,6 +475,38 @@ pub struct AgentCreateReceipt {
 pub struct AgentCreateResult {
     pub identity: AgentIdentityRecord,
     pub receipt: AgentCreateReceipt,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct AgentDetail {
+    pub identity: AgentIdentityView,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub display_name: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deletion: Option<AgentDeletionJob>,
+}
+
+pub fn normalize_agent_name(value: &str) -> anyhow::Result<String> {
+    let name = value.trim();
+    anyhow::ensure!(!name.is_empty(), "agent name must not be empty");
+    anyhow::ensure!(
+        name.chars().count() <= 64,
+        "agent name must be at most 64 characters"
+    );
+    anyhow::ensure!(
+        !name
+            .chars()
+            .any(|character| { character.is_control() || matches!(character, '/' | '\\' | ':') }),
+        "agent name must not contain control characters or path separators"
+    );
+    Ok(name.to_string())
+}
+
+pub fn agent_name_key(value: &str) -> String {
+    value.case_fold().collect()
 }
 
 impl AgentIdentityRecord {
@@ -484,6 +522,7 @@ impl AgentIdentityRecord {
         let now = Utc::now();
         Self {
             agent_id: agent_id.into(),
+            name: None,
             kind,
             visibility,
             ownership: Some(ownership),
@@ -498,6 +537,10 @@ impl AgentIdentityRecord {
             updated_at: now,
             deleted_at: None,
         }
+    }
+
+    pub fn display_name(&self) -> String {
+        self.name.clone().unwrap_or_else(|| self.agent_id.clone())
     }
 
     pub fn with_lineage_parent_agent_id(mut self, lineage_parent_agent_id: Option<String>) -> Self {
@@ -602,6 +645,8 @@ pub struct AgentDeletionJob {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct AgentIdentityView {
     pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     pub kind: AgentKind,
     pub visibility: AgentVisibility,
     pub ownership: AgentOwnership,
@@ -620,6 +665,7 @@ impl AgentIdentityView {
     pub fn from_record(record: &AgentIdentityRecord, default_agent_id: &str) -> Self {
         Self {
             agent_id: record.agent_id.clone(),
+            name: record.name.clone(),
             kind: record.kind,
             visibility: record.visibility,
             ownership: record.ownership(),
@@ -630,6 +676,10 @@ impl AgentIdentityView {
             lineage_parent_agent_id: record.lineage_parent_agent_id.clone(),
             delegated_from_task_id: record.delegated_from_task_id.clone(),
         }
+    }
+
+    pub fn display_name(&self) -> &str {
+        self.name.as_deref().unwrap_or(&self.agent_id)
     }
 
     pub fn contract_badge(&self) -> String {

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -93,7 +93,7 @@ fn render_live_inventory() -> String {
             route
         })
         .collect();
-    assert_eq!(routes.len(), 110, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 112, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -56,6 +56,7 @@ const CONTEXT_CONTRACT: &str = r#"Interpret the memory block with this priority:
 fn sample_identity() -> AgentIdentityView {
     AgentIdentityView {
         agent_id: "default".into(),
+        name: None,
         kind: AgentKind::Default,
         visibility: AgentVisibility::Public,
         ownership: AgentOwnership::SelfOwned,

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -688,6 +688,28 @@
   },
   {
     "method": "get",
+    "path": "/api/control/agents/{agent_id}/detail",
+    "handler": "agent_detail",
+    "operation_id": "agentDetail",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/api/control/agents/{agent_id}/scheduler-repair",
     "handler": "scheduler_repair_inspect",
     "operation_id": "inspectSchedulerRepair",
@@ -1012,6 +1034,28 @@
     "parameters": [],
     "request_schema": null,
     "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "patch",
+    "path": "/api/control/agents/{agent_id}/name",
+    "handler": "rename_agent",
+    "operation_id": "renameAgent",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "RenameAgentRequest",
+    "request_strict": false,
     "response_content_types": [
       "application/json"
     ],


### PR DESCRIPTION
## Summary

- 在 `AgentIdentityRecord` 与 create receipt 中增加 optional display `name`，并保持 `agent_id` 为唯一技术 identity 与调度键。
- 增加 Unicode-aware case-fold 唯一约束、原子 rename/audit 持久化，以及旧记录无 name 时回退到 `agent_id` 的兼容展示。
- 增加 canonical agent detail 与 rename control API，并在 Deleting/Deleted 状态保留名称和 deletion 摘要。
- 同步 TUI 展示、OpenAPI registry 及 checked-in HTTP/OpenAPI snapshots。

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
- `git diff --check origin/main`

## Scope

这是 Phase 2 的独立实现切片。name 仅用于展示，不参与权限、调度、消息投递或历史引用；template/skill provenance 与 bootstrap repair 留给 Phase 3，AgentInvoke/message delivery 留给 Phase 4。
