### PR TITLE
fix: stabilize user-global instruction loading

### DIFF
--- a/docs/rfcs/instruction-loading.md
+++ b/docs/rfcs/instruction-loading.md
@@ -5,6 +5,7 @@ status: accepted
 issue:
   - 64
   - 68
+  - 2793
 ---
 
 # RFC: Instruction Loading
@@ -14,6 +15,7 @@ issue:
 Holon should define instruction loading independently from shell cwd. The
 phase-1 contract is:
 
+- user-global instructions load from `<user_home>/.agents/AGENTS.md`
 - agent-scoped instructions load from `<agent_home>/AGENTS.md`
 - workspace-scoped instructions load from `<workspace_anchor>/AGENTS.md`
 - `CLAUDE.md` is a fallback only when workspace `AGENTS.md` is absent
@@ -26,6 +28,17 @@ shell `cd` can all accidentally redefine instructions. That makes long-lived
 runtime behavior hard to inspect and reason about.
 
 ## Root Selection
+
+### User-Global Scope
+
+User-global scope is rooted at the operating-system user home captured when the
+daemon configuration is loaded. It is not `HOLON_HOME`, `AppConfig.home_dir`,
+the shell cwd, the workspace anchor, or a provider capability.
+
+The captured `user_home` is passed into each runtime independently of whether
+the runtime uses a static or reconfigurable provider. Config reloads preserve
+the runtime's original user home so an environment change cannot redefine
+instructions between turns.
 
 ### Agent Scope
 
@@ -43,12 +56,16 @@ subdirectory or worktree projection.
 Holon should load:
 
 1. runtime/base instructions
-2. agent-scoped `AGENTS.md`
-3. workspace-scoped `AGENTS.md`
-4. activated skills
-5. dynamic runtime attachments
+2. user-global `AGENTS.md`
+3. agent-scoped `AGENTS.md`
+4. workspace-scoped `AGENTS.md`
+5. activated skills
+6. dynamic runtime attachments
 
 The default contract is intentionally simple and inspectable.
+
+Turn-scoped operator instructions remain later and therefore more specific
+than these stable instruction roots.
 
 ## `CLAUDE.md` Compatibility
 
@@ -66,8 +83,27 @@ shows it improves coding flows without destabilizing workspace identity.
 Prompt and debug surfaces should be able to report:
 
 - which instruction sources were loaded
-- whether they came from agent or workspace scope
+- whether they came from user-global, agent, or workspace scope
 - which path won when `AGENTS.md` and `CLAUDE.md` were both possible
+- `not_found` when a known root does not contain the candidate file
+- `root_unavailable` when the runtime mode has no root for that scope
+- `not_evaluated` when a storage-only summary intentionally avoids file I/O
+
+Unreadable files and decoding failures are context-build errors. They should
+include the instruction scope and candidate path and must not be silently
+treated as absent.
+
+## Startup and Inspection Modes
+
+Normal operator/external turns, recovered runtimes, prompt preview, public
+named agents, and private child agents use the same captured user-global root.
+A detached runtime projects its agent home as the active workspace root, so
+workspace status describes that explicit projection; detachment does not
+disable user-global or agent-scoped loading.
+
+Offline runtimes may omit user home when they do not build provider prompts.
+Storage-only summaries do not read instruction files and report
+`not_evaluated` instead of claiming that files are missing.
 
 ## Related Historical Notes
 

--- a/src/agents_md.rs
+++ b/src/agents_md.rs
@@ -1,8 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
-use crate::types::{AgentsMdKind, AgentsMdScope, AgentsMdSource, LoadedAgentsMd};
+use crate::types::{
+    AgentsMdKind, AgentsMdLoadStatus, AgentsMdScope, AgentsMdSource, LoadedAgentsMd,
+};
 
 const AGENTS_MD_FILENAME: &str = "AGENTS.md";
 const CLAUDE_MD_FILENAME: &str = "CLAUDE.md";
@@ -12,35 +14,46 @@ pub fn load_agents_md(
     agent_home: &Path,
     workspace_anchor: Option<&Path>,
 ) -> Result<LoadedAgentsMd> {
+    let (user_global_source, user_global_status) = load_user_global_agents_md(user_home)?;
+    let (agent_source, agent_status) = load_agent_agents_md(agent_home)?;
+    let (workspace_source, workspace_status) = load_workspace_agents_md(workspace_anchor)?;
     Ok(LoadedAgentsMd {
-        user_global_source: load_user_global_agents_md(user_home)?,
-        agent_source: load_agent_agents_md(agent_home)?,
-        workspace_source: load_workspace_agents_md(workspace_anchor)?,
+        user_global_source,
+        user_global_status,
+        agent_source,
+        agent_status,
+        workspace_source,
+        workspace_status,
     })
 }
 
