### PR TITLE
refactor: simplify GitHub solve template delivery

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -43,6 +43,9 @@ jobs:
             shasum -a 256 -c linux-amd64.checksums
           )
           tar -xzf dist/holon-linux-amd64.tar.gz -C smoke
+          test -f smoke/agent_templates/holon-github-solve/AGENTS.md
+          test -f smoke/agent_templates/holon-github-solve/template.toml
+          test -f smoke/agent_templates/holon-github-solve/skills.toml
 
       - name: Run release asset
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,9 @@ jobs:
           mkdir -p dist
           tmpdir="$(mktemp -d)"
           cp "target/${{ matrix.target }}/release/holon" "$tmpdir/holon"
-          tar -czf "dist/${{ matrix.asset }}.tar.gz" -C "$tmpdir" holon
+          mkdir -p "$tmpdir/agent_templates"
+          cp -R agent_templates/holon-github-solve "$tmpdir/agent_templates/"
+          tar -czf "dist/${{ matrix.asset }}.tar.gz" -C "$tmpdir" holon agent_templates
           shasum -a 256 "dist/${{ matrix.asset }}.tar.gz" > "dist/${{ matrix.asset }}.tar.gz.sha256"
 
       - name: Upload release artifact

--- a/action.yml
+++ b/action.yml
@@ -608,6 +608,12 @@ runs:
             template="$source_template"
           fi
         fi
+        if [ -z "$template" ]; then
+          release_template="$RUNNER_TEMP/holon/bin/agent_templates/holon-github-solve"
+          if [ -f "$release_template/AGENTS.md" ]; then
+            template="$release_template"
+          fi
+        fi
 
         args=("$INPUT_REF" --home "$state_dir" --workspace "$workspace" --cwd "$cwd" --input "$input_dir" --output "$output_dir" --max-turns "$INPUT_MAX_TURNS" --json)
         if [ -n "$INPUT_REPO" ]; then

--- a/agent_templates/holon-github-solve/AGENTS.md
+++ b/agent_templates/holon-github-solve/AGENTS.md
@@ -1,25 +1,35 @@
 # Holon GitHub Solve Agent
 
-You are a GitHub task agent created by `holon solve`.
+You are the command-owned execution preset created by `holon solve` for one
+GitHub issue or pull request. You are not a general-purpose or long-lived agent
+role.
 
 ## Responsibilities
 
-- interpret the target issue or pull request from the solve prompt
-- collect current GitHub context with `gh` when needed
-- choose the matching GitHub skill workflow
-- implement, review, comment, or publish exactly as the target requires
-- write completion artifacts under `GITHUB_OUTPUT_DIR`
+- treat the solve prompt as the source of truth for the target, goal, output
+  contract, and required publish actions
+- select the matching GitHub workflow and complete the requested task through
+  verification and publishing
+- report completed actions, evidence, and residual blockers accurately
 
-## Operating Rules
+## Authority Boundaries
 
 - Assume the caller has already checked out the repository.
 - Do not clone a fresh copy of the repository unless the prompt explicitly asks.
 - Use `GITHUB_TOKEN` or `GH_TOKEN` for GitHub operations.
-- Do not report success until required publish actions are complete.
+- Do not merge or approve a pull request unless the prompt or operator
+  explicitly authorizes it.
+- Do not subscribe to events or continue tracking a pull request after the
+  one-shot solve run unless the prompt or operator explicitly requests it.
+- Do not report success until all actions required by the solve prompt are
+  complete.
 
-## Available Skills
+## Skill Responsibility Layering
 
-- `github-issue-solve`: use for issue implementation and PR publishing
-- `github-pr-fix`: use for existing PR feedback or CI remediation
-- `github-review`: use for review-only tasks
-- `ghx`: use for raw GitHub CLI/API safety and payload handling
+- `sview`: navigate code and Markdown structure before broad reads.
+- `code-review`: apply the platform-neutral review methodology when review is
+  part of the task.
+- `github-issue-solve`: implement an issue and publish or update its PR.
+- `github-pr-fix`: address existing PR feedback or CI failures.
+- `github-review`: adapt review work to GitHub and publish only when requested.
+- `ghx`: use safe GitHub CLI/API command and payload patterns.

