### PR TITLE
docs: upgrade mdorigin to 0.5.2 and add zh-CN multilingual site

### DIFF
--- a/docs/website/.tools/package-lock.json
+++ b/docs/website/.tools/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "holon-docs-site",
       "devDependencies": {
-        "mdorigin": "^0.5.0",
+        "mdorigin": "^0.5.2",
         "wrangler": "^4.0.0"
       }
     },
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/@indexbind/native-darwin-arm64": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@indexbind/native-darwin-arm64/-/native-darwin-arm64-0.6.3.tgz",
-      "integrity": "sha512-a4QC6UF+3YT+8JWr0bi1BbIVQEzQWJIiTF40ZkpeY+WzGFV2MZ7cI7q24kvYQ3J5cUK7l7lo7kXuOkSC/wbsnA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@indexbind/native-darwin-arm64/-/native-darwin-arm64-0.6.4.tgz",
+      "integrity": "sha512-0CAwWlo6gDtadKiOF1GdMKwkjpTQP0PIjCGcAk8e7tTl/IdIMPL/Hyc+q5mwVMg0qyunBVSnguXJHxkjF/6WCQ==",
       "cpu": [
         "arm64"
       ],
@@ -1092,9 +1092,9 @@
       ]
     },
     "node_modules/@indexbind/native-darwin-x64": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@indexbind/native-darwin-x64/-/native-darwin-x64-0.6.3.tgz",
-      "integrity": "sha512-nxboQgKDDWtN/oBbrxTLKJ2jNE7NfWotRCK+JSY8zadDjYKZ+VFI1j9Sg4SaoqjZQWKseFkM80kxJ0xVGNThmA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@indexbind/native-darwin-x64/-/native-darwin-x64-0.6.4.tgz",
+      "integrity": "sha512-rzjgVHK8I6sfeMbhK6gKFkfzhsZxfZp0BhtzbjEX6jJF5rV5gYuO4L7D8lKbuVyh4vY/BKhUxqqP9NXPR7xT8g==",
       "cpu": [
         "x64"
       ],
@@ -1106,9 +1106,9 @@
       ]
     },
     "node_modules/@indexbind/native-linux-x64-gnu": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@indexbind/native-linux-x64-gnu/-/native-linux-x64-gnu-0.6.3.tgz",
-      "integrity": "sha512-VfKfdZBBalwR1BbrNSrfkpBEThG4Aw7A1CsXFBVdwKxGsPAzOx8sZiJJZU1mx9b3xA1h/4oqw7RjXNwWulwBWg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@indexbind/native-linux-x64-gnu/-/native-linux-x64-gnu-0.6.4.tgz",
+      "integrity": "sha512-yGtTO0ui4VdU+q+sumVKEwy+93w4Xi/S9hWnhC++24qOQzBPHNA/+iBFvLqRNpSleJP2JhfY/z+yvKiNffCCOw==",
       "cpu": [
         "x64"
       ],
@@ -1729,9 +1729,9 @@
       }
     },
     "node_modules/indexbind": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/indexbind/-/indexbind-0.6.3.tgz",
-      "integrity": "sha512-BC5bcvMaEbyo0IM+ro52bJ4aeR5CXVqpkKM4XnSDy5YPua/xN5bdAz4tycpK7pImtrHOm+Omhpa7PTyfdTW3+g==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/indexbind/-/indexbind-0.6.4.tgz",
+      "integrity": "sha512-Dd5xf8MKRVY0ne9q7QKp5CgMPpshrGDyJ4dmofjRfgVBor2JCkKdteUFxtkbUMw6he6GdeOWZrnfkoe5EFprlg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1745,9 +1745,9 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@indexbind/native-darwin-arm64": "0.6.3",
-        "@indexbind/native-darwin-x64": "0.6.3",
-        "@indexbind/native-linux-x64-gnu": "0.6.3"
+        "@indexbind/native-darwin-arm64": "0.6.4",
+        "@indexbind/native-darwin-x64": "0.6.4",
+        "@indexbind/native-linux-x64-gnu": "0.6.4"
       }
     },
     "node_modules/is-extendable": {
@@ -2052,9 +2052,9 @@
       }
     },
     "node_modules/mdorigin": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/mdorigin/-/mdorigin-0.5.0.tgz",
-      "integrity": "sha512-p6QqmCcH+JWLdD1uu5ztfk2zQonjMqO79ioLCFtSNyUnt0HZD4AgvtVoFO+yMrD+GIunQzx4YzwztbX0KRUevQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/mdorigin/-/mdorigin-0.5.2.tgz",
+      "integrity": "sha512-TKxUg0ci7tSbOvTgHOLswYy4DHgTh54Q6HfHOtrNYEuIqJiDGLf4UOYEuEVU5QcQ8X4qMSZswXdzWyuFLtFXPQ==",
       "dev": true,
       "dependencies": {
         "gray-matter": "^4.0.3",
@@ -3055,7 +3055,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }

--- a/docs/website/.tools/package.json
+++ b/docs/website/.tools/package.json
@@ -11,7 +11,7 @@
     "deploy": "wrangler deploy --config ../wrangler.jsonc"
   },
   "devDependencies": {
-    "mdorigin": "^0.5.0",
+    "mdorigin": "^0.5.2",
     "wrangler": "^4.0.0"
   }
 }

--- a/docs/website/mdorigin.config.json
+++ b/docs/website/mdorigin.config.json
@@ -2,6 +2,35 @@
   "siteTitle": "Holon",
   "siteDescription": "A local workbench for agents doing continuous work with explicit waits, wakes, state, and trust boundaries.",
   "siteUrl": "https://holon.run",