-fn load_user_global_agents_md(user_home: Option<&Path>) -> Result<Option<AgentsMdSource>> {
+fn load_user_global_agents_md(
+    user_home: Option<&Path>,
+) -> Result<(Option<AgentsMdSource>, AgentsMdLoadStatus)> {
     let Some(user_home) = user_home else {
-        return Ok(None);
+        return Ok((None, AgentsMdLoadStatus::RootUnavailable));
     };
     let path = user_home.join(".agents").join(AGENTS_MD_FILENAME);
     load_source(AgentsMdScope::UserGlobal, AgentsMdKind::AgentsMd, &path)
 }
 
-fn load_agent_agents_md(agent_home: &Path) -> Result<Option<AgentsMdSource>> {
+fn load_agent_agents_md(agent_home: &Path) -> Result<(Option<AgentsMdSource>, AgentsMdLoadStatus)> {
     let path = agent_home.join(AGENTS_MD_FILENAME);
     load_source(AgentsMdScope::Agent, AgentsMdKind::AgentsMd, &path)
 }
 
-fn load_workspace_agents_md(workspace_anchor: Option<&Path>) -> Result<Option<AgentsMdSource>> {
+fn load_workspace_agents_md(
+    workspace_anchor: Option<&Path>,
+) -> Result<(Option<AgentsMdSource>, AgentsMdLoadStatus)> {
     let Some(workspace_anchor) = workspace_anchor else {
-        return Ok(None);
+        return Ok((None, AgentsMdLoadStatus::RootUnavailable));
     };
 
     let agents_md = workspace_anchor.join(AGENTS_MD_FILENAME);
-    if let Some(source) = load_source(AgentsMdScope::Workspace, AgentsMdKind::AgentsMd, &agents_md)?
-    {
-        return Ok(Some(source));
+    let (source, status) =
+        load_source(AgentsMdScope::Workspace, AgentsMdKind::AgentsMd, &agents_md)?;
+    if source.is_some() {
+        return Ok((source, status));
     }
 
     let claude_md = workspace_anchor.join(CLAUDE_MD_FILENAME);
@@ -55,18 +68,39 @@ fn load_source(
     scope: AgentsMdScope,
     kind: AgentsMdKind,
     path: &Path,
-) -> Result<Option<AgentsMdSource>> {
+) -> Result<(Option<AgentsMdSource>, AgentsMdLoadStatus)> {
     let content = match std::fs::read_to_string(path) {
         Ok(content) => content,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => return Err(err.into()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((None, AgentsMdLoadStatus::NotFound));
+        }
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!(
+                    "failed to read {} instruction file at {}",
+                    agents_md_scope_name(&scope),
+                    path.display()
+                )
+            });
+        }
     };
-    Ok(Some(AgentsMdSource {
-        scope,
-        kind,
-        path: PathBuf::from(path),
-        content,
-    }))
+    Ok((
+        Some(AgentsMdSource {
+            scope,
+            kind,
+            path: PathBuf::from(path),
+            content,
+        }),
+        AgentsMdLoadStatus::Loaded,
+    ))
+}
+
+fn agents_md_scope_name(scope: &AgentsMdScope) -> &'static str {
+    match scope {
+        AgentsMdScope::UserGlobal => "user-global",
+        AgentsMdScope::Agent => "agent",
+        AgentsMdScope::Workspace => "workspace",
+    }
 }
 
 #[cfg(test)]
@@ -143,7 +177,9 @@ mod tests {
                 path: PathBuf::from("/tmp/agent/AGENTS.md"),
                 content: "secret agent content".into(),
             }),
+            agent_status: AgentsMdLoadStatus::Loaded,
             workspace_source: None,
+            ..LoadedAgentsMd::default()
         };
 
         let json = serde_json::to_value(&loaded).unwrap();
@@ -179,6 +215,39 @@ mod tests {
         );
         assert!(loaded.agent_source.is_some());
         assert!(loaded.workspace_source.is_some());