--- a/agent_templates/holon-github-solve/skills.toml
+++ b/agent_templates/holon-github-solve/skills.toml
@@ -5,6 +5,11 @@ path = "skills/ghx"
 
 [[skills]]
 kind = "github"
+repo = "holon-run/sview"
+path = "skills/sview"
+
+[[skills]]
+kind = "github"
 repo = "holon-run/holon"
 path = "skills/github-issue-solve"
 
@@ -17,4 +22,9 @@ path = "skills/github-pr-fix"
 kind = "github"
 repo = "holon-run/holon"
 path = "skills/github-review"
+
+[[skills]]
+kind = "github"
+repo = "holon-run/holon"
+path = "skills/code-review"
 

--- a/agent_templates/holon-github-solve/template.toml
+++ b/agent_templates/holon-github-solve/template.toml
@@ -1,7 +1,7 @@
 schema = "holon.agent_template.v1"
 id = "holon-github-solve"
 name = "Holon GitHub Solve"
-summary = "You are a GitHub task agent created by `holon solve`."
+summary = "Command-owned preset for one-shot GitHub tasks run by `holon solve`."
 
 [compatibility]
 holon = ">=0.1.0"

--- a/docs/rfcs/agent-initialization-and-template.md
+++ b/docs/rfcs/agent-initialization-and-template.md
@@ -327,6 +327,9 @@ available, but they should not create duplicate visible catalog entries.
 Common role templates such as developer, reviewer, release, or GitHub issue
 solver should be delivered through the official remote template source and
 materialized into `~/.agents/agent_templates` by sync/install operations.
+Commands and integrations may select one of those templates or pass an explicit
+template path, but template initialization must not add command-specific
+built-ins or resolution branches.
 
 ### `skills.toml` format
 

--- a/docs/website/guides/agent-templates.md
+++ b/docs/website/guides/agent-templates.md
@@ -19,7 +19,7 @@ Common scenarios:
 
 - **Creating a synced reviewer agent** — `holon agent create reviewer --template holon-reviewer`
 - **One-shot tasks with a role** — `holon run --template holon-developer "Fix the null check in handler.rs"`
-- **Solving GitHub issues** — `holon solve --template holon-github-solve https://github.com/owner/repo/issues/42`
+- **Solving GitHub issues** — `holon solve https://github.com/owner/repo/issues/42`
 
 ## Template library and default bootstrap
 
@@ -53,6 +53,11 @@ The official template source is the Holon repository. When synced, templates
 under its top-level `agent_templates/` directory become normal local catalog
 entries from `~/.agents/agent_templates`.
 
+`holon solve` selects the normal `holon-github-solve` template by default. Sync
+the official template source before using the standalone command on a new
+installation. The GitHub Action supplies the same checked-in template as an
+explicit path, including when installed from a release archive.
+
 ## Using `--template`
 
 ### Create an Agent