+  "locales": [
+    {
+      "code": "en",
+      "default": true
+    },
+    {
+      "code": "zh-CN",
+      "label": "中文",
+      "siteDescription": "为持续工作的 Agent 提供的本地工作台：显式等待与唤醒、状态持久化、清晰的信任边界。",
+      "topNav": [
+        {
+          "label": "开始",
+          "href": "/zh-CN/getting-started/"
+        },
+        {
+          "label": "概念",
+          "href": "/zh-CN/concepts/"
+        },
+        {
+          "label": "指南",
+          "href": "/zh-CN/guides/"
+        },
+        {
+          "label": "参考",
+          "href": "/zh-CN/reference/"
+        }
+      ]
+    }
+  ],
   "favicon": "/assets/logo.png",
   "socialImage": "/assets/logo.png",
   "logo": {

--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -16,6 +16,9 @@ behavior changes.
 > version it was last regenerated against where applicable. See the repository
 > [RFC index](https://github.com/holon-run/holon/tree/main/docs/rfcs) for design direction and stability status.
 
+Machine-readable surfaces: the generated baseline
+[OpenAPI 3.1 schema](./openapi.json) describes the current HTTP control-plane.
+
 <!-- INDEX:START -->
 
 - [CLI reference](./cli.md)
@@ -40,10 +43,6 @@ behavior changes.
 
 - [HTTP control plane](./http-control-plane.md)
   How to think about Holon's headless integration surface.
-  <!-- mdorigin:index kind=article -->
-
-- [OpenAPI schema](./openapi.json)
-  Generated baseline OpenAPI 3.1 schema for Holon's current HTTP control-plane surface.
   <!-- mdorigin:index kind=article -->
 
 - [API contract inventory](./api-contract-inventory.md)

--- a/docs/website/zh-CN/README.md
+++ b/docs/website/zh-CN/README.md
@@ -1,0 +1,152 @@
+---
+title: Holon
+summary: 为持续工作的 Agent 提供的本地工作台。
+order: 1
+---
+
+# Holon
+
+**Holon 是一个为持续工作的 Agent 提供的本地工作台。**
+
+Holon 本身不是 Agent。它为多个 Agent 提供本地工作环境：Agent 理解目标并驱动执行，Holon
+把"工作"作为核心单元——保存状态、组织上下文、记录等待与唤醒，让跨会话、跨命令、跨人工确认或外部事件的任务都能在合适的时机恢复，并最终把结果交付给操作者。
+
+## Holon 提供什么
+
+| 能力 | 含义 |
+|---|---|
+| **持续的 Agent 工作区** | 每个 Agent 在 Holon 中拥有持续的工作上下文，而不是随终端、请求或客户端连接重启。 |
+| **以工作为核心的任务模型** | Holon 把任务、等待、执行进度和最终交付组织成显式的工作单元，而不是散落在对话里。 |
+| **事件驱动的等待与唤醒** | Agent 可以等待任务结果、外部事件或操作者输入，条件满足时自动回到对应的工作。 |
+| **显式的上下文与信任边界** | Holon 区分操作者输入、外部事件、工具结果和内部执行痕迹，不同来源的信息不会被混在一起。 |
+| **本地优先的执行环境** | Holon 面向本地仓库、shell、worktree 和开发工具链构建，让 Agent 在真实的工作环境中执行任务。 |
+
+> 让 Agent 的工作在你的本地工作区里持续存活。
+
+## 试用 Holon
+
+Holon 提供两种交互方式：**TUI**（终端）和 **Web GUI**（浏览器）。
+
+### 安装
+
+```bash
+brew tap holon-run/tap && brew install holon
+holon --help
+```
+
+或从 [GitHub Releases](https://github.com/holon-run/holon/releases/latest) 下载二进制文件。
+
+macOS 13 及以上用户可以从同一发布页安装通用 `Holon-<version>.dmg`，获得支持开机自启的原生菜单栏应用。
+
+### 配置模型提供商
+
+```bash
+holon onboard
+```
+
+该命令会启动交互式引导，完成提供商凭据配置。启动 daemon 后，也可以通过 Web GUI 的
+**Settings** 页面配置。详见[配置参考](/reference/configuration)（英文）和
+[Web GUI 指南](/guides/web-gui)（英文）。
+
+### 启动 daemon
+
+```bash
+holon daemon start
+```
+
+### TUI（终端）
+
+```bash
+holon tui
+```
+
+选择一个 Agent 开始工作。断开连接后 Agent 仍在继续运行。
+
+### Web GUI（浏览器）
+
+打开 <http://localhost:7878>。创建 Agent，通过聊天界面工作，内置文件浏览器、任务跟踪等能力。
+
+Holon 会自动提供一个默认的 main agent。你可以通过 TUI 或 Web GUI 创建更多专门化的
+Agent。更多信息：[开始使用](/zh-CN/getting-started/) ·
+[TUI 指南](/guides/tui)（英文）· [Web GUI 指南](/guides/web-gui)（英文）
+
+Holon 支持 Anthropic、OpenAI、DeepSeek、OpenRouter、Qwen、GLM、Xiaomi、Kimi、MiniMax
+等提供商。高级配置见[配置参考](/reference/configuration)（英文）和
+[支持的模型](/reference/models)（英文）。
+
+## 核心概念
+
+Holon 把 Agent 的工作拆解为几个显式的运行时对象：
+
+- **Agent**：长存的本地身份，拥有自己的队列、状态、历史和工作上下文。
+- **WorkItem（工作项）**：可持续推进的目标，包含计划、进度、阻塞项、等待条件和完成报告。
+- **Task（任务）**：受监督的异步执行，例如命令、后台任务或子 Agent。
+- **WaitFor / wake（等待与唤醒）**：让 Agent 显式声明正在等待任务结果、外部事件或操作者输入，并在条件满足时恢复。
+- **Workspace / worktree（工作区）**：让 Agent 在本地仓库中执行，并通过受管理的 worktree 隔离编码任务。
+- **Origin / brief（来源与简报）**：保留输入来源与信任信息，同时把内部执行痕迹与操作者可见的交付分开。
+
+这些概念共同解决一个问题：Agent 的工作不应依赖于某一次聊天或终端连接。它应该是可观察、可恢复、可等待、可委托、可交付的。
+
+## 状态与兼容性
+
+当前推荐版本是
+[`v0.37.0`](https://github.com/holon-run/holon/releases/tag/v0.37.0)。
+
+`v0.15.0` 是 Holon Rust 运行时进入公开兼容性维护的基线版本。从该版本起，项目对 CLI、
+daemon/API 语义和本地持久化存储维持兼容性预期。
+
+Holon 仍在积极开发中。当前重心仍是 Rust 运行时：Agent 生命周期、队列、WaitFor/唤醒、
+任务、WorkItem、信任边界、本地工作区，以及结构化交付。
+
+## 项目边界
+
+Holon 专注运行时语义：Agent 身份、工作连续性、执行状态、本地工作区投影，以及操作者可见的结果。
+
+Holon Run 的相邻项目覆盖其他层面：
+
+- **[AgentInbox](https://github.com/holon-run/agentinbox)** — 源托管、激活与交付
+- **[UXC](https://github.com/holon-run/uxc)** — 统一的能力与工具访问
+- **[WebMCP Bridge](https://github.com/holon-run/webmcp-bridge)** — 浏览器与 Web 应用边缘访问
+
+组合使用时，AgentInbox 把外部事件送达并唤醒 Holon；Holon 在运行时内部决定这些事件的含义。
+
+## 我该读哪些文档？
+
+- **我想安装并运行 Holon** → [开始使用](/zh-CN/getting-started/)
+- **我想理解这些概念** → [概念](/zh-CN/concepts/)，尤其是
+  [运行时模型](/concepts/runtime-model)（英文）和
+  [安全与执行边界](/concepts/security-and-execution-boundaries)（英文）
+- **我想查命令或配置项** → [参考](/zh-CN/reference/)
+- **我想集成 Holon** → [集成指南](/guides/integration)（英文）
+- **我想为运行时做贡献** →
+  [架构概览](https://github.com/holon-run/holon/blob/main/docs/architecture-overview.md)
+  和 [RFCs](https://github.com/holon-run/holon/tree/main/docs/rfcs)（英文）
+
+## 文档目录
+
+- [运行时规格](./spec/)
+- [开始使用](./getting-started/)
+- [概念](./concepts/)
+- [指南](./guides/)
+- [参考](./reference/)
+
+> 中文文档正在逐步完善中。尚未翻译的页面会链接到对应的英文版本。
+
+<!-- INDEX:START -->
+
+- [运行时规格](./spec/)
+  <!-- mdorigin:index kind=directory -->
+
+- [开始使用](./getting-started/)
+  <!-- mdorigin:index kind=directory -->
+
+- [概念](./concepts/)
+  <!-- mdorigin:index kind=directory -->
+
+- [指南](./guides/)
+  <!-- mdorigin:index kind=directory -->
+
+- [参考](./reference/)
+  <!-- mdorigin:index kind=directory -->
+
+<!-- INDEX:END -->

--- a/docs/website/zh-CN/concepts/README.md
+++ b/docs/website/zh-CN/concepts/README.md
@@ -1,0 +1,92 @@
+---
+title: 概念
+summary: Holon 背后的心智模型——让 Agent 工作持久化的四个简单对象。
+order: 20
+---
+
+# 概念
+
+把 Holon 理解为一个运行时（runtime），而不是一个聊天外壳，是最容易的入门方式。
+这个运行时围绕四个简单对象构建，它们相互配合：
+
+## 四个对象的心智模型
+
+**Agent（代理）** 是行动者。每个 Agent 有持久的 home 目录、自己的指导文件
+（`AGENTS.md`）、本地记忆和工作队列。你通过 ID 寻址一个 Agent，它跨轮次存在——
+可以休眠、唤醒、继续工作而不丢失状态。
+
+**Work item（工作项）** 是目标。它记录 Agent 想要达成*什么*，带有持久计划、
+todo 清单和完成目标。工作项跨轮次、跨模型调用存活，所以 Agent 几小时或几天后
+恢复也不会丢失进度。
+
+**Task（任务）** 是执行。每条命令、每次子 Agent 委托、每个后台操作都包装在
+任务句柄里。你可以检查任务状态、读取输出、发送输入或停止任务——运行时全程跟踪。
+
+**Trust boundary（信任边界）** 是来源。操作者输入、外部 webhook、子 Agent 输出、
+网页来源内容，各自携带来源（origin）和信任级别。Holon 从不把它们压平成一条
+无差别的提示流。
+
+```
+Agent（谁）
+  └── Work items（在做什么）
+        └── Tasks（怎么做）
+              └── Trust classification（输入来自哪里）
+```
+
+## 为什么这很重要
+
+大多数 Agent 工具像聊天会话：提示进去，回答出来，状态消失。Holon 不一样：
+
+- 你可以离开，Agent 继续工作。
+- 你不用读完整个对话记录就能检查 Agent *正在做*什么。
+- 你能看到每个输入*来自哪里*、可信度多高。
+- 你可以把工作委托给子 Agent 并监督它们的进度。
+
+## 深入阅读
+
+**记忆系统**页面解释 Holon 如何通过工作项、work refs、episode 归档和索引搜索，
+跨轮次保持连续性。（[英文](/concepts/memory)）
+
+**上下文连续性**页面解释 Holon 如何从轮次、工作项、任务结果、简报和结构化
+episode 中组装有界的提示上下文，而不依赖原始对话回放。（[英文](/concepts/context-continuity)）
+
+**运行时模型**页面把四对象心智模型展开为精确的生命周期词汇：Agent profile、
+工作项状态、任务种类、队列语义、触发器和 workspace 隔离。（[英文](/concepts/runtime-model)）
+
+**信任边界**页面面向产品：它解释 origin 和 trust 对真实集成为什么重要，
+而不只是安全理论。（[英文](/concepts/trust-boundaries)）
+
+**文档分层**页面解释 Holon 如何区分产品文档、当前契约参考和维护者设计记录——
+让你知道哪类文档在哪种用途下是权威的。（[英文](/concepts/documentation-layers)）
+
+这些概念背后的权威设计契约，见仓库的
+[RFCs](https://github.com/holon-run/holon/tree/main/docs/rfcs) 和
+[实现决策](https://github.com/holon-run/holon/tree/main/docs/implementation-decisions/)（英文）。
+这些是面向维护者的文档；使用 Holon 不需要它们。
+
+## 本节页面
+
+- [运行时模型](/concepts/runtime-model.md)（英文）
+  Agent、任务、工作项、工作区，以及构成 Holon 运行时的执行循环。
+
+- [上下文连续性](/concepts/context-continuity.md)（英文）
+  Holon 如何在不回放每一轮对话的情况下保持长生命周期的 Agent 上下文连贯。
+
+- [记忆系统](/concepts/memory.md)（英文）
+  Holon 的记忆分层如何跨轮次保持连续性——工作项、work refs、episode、持久账本和索引搜索。
+
+- [文档分层](/concepts/documentation-layers.md)（英文）
+  Holon 如何区分产品文档、当前契约参考和维护者设计记录。
+
+- [信任边界](/concepts/trust-boundaries.md)（英文）
+  Holon 如何分类 origin、trust 和 priority，保障长生命周期 Agent 的安全。
+
+- [外部触发器](/concepts/external-triggers.md)（英文）
+  Holon Agent 如何通过 webhook 唤醒端点和回调 URL 等待并接收外部事件。
+
+- [安全与执行边界](/concepts/security-and-execution-boundaries.md)（英文）
+  Holon 沙箱化什么、不沙箱化什么：本地执行、workspace 绑定、远程访问、能力密钥和信任元数据。
+
+<!-- INDEX:START -->
+
+<!-- INDEX:END -->

--- a/docs/website/zh-CN/getting-started/README.md
+++ b/docs/website/zh-CN/getting-started/README.md
@@ -1,0 +1,91 @@
+---
+title: 开始使用
+summary: 从零开始，15 分钟内创建你的第一个 Holon Agent。
+order: 10
+---
+
+# 开始使用
+
+Holon 以可安装的发布形式分发。本节给出从安装到运行 Agent 的最短路径，
+并告诉你接下来该往哪里走。
+
+## 第一次接触 Holon？
+
+如果你是第一次使用 Holon：
+
+- **[引导配置](onboarding.md)** — 通过 `holon onboard` 交互式完成提供商、凭据、模型和搜索配置
+- **[创建你的第一个 Agent](first-agent.md)** — 安装、启动、连接 TUI、创建 Agent、配置模型，约 15 分钟
+
+教程涵盖：
+
+- 安装 Holon 并启动运行时
+- 用终端 UI（TUI）连接
+- 创建 Agent 并发送第一条提示
+- 配置模型和提供商
+
+## 该用哪种运行模式？
+
+Holon 提供三种与运行时交互的方式：
+
+| 模式 | 命令 | 适合场景 |
+|------|---------|----------|
+| **单次执行** | `holon run "..."` | 快速的单轮任务，不需要 daemon |
+| **Daemon + TUI** | `holon daemon start` + `holon tui` | 交互式 Agent 会话，带状态、队列和工作区 |
+| **Daemon + HTTP** | `holon daemon start` + HTTP 客户端 | 集成、自动化、控制平面消费方 |
+
+[第一个 Agent 教程](first-agent.md)使用 daemon + TUI，因为它提供完整的交互体验。
+单次执行参见[快速示例](/guides/quick-examples)（英文）。
+
+## 评估或探索？
+
+如果你已经熟悉 Holon，或想直接深入细节：
+
+- **[快速示例](/guides/quick-examples)**（英文）— 单次执行与常见任务模式
+- **[持久 Agent 工作流](/guides/durable-agent-workflow)**（英文）— 持久 Agent 工作的完整生命周期
+- **[概念](/zh-CN/concepts/)** — 深入内部机制前的心智模型
+- **[CLI 参考](/reference/cli.md)**（英文）— 完整命令面
+- **[故障排查](/guides/troubleshooting)**（英文）— 诊断常见安装问题
+
+## 贡献或开发？
+
+如果你打算修改 Holon 本身或为其做贡献：
+
+- **[本地运行时指南](/guides/local-runtime)**（英文）— 保守的开发工作流
+- **[文档工作流](/guides/documentation-workflow)**（英文）— 如何构建和预览本站
+- **[集成指南](/guides/integration)**（英文）— 把 Holon 接入外部系统
+- 仓库 `docs/` 目录 — RFC、实现决策和架构笔记
+
+## 环境要求
+
+- Holon 已安装并在 `PATH` 上（Homebrew 或直接下载二进制；分步说明见[创建第一个 Agent](first-agent.md)）
+- 一个模型提供商 API key（Anthropic、OpenAI 或兼容服务）
+
+## 仓库导览（贡献者）
+
+这是给贡献者的简短导览。最终用户不需要了解仓库布局。
+
+- `src/` 包含 Rust 运行时实现和可执行入口。
+- `tests/` 包含 Rust 集成测试和共享测试支持。
+- `docs/` 包含运行时契约、设计记录和当前架构笔记。
+- `agent_templates/` 包含可远程同步的 Agent 模板。
+- `docs/website/` 包含本 mdorigin 文档站。
+
+## 本节页面
+
+- [创建你的第一个 Agent](first-agent.md)
+  从零到你的第一个 Holon Agent：安装、启动、TUI 基础、创建 Agent、配置模型。
+
+- [引导配置](onboarding.md)
+  用 `holon onboard` 交互式完成提供商、凭据、模型和搜索配置。
+
+<!-- INDEX:START -->
+
+- [创建你的第一个 Agent](./first-agent.md)
+  从零到你的第一个 Holon Agent：安装、启动、TUI 基础、创建 Agent、配置模型。
+  <!-- mdorigin:index kind=article -->
+
+- [引导配置](./onboarding.md)
+  用 `holon onboard` 交互式完成提供商、凭据、模型和搜索配置。
+  <!-- mdorigin:index kind=article -->
+
+<!-- INDEX:END -->

--- a/docs/website/zh-CN/getting-started/first-agent.md
+++ b/docs/website/zh-CN/getting-started/first-agent.md
@@ -1,0 +1,328 @@
+---
+title: 创建你的第一个 Agent
+summary: "从零到你的第一个 Holon Agent：安装、启动、TUI 基础、创建 Agent、配置模型。"
+order: 20
+updated: 2026-05-23
+---
+
+# 创建你的第一个 Agent
+
+本指南带你从零创建第一个 Holon Agent。你将：
+
+1. 安装 Holon
+2. 启动运行时（单次执行与 daemon 模式）
+3. 用 TUI 连接
+4. 创建 Agent
+5. 配置模型
+
+**耗时：** 约 10 分钟（Homebrew）；约 15 分钟（源码构建）
+
+## 前置条件
+
+- **Holon** 已安装并在 `PATH` 上（见第 1 步）
+- 一个**模型提供商**账号（Anthropic、OpenAI 或兼容服务）
+- 基本的**终端**操作能力
+
+## 第 1 步：安装 Holon
+
+Holon v0.14.0 及以后版本以可安装发布形式分发。选择适合你的方式。
+
+### 方式 A：Homebrew（推荐）
+
+```bash
+brew tap holon-run/tap
+brew install holon
+```
+
+### 方式 B：直接下载二进制
+
+从 [GitHub Releases 页面](https://github.com/holon-run/holon/releases/latest)
+下载对应平台的最新二进制，放到 `PATH` 上：
+
+```bash
+# 示例：Linux amd64
+curl -L https://github.com/holon-run/holon/releases/latest/download/holon-linux-amd64 -o holon
+chmod +x holon
+sudo mv holon /usr/local/bin/
+```
+
+可用平台：Linux amd64、macOS amd64、macOS arm64。
+
+### 方式 C：源码构建
+
+如果你偏好源码构建或打算给 Holon 做贡献：
+
+```bash
+git clone https://github.com/holon-run/holon.git
+cd holon
+cargo build --release
+```
+
+源码构建时，把下文示例中的 `holon` 命令替换为 `cargo run --`。例如
+`holon --help` 变成 `cargo run -- --help`。
+
+### 验证安装
+
+```bash
+holon --help
+```
+
+你应该看到带可用命令列表的 CLI 帮助输出。
+
+## 第 2 步：启动 Holon 运行时
+
+Holon 有两种运行模式：
+
+- **CLI 模式**（默认）：单次命令，直接输出
+- **Daemon 模式**：后台服务，支持 TUI
+
+### 方式 A：CLI 模式（快速上手）
+
+执行单条命令：
+
+```bash
+holon run "What is Holon?"
+```
+
+执行一轮后退出。适合快速任务，不适合交互式会话。
+
+### 方式 B：Daemon 模式（Agent 场景推荐）
+
+启动后台 daemon：
+
+```bash
+holon daemon start
+```
+
+这会把 Holon 作为后台服务启动，提供：
+
+- **Unix socket** 位于 `~/.holon/run/holon.sock`（本地访问）
+- 供 TUI 和 HTTP 客户端使用的**控制平面**
+- 跨会话的**持久状态**
+
+#### 验证 daemon 正在运行
+
+```bash
+holon daemon status
+```
+
+你应该看到包含默认 Agent 的运行时状态。
+
+#### 停止 daemon
+
+```bash
+holon daemon stop
+```
+
+## 第 3 步：用 TUI 连接
+
+**终端 UI（TUI）** 提供与 Agent 协作的交互界面。
+
+### 启动 TUI
+
+```bash
+holon tui
+```
+
+TUI 默认连接本地 Unix socket。
+
+### TUI 基础
+
+TUI 界面包含：
+
+- **Agent 列表**：当前 Agent 及其状态
+- **活跃 Agent**：正在接收你输入的 Agent
+- **对话记录**：会话历史
+- **任务列表**：后台任务和工作项
+
+### 基本操作
+
+- **输入**消息后回车发送
+- **Ctrl+C** 退出 TUI
+- **方向键**或 **Page Up/Down** 滚动历史
+
+### 远程 TUI（可选）
+
+连接远程 Holon 实例：
+
+```bash
+# 在远程主机上
+holon serve --access lan --host 192.168.1.10 --token-file ~/.holon/remote.token
+
+# 从本地机器
+holon tui --connect http://192.168.1.10:7878 --token-file ~/.holon/remote.token
+```
+
+详见 [Remote TUI Access RFC](https://github.com/holon-run/holon/blob/main/docs/rfcs/remote-tui-access.md)（英文）。
+
+## 第 4 步：创建 Agent
+
+Holon 支持面向不同用途的多种 Agent 类型。
+
+### 默认 Agent
+
+启动 Holon 时，它会自动在 `~/.holon/agents/main/` 创建一个**默认 Agent**。该 Agent：
+
+- 拥有自己的 `agent_home` 和 `AGENTS.md`
+- 可以有 Agent 本地 skills
+- 保存会话历史和工作状态
+
+### 创建命名 Agent
+
+为特定角色创建专门化 Agent：
+
+```bash
+holon agent create reviewer
+```
+
+这会在 `~/.holon/agents/reviewer/` 创建一个使用默认角色契约初始化的新 Agent。
+
+### 使用模板
+
+模板提供可复用的 Agent 配置：
+
+```bash
+# 用已安装或已同步的模板 ID
+holon agent create docs-helper --template holon-developer
+
+# 用本地模板路径
+holon agent create custom --template /path/to/template
+
+# 用 GitHub 模板 URL
+holon agent create github-agent --template https://github.com/owner/repo/tree/main/template-path
+```
+
+### 列出 Agent
+
+```bash
+holon agent list
+```
+
+### 在 TUI 中切换 Agent
+
+在 TUI 中，通过 Agent 列表视图切换 Agent。
+
+## 第 5 步：配置模型
+
+### 推荐：用 `holon onboard` 快速配置
+
+最快的配置方式是交互式引导向导：
+
+```bash
+holon onboard
+```
+
+在终端中，这会启动交互式 TUI，带你完成：
+
+1. **选择提供商** — 从内置提供商（Anthropic、OpenAI、DeepSeek、Codex 等）或自定义提供商中选择
+2. **录入凭据** — OpenAI Codex 走浏览器 OAuth 登录；其他提供商输入 API key
+   （输入不会回显，也不会记入日志）
+3. **选择模型** — 选择默认模型，或输入自定义模型 ID
+4. **搜索配置** — 启用 DuckDuckGo 托管搜索、模型原生搜索，或保持禁用
+
+`holon onboard` 会写入配置、安全保存凭据并打印摘要。这是首次配置的推荐路径。
+
+### 手动配置（备选）
+
+Holon 需要模型配置才能与 Anthropic、OpenAI 等提供商协作。
+
+### 配置分层
+
+Holon 使用三层配置：
+
+1. **启动设置**（环境变量、CLI 标志）
+2. **运行时配置**（`config.json`）
+3. **Agent 状态**（按 Agent 覆盖）
+
+详见 [Runtime Configuration Surface RFC](https://github.com/holon-run/holon/blob/main/docs/rfcs/runtime-configuration-surface.md)（英文）。
+
+### 设置提供商凭据
+
+#### 方式 A：环境变量（快速上手）
+
+```bash
+# Anthropic
+export ANTHROPIC_AUTH_TOKEN="your-api-key"
+
+# OpenAI
+export OPENAI_API_KEY="your-api-key"
+```
+
+#### 方式 B：凭据存储（持久配置推荐）
+
+安全保存凭据，避免暴露在 shell 历史或环境变量中：
+
+```bash
+holon config credentials set --kind api_key --stdin anthropic
+# 粘贴你的 ANTHROPIC_AUTH_TOKEN 并回车
+```
+
+### 设置默认模型
+
+```bash
+holon config set model.default "anthropic@default/claude-sonnet-4-6"
+```
+
+### Agent 级模型覆盖
+
+单个 Agent 可以覆盖默认模型：
+
+```bash
+holon agent model set "anthropic@default/claude-sonnet-4-6" reviewer
+```
+
+Agent 模型覆盖的更多细节见[配置参考](/reference/configuration.md)（英文）。
+
+### 验证模型配置
+
+```bash
+holon config get model.default
+holon config doctor
+```
+
+查看可用模型：
+
+```bash
+holon config models list
+```
+
+## 下一步
+
+你的第一个 Agent 已经跑起来了，接下来可以：
+
+- **了解概念**：阅读[运行时模型](/concepts/runtime-model.md)（英文）和[信任边界](/concepts/trust-boundaries.md)（英文）
+- **试试示例**：参见[快速示例](/guides/quick-examples.md)（英文）
+- **构建集成**：查看[集成指南](/guides/integration.md)（英文）
+- **参考文档**：[CLI 参考](/reference/cli.md)、[HTTP 控制平面](/reference/http-control-plane.md)、[配置参考](/reference/configuration.md)（英文）
+
+## 故障排查
+
+### daemon 启动失败
+
+检查是否有其他实例在运行：
+
+```bash
+holon daemon status
+holon daemon stop
+holon daemon start
+```
+
+### TUI 连接不上
+
+确认 daemon 正在运行且 socket 存在：
+
+```bash
+ls ~/.holon/run/holon.sock
+holon daemon status
+```
+
+### 模型错误
+
+检查凭据：
+
+```bash
+echo $ANTHROPIC_AUTH_TOKEN
+holon config get model.default
+```
+
+更多帮助见[故障排查指南](/guides/troubleshooting.md)（英文）。

--- a/docs/website/zh-CN/getting-started/onboarding.md
+++ b/docs/website/zh-CN/getting-started/onboarding.md
@@ -1,0 +1,153 @@
+---
+title: 引导配置
+summary: 用 `holon onboard` 交互式完成提供商、凭据、模型和搜索配置。
+order: 30
+---
+
+# 引导配置
+
+`holon onboard` 是配置 Holon 最快的方式。它会启动一个交互式终端 UI 向导，带你完成提供商选择、
+凭据录入、模型选择和搜索配置，并把结果写入 Holon 配置和凭据存储。
+
+## 什么时候用引导配置
+
+- **首次安装** — 你刚安装 Holon，需要在创建 Agent 前配置模型提供商。
+- **切换提供商** — 你想更换默认提供商或模型，且偏好引导式流程而非手工编辑配置。
+- **凭据修复** — 已保存的凭据过期或失效，Holon 检测到需要处理。
+
+## 快速开始
+
+```bash
+holon onboard
+```
+
+这会启动交互式 TUI。完成后你就拥有可用的默认模型配置——不需要手动编辑配置文件。
+
+## 引导流程
+
+向导共五步。用方向键导航，回车选择，Esc 返回。每一步确认后才进入下一步。
+
+### 1. 选择提供商
+
+从内置列表中选择你的模型提供商：
+
+- **Anthropic** — 通过 Anthropic Messages API 使用 Claude 模型（API key）
+- **OpenAI** — 通过 OpenAI API 使用 GPT 和 o 系列模型（API key）
+- **OpenAI Codex** — Codex 托管模型（浏览器 OAuth 登录）
+- **DeepSeek** — DeepSeek 模型（API key）
+- **Gemini** — Google Gemini 模型（API key）
+- **自定义提供商** — 任何 OpenAI 兼容端点
+
+向导只显示尚未配置的提供商。如果已经配置了一个提供商并想切换，向导会把它作为更新候选显示。
+
+### 2. 录入凭据
+
+凭据步骤取决于提供商：
+
+- **API key 提供商** — 输入 key。输入不会回显到屏幕，也不会以明文存进配置文件。
+- **OpenAI Codex（OAuth）** — 向导打开浏览器完成 OAuth 登录，然后自动捕获凭据。
+- **免凭据提供商** — 跳过；直接完成配置，无需认证。
+
+凭据保存在 `~/.holon/credentials.json` 的 Holon 凭据存储中，而不是 `config.json`。
+这样密钥不会出现在配置文件和 shell 历史里。该存储是单个加密的 JSON 文件。
+
+### 3. 选择模型
+
+选择默认模型。向导列出该提供商的常用模型并附简短说明。如果列表中没有你想要的，
+也可以直接输入自定义模型 ID。
+
+选中的可执行路由会以规范的 `provider@endpoint/model` 形式写入 `model.default`。
+之后可以按 Agent 覆盖（`holon agent model set`）；旧的 `provider/model` 写法仍然接受。
+
+### 4. 搜索配置
+
+Holon Agent 可以把 WebSearch 作为内置工具使用。向导提供三种搜索模式：
+
+| 模式 | 行为 |
+|------|----------|
+| **禁用** | 不提供网页搜索能力 |
+| **自动** | 优先使用模型原生搜索（如可用），否则回退到托管 DuckDuckGo |
+| **托管（DuckDuckGo）** | 使用 Holon 内置的 DuckDuckGo 搜索提供商 |
+
+搜索配置之后可以用 `holon config set` 修改。
+
+### 5. 确认并应用
+
+应用之前，向导会展示所有选择的摘要。确认后写入配置和凭据存储。完成后 Holon 会打印确认摘要。
+
+## 引导完成之后
+
+引导完成后，Holon 配置即可使用：
+
+```bash
+# 检查配置
+holon config doctor
+
+# 查看默认模型
+holon config get model.default
+
+# 启动 daemon 并创建第一个 Agent
+holon daemon start
+holon agent create my-first-agent
+```
+
+完整流程见[创建你的第一个 Agent](first-agent.md)。
+
+## 凭据修复
+
+如果已保存的凭据失效——例如 API key 过期或 OAuth token 被撤销——Holon 会在启动时检测到，
+并建议重新运行引导：
+
+```bash
+holon onboard
+```
+
+向导会显示哪个提供商的凭据有问题，并引导你更新。其他提供商的已有配置不受影响。
+
+当凭据修复针对的是已配置的提供商时，向导在覆盖前会要求确认——它会显示受影响的提供商并请你确认更新。
+
+## 非交互式诊断
+
+如果不想进入交互式向导，只想查看引导状态，使用 `--json`：
+
+```bash
+holon onboard --json
+```
+
+这会打印机器可读的引导报告，包含每部分的状态：
+
+- `configured` — 已配置且工作正常
+- `missing` — 尚未配置
+- `unavailable` — 提供商不可达
+- `restricted` — 部分配置完成，需要处理
+- `skipped` — 有意跳过或不适用
+- `failed` — 配置尝试失败，需要修复
+
+每部分包含 `summary` 字符串、可选的 `details`，以及带建议 CLI 命令的 `actions`。
+
+## 配置文件
+
+| 文件 | 用途 |
+|------|---------|
+| `~/.holon/config.json` | 提供商定义、模型默认值、搜索设置 |
+| `~/.holon/credentials.json` | 加密的凭据配置（API key、OAuth token） |
+
+引导配置会写入这两个文件。不要直接编辑凭据文件；请使用 `holon onboard` 或
+`holon config credentials`。
+
+## CLI 参考
+
+```
+holon onboard [--json]
+```
+
+| 标志 | 说明 |
+|------|-------------|
+| `--json` | 以 JSON 打印引导诊断并退出（非交互） |
+
+## 相关阅读
+
+- [创建你的第一个 Agent](first-agent.md) — 从安装到第一条提示的完整流程
+- [配置参考](/reference/configuration.md)（英文）— 配置文件结构与凭据管理
+- [模型参考](/reference/models.md)（英文）— 支持的模型与提供商详情
+- [故障排查](/guides/troubleshooting.md)（英文）— 诊断常见安装问题

--- a/docs/website/zh-CN/guides/README.md
+++ b/docs/website/zh-CN/guides/README.md
@@ -1,0 +1,113 @@
+---
+title: 指南
+summary: 按你用 Holon 做什么来分组的任务导向指南。
+order: 30
+---
+
+# 指南
+
+指南按用户任务组织——找到你的目标，顺着路径走。
+
+> 本节除本页外暂为英文，链接会跳转到对应英文页面。中文翻译在逐步补充中。
+
+## 评估和试用 Holon
+
+想用最少的配置看看 Holon 能做什么，从这里开始。
+
+- **[快速示例](/guides/quick-examples)**（英文）— 单次命令、Agent 创建、模型配置、daemon 和 TUI 基础。
+- **[本地运行时](/guides/local-runtime)**（英文）— 从源码运行和检查 Holon 的保守工作流。
+
+## 使用图形界面
+
+- **[Web GUI](/guides/web-gui)**（英文）— 内置浏览器界面，用于 Agent 管理、对话、搜索和设置。
+
+## 自动化 GitHub 工作
+
+- **[holon solve](/guides/solve)**（英文）— GitHub issue 和 pull request 的无头自动化，带自动 skill 分发。
+
+## 运维和配置
+
+让长期运行的 Holon 实例保持健康和配置正确。
+
+- **[故障排查](/guides/troubleshooting)**（英文）— 按常见遭遇顺序诊断 daemon、模型、配置和 TUI 问题。
+
+## 集成和自动化
+
+通过控制平面把 Holon 接入外部系统。
+
+- **[集成指南](/guides/integration)**（英文）— HTTP 控制平面，含 curl 示例和端点参考。
+
+## 协作和委托
+
+与多个 Agent、持久目标和可复用 skills 协作。
+
+- **[多 Agent 协作](/guides/multi-agent)**（英文）— 派生子 Agent、监督契约和 workspace 模式。
+- **[工作项指南](/guides/work-items)**（英文）— 用计划、todo 清单和生命周期管理跟踪持久目标。
+- **[持久 Agent 工作流](/guides/durable-agent-workflow)**（英文）— 端到端的持久 Agent 故事：WorkItem、wait/wake/resume 和最终简报。
+- **[Skills 指南](/guides/skills)**（英文）— 可复用的 SKILL.md 工作流、skill 位置和自定义 skill 开发。
+
+## 为这些文档做贡献
+
+编辑和构建 Holon 文档网站。
+
+- **[文档工作流](/guides/documentation-workflow)**（英文）— 如何编辑和构建由 mdorigin 驱动的 Holon 网站。
+
+## 本节页面
+
+- [持久 Agent 工作流](/guides/durable-agent-workflow.md)（英文）
+  端到端的持久 Agent 故事：创建 Agent、启动长任务、断线存活、等待事件、交付最终简报。
+
+- [holon solve](/guides/solve.md)（英文）
+  用 holon solve 以无头模式自动化 GitHub issue 和 pull request。
+
+- [本地运行时](/guides/local-runtime.md)（英文）
+  在本地运行和检查 Holon 的保守工作流。
+
+- [TUI 指南](/guides/tui.md)（英文）
+  Holon 的交互式终端 UI——导航、斜杠命令、事件日志、模型选择和远程连接。
+
+- [快速示例](/guides/quick-examples.md)（英文）
+  完成 Getting Started 后可以尝试的常见 Holon 任务。
+
+- [工作区](/guides/workspaces.md)（英文）
+  Workspace 生命周期——attach、exit、detach、worktree 隔离，以及 workspace 与 shell 目录的区别。
+
+- [Agent 模板](/guides/agent-templates.md)（英文）
+  Agent 模板是什么、如何同步或安装、如何使用 --template，以及如何创建自定义模板。
+
+- [文档工作流](/guides/documentation-workflow.md)（英文）
+  如何编辑和构建由 mdorigin 驱动的 Holon 网站。
+
+- [远程访问](/guides/remote-access.md)（英文）
+  远程 daemon 访问——tunnel、tailnet、LAN 模式，token 管理，以及从远程 TUI 连接。
+
+- [集成指南](/guides/integration.md)（英文）
+  通过 curl 示例和端点参考以编程方式访问 Holon 的 HTTP 控制平面。
+
+- [Web GUI](/guides/web-gui.md)（英文）
+  用 Holon 内置的 Web 界面在浏览器中管理 Agent、监控运行时状态和配置设置。
+
+- [故障排查](/guides/troubleshooting.md)（英文）
+  覆盖 daemon、配置、模型和 TUI 问题的常见 Holon 问题解决方案。
+
+- [多 Agent 协作](/guides/multi-agent.md)（英文）
+  派生子 Agent、监督契约和用于并行工作的 workspace 模式。
+
+- [Skills 指南](/guides/skills.md)（英文）
+  可复用的 SKILL.md 工作流、skill 位置，以及如何开发自定义 skill。
+
+- [WebFetch 和 WebSearch 指南](/guides/webfetch-websearch.md)（英文）
+  获取网页和搜索网络的 Agent 工具——工具参考、extract 模式、搜索提供商和使用模式。
+
+- [工作项指南](/guides/work-items.md)（英文）
+  用工作项、计划、todo 清单和生命周期管理进行持久目标跟踪。
+
+- [ViewImage 指南](/guides/view-image.md)（英文）
+  通过视觉模型检查本地图片的 Agent 工具——模型选择、视觉观察、持久元数据和缓存。
+
+- [图像生成指南](/guides/image-generation.md)（英文）
+  从文本提示生成图像的 Agent 工具——模型选择、尺寸和格式选项、输出管理和缓存。
+
+<!-- INDEX:START -->
+
+<!-- INDEX:END -->

--- a/docs/website/zh-CN/reference/README.md
+++ b/docs/website/zh-CN/reference/README.md
@@ -1,0 +1,55 @@
+---
+title: 参考
+summary: Holon CLI、配置和控制平面的当前契约快照。
+order: 40
+---
+
+# 参考
+
+参考页面描述 Holon 当前公开接口的实际行为——而不是计划或承诺中的行为。
+它们基于编译产物（`holon --help`、`holon config schema`）验证，行为变化时应随之刷新。
+
+> **稳定性说明：** 运行时处于 1.0 之前。CLI 形态、配置键和 HTTP 端点可能不经通知即变更。
+> 各参考页面在适用处记录了最后一次重新生成时对应的版本。设计方向和稳定性状态见仓库
+> [RFC 索引](https://github.com/holon-run/holon/tree/main/docs/rfcs)（英文）。
+
+> 本节除本页外暂为英文，链接会跳转到对应英文页面。中文翻译在逐步补充中。
+
+## 本节页面
+
+- [CLI 参考](/reference/cli.md)（英文）
+  Holon 命令行界面——基于 holon --help 验证（v0.30.0）。
+
+- [CLI 契约清单](/reference/cli-contract-inventory.md)（英文）
+  Holon 命令行参数、输出和后续契约工作的第一版稳定性清单。
+
+- [CLI 稳定性策略](/reference/cli-stability-policy.md)（英文）
+  Holon 命令行接口和机器可读输出契约的支持策略。
+
+- [CLI 退出码](/reference/cli-exit-codes.md)（英文）
+  Holon 命令行界面的退出码和流路由契约。
+
+- [配置](/reference/configuration.md)（英文）
+  Holon 配置文件、配置键、凭据、环境变量和诊断。
+
+- [HTTP 控制平面](/reference/http-control-plane.md)（英文）
+  如何理解 Holon 的无头集成接口。
+
+- [OpenAPI schema](/reference/openapi.json)（英文）
+  Holon 当前 HTTP 控制平面接口的基线 OpenAPI 3.1 schema。
+
+- [API 契约清单](/reference/api-contract-inventory.md)（英文）
+  Holon HTTP 控制平面 API 参数、响应和第二阶段契约工作的基线后稳定性清单。
+
+- [模型工具 schema 清单](/reference/model-tool-schema-inventory.md)（英文）
+  Holon 面向模型的内置工具 schema、结果信封和稳定性标签的版本化清单。
+
+- [运行时状态枚举清单](/reference/runtime-status-enum-inventory.md)（英文）
+  稳定序列化运行时生命周期和状态枚举的机器可读基线。
+
+- [支持的模型](/reference/models.md)（英文）
+  Holon 内置支持的所有模型和提供商的完整参考。
+
+<!-- INDEX:START -->
+
+<!-- INDEX:END -->

--- a/docs/website/zh-CN/spec/README.md
+++ b/docs/website/zh-CN/spec/README.md
@@ -1,0 +1,81 @@
+---
+title: 运行时规格
+summary: 面向维护者和贡献者的当前实现侧运行时契约。
+order: 1
+---
+
+# 运行时规格
+
+规格（spec）页面描述**当前运行时契约**——Holon 运行时今天实际做了什么，
+并基于实现和测试验证。
+
+规格不是教程或用户指南。它们是给需要理解或修改运行时行为的贡献者、
+维护者和集成方的权威契约。
+
+## 规格在文档模型中的位置
+
+| 层 | 内容 | 读者 |
+|-------|------|----------|
+| [指南](/guides/) | 任务导向的工作流 | 用户 |
+| [概念](/zh-CN/concepts/) | 心智模型 | 用户、评估者 |
+| [参考](/zh-CN/reference/) | CLI、配置、控制平面快照 | 用户、集成方 |
+| **规格**（本节） | 当前运行时契约 | 维护者、贡献者 |
+| [RFCs](https://github.com/holon-run/holon/tree/main/docs/rfcs) | 设计记录和理由 | 维护者 |
+
+规格桥接用户文档和 RFC 设计历史之间的空隙。当 RFC 稳定为运行时行为后，
+当前契约会被提取到这里。RFC 保留为设计记录；规格是活契约。
+
+> 本节除本页外暂为英文，链接会跳转到对应英文页面。中文翻译在逐步补充中。
+
+## 如何阅读规格
+
+每个规格页面遵循一致的结构：
+
+- **契约（Contract）** — 运行时实现的规范行为。
+- **验证（Validation）** — 契约如何基于实现、测试和 RFC 检查。
+- **RFCs** — 关联的源设计记录。
+- **已知缺口（Known gaps）** — 未解决漂移的跟踪后续 issue。
+
+## 当前规格页面
+
+- [Agent 状态](/spec/agent-state.md)（英文）
+  当前 Agent 状态、生命周期标签、运行时投影和用户可见的展示契约。
+
+- [工作项](/spec/work-items.md)（英文）
+  当前 WorkItem 生命周期、focus、readiness、规划、阻塞和完成契约。
+
+- [调度器](/spec/scheduler.md)（英文）
+  当前调度器输入、runnable/waiting 决策、WorkItem readiness 和 wake/sleep 边界。
+
+- [唤醒与延续](/spec/wake-and-continuation.md)（英文）
+  当前触发器分类、外部 ingress 能力、continuation 解析和 wake/sleep 生命周期。
+
+- [任务](/spec/tasks.md)（英文）
+  当前任务生命周期、terminal re-entry 和命令/子 Agent 监督契约。
+
+- [工具](/spec/tools.md)（英文）
+  当前面向模型的工具家族、权限边界、输入/结果契约和已废弃接口。
+
+- [Workspace 与执行](/spec/workspace-and-execution.md)（英文）
+  当前 workspace 身份、agent home、execution root、worktree 和 host-local 策略契约。
+
+- [信任与来源](/spec/trust-and-provenance.md)（英文）
+  当前 provenance、admission/authentication、指令权威和执行策略契约。
+
+## 与 `docs/runtime-spec.md` 的关系
+
+[`docs/runtime-spec.md`](https://github.com/holon-run/holon/blob/main/docs/runtime-spec.md)
+现在是一个聚合索引，把最初的 v0 单体规格映射到当前的聚焦规格页面。
+它不再包含规范内容。
+
+**这里的聚焦规格页面是唯一的权威实现侧契约。** 当某个主题有专门的规格页面时，
+该页面就是当前权威。
+
+## 给贡献者
+
+当你修改运行时行为时，同步更新相关规格页面和 RFC。规格页面基于实现验证——
+如果实现和规格不一致，修复错误的一方，并为另一方开 issue。
+
+<!-- INDEX:START -->
+
+<!-- INDEX:END -->


### PR DESCRIPTION
## What changed

Upgrades the docs site toolchain and makes https://holon.run multilingual (English + 简体中文).

### mdorigin upgrade

- `mdorigin` `^0.5.0` → `^0.5.2`; `indexbind` 0.6.4 comes along as its optional dependency (lock-only bump, no direct dependency added)
- mdorigin 0.5.2 managed index blocks no longer keep non-markdown entries, so the `reference/README.md` index entry for `openapi.json` moved into the prose section above the managed block

### Multilingual site

- `mdorigin.config.json` now configures `locales`: `en` (default, unprefixed root content) and `zh-CN` (`/zh-CN/` prefix) with a per-locale description and translated top nav
- New translated pages under `docs/website/zh-CN/`:
  - homepage (`/zh-CN/`)
  - full getting-started section: index, onboarding guide, first-agent tutorial
  - section indexes for concepts / guides / reference / spec so the translated top nav and homepage directory links resolve
- Behavior (per mdorigin locales contract):
  - header language switcher on every page; falls back to the locale home when a page has no translation
  - `hreflang` alternates (+ `x-default`) emitted only for translated pages
  - untranslated deep pages return 404 under `/zh-CN/` instead of silently falling back — zh-CN pages link to the English originals, marked （英文）
  - `/zh-CN/feed.xml` serves the zh-CN locale; search results are filtered to the current locale
- Remaining untranslated pages are linked from the zh-CN section indexes to their English originals and will be translated incrementally in follow-up PRs

## Verification

- `check-links.py`, `test-check-contract-refs.py`, `check-contract-refs.py` — all pass (including the new `/zh-CN/` nav targets)
- `npm ci` under Node 22 installs indexbind 0.6.4 (CI's Node version; note that local npm 10.7/node 20 skips this optional transitive dep, but CI and the lock are unaffected)
- `build:index` and `build:cloudflare` run locally; the bundle embeds all six `/zh-CN/` routes
- `mdorigin dev` smoke test: `/zh-CN/` 200 with `lang="zh-CN"` + hreflang alternates, `/zh-CN/getting-started/` 200, untranslated `/zh-CN/concepts/runtime-model` 404, `/zh-CN/feed.xml` 200, `Accept: text/markdown` negotiation returns translated markdown
- local `build:search` cannot run on this machine because both indexbind 0.6.3 and 0.6.4 native binaries require glibc ≥ 2.39 (local is 2.35); CI's ubuntu-latest runners provide 2.39 — verified this is pre-existing, not introduced by the upgrade