+        assert_eq!(loaded.user_global_status, AgentsMdLoadStatus::Loaded);
+        assert_eq!(loaded.agent_status, AgentsMdLoadStatus::Loaded);
+        assert_eq!(loaded.workspace_status, AgentsMdLoadStatus::Loaded);
+    }
+
+    #[test]
+    fn reports_missing_and_unavailable_instruction_roots() {
+        let dir = tempdir().unwrap();
+        let agent_home = dir.path().join("agent");
+        std::fs::create_dir_all(&agent_home).unwrap();
+
+        let loaded = load_agents_md(None, &agent_home, None).unwrap();
+
+        assert_eq!(
+            loaded.user_global_status,
+            AgentsMdLoadStatus::RootUnavailable
+        );
+        assert_eq!(loaded.agent_status, AgentsMdLoadStatus::NotFound);
+        assert_eq!(loaded.workspace_status, AgentsMdLoadStatus::RootUnavailable);
+    }
+
+    #[test]
+    fn unreadable_instruction_error_includes_scope_and_path() {
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("user");
+        let agents_md = user_home.join(".agents").join(AGENTS_MD_FILENAME);
+        std::fs::create_dir_all(&agents_md).unwrap();
+
+        let error = load_agents_md(Some(&user_home), dir.path(), None).unwrap_err();
+        let message = format!("{error:#}");
+
+        assert!(message.contains("failed to read user-global instruction file"));
+        assert!(message.contains(&agents_md.display().to_string()));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -46,6 +46,7 @@ pub struct AppConfig {
     pub default_agent_id: String,
     pub http_addr: String,
     pub callback_base_url: String,
+    pub user_home_dir: Option<PathBuf>,
     pub home_dir: PathBuf,
     pub data_dir: PathBuf,
     pub socket_path: PathBuf,
@@ -114,6 +115,7 @@ impl AppConfig {
         reloaded.default_agent_id = self.default_agent_id.clone();
         reloaded.http_addr = self.http_addr.clone();
         reloaded.callback_base_url = self.callback_base_url.clone();
+        reloaded.user_home_dir = self.user_home_dir.clone();
         reloaded.home_dir = self.home_dir.clone();
         reloaded.data_dir = self.data_dir.clone();
         reloaded.socket_path = self.socket_path.clone();
@@ -156,6 +158,7 @@ impl AppConfig {
         mode: ConfigLoadMode,
     ) -> Result<Self> {
         let settings_env = load_settings_env().unwrap_or_default();
+        let user_home_dir = default_user_home_dir();
         let home_dir = home_override.unwrap_or_else(|| {
             env::var("HOLON_HOME")
                 .map(PathBuf::from)
@@ -312,6 +315,7 @@ impl AppConfig {
             default_agent_id,
             http_addr,
             callback_base_url,
+            user_home_dir,
             home_dir,
             data_dir,
             socket_path,
@@ -500,6 +504,23 @@ pub fn load_settings_env() -> Result<HashMap<String, String>> {
 pub fn default_holon_home() -> PathBuf {
     let home = env::var("HOME").unwrap_or_else(|_| ".".into());
     Path::new(&home).join(".holon")
+}
+
+pub fn default_user_home_dir() -> Option<PathBuf> {
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+        .or_else(|| {
+            env::var_os("USERPROFILE")
+                .map(PathBuf::from)
+                .filter(|path| !path.as_os_str().is_empty())
+        })
+        .or_else(|| {
+            let drive = env::var_os("HOMEDRIVE")?;
+            let path = env::var_os("HOMEPATH")?;
+            let joined = PathBuf::from(drive).join(path);
+            (!joined.as_os_str().is_empty()).then_some(joined)
+        })
 }
 
 pub fn default_codex_home() -> PathBuf {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -137,6 +137,7 @@ fn test_app_config(default_model: &str, fallback_models: &[&str]) -> TestAppConf
         default_agent_id: "default".into(),
         http_addr: "127.0.0.1:0".into(),
         callback_base_url: "http://127.0.0.1:0".into(),
+        user_home_dir: None,
         home_dir: home_path.clone(),
         data_dir: home_path.clone(),
         socket_path: home_path.join("run").join("holon.sock"),
@@ -561,6 +562,25 @@ fn default_holon_home_uses_home_directory() {
         default_holon_home(),
         Path::new("/tmp/holon-home-test/.holon")
     );
+}
+
+#[test]
+fn app_config_keeps_user_home_separate_from_holon_home() {
+    let _home_guard = EnvVarGuard::set("HOME", "/tmp/holon-user-home-test");
+    let holon_home = tempfile::tempdir().unwrap();
+    std::fs::write(
+        holon_home.path().join("config.json"),
+        r#"{"model":{"default":"openai/gpt-5.4"}}"#,
+    )
+    .unwrap();
+
+    let config = AppConfig::load_with_home(Some(holon_home.path().to_path_buf())).unwrap();
+
+    assert_eq!(
+        config.user_home_dir,
+        Some(PathBuf::from("/tmp/holon-user-home-test"))
+    );
+    assert_eq!(config.home_dir, holon_home.path());
 }
 
 #[test]

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -1095,6 +1095,20 @@ pub(crate) fn effective_config_mismatch_summary(
     if let Some(startup) = &status.startup_surface {
         push_diff(
             &mut differences,
+            "user_home_dir",
+            config
+                .user_home_dir
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "none".into()),
+            startup
+                .user_home_dir
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "none".into()),
+        );
+        push_diff(
+            &mut differences,
             "workspace_dir",
             config.workspace_dir.display().to_string(),
             startup.workspace_dir.display().to_string(),

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -76,6 +76,8 @@ pub struct RuntimeStatusResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeStartupSurface {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_home_dir: Option<PathBuf>,
     pub home_dir: PathBuf,
     pub socket_path: PathBuf,
     pub workspace_dir: PathBuf,

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -64,6 +64,7 @@ fn test_config() -> AppConfig {
         default_agent_id: "default".into(),
         http_addr: "127.0.0.1:0".into(),
         callback_base_url: "http://127.0.0.1:0".into(),
+        user_home_dir: None,
         home_dir: home.path().to_path_buf(),
         data_dir: home.path().to_path_buf(),
         socket_path: home.path().join("run").join("holon.sock"),
@@ -635,6 +636,7 @@ fn effective_config_mismatch_summary_lists_actionable_differences() {
         executable_path: std::env::current_exe().unwrap(),
         activity: None,
         startup_surface: Some(RuntimeStartupSurface {
+            user_home_dir: expected.user_home_dir.clone(),
             home_dir: expected.home_dir.clone(),
             socket_path: expected.socket_path.clone(),
             workspace_dir: expected.workspace_dir.clone(),

--- a/src/host.rs
+++ b/src/host.rs
@@ -1465,9 +1465,10 @@ impl RuntimeHost {
             .active_workspace_entry
             .as_ref()
             .map(|entry| entry.execution_root.as_path());
+        let config = self.config();
         let skill_roots = effective_skill_root_registrations(
             skill_visibility(&identity_view),
-            Some(self.config().home_dir.as_path()),
+            config.user_home_dir.as_deref(),
             agent_id,
             &agent_home,
             workspace_skill_root,
@@ -1482,7 +1483,7 @@ impl RuntimeHost {
             &state.active_skills,
         );
         skills.agent_templates_catalog =
-            discover_agent_templates_catalog(Some(self.config().home_dir.as_path()), &agent_home);
+            discover_agent_templates_catalog(config.user_home_dir.as_deref(), &agent_home);
         Ok(skills)
     }
 
@@ -2550,12 +2551,16 @@ impl RuntimeHost {
             "agent {} AGENTS.md already exists without a runtime template marker; repair refuses to overwrite user content",
             bootstrap.agent_id
         );
-        let user_home = self.config().home_dir.clone();
+        let config = self.config();
+        let template_home = config
+            .user_home_dir
+            .as_deref()
+            .unwrap_or(config.home_dir.as_path());
         if let Some(template) = bootstrap.desired.template.as_deref() {
             if let Some(catalog_agent_home) = bootstrap.desired.catalog_agent_home.as_deref() {
                 ensure_agent_home_agents_md_from_template_with_catalog(
                     &agent_home,
-                    &user_home,
+                    template_home,
                     catalog_agent_home,
                     template,
                 )
@@ -2563,13 +2568,14 @@ impl RuntimeHost {
             } else {
                 ensure_agent_home_agents_md_from_template_with_home(
                     &agent_home,
-                    &user_home,
+                    template_home,
                     template,
                 )
                 .await?;
             }
         } else {
-            ensure_agent_home_agents_md_without_template_with_home(&agent_home, &user_home).await?;
+            ensure_agent_home_agents_md_without_template_with_home(&agent_home, template_home)
+                .await?;
         }
         Ok(())
     }
@@ -3407,21 +3413,21 @@ impl RuntimeHost {
         )
         .snapshot();
         let agent_home = self.agent_data_dir(&identity.agent_id);
+        let config = self.config();
         let loaded_agents_md = load_agents_md(
-            Some(self.config().home_dir.as_path()),
+            config.user_home_dir.as_deref(),
             agent_home.as_path(),
             crate::runtime::workspace::workspace_anchor_for_state_ref(&state),
         )?;
         let loaded_agent_memory = load_agent_memory(agent_home.as_path())?;
         let skill_visibility = skill_visibility(&identity_view);
-        let user_home = self.config().home_dir.clone();
         let workspace_skill_root = state
             .active_workspace_entry
             .as_ref()
             .map(|entry| entry.execution_root.as_path());
         let skill_roots = effective_skill_root_registrations(
             skill_visibility,
-            Some(user_home.as_path()),
+            config.user_home_dir.as_deref(),
             &state.id,
             agent_home.as_path(),
             workspace_skill_root,
@@ -3433,11 +3439,8 @@ impl RuntimeHost {
             &skill_roots,
             &state.active_skills,
         );
-        skills.agent_templates_catalog = discover_agent_templates_catalog(
-            Some(self.config().home_dir.as_path()),
-            agent_home.as_path(),
-        );
-        let config = self.config();
+        skills.agent_templates_catalog =
+            discover_agent_templates_catalog(config.user_home_dir.as_deref(), agent_home.as_path());
         let model_catalog = RuntimeModelCatalog::from_config(&config);
         let model_ref = model_catalog
             .provider_chain(state.model_override.as_ref())
@@ -3613,10 +3616,14 @@ impl RuntimeHost {
     }
 
     async fn ensure_default_agent_home_initialized(&self) -> Result<()> {
-        let agent_home = self.agent_data_dir(&self.config().default_agent_id);
-        let user_home = self.config().home_dir.clone();
-        let _ =
-            ensure_agent_home_agents_md_without_template_with_home(&agent_home, &user_home).await?;
+        let config = self.config();
+        let agent_home = self.agent_data_dir(&config.default_agent_id);
+        let template_home = config
+            .user_home_dir
+            .as_deref()
+            .unwrap_or(config.home_dir.as_path());
+        let _ = ensure_agent_home_agents_md_without_template_with_home(&agent_home, template_home)
+            .await?;
         Ok(())
     }
 
@@ -3629,20 +3636,23 @@ impl RuntimeHost {
     ) -> Result<AgentIdentityRecord> {
         let child_agent_id = ids::runtime_id(TEMP_CHILD_AGENT_PREFIX.trim_end_matches('_'));
         self.validate_agent_id(&child_agent_id)?;
+        let config = self.config();
+        let template_home = config
+            .user_home_dir
+            .as_deref()
+            .unwrap_or(config.home_dir.as_path());
         if let Some(template) = template {
-            let user_home = self.config().home_dir.clone();
             initialize_agent_home_from_template_with_catalog(
                 &self.agent_data_dir(&child_agent_id),
-                &user_home,
+                template_home,
                 catalog_agent_home,
                 template,
             )
             .await?;
         } else {
-            let user_home = self.config().home_dir.clone();
             initialize_agent_home_without_template_with_home(
                 &self.agent_data_dir(&child_agent_id),
-                &user_home,
+                template_home,
             )
             .await?;
         }
@@ -4214,6 +4224,7 @@ impl RuntimeHost {
                 provider.clone(),
                 config.default_agent_id.clone(),
                 self.runtime_context_config(),
+                config.user_home_dir.clone(),
                 self.inner.runtime_db.clone(),
                 self.bridge(),
                 RuntimeModelCatalog::from_config(&config),
@@ -4668,7 +4679,8 @@ mod tests {
     fn test_host() -> (tempfile::TempDir, RuntimeHost) {
         let home = tempdir().unwrap();
         write_test_model_config(home.path());
-        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let mut config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        config.user_home_dir = Some(home.path().to_path_buf());
         let host =
             RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
         (home, host)
@@ -4677,7 +4689,8 @@ mod tests {
     fn canonical_test_host() -> (tempfile::TempDir, RuntimeHost) {
         let home = tempdir().unwrap();
         write_test_model_config(home.path());
-        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let mut config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        config.user_home_dir = Some(home.path().to_path_buf());
         let host =
             RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
         (home, host)
@@ -4735,6 +4748,181 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].message_id, message.id);
         assert_eq!(entries[0].status, QueueEntryStatus::Queued);
+    }
+
+    async fn assert_runtime_prompt_uses_configured_user_home(
+        mut config: AppConfig,
+        static_provider: bool,
+    ) {
+        let user_home = tempdir().unwrap();
+        let user_agents_dir = user_home.path().join(".agents");
+        fs::create_dir_all(&user_agents_dir).unwrap();
+        let user_agents_md = user_agents_dir.join("AGENTS.md");
+        fs::write(&user_agents_md, "configured user-global marker").unwrap();
+        assert_ne!(config.home_dir, user_home.path());
+        config.user_home_dir = Some(user_home.path().to_path_buf());
+
+        let host = if static_provider {
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap()
+        } else {
+            RuntimeHost::new(config).unwrap()
+        };
+        let runtime = host.default_runtime().await.unwrap();
+        let prompt = runtime
+            .preview_prompt(
+                "inspect configured user guidance".into(),
+                AuthorityClass::OperatorInstruction,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            prompt.loaded_agents_md.user_global_status,
+            crate::types::AgentsMdLoadStatus::Loaded
+        );
+        assert_eq!(
+            prompt
+                .loaded_agents_md
+                .user_global_source
+                .as_ref()
+                .map(|source| source.path.as_path()),
+            Some(user_agents_md.as_path())
+        );
+        assert!(prompt
+            .system_sections
+            .iter()
+            .any(|section| section.name == "user_global_agents_md"
+                && section.content.contains("configured user-global marker")));
+
+        host.unload_runtime(&host.config().default_agent_id).await;
+        let recovered = host.default_runtime().await.unwrap();
+        let recovered_prompt = recovered
+            .preview_prompt(
+                "inspect recovered user guidance".into(),
+                AuthorityClass::OperatorInstruction,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            recovered_prompt
+                .loaded_agents_md
+                .user_global_source
+                .as_ref()
+                .map(|source| source.path.as_path()),
+            Some(user_agents_md.as_path())
+        );
+
+        host.create_named_agent("configured-home-named", None)
+            .await
+            .unwrap();
+        let named = host
+            .get_public_agent("configured-home-named")
+            .await
+            .unwrap();
+        let named_prompt = named
+            .preview_prompt(
+                "inspect named agent user guidance".into(),
+                AuthorityClass::OperatorInstruction,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            named_prompt
+                .loaded_agents_md
+                .user_global_source
+                .as_ref()
+                .map(|source| source.path.as_path()),
+            Some(user_agents_md.as_path())
+        );
+
+        let parent_state = recovered.agent_state().await.unwrap();
+        let child_identity = host
+            .create_child_identity(
+                &parent_state.id,
+                "configured-home-task",
+                None,
+                recovered.agent_home().as_path(),
+            )
+            .await
+            .unwrap();
+        let child = host
+            .get_or_create_agent(&child_identity.agent_id)
+            .await
+            .unwrap();
+        let child_prompt = child
+            .preview_prompt(
+                "inspect private child user guidance".into(),
+                AuthorityClass::OperatorInstruction,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            child_prompt
+                .loaded_agents_md
+                .user_global_source
+                .as_ref()
+                .map(|source| source.path.as_path()),
+            Some(user_agents_md.as_path())
+        );
+    }
+
+    #[tokio::test]
+    async fn static_runtime_prompt_uses_configured_user_home() {
+        let fixture = provider_test_config(Some("dummy-token"));
+        assert_runtime_prompt_uses_configured_user_home(fixture.config, true).await;
+    }
+
+    #[tokio::test]
+    async fn reconfigurable_runtime_prompt_uses_configured_user_home() {
+        let fixture = provider_test_config(Some("dummy-token"));
+        assert_runtime_prompt_uses_configured_user_home(fixture.config, false).await;
+    }
+
+    #[tokio::test]
+    async fn config_reload_preserves_runtime_user_home() {
+        let mut fixture = provider_test_config(Some("dummy-token"));
+        let original_user_home = tempdir().unwrap();
+        let replacement_user_home = tempdir().unwrap();
+        fs::create_dir_all(original_user_home.path().join(".agents")).unwrap();
+        fs::create_dir_all(replacement_user_home.path().join(".agents")).unwrap();
+        let original_agents_md = original_user_home.path().join(".agents/AGENTS.md");
+        fs::write(&original_agents_md, "original stable guidance").unwrap();
+        fs::write(
+            replacement_user_home.path().join(".agents/AGENTS.md"),
+            "replacement guidance",
+        )
+        .unwrap();
+        fixture.config.user_home_dir = Some(original_user_home.path().to_path_buf());
+        let host = RuntimeHost::new(fixture.config.clone()).unwrap();
+        let runtime = host.default_runtime().await.unwrap();
+
+        let mut reloaded = fixture.config;
+        reloaded.user_home_dir = Some(replacement_user_home.path().to_path_buf());
+        runtime.reload_config(&reloaded).await.unwrap();
+
+        let prompt = runtime
+            .preview_prompt(
+                "inspect stable reloaded user guidance".into(),
+                AuthorityClass::OperatorInstruction,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            prompt
+                .loaded_agents_md
+                .user_global_source
+                .as_ref()
+                .map(|source| source.path.as_path()),
+            Some(original_agents_md.as_path())
+        );
+        assert!(prompt
+            .system_sections
+            .iter()
+            .any(|section| section.content.contains("original stable guidance")));
+        assert!(!prompt
+            .system_sections
+            .iter()
+            .any(|section| section.content.contains("replacement guidance")));
     }
 
     #[tokio::test]
@@ -4808,6 +4996,7 @@ mod tests {
             default_agent_id: "default".into(),
             http_addr: "127.0.0.1:0".into(),
             callback_base_url: "http://127.0.0.1:0".into(),
+            user_home_dir: None,
             home_dir: home_path.clone(),
             data_dir: home_path.clone(),
             socket_path: home_path.join("run").join("holon.sock"),
@@ -4917,7 +5106,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn named_agent_template_resolution_uses_config_home_not_os_home() {
+    async fn named_agent_template_resolution_uses_user_home_not_config_home() {
         struct HomeGuard(Option<String>);
 
         impl Drop for HomeGuard {
@@ -4933,7 +5122,7 @@ mod tests {
         let os_home = tempdir().unwrap();
         write_test_model_config(config_home.path());
 
-        let worker = config_home
+        let worker = os_home
             .path()
             .join(".agents")
             .join("agent_templates")
@@ -4941,7 +5130,7 @@ mod tests {
         fs::create_dir_all(&worker).unwrap();
         fs::write(
             worker.join("AGENTS.md"),
-            "# Config worker\n\nfrom config home\n",
+            "# User worker\n\nfrom user home\n",
         )
         .unwrap();
 
@@ -4957,7 +5146,7 @@ mod tests {
 
         let agents_md =
             fs::read_to_string(host.agent_data_dir("worker-bot").join("AGENTS.md")).unwrap();
-        assert!(agents_md.starts_with("# Config worker\n\nfrom config home\n"));
+        assert!(agents_md.starts_with("# User worker\n\nfrom user home\n"));
     }
 
     #[tokio::test]
@@ -8032,6 +8221,18 @@ mod tests {
             .await
             .expect("local agent summary");
         assert_eq!(summary.agent.id, agent_id);
+        assert_eq!(
+            summary.loaded_agents_md.user_global_status,
+            crate::types::AgentsMdLoadStatus::NotEvaluated
+        );
+        assert_eq!(
+            summary.loaded_agents_md.agent_status,
+            crate::types::AgentsMdLoadStatus::NotEvaluated
+        );
+        assert_eq!(
+            summary.loaded_agents_md.workspace_status,
+            crate::types::AgentsMdLoadStatus::NotEvaluated
+        );
         assert!(host.inner.runtimes.read().await.agents.is_empty());
 
         let _worktree_summary = host

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -433,6 +433,7 @@ pub(super) fn runtime_surfaces(
 ) -> (crate::daemon::RuntimeStartupSurface, RuntimeConfigSurface) {
     let config = state.host.config();
     let startup_surface = crate::daemon::RuntimeStartupSurface {
+        user_home_dir: config.user_home_dir.clone(),
         home_dir: config.home_dir.clone(),
         socket_path: config.socket_path.clone(),
         workspace_dir: config.workspace_dir.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1129,6 +1129,7 @@ mod tests {
             default_agent_id: "default".into(),
             http_addr: "127.0.0.1:7878".into(),
             callback_base_url: "http://127.0.0.1:7878".into(),
+            user_home_dir: None,
             home_dir: home.clone(),
             data_dir: home.clone(),
             socket_path: home.join("run").join("holon.sock"),

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1017,6 +1017,7 @@ mod tests {
             default_agent_id: "default".into(),
             http_addr: "127.0.0.1:0".into(),
             callback_base_url: "http://127.0.0.1:0".into(),
+            user_home_dir: None,
             home_dir: home_dir.clone(),
             data_dir: home_dir.clone(),
             socket_path: home_dir.join("run").join("holon.sock"),

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -30,9 +30,10 @@ use crate::{
     system::{execution_policy_summary_lines, ExecutionSnapshot},
     tool::{ApplyPatchSurface, ToolSpec},
     types::{
-        AgentIdentityView, AgentKind, AgentMemorySource, AgentState, AgentsMdKind, AgentsMdSource,
-        ContinuationResolution, ExternalTriggerRecord, LoadedAgentMemory, LoadedAgentsMd,
-        MessageBody, MessageEnvelope, MessageOrigin, SkillsRuntimeView,
+        AgentIdentityView, AgentKind, AgentMemorySource, AgentState, AgentsMdKind,
+        AgentsMdLoadStatus, AgentsMdSource, ContinuationResolution, ExternalTriggerRecord,
+        LoadedAgentMemory, LoadedAgentsMd, MessageBody, MessageEnvelope, MessageOrigin,
+        SkillsRuntimeView,
     },
 };
 
@@ -307,15 +308,24 @@ impl EffectivePrompt {
         output.extend(execution_policy_summary_lines(&self.execution));
         output.push(format!(
             "User-global AGENTS.md: {}",
-            describe_agents_md_source(self.loaded_agents_md.user_global_source.as_ref())
+            describe_agents_md_source(
+                self.loaded_agents_md.user_global_source.as_ref(),
+                self.loaded_agents_md.user_global_status,
+            )
         ));
         output.push(format!(
             "Agent AGENTS.md: {}",
-            describe_agents_md_source(self.loaded_agents_md.agent_source.as_ref())
+            describe_agents_md_source(
+                self.loaded_agents_md.agent_source.as_ref(),
+                self.loaded_agents_md.agent_status,
+            )
         ));
         output.push(format!(
             "Workspace AGENTS.md: {}",
-            describe_agents_md_source(self.loaded_agents_md.workspace_source.as_ref())
+            describe_agents_md_source(
+                self.loaded_agents_md.workspace_source.as_ref(),
+                self.loaded_agents_md.workspace_status,
+            )
         ));
         output.push("".to_string());
         output.push("System sections:".to_string());
@@ -1073,9 +1083,17 @@ fn workspace_agents_md_section(source: Option<&AgentsMdSource>) -> Option<Prompt
     })
 }
 
-fn describe_agents_md_source(source: Option<&AgentsMdSource>) -> String {
+fn describe_agents_md_source(
+    source: Option<&AgentsMdSource>,
+    status: AgentsMdLoadStatus,
+) -> String {
     let Some(source) = source else {
-        return "none".to_string();
+        return match status {
+            AgentsMdLoadStatus::Loaded => "loaded (source unavailable)".to_string(),
+            AgentsMdLoadStatus::NotFound => "not found".to_string(),
+            AgentsMdLoadStatus::RootUnavailable => "root unavailable".to_string(),
+            AgentsMdLoadStatus::NotEvaluated => "not evaluated".to_string(),
+        };
     };
     let kind = match source.kind {
         AgentsMdKind::AgentsMd => "AGENTS.md",
@@ -2051,6 +2069,7 @@ mod tests {
                     path: PathBuf::from("/repo/AGENTS.md"),
                     content: "Workspace guidance".into(),
                 }),
+                ..LoadedAgentsMd::default()
             },
             &LoadedAgentMemory::default(),
             &SkillsRuntimeView::default(),
@@ -2342,6 +2361,7 @@ mod tests {
                     path: PathBuf::from("/repo/AGENTS.md"),
                     content: "workspace guidance".into(),
                 }),
+                ..LoadedAgentsMd::default()
             },
             &LoadedAgentMemory::default(),
             &SkillsRuntimeView {
@@ -2429,6 +2449,7 @@ mod tests {
                     path: PathBuf::from("/repo/CLAUDE.md"),
                     content: "workspace guidance".into(),
                 }),
+                ..LoadedAgentsMd::default()
             },
             loaded_agent_memory: LoadedAgentMemory::default(),
             cache_identity: sample_cache_identity(),
@@ -2475,7 +2496,7 @@ mod tests {
         assert!(dump.contains("Workspace anchor: /repo"));
         assert!(dump.contains("Execution root: /repo"));
         assert!(dump.contains("Cwd: /repo/src"));
-        assert!(dump.contains("User-global AGENTS.md: none"));
+        assert!(dump.contains("User-global AGENTS.md: not evaluated"));
         assert!(dump.contains("Agent AGENTS.md: /tmp/agent-home/AGENTS.md (AGENTS.md)"));
         assert!(dump.contains("Workspace AGENTS.md: /repo/CLAUDE.md (CLAUDE.md fallback)"));
         assert!(dump.contains("Section inventory:"));
@@ -2571,6 +2592,7 @@ mod tests {
                     content: "very secret agent guidance".into(),
                 }),
                 workspace_source: None,
+                ..LoadedAgentsMd::default()
             },
             loaded_agent_memory: LoadedAgentMemory::default(),
             cache_identity: sample_cache_identity(),

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -186,6 +186,7 @@ mod tests {
             default_agent_id: "default".into(),
             http_addr: "127.0.0.1:0".into(),
             callback_base_url: "http://127.0.0.1:0".into(),
+            user_home_dir: None,
             home_dir: home.clone(),
             data_dir: home.clone(),
             socket_path: home.join("holon.sock"),

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -561,6 +561,7 @@ mod tests {
             default_agent_id: "default".into(),
             http_addr: "127.0.0.1:0".into(),
             callback_base_url: "http://127.0.0.1:0".into(),
+            user_home_dir: None,
             home_dir: home_path.clone(),
             data_dir: home_path.clone(),
             socket_path: home_path.join("run").join("holon.sock"),

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -287,6 +287,7 @@ pub fn test_config(
         default_agent_id: "default".into(),
         http_addr: "127.0.0.1:0".into(),
         callback_base_url: "http://127.0.0.1:0".into(),
+        user_home_dir: None,
         home_dir: home_path.clone(),
         data_dir: home_path.clone(),
         socket_path: home_path.join("run").join("holon.sock"),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3056,12 +3056,7 @@ impl RuntimeHandle {
     }
 
     fn user_home(&self) -> Option<PathBuf> {
-        if let Some(provider_reconfig) =
-            self.inner.config_snapshot.load().provider_reconfig.as_ref()
-        {
-            return Some(provider_reconfig.config.home_dir.clone());
-        }
-        std::env::var_os("HOME").map(PathBuf::from)
+        self.inner.config_snapshot.load().user_home_dir.clone()
     }
 
     fn fallback_identity_view(&self, agent_id: &str) -> AgentIdentityView {

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -63,6 +63,7 @@ fn model_route_reasoning_effort_override(
 /// Stored behind an `ArcSwap` so that config reloads take effect on the next turn
 /// without disturbing an in-progress turn.
 pub(super) struct ConfigSnapshot {
+    pub user_home_dir: Option<PathBuf>,
     pub model_catalog: RuntimeModelCatalog,
     pub model_availability: Vec<ResolvedModelAvailability>,
     pub base_context_config: ContextConfig,
@@ -94,6 +95,7 @@ impl ConfigSnapshot {
             ..ContextConfig::default()
         };
         Ok(Self {
+            user_home_dir: config.user_home_dir.clone(),
             model_catalog,
             model_availability,
             base_context_config,
@@ -184,6 +186,7 @@ impl RuntimeHandle {
         context_config: ContextConfig,
     ) -> Result<Self> {
         let base_context_config = context_config.clone();
+        let user_home_dir = crate::config::default_user_home_dir();
         Self::new_internal(
             agent_id,
             data_dir,
@@ -193,6 +196,7 @@ impl RuntimeHandle {
             default_agent_id,
             base_context_config,
             context_config,
+            user_home_dir,
             RuntimeModelCatalog::default(),
             Vec::new(),
             crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS,
@@ -221,6 +225,7 @@ impl RuntimeHandle {
             String::new(),
             ContextConfig::default(),
             ContextConfig::default(),
+            None,
             RuntimeModelCatalog::default(),
             Vec::new(),
             crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS,
@@ -246,6 +251,7 @@ impl RuntimeHandle {
         clock: Arc<dyn Clock>,
     ) -> Result<Self> {
         let base_context_config = context_config.clone();
+        let user_home_dir = crate::config::default_user_home_dir();
         Self::new_internal(
             agent_id,
             data_dir,
@@ -255,6 +261,7 @@ impl RuntimeHandle {
             default_agent_id,
             base_context_config,
             context_config,
+            user_home_dir,
             RuntimeModelCatalog::default(),
             Vec::new(),
             crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS,
@@ -276,6 +283,7 @@ impl RuntimeHandle {
         provider: Arc<dyn AgentProvider>,
         default_agent_id: String,
         context_config: ContextConfig,
+        user_home_dir: Option<PathBuf>,
         runtime_db: RuntimeDb,
         host_bridge: RuntimeHostBridge,
         model_catalog: RuntimeModelCatalog,
@@ -291,6 +299,7 @@ impl RuntimeHandle {
             default_agent_id,
             base_context_config,
             context_config,
+            user_home_dir,
             model_catalog,
             Vec::new(),
             crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS,
@@ -336,6 +345,7 @@ impl RuntimeHandle {
             default_agent_id,
             base_context_config,
             resolved_context_config,
+            config.user_home_dir.clone(),
             model_catalog,
             model_availability,
             config.default_tool_output_tokens as u64,
@@ -358,6 +368,7 @@ impl RuntimeHandle {
         default_agent_id: String,
         base_context_config: ContextConfig,
         context_config: ContextConfig,
+        user_home_dir: Option<PathBuf>,
         model_catalog: RuntimeModelCatalog,
         model_availability: Vec<ResolvedModelAvailability>,
         default_tool_output_tokens: u64,
@@ -375,6 +386,7 @@ impl RuntimeHandle {
             .transpose()?
             .flatten();
         let config_snapshot = Arc::new(ConfigSnapshot {
+            user_home_dir,
             model_catalog: model_catalog.clone(),
             model_availability: model_availability.clone(),
             base_context_config: base_context_config.clone(),
@@ -641,7 +653,9 @@ impl RuntimeHandle {
     /// the old snapshot continues unaffected; the next turn picks up the
     /// new snapshot automatically.
     pub(crate) async fn reload_config(&self, config: &AppConfig) -> Result<()> {
-        let new_snapshot = Arc::new(ConfigSnapshot::from_config(config)?);
+        let mut config = config.clone();
+        config.user_home_dir = self.inner.config_snapshot.load().user_home_dir.clone();
+        let new_snapshot = Arc::new(ConfigSnapshot::from_config(&config)?);
         // Atomically swap the snapshot.
         self.inner.config_snapshot.store(new_snapshot);
         // Rebuild provider + context_config for current state.

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -221,6 +221,10 @@ async fn detached_agent_does_not_load_workspace_agents_md() {
 
     let loaded = runtime.loaded_agents_md().await.unwrap();
     assert!(loaded.workspace_source.is_none());
+    assert_eq!(
+        loaded.workspace_status,
+        crate::types::AgentsMdLoadStatus::NotFound
+    );
 }
 
 #[tokio::test]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -49,6 +49,7 @@ fn test_config() -> AppConfig {
         default_agent_id: "default".into(),
         http_addr: "127.0.0.1:0".into(),
         callback_base_url: "http://127.0.0.1:0".into(),
+        user_home_dir: None,
         home_dir: temp.clone(),
         data_dir: temp.clone(),
         socket_path: temp.join("run").join("holon.sock"),

--- a/src/types.rs
+++ b/src/types.rs
@@ -939,6 +939,16 @@ pub struct AgentsMdSource {
     pub content: String,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentsMdLoadStatus {
+    Loaded,
+    NotFound,
+    RootUnavailable,
+    #[default]
+    NotEvaluated,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct LoadedAgentsMd {
     #[serde(
@@ -947,10 +957,16 @@ pub struct LoadedAgentsMd {
         skip_serializing_if = "Option::is_none"
     )]
     pub user_global_source: Option<AgentsMdSource>,
+    #[serde(default)]
+    pub user_global_status: AgentsMdLoadStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_source: Option<AgentsMdSource>,
+    #[serde(default)]
+    pub agent_status: AgentsMdLoadStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_source: Option<AgentsMdSource>,
+    #[serde(default)]
+    pub workspace_status: AgentsMdLoadStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -978,10 +994,16 @@ pub struct LoadedAgentsMdView {
         skip_serializing_if = "Option::is_none"
     )]
     pub user_global_source: Option<AgentsMdSourceView>,
+    #[serde(default)]
+    pub user_global_status: AgentsMdLoadStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_source: Option<AgentsMdSourceView>,
+    #[serde(default)]
+    pub agent_status: AgentsMdLoadStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_source: Option<AgentsMdSourceView>,
+    #[serde(default)]
+    pub workspace_status: AgentsMdLoadStatus,
 }
 
 impl From<&LoadedAgentsMd> for LoadedAgentsMdView {
@@ -991,12 +1013,35 @@ impl From<&LoadedAgentsMd> for LoadedAgentsMdView {
                 .user_global_source
                 .as_ref()
                 .map(AgentsMdSourceView::from),
+            user_global_status: effective_agents_md_status(
+                value.user_global_source.as_ref(),
+                value.user_global_status,
+            ),
             agent_source: value.agent_source.as_ref().map(AgentsMdSourceView::from),
+            agent_status: effective_agents_md_status(
+                value.agent_source.as_ref(),
+                value.agent_status,
+            ),
             workspace_source: value
                 .workspace_source
                 .as_ref()
                 .map(AgentsMdSourceView::from),
+            workspace_status: effective_agents_md_status(
+                value.workspace_source.as_ref(),
+                value.workspace_status,
+            ),
         }
+    }
+}
+
+fn effective_agents_md_status(
+    source: Option<&AgentsMdSource>,
+    status: AgentsMdLoadStatus,
+) -> AgentsMdLoadStatus {
+    if source.is_some() {
+        AgentsMdLoadStatus::Loaded
+    } else {
+        status
     }
 }
 

--- a/tests/scripted_agent_provider.rs
+++ b/tests/scripted_agent_provider.rs
@@ -20,6 +20,7 @@ fn test_config() -> AppConfig {
         default_agent_id: "default".into(),
         http_addr: "127.0.0.1:0".into(),
         callback_base_url: "http://127.0.0.1:0".into(),
+        user_home_dir: None,
         home_dir: home_dir.clone(),
         data_dir: home_dir.clone(),
         socket_path: home_dir.join("run").join("holon.sock"),

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -2367,6 +2367,15 @@ pub async fn runtime_status_route_reports_runtime_metadata() -> Result<()> {
         config.home_dir.display().to_string()
     );
     assert_eq!(
+        payload["startup_surface"]["user_home_dir"],
+        serde_json::to_value(
+            config
+                .user_home_dir
+                .as_ref()
+                .map(|path| path.display().to_string())
+        )?
+    );
+    assert_eq!(
         payload["startup_surface"]["socket_path"],
         config.socket_path.display().to_string()
     );

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -184,6 +184,7 @@ impl TestConfigBuilder {
             default_agent_id: "default".into(),
             http_addr: self.http_addr,
             callback_base_url: "http://127.0.0.1:0".into(),
+            user_home_dir: None,
             home_dir: data_dir.clone(),
             data_dir: data_dir.clone(),
             socket_path: data_dir.join("run").join("holon.sock"),

--- a/tests/wt201_multiple_worktree_tasks.rs
+++ b/tests/wt201_multiple_worktree_tasks.rs
@@ -22,6 +22,7 @@ fn test_config() -> AppConfig {
         default_agent_id: "default".into(),
         http_addr: "127.0.0.1:0".into(),
         callback_base_url: "http://127.0.0.1:0".into(),
+        user_home_dir: None,
         home_dir: home_dir.clone(),
         data_dir: home_dir.clone(),
         socket_path: home_dir.join("run").join("holon.sock"),

--- a/tests/wt202_worktree_task_summary.rs
+++ b/tests/wt202_worktree_task_summary.rs
@@ -21,6 +21,7 @@ fn test_config() -> AppConfig {
         default_agent_id: "default".into(),
         http_addr: "127.0.0.1:0".into(),
         callback_base_url: "http://127.0.0.1:0".into(),
+        user_home_dir: None,
         home_dir: home_dir.clone(),
         data_dir: home_dir.clone(),
         socket_path: home_dir.join("run").join("holon.sock"),

--- a/tests/wt204_parallel_worktree_workflow.rs
+++ b/tests/wt204_parallel_worktree_workflow.rs
@@ -21,6 +21,7 @@ fn test_config() -> AppConfig {
         default_agent_id: "default".into(),
         http_addr: "127.0.0.1:0".into(),
         callback_base_url: "http://127.0.0.1:0".into(),
+        user_home_dir: None,
         home_dir: home_dir.clone(),
         data_dir: home_dir.clone(),
         socket_path: home_dir.join("run").join("holon.sock"),

--- a/tests/wt205_worktree_lifecycle_edge_cases.rs
+++ b/tests/wt205_worktree_lifecycle_edge_cases.rs
@@ -21,6 +21,7 @@ fn test_config() -> AppConfig {
         default_agent_id: "default".into(),
         http_addr: "127.0.0.1:0".into(),
         callback_base_url: "http://127.0.0.1:0".into(),
+        user_home_dir: None,
         home_dir: home_dir.clone(),
         data_dir: home_dir.clone(),
         socket_path: home_dir.join("run").join("holon.sock"),


### PR DESCRIPTION
## Summary

- capture the OS user home independently from Holon's config/state home and propagate it through static, reconfigurable, daemon, recovery, and agent dispatch paths
- report user-global, agent, and workspace instruction loading as `loaded`, `not_found`, `root_unavailable`, or `not_evaluated`, while preserving fail-fast errors with path/scope context
- align template and skill catalog discovery with the stable user home, add dispatch/recovery coverage, and document the contract in the instruction-loading RFC

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib` (3010 passed, 2 ignored)

Closes #2793