@@ -82,7 +87,9 @@ holon solve --template holon-github-solve https://github.com/owner/repo/issues/4
 ```
 
 The agent starts with GitHub workflow guidance and the four GitHub skills
-pre-installed.
+plus `sview` and `code-review` pre-installed. The preset does not authorize
+merging, approval, or ongoing event tracking unless the solve prompt explicitly
+requests it.
 
 ## Template Structure
 

--- a/docs/website/guides/solve.md
+++ b/docs/website/guides/solve.md
@@ -131,8 +131,9 @@ When you run `holon solve`, these steps happen inside the runtime:
    input metadata.
 
 3. **Create the agent** — Holon creates an agent from the configured solve
-   template, normally `holon-github-solve`, which includes the `github-issue-solve`,
-   `github-pr-fix`, `github-review`, and `ghx` skills.
+   template, normally the command-owned `holon-github-solve` preset. It includes
+   `sview`, `code-review`, `github-issue-solve`, `github-pr-fix`,
+   `github-review`, and `ghx`.
 
 4. **Run the prompt** — The runtime constructs a prompt describing the target
    and goal, then runs the agent with the configured trust level and turn
@@ -188,7 +189,8 @@ serve different purposes:
 
 Use `holon run` for general automation and scripting. Use `holon solve` when
 your task starts from a GitHub issue or pull request and you want automatic
-skill selection.
+skill selection. The solve preset is one-shot: merging, approval, or continued
+PR event tracking requires explicit instructions.
 
 ## Scripting with solve
 

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -66,19 +66,7 @@ const DEFAULT_BUILTIN_TEMPLATE: BuiltinTemplate = BuiltinTemplate {
     template_toml: include_str!("../builtin_templates/holon-default/template.toml"),
     skill_names: &[],
 };
-const GITHUB_SOLVE_BUILTIN_TEMPLATE: BuiltinTemplate = BuiltinTemplate {
-    template_id: GITHUB_SOLVE_AGENT_TEMPLATE_ID,
-    agents_md: include_str!("../agent_templates/holon-github-solve/AGENTS.md"),
-    template_toml: include_str!("../agent_templates/holon-github-solve/template.toml"),
-    skill_names: &[
-        "ghx",
-        "github-issue-solve",
-        "github-pr-fix",
-        "github-review",
-    ],
-};
-const BUILTIN_TEMPLATES: &[BuiltinTemplate] =
-    &[DEFAULT_BUILTIN_TEMPLATE, GITHUB_SOLVE_BUILTIN_TEMPLATE];
+const BUILTIN_TEMPLATES: &[BuiltinTemplate] = &[DEFAULT_BUILTIN_TEMPLATE];
 
 struct BuiltinTemplate {
     template_id: &'static str,
@@ -3459,6 +3447,13 @@ mod tests {
             .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
             .collect();
         assert_eq!(builtin_ids, vec!["holon-default"]);
+        assert_eq!(
+            BUILTIN_TEMPLATES
+                .iter()
+                .map(|template| template.template_id)
+                .collect::<Vec<_>>(),
+            vec!["holon-default"]
+        );
 
         for template_id in [
             "holon-developer",
@@ -3476,6 +3471,24 @@ mod tests {
                 "{template_id} should declare template metadata"
             );
         }
+
+        let solve_template = syncable.join(GITHUB_SOLVE_AGENT_TEMPLATE_ID);
+        assert_eq!(
+            local_template_skills(&solve_template),
+            vec![
+                "holon-run/holon/skills/code-review",
+                "holon-run/holon/skills/ghx",
+                "holon-run/holon/skills/github-issue-solve",
+                "holon-run/holon/skills/github-pr-fix",
+                "holon-run/holon/skills/github-review",
+                "holon-run/sview/skills/sview",
+            ]
+        );
+        let solve_agents_md =
+            fs::read_to_string(solve_template.join(TEMPLATE_AGENTS_FILENAME)).unwrap();
+        assert!(solve_agents_md.contains("command-owned execution preset"));
+        assert!(solve_agents_md.contains("Do not merge or approve"));
+        assert!(solve_agents_md.contains("continue tracking a pull request"));
     }
 
     #[test]
@@ -3623,35 +3636,6 @@ mod tests {
         assert!(!catalog
             .iter()
             .any(|entry| entry.catalog_id == "builtin:holon-default"));
-    }
-
-    #[test]
-    fn github_solve_builtin_template_resolves_without_user_catalog() {
-        let user_home = tempdir().unwrap();
-        let agent_home = tempdir().unwrap();
-
-        let entry = resolve_template_catalog_entry(
-            GITHUB_SOLVE_AGENT_TEMPLATE_ID,
-            user_home.path(),
-            agent_home.path(),
-        )
-        .unwrap();
-        assert_eq!(entry.catalog_id, "builtin:holon-github-solve");
-        assert_eq!(entry.source, AgentTemplateSourceKind::Builtin);
-        assert_eq!(
-            entry.included_skills,
-            vec![
-                "ghx",
-                "github-issue-solve",
-                "github-pr-fix",
-                "github-review"
-            ]
-        );
-
-        let resolved =
-            resolve_builtin_template(GITHUB_SOLVE_AGENT_TEMPLATE_ID, user_home.path()).unwrap();
-        assert!(resolved.agents_md.contains("Holon GitHub Solve"));
-        assert_eq!(resolved.skill_refs.len(), 4);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- keep `holon-github-solve` as the default `holon solve` preset while removing its template-initialization builtin special case
- make source and release GitHub Action paths pass the same checked-in template explicitly, and package it in release archives
- narrow the preset contract, add `sview` and `code-review`, and require explicit merge, approval, or ongoing tracking authority
- update template architecture/guides and checked-in template/release smoke coverage

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo test --all-targets checked_in_templates`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- release archive layout/template parsing smoke simulation
