### PR TITLE
fix: preserve typed agent name HTTP errors

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -226,6 +226,7 @@ pub enum PublicAgentError {
     Deleting { agent_id: String },
     Deleted { agent_id: String },
     DeleteForbidden { agent_id: String, reason: String },
+    RenameForbidden { agent_id: String, reason: String },
     InvalidName { agent_id: String, reason: String },
     NameConflict { agent_id: String, name: String },
     Private { agent_id: String },
@@ -245,6 +246,9 @@ impl std::fmt::Display for PublicAgentError {
             Self::Deleted { agent_id } => write!(f, "agent {} was deleted", agent_id),
             Self::DeleteForbidden { agent_id, reason } => {
                 write!(f, "agent {} cannot be deleted: {}", agent_id, reason)
+            }
+            Self::RenameForbidden { agent_id, reason } => {
+                write!(f, "agent {} cannot be renamed: {}", agent_id, reason)
             }
             Self::InvalidName { agent_id, reason } => {
                 write!(f, "agent {} has an invalid name: {}", agent_id, reason)
@@ -440,6 +444,18 @@ fn named_agent_name_already_exists_error(agent_id: &str, name: &str) -> anyhow::
             "preset": AgentProfilePreset::PublicNamed,
         }))
         .with_recovery_hint("choose a different name for the new public named agent"),
+    )
+}
+
+fn named_agent_invalid_name_error(agent_id: &str, error: anyhow::Error) -> anyhow::Error {
+    anyhow::Error::from(
+        ToolError::new("agent_name_invalid", error.to_string())
+            .with_domain(crate::runtime_error::RuntimeErrorDomain::Validation)
+            .with_details(json!({
+                "agent_id": agent_id,
+                "preset": AgentProfilePreset::PublicNamed,
+            }))
+            .with_recovery_hint("choose a valid name for the new public named agent"),
     )
 }
 
@@ -1840,7 +1856,7 @@ impl RuntimeHost {
             });
         }
         if agent_id == self.config().default_agent_id {
-            return Err(PublicAgentError::DeleteForbidden {
+            return Err(PublicAgentError::RenameForbidden {
                 agent_id: agent_id.to_string(),
                 reason: "the configured default agent cannot be renamed".into(),
             });
@@ -2249,7 +2265,12 @@ impl RuntimeHost {
             }
             return Ok((existing, false));
         }
-        let normalized_name = requested_name.map(normalize_agent_name).transpose()?;
+        let normalized_name = requested_name
+            .map(|name| {
+                normalize_agent_name(name)
+                    .map_err(|error| named_agent_invalid_name_error(agent_id, error))
+            })
+            .transpose()?;
         if let Some(template) = template {
             let agent_home = self.agent_data_dir(agent_id);
             let user_home = self.config().home_dir.clone();

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1295,6 +1295,12 @@ pub(crate) fn agent_access_error(error: PublicAgentError) -> (StatusCode, Json<V
                 .code("agent_delete_forbidden")
                 .extension("agent_id", agent_id),
         ),
+        PublicAgentError::RenameForbidden { agent_id, reason } => http_error(
+            StatusCode::CONFLICT,
+            HttpErrorEnvelope::new(reason)
+                .code("agent_rename_forbidden")
+                .extension("agent_id", agent_id),
+        ),
         PublicAgentError::InvalidName { agent_id, reason } => http_error(
             StatusCode::BAD_REQUEST,
             HttpErrorEnvelope::new(reason)

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -37,6 +37,7 @@ http_async_tests!(
     control_agent_model_override_validates_codex_reasoning_effort,
     control_agent_delete_fences_runtime_and_is_idempotent,
     control_agent_delete_rejects_default_and_reports_unknown,
+    control_agent_name_validation_and_default_rename_errors_are_typed,
     control_prompt_requires_bearer_token_when_required,
     control_prompt_rejects_oversized_body,
     remote_tcp_surfaces_require_bearer_token_when_required,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -156,6 +156,36 @@ pub async fn control_agent_delete_rejects_default_and_reports_unknown() -> Resul
     Ok(())
 }
 
+pub async fn control_agent_name_validation_and_default_rename_errors_are_typed() -> Result<()> {
+    let (_host, base, server) = spawn_server().await?;
+    let client = Client::new();
+
+    let invalid_create = client
+        .post(format!("{base}/api/control/agents/invalid-name/create"))
+        .json(&serde_json::json!({ "name": "   " }))
+        .send()
+        .await?;
+    assert_eq!(invalid_create.status(), reqwest::StatusCode::BAD_REQUEST);
+    assert_eq!(
+        invalid_create.json::<serde_json::Value>().await?["code"],
+        "agent_name_invalid"
+    );
+
+    let default_rename = client
+        .patch(format!("{base}/api/control/agents/default/name"))
+        .json(&serde_json::json!({ "name": "Renamed Default" }))
+        .send()
+        .await?;
+    assert_eq!(default_rename.status(), reqwest::StatusCode::CONFLICT);
+    assert_eq!(
+        default_rename.json::<serde_json::Value>().await?["code"],
+        "agent_rename_forbidden"
+    );
+
+    server.abort();
+    Ok(())
+}
+
 #[cfg(unix)]
 pub async fn control_prompt_is_open_over_unix_socket_auto() -> Result<()> {
     let config = test_config();


### PR DESCRIPTION
## Summary
- preserve the typed `agent_name_invalid` validation descriptor when public agent creation rejects a name
- return a dedicated `agent_rename_forbidden` HTTP error when renaming the configured default agent
- add HTTP regression coverage for both error contracts

## Context
Follow-up to #2801. These small typed-error fixes were validated during that PR but were not included in its merged head.

## Verification
- `cargo test --test http_control control_agent_name_validation_and_default_rename_errors_are_typed -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
