### PR TITLE
feat: expose operator agent tree and canonical detail

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -699,6 +699,447 @@
               "null"
             ]
           },
+          "canonical_relations": {
+            "properties": {
+              "agent_id": {
+                "type": "string"
+              },
+              "capability_policy": {
+                "properties": {
+                  "agent_id": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "rules": {
+                    "items": {
+                      "properties": {
+                        "effect": {
+                          "enum": [
+                            "allow",
+                            "deny"
+                          ],
+                          "type": "string"
+                        },
+                        "family": {
+                          "enum": [
+                            "core_agent",
+                            "local_environment",
+                            "web",
+                            "agent_creation",
+                            "authority_expanding",
+                            "external_trigger"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "family",
+                        "effect"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "agent_id",
+                  "revision",
+                  "rules",
+                  "created_at"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "durability": {
+                "properties": {
+                  "agent_id": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "durability": {
+                    "enum": [
+                      "persistent",
+                      "ephemeral"
+                    ],
+                    "type": "string"
+                  },
+                  "revision": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "agent_id",
+                  "durability",
+                  "revision",
+                  "created_at"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "identity_lifecycle": {
+                "enum": [
+                  "active",
+                  "deleting",
+                  "deleted"
+                ],
+                "type": "string"
+              },
+              "issues": {
+                "items": {
+                  "properties": {
+                    "axis": {
+                      "enum": [
+                        "lineage",
+                        "supervision",
+                        "durability",
+                        "lifecycle_attachment",
+                        "capability_policy",
+                        "message_policy"
+                      ],
+                      "type": "string"
+                    },
+                    "detail": {
+                      "type": "string"
+                    },
+                    "resolution": {
+                      "enum": [
+                        "resolved",
+                        "ambiguous",
+                        "contradictory",
+                        "missing_evidence"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "axis",
+                    "resolution",
+                    "detail"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "lifecycle_attachment": {
+                "properties": {
+                  "agent_id": {
+                    "type": "string"
+                  },
+                  "attachment": {
+                    "enum": [
+                      "independent",
+                      "supervision_attached"
+                    ],
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "agent_id",
+                  "attachment",
+                  "revision",
+                  "created_at"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "lifecycle_fence": {
+                "enum": [
+                  "open",
+                  "deletion_fenced",
+                  "tombstoned"
+                ],
+                "type": "string"
+              },
+              "lineage": {
+                "properties": {
+                  "child_agent_id": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "creation_cause": {
+                    "enum": [
+                      "legacy_spawn",
+                      "create_agent",
+                      "migration"
+                    ],
+                    "type": "string"
+                  },
+                  "parent_agent_id": {
+                    "type": "string"
+                  },
+                  "revision": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "child_agent_id",
+                  "parent_agent_id",
+                  "creation_cause",
+                  "revision",
+                  "created_at"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "message_policy": {
+                "properties": {
+                  "agent_id": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "default_effect": {
+                    "enum": [
+                      "allow",
+                      "deny"
+                    ],
+                    "type": "string"
+                  },
+                  "revision": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "rules": {
+                    "items": {
+                      "properties": {
+                        "effect": {
+                          "enum": [
+                            "allow",
+                            "deny"
+                          ],
+                          "type": "string"
+                        },
+                        "principal_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "principal_kind": {
+                          "enum": [
+                            "operator",
+                            "supervising_parent",
+                            "peer_agent",
+                            "external_ingress",
+                            "runtime_capability"
+                          ],
+                          "type": "string"
+                        },
+                        "route": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "principal_kind",
+                        "effect"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "agent_id",
+                  "revision",
+                  "default_effect",
+                  "rules",
+                  "created_at"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "resolution": {
+                "enum": [
+                  "resolved",
+                  "ambiguous",
+                  "contradictory",
+                  "missing_evidence"
+                ],
+                "type": "string"
+              },
+              "sources": {
+                "properties": {
+                  "capability_policy": {
+                    "enum": [
+                      "canonical",
+                      "legacy",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "durability": {
+                    "enum": [
+                      "canonical",
+                      "legacy",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lifecycle_attachment": {
+                    "enum": [
+                      "canonical",
+                      "legacy",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lineage": {
+                    "enum": [
+                      "canonical",
+                      "legacy",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "message_policy": {
+                    "enum": [
+                      "canonical",
+                      "legacy",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "supervision": {
+                    "enum": [
+                      "canonical",
+                      "legacy",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "supervision": {
+                "properties": {
+                  "child_agent_id": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "delegated_from_task_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "delegated_from_work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "revision": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "state": {
+                    "enum": [
+                      "active",
+                      "cleanup_required",
+                      "closed"
+                    ],
+                    "type": "string"
+                  },
+                  "supervision_id": {
+                    "type": "string"
+                  },
+                  "supervisor_agent_id": {
+                    "type": "string"
+                  },
+                  "updated_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "supervision_id",
+                  "supervisor_agent_id",
+                  "child_agent_id",
+                  "state",
+                  "revision",
+                  "created_at",
+                  "updated_at"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "agent_id",
+              "identity_lifecycle",
+              "lifecycle_fence",
+              "sources",
+              "resolution"
+            ],
+            "type": "object"
+          },
           "created_at": {
             "format": "date-time",
             "type": "string"
@@ -872,6 +1313,44 @@
             ],
             "type": "object"
           },
+          "lineage_children": {
+            "items": {
+              "properties": {
+                "child_agent_id": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "creation_cause": {
+                  "enum": [
+                    "legacy_spawn",
+                    "create_agent",
+                    "migration"
+                  ],
+                  "type": "string"
+                },
+                "parent_agent_id": {
+                  "type": "string"
+                },
+                "revision": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "child_agent_id",
+                "parent_agent_id",
+                "creation_cause",
+                "revision",
+                "created_at"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "name": {
             "type": [
               "string",
@@ -887,7 +1366,8 @@
           "identity",
           "display_name",
           "created_at",
-          "updated_at"
+          "updated_at",
+          "canonical_relations"
         ],
         "title": "AgentDetail",
         "type": "object"
@@ -2752,6 +3232,1632 @@
           "tasks"
         ],
         "title": "AgentStateSnapshotDto",
+        "type": "object"
+      },
+      "AgentTreeProjection": {
+        "definitions": {
+          "AgentTreeNode": {
+            "properties": {
+              "agent": {
+                "properties": {
+                  "active_workspace_entry": {
+                    "properties": {
+                      "access_mode": {
+                        "enum": [
+                          "shared_read",
+                          "exclusive_write"
+                        ],
+                        "type": "string"
+                      },
+                      "cwd": {
+                        "type": "string"
+                      },
+                      "execution_root": {
+                        "type": "string"
+                      },
+                      "execution_root_id": {
+                        "type": "string"
+                      },
+                      "occupancy_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "projection_kind": {
+                        "enum": [
+                          "canonical_root",
+                          "git_worktree_root"
+                        ],
+                        "type": "string"
+                      },
+                      "projection_metadata": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "original_branch": {
+                                    "type": "string"
+                                  },
+                                  "original_cwd": {
+                                    "type": "string"
+                                  },
+                                  "worktree_branch": {
+                                    "type": "string"
+                                  },
+                                  "worktree_path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "original_cwd",
+                                  "original_branch",
+                                  "worktree_path",
+                                  "worktree_branch"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "properties": {
+                                  "worktree_root": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "worktree_root"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "description": "Typed metadata for workspace projections, replacing untyped `serde_json::Value`.\n Uses `untagged` serde for backward compatibility with previously serialized JSON."
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "workspace_anchor": {
+                        "type": "string"
+                      },
+                      "workspace_id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "workspace_id",
+                      "workspace_anchor",
+                      "execution_root_id",
+                      "execution_root",
+                      "projection_kind",
+                      "access_mode",
+                      "cwd"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "current_run_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "identity": {
+                    "properties": {
+                      "agent_id": {
+                        "type": "string"
+                      },
+                      "delegated_from_task_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "is_default_agent": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "enum": [
+                          "default",
+                          "named",
+                          "child"
+                        ],
+                        "type": "string"
+                      },
+                      "lineage_parent_agent_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "ownership": {
+                        "enum": [
+                          "parent_supervised",
+                          "self_owned"
+                        ],
+                        "type": "string"
+                      },
+                      "parent_agent_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "profile_preset": {
+                        "enum": [
+                          "private_child",
+                          "public_named"
+                        ],
+                        "type": "string"
+                      },
+                      "status": {
+                        "enum": [
+                          "active",
+                          "deleting",
+                          "deleted"
+                        ],
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "enum": [
+                          "public",
+                          "private"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "agent_id",
+                      "kind",
+                      "visibility",
+                      "ownership",
+                      "profile_preset",
+                      "status",
+                      "is_default_agent"
+                    ],
+                    "type": "object"
+                  },
+                  "lifecycle": {
+                    "default": {
+                      "accepts_external_messages": true
+                    },
+                    "properties": {
+                      "accepts_external_messages": {
+                        "type": "boolean"
+                      },
+                      "operator_hint": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "accepts_external_messages"
+                    ],
+                    "type": "object"
+                  },
+                  "model": {
+                    "properties": {
+                      "active_model": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "effective_fallback_models": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "effective_model": {
+                        "type": "string"
+                      },
+                      "fallback_active": {
+                        "default": false,
+                        "type": "boolean"
+                      },
+                      "override_model": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "override_reasoning_effort": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "requested_model": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "runtime_default_model": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "enum": [
+                          "runtime_default",
+                          "agent_override"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "source",
+                      "runtime_default_model",
+                      "effective_model"
+                    ],
+                    "type": "object"
+                  },
+                  "pending": {
+                    "default": 0,
+                    "format": "uint",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "scheduling_posture": {
+                    "default": {
+                      "posture": "unknown",
+                      "reason": "posture projection unavailable"
+                    },
+                    "properties": {
+                      "posture": {
+                        "enum": [
+                          "unknown",
+                          "stopped",
+                          "active_turn",
+                          "has_queued_input",
+                          "has_runnable_work",
+                          "waiting_for_task",
+                          "waiting_for_external",
+                          "waiting_for_operator",
+                          "blocked",
+                          "idle"
+                        ],
+                        "type": "string"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "run_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "task_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "work_item_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "posture",
+                      "reason"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "enum": [
+                      "booting",
+                      "awake_idle",
+                      "awake_running",
+                      "awaiting_task",
+                      "asleep",
+                      "stopped"
+                    ],
+                    "type": "string"
+                  },
+                  "waiting_reason": {
+                    "enum": [
+                      "awaiting_operator_input",
+                      "awaiting_external_change",
+                      "awaiting_task_result",
+                      "awaiting_timer",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "identity",
+                  "status",
+                  "model"
+                ],
+                "type": "object"
+              },
+              "canonical_relations": {
+                "properties": {
+                  "agent_id": {
+                    "type": "string"
+                  },
+                  "capability_policy": {
+                    "properties": {
+                      "agent_id": {
+                        "type": "string"
+                      },
+                      "created_at": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "rules": {
+                        "items": {
+                          "properties": {
+                            "effect": {
+                              "enum": [
+                                "allow",
+                                "deny"
+                              ],
+                              "type": "string"
+                            },
+                            "family": {
+                              "enum": [
+                                "core_agent",
+                                "local_environment",
+                                "web",
+                                "agent_creation",
+                                "authority_expanding",
+                                "external_trigger"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "family",
+                            "effect"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "agent_id",
+                      "revision",
+                      "rules",
+                      "created_at"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "durability": {
+                    "properties": {
+                      "agent_id": {
+                        "type": "string"
+                      },
+                      "created_at": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "durability": {
+                        "enum": [
+                          "persistent",
+                          "ephemeral"
+                        ],
+                        "type": "string"
+                      },
+                      "revision": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "agent_id",
+                      "durability",
+                      "revision",
+                      "created_at"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "identity_lifecycle": {
+                    "enum": [
+                      "active",
+                      "deleting",
+                      "deleted"
+                    ],
+                    "type": "string"
+                  },
+                  "issues": {
+                    "items": {
+                      "properties": {
+                        "axis": {
+                          "enum": [
+                            "lineage",
+                            "supervision",
+                            "durability",
+                            "lifecycle_attachment",
+                            "capability_policy",
+                            "message_policy"
+                          ],
+                          "type": "string"
+                        },
+                        "detail": {
+                          "type": "string"
+                        },
+                        "resolution": {
+                          "enum": [
+                            "resolved",
+                            "ambiguous",
+                            "contradictory",
+                            "missing_evidence"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "axis",
+                        "resolution",
+                        "detail"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "lifecycle_attachment": {
+                    "properties": {
+                      "agent_id": {
+                        "type": "string"
+                      },
+                      "attachment": {
+                        "enum": [
+                          "independent",
+                          "supervision_attached"
+                        ],
+                        "type": "string"
+                      },
+                      "created_at": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "agent_id",
+                      "attachment",
+                      "revision",
+                      "created_at"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "lifecycle_fence": {
+                    "enum": [
+                      "open",
+                      "deletion_fenced",
+                      "tombstoned"
+                    ],
+                    "type": "string"
+                  },
+                  "lineage": {
+                    "properties": {
+                      "child_agent_id": {
+                        "type": "string"
+                      },
+                      "created_at": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "creation_cause": {
+                        "enum": [
+                          "legacy_spawn",
+                          "create_agent",
+                          "migration"
+                        ],
+                        "type": "string"
+                      },
+                      "parent_agent_id": {
+                        "type": "string"
+                      },
+                      "revision": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "child_agent_id",
+                      "parent_agent_id",
+                      "creation_cause",
+                      "revision",
+                      "created_at"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "message_policy": {
+                    "properties": {
+                      "agent_id": {
+                        "type": "string"
+                      },
+                      "created_at": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "default_effect": {
+                        "enum": [
+                          "allow",
+                          "deny"
+                        ],
+                        "type": "string"
+                      },
+                      "revision": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "rules": {
+                        "items": {
+                          "properties": {
+                            "effect": {
+                              "enum": [
+                                "allow",
+                                "deny"
+                              ],
+                              "type": "string"
+                            },
+                            "principal_id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "principal_kind": {
+                              "enum": [
+                                "operator",
+                                "supervising_parent",
+                                "peer_agent",
+                                "external_ingress",
+                                "runtime_capability"
+                              ],
+                              "type": "string"
+                            },
+                            "route": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "principal_kind",
+                            "effect"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "agent_id",
+                      "revision",
+                      "default_effect",
+                      "rules",
+                      "created_at"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "resolution": {
+                    "enum": [
+                      "resolved",
+                      "ambiguous",
+                      "contradictory",
+                      "missing_evidence"
+                    ],
+                    "type": "string"
+                  },
+                  "sources": {
+                    "properties": {
+                      "capability_policy": {
+                        "enum": [
+                          "canonical",
+                          "legacy",
+                          null
+                        ],
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "durability": {
+                        "enum": [
+                          "canonical",
+                          "legacy",
+                          null
+                        ],
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "lifecycle_attachment": {
+                        "enum": [
+                          "canonical",
+                          "legacy",
+                          null
+                        ],
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "lineage": {
+                        "enum": [
+                          "canonical",
+                          "legacy",
+                          null
+                        ],
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "message_policy": {
+                        "enum": [
+                          "canonical",
+                          "legacy",
+                          null
+                        ],
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "supervision": {
+                        "enum": [
+                          "canonical",
+                          "legacy",
+                          null
+                        ],
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "supervision": {
+                    "properties": {
+                      "child_agent_id": {
+                        "type": "string"
+                      },
+                      "created_at": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "delegated_from_task_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "delegated_from_work_item_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "revision": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "state": {
+                        "enum": [
+                          "active",
+                          "cleanup_required",
+                          "closed"
+                        ],
+                        "type": "string"
+                      },
+                      "supervision_id": {
+                        "type": "string"
+                      },
+                      "supervisor_agent_id": {
+                        "type": "string"
+                      },
+                      "updated_at": {
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "supervision_id",
+                      "supervisor_agent_id",
+                      "child_agent_id",
+                      "state",
+                      "revision",
+                      "created_at",
+                      "updated_at"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "agent_id",
+                  "identity_lifecycle",
+                  "lifecycle_fence",
+                  "sources",
+                  "resolution"
+                ],
+                "type": "object"
+              },
+              "children": {
+                "items": {
+                  "$ref": "#/definitions/AgentTreeNode"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "agent",
+              "canonical_relations"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "roots": {
+            "default": [],
+            "items": {
+              "properties": {
+                "agent": {
+                  "properties": {
+                    "active_workspace_entry": {
+                      "properties": {
+                        "access_mode": {
+                          "enum": [
+                            "shared_read",
+                            "exclusive_write"
+                          ],
+                          "type": "string"
+                        },
+                        "cwd": {
+                          "type": "string"
+                        },
+                        "execution_root": {
+                          "type": "string"
+                        },
+                        "execution_root_id": {
+                          "type": "string"
+                        },
+                        "occupancy_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "projection_kind": {
+                          "enum": [
+                            "canonical_root",
+                            "git_worktree_root"
+                          ],
+                          "type": "string"
+                        },
+                        "projection_metadata": {
+                          "anyOf": [
+                            {
+                              "anyOf": [
+                                {
+                                  "properties": {
+                                    "original_branch": {
+                                      "type": "string"
+                                    },
+                                    "original_cwd": {
+                                      "type": "string"
+                                    },
+                                    "worktree_branch": {
+                                      "type": "string"
+                                    },
+                                    "worktree_path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "original_cwd",
+                                    "original_branch",
+                                    "worktree_path",
+                                    "worktree_branch"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "properties": {
+                                    "worktree_root": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "worktree_root"
+                                  ],
+                                  "type": "object"
+                                }
+                              ],
+                              "description": "Typed metadata for workspace projections, replacing untyped `serde_json::Value`.\n Uses `untagged` serde for backward compatibility with previously serialized JSON."
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "workspace_anchor": {
+                          "type": "string"
+                        },
+                        "workspace_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "workspace_id",
+                        "workspace_anchor",
+                        "execution_root_id",
+                        "execution_root",
+                        "projection_kind",
+                        "access_mode",
+                        "cwd"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "current_run_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "identity": {
+                      "properties": {
+                        "agent_id": {
+                          "type": "string"
+                        },
+                        "delegated_from_task_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "is_default_agent": {
+                          "type": "boolean"
+                        },
+                        "kind": {
+                          "enum": [
+                            "default",
+                            "named",
+                            "child"
+                          ],
+                          "type": "string"
+                        },
+                        "lineage_parent_agent_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "ownership": {
+                          "enum": [
+                            "parent_supervised",
+                            "self_owned"
+                          ],
+                          "type": "string"
+                        },
+                        "parent_agent_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "profile_preset": {
+                          "enum": [
+                            "private_child",
+                            "public_named"
+                          ],
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": [
+                            "active",
+                            "deleting",
+                            "deleted"
+                          ],
+                          "type": "string"
+                        },
+                        "visibility": {
+                          "enum": [
+                            "public",
+                            "private"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "agent_id",
+                        "kind",
+                        "visibility",
+                        "ownership",
+                        "profile_preset",
+                        "status",
+                        "is_default_agent"
+                      ],
+                      "type": "object"
+                    },
+                    "lifecycle": {
+                      "default": {
+                        "accepts_external_messages": true
+                      },
+                      "properties": {
+                        "accepts_external_messages": {
+                          "type": "boolean"
+                        },
+                        "operator_hint": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "accepts_external_messages"
+                      ],
+                      "type": "object"
+                    },
+                    "model": {
+                      "properties": {
+                        "active_model": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "effective_fallback_models": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "effective_model": {
+                          "type": "string"
+                        },
+                        "fallback_active": {
+                          "default": false,
+                          "type": "boolean"
+                        },
+                        "override_model": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "override_reasoning_effort": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "requested_model": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "runtime_default_model": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "enum": [
+                            "runtime_default",
+                            "agent_override"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "source",
+                        "runtime_default_model",
+                        "effective_model"
+                      ],
+                      "type": "object"
+                    },
+                    "pending": {
+                      "default": 0,
+                      "format": "uint",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "scheduling_posture": {
+                      "default": {
+                        "posture": "unknown",
+                        "reason": "posture projection unavailable"
+                      },
+                      "properties": {
+                        "posture": {
+                          "enum": [
+                            "unknown",
+                            "stopped",
+                            "active_turn",
+                            "has_queued_input",
+                            "has_runnable_work",
+                            "waiting_for_task",
+                            "waiting_for_external",
+                            "waiting_for_operator",
+                            "blocked",
+                            "idle"
+                          ],
+                          "type": "string"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "run_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "task_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "work_item_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "posture",
+                        "reason"
+                      ],
+                      "type": "object"
+                    },
+                    "status": {
+                      "enum": [
+                        "booting",
+                        "awake_idle",
+                        "awake_running",
+                        "awaiting_task",
+                        "asleep",
+                        "stopped"
+                      ],
+                      "type": "string"
+                    },
+                    "waiting_reason": {
+                      "enum": [
+                        "awaiting_operator_input",
+                        "awaiting_external_change",
+                        "awaiting_task_result",
+                        "awaiting_timer",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "identity",
+                    "status",
+                    "model"
+                  ],
+                  "type": "object"
+                },
+                "canonical_relations": {
+                  "properties": {
+                    "agent_id": {
+                      "type": "string"
+                    },
+                    "capability_policy": {
+                      "properties": {
+                        "agent_id": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "revision": {
+                          "format": "uint64",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "rules": {
+                          "items": {
+                            "properties": {
+                              "effect": {
+                                "enum": [
+                                  "allow",
+                                  "deny"
+                                ],
+                                "type": "string"
+                              },
+                              "family": {
+                                "enum": [
+                                  "core_agent",
+                                  "local_environment",
+                                  "web",
+                                  "agent_creation",
+                                  "authority_expanding",
+                                  "external_trigger"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "family",
+                              "effect"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "agent_id",
+                        "revision",
+                        "rules",
+                        "created_at"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "durability": {
+                      "properties": {
+                        "agent_id": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "durability": {
+                          "enum": [
+                            "persistent",
+                            "ephemeral"
+                          ],
+                          "type": "string"
+                        },
+                        "revision": {
+                          "format": "uint64",
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "agent_id",
+                        "durability",
+                        "revision",
+                        "created_at"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "identity_lifecycle": {
+                      "enum": [
+                        "active",
+                        "deleting",
+                        "deleted"
+                      ],
+                      "type": "string"
+                    },
+                    "issues": {
+                      "items": {
+                        "properties": {
+                          "axis": {
+                            "enum": [
+                              "lineage",
+                              "supervision",
+                              "durability",
+                              "lifecycle_attachment",
+                              "capability_policy",
+                              "message_policy"
+                            ],
+                            "type": "string"
+                          },
+                          "detail": {
+                            "type": "string"
+                          },
+                          "resolution": {
+                            "enum": [
+                              "resolved",
+                              "ambiguous",
+                              "contradictory",
+                              "missing_evidence"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "axis",
+                          "resolution",
+                          "detail"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "lifecycle_attachment": {
+                      "properties": {
+                        "agent_id": {
+                          "type": "string"
+                        },
+                        "attachment": {
+                          "enum": [
+                            "independent",
+                            "supervision_attached"
+                          ],
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "revision": {
+                          "format": "uint64",
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "agent_id",
+                        "attachment",
+                        "revision",
+                        "created_at"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "lifecycle_fence": {
+                      "enum": [
+                        "open",
+                        "deletion_fenced",
+                        "tombstoned"
+                      ],
+                      "type": "string"
+                    },
+                    "lineage": {
+                      "properties": {
+                        "child_agent_id": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "creation_cause": {
+                          "enum": [
+                            "legacy_spawn",
+                            "create_agent",
+                            "migration"
+                          ],
+                          "type": "string"
+                        },
+                        "parent_agent_id": {
+                          "type": "string"
+                        },
+                        "revision": {
+                          "format": "uint64",
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "child_agent_id",
+                        "parent_agent_id",
+                        "creation_cause",
+                        "revision",
+                        "created_at"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "message_policy": {
+                      "properties": {
+                        "agent_id": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "default_effect": {
+                          "enum": [
+                            "allow",
+                            "deny"
+                          ],
+                          "type": "string"
+                        },
+                        "revision": {
+                          "format": "uint64",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "rules": {
+                          "items": {
+                            "properties": {
+                              "effect": {
+                                "enum": [
+                                  "allow",
+                                  "deny"
+                                ],
+                                "type": "string"
+                              },
+                              "principal_id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "principal_kind": {
+                                "enum": [
+                                  "operator",
+                                  "supervising_parent",
+                                  "peer_agent",
+                                  "external_ingress",
+                                  "runtime_capability"
+                                ],
+                                "type": "string"
+                              },
+                              "route": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "principal_kind",
+                              "effect"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "agent_id",
+                        "revision",
+                        "default_effect",
+                        "rules",
+                        "created_at"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "resolution": {
+                      "enum": [
+                        "resolved",
+                        "ambiguous",
+                        "contradictory",
+                        "missing_evidence"
+                      ],
+                      "type": "string"
+                    },
+                    "sources": {
+                      "properties": {
+                        "capability_policy": {
+                          "enum": [
+                            "canonical",
+                            "legacy",
+                            null
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "durability": {
+                          "enum": [
+                            "canonical",
+                            "legacy",
+                            null
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "lifecycle_attachment": {
+                          "enum": [
+                            "canonical",
+                            "legacy",
+                            null
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "lineage": {
+                          "enum": [
+                            "canonical",
+                            "legacy",
+                            null
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "message_policy": {
+                          "enum": [
+                            "canonical",
+                            "legacy",
+                            null
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "supervision": {
+                          "enum": [
+                            "canonical",
+                            "legacy",
+                            null
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "supervision": {
+                      "properties": {
+                        "child_agent_id": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "delegated_from_task_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "delegated_from_work_item_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "revision": {
+                          "format": "uint64",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "state": {
+                          "enum": [
+                            "active",
+                            "cleanup_required",
+                            "closed"
+                          ],
+                          "type": "string"
+                        },
+                        "supervision_id": {
+                          "type": "string"
+                        },
+                        "supervisor_agent_id": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "format": "date-time",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "supervision_id",
+                        "supervisor_agent_id",
+                        "child_agent_id",
+                        "state",
+                        "revision",
+                        "created_at",
+                        "updated_at"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "agent_id",
+                    "identity_lifecycle",
+                    "lifecycle_fence",
+                    "sources",
+                    "resolution"
+                  ],
+                  "type": "object"
+                },
+                "children": {
+                  "items": {
+                    "$ref": "#/definitions/AgentTreeNode"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "agent",
+                "canonical_relations"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "AgentTreeProjection",
         "type": "object"
       },
       "AgentWorkItemAnchor": {
@@ -11900,6 +14006,54 @@
         "summary": "Callback wake ingress",
         "tags": [
           "callbacks"
+        ]
+      }
+    },
+    "/api/control/agents/tree": {
+      "get": {
+        "description": "Return the authenticated operator Agent tree built from canonical lineage.",
+        "operationId": "agentTree",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTreeProjection"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Agent tree",
+        "tags": [
+          "control"
         ]
       }
     },

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,10 +25,11 @@ use crate::{
     runtime_error::{RuntimeErrorContext, RuntimeErrorDomain},
     system::ExecutionSnapshot,
     types::{
-        AgentListEntry, AgentSummary, AuthorityClass, BriefRecord, ExternalTriggerStateSnapshot,
-        MessageEnvelope, OperatorNotificationRecord, ResolvedModelAvailability, TaskInputResult,
-        TaskOutputResult, TaskRecord, TaskStatusSnapshot, TaskStopResult, TimerRecord,
-        ToolExecutionRecord, TranscriptEntry, TurnTerminalRecord, WorkItemRecord,
+        AgentDetail, AgentListEntry, AgentSummary, AgentTreeProjection, AuthorityClass,
+        BriefRecord, ExternalTriggerStateSnapshot, MessageEnvelope, OperatorNotificationRecord,
+        ResolvedModelAvailability, TaskInputResult, TaskOutputResult, TaskRecord,
+        TaskStatusSnapshot, TaskStopResult, TimerRecord, ToolExecutionRecord, TranscriptEntry,
+        TurnTerminalRecord, WorkItemRecord,
     },
     work_item_scheduling::WorkItemSchedulingProjection,
 };
@@ -405,6 +406,15 @@ impl LocalClient {
         self.get_json("/agents/list").await
     }
 
+    pub async fn operator_agent_tree(&self) -> Result<AgentTreeProjection> {
+        self.get_json("/control/agents/tree").await
+    }
+
+    pub async fn agent_detail(&self, agent_id: &str) -> Result<AgentDetail> {
+        self.get_json(&format!("/control/agents/{agent_id}/detail"))
+            .await
+    }
+
     pub async fn fetch_models(&self) -> Result<ModelsResponse> {
         self.get_json("/models").await
     }
@@ -741,7 +751,7 @@ impl LocalClient {
         .await
     }
 
-    pub async fn repair_agent(&self, agent_id: &str) -> Result<crate::types::AgentDetail> {
+    pub async fn repair_agent(&self, agent_id: &str) -> Result<AgentDetail> {
         self.post_control_json(
             &format!("/control/agents/{agent_id}/repair"),
             &serde_json::json!({}),

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs,
     future::Future,
     path::{Path, PathBuf},
@@ -59,14 +59,14 @@ use crate::{
         AgentCreateReceipt, AgentCreateResult, AgentCreateStage, AgentDeletionJob, AgentDetail,
         AgentDurability, AgentIdentityRecord, AgentIdentityView, AgentKind, AgentLifecycleHint,
         AgentListEntry, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState,
-        AgentStatus, AgentSummary, AgentTokenUsageSummary, AgentVisibility, AuthorityClass,
-        ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord, ExternalTriggerStatus,
-        ExternalTriggerSummary, LoadedAgentsMdView, MessageBody, MessageDeliverySurface,
-        MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationRecord, Priority,
-        QueueEntryStatus, RuntimeFailureSummary, SpawnAgentModelResolution,
-        SpawnAgentModelResolutionStatus, TaskKind, TaskRecord, TaskStatus, TimerRecord, TokenUsage,
-        TranscriptEntry, TranscriptEntryKind, WaitConditionSummary, WorkspaceEntry,
-        WorkspaceOccupancyRecord,
+        AgentStatus, AgentSummary, AgentTokenUsageSummary, AgentTreeNode, AgentTreeProjection,
+        AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord,
+        ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMdView, MessageBody,
+        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
+        OperatorNotificationRecord, Priority, QueueEntryStatus, RuntimeFailureSummary,
+        SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, TaskKind, TaskRecord,
+        TaskStatus, TimerRecord, TokenUsage, TranscriptEntry, TranscriptEntryKind,
+        WaitConditionSummary, WorkspaceEntry, WorkspaceOccupancyRecord,
     },
 };
 
@@ -1421,11 +1421,11 @@ impl RuntimeHost {
         }
     }
 
-    pub(crate) fn public_agent_read_storage(
+    pub(crate) fn operator_agent_read_storage(
         &self,
         agent_id: &str,
     ) -> std::result::Result<AppStorage, PublicAgentError> {
-        self.public_agent_identity(agent_id)?;
+        self.active_agent_identity(agent_id)?;
         self.agent_storage_read_only(agent_id)
             .map_err(PublicAgentError::Runtime)
     }
@@ -1439,19 +1439,19 @@ impl RuntimeHost {
             .map(|entry| entry.runtime.clone())
     }
 
-    pub(crate) async fn try_get_public_loaded_runtime(
+    pub(crate) async fn try_get_operator_loaded_runtime(
         &self,
         agent_id: &str,
     ) -> std::result::Result<Option<RuntimeHandle>, PublicAgentError> {
-        self.public_agent_identity(agent_id)?;
+        self.active_agent_identity(agent_id)?;
         Ok(self.try_get_loaded_runtime(agent_id).await)
     }
 
-    pub(crate) async fn public_agent_skills_view(
+    pub(crate) async fn operator_agent_skills_view(
         &self,
         agent_id: &str,
     ) -> std::result::Result<crate::types::SkillsRuntimeView, PublicAgentError> {
-        let identity = self.public_agent_identity(agent_id)?;
+        let identity = self.active_agent_identity(agent_id)?;
         let identity_view =
             AgentIdentityView::from_record(&identity, &self.config().default_agent_id);
         let storage = self
@@ -1713,7 +1713,7 @@ impl RuntimeHost {
                 last_delivered_at: record.last_delivered_at,
             })
             .collect();
-        let skills = self.public_agent_skills_view(agent_id).await?;
+        let skills = self.operator_agent_skills_view(agent_id).await?;
         let loaded_agents_md = LoadedAgentsMdView::default();
         let summary = AgentSummary {
             identity: identity_view,
@@ -1753,6 +1753,22 @@ impl RuntimeHost {
         agent_id: &str,
     ) -> std::result::Result<RuntimeHandle, PublicAgentError> {
         self.public_agent_identity(agent_id)?;
+        let runtime = self
+            .activate_agent(agent_id, RuntimeActivationReason::OperatorControl)
+            .await
+            .map_err(Self::public_activation_error)?;
+        runtime
+            .wait_for_bootstrap()
+            .await
+            .map_err(PublicAgentError::Runtime)?;
+        Ok(runtime)
+    }
+
+    pub async fn get_operator_agent(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<RuntimeHandle, PublicAgentError> {
+        self.active_agent_identity(agent_id)?;
         let runtime = self
             .activate_agent(agent_id, RuntimeActivationReason::OperatorControl)
             .await
@@ -1864,23 +1880,53 @@ impl RuntimeHost {
                 agent_id: agent_id.to_string(),
             });
         }
+        self.agent_detail_from_identity(identity)
+            .map_err(PublicAgentError::Runtime)
+    }
+
+    pub fn operator_agent_detail(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<AgentDetail, PublicAgentError> {
+        self.validate_agent_id(agent_id)
+            .map_err(PublicAgentError::Runtime)?;
+        let identity = self
+            .agent_identity_record(agent_id)
+            .map_err(PublicAgentError::Runtime)?
+            .ok_or_else(|| PublicAgentError::NotFound {
+                agent_id: agent_id.to_string(),
+            })?;
+        self.agent_detail_from_identity(identity)
+            .map_err(PublicAgentError::Runtime)
+    }
+
+    fn agent_detail_from_identity(&self, identity: AgentIdentityRecord) -> Result<AgentDetail> {
         let deletion = self
             .runtime_db()
             .agent_deletions()
-            .latest_for_agent(agent_id)
-            .map_err(PublicAgentError::Runtime)?;
+            .latest_for_agent(&identity.agent_id)?;
         let bootstrap = self
             .runtime_db()
             .agent_bootstraps()
-            .latest(agent_id)
-            .map_err(PublicAgentError::Runtime)?
+            .latest(&identity.agent_id)?
             .map(|record| record.summary());
+        let canonical_relations = self
+            .runtime_db()
+            .agent_canonical_relations()
+            .latest(&identity.agent_id)?
+            .ok_or_else(|| anyhow!("missing canonical relations for {}", identity.agent_id))?;
+        let lineage_children = self
+            .runtime_db()
+            .agent_canonical_relations()
+            .lineage_children(&identity.agent_id)?;
         Ok(AgentDetail {
             display_name: identity.display_name(),
             name: identity.name.clone(),
             created_at: identity.created_at,
             updated_at: identity.updated_at,
             identity: AgentIdentityView::from_record(&identity, &self.config().default_agent_id),
+            canonical_relations,
+            lineage_children,
             bootstrap,
             deletion,
         })
@@ -1945,35 +1991,17 @@ impl RuntimeHost {
             .registry
             .cache_agent_identity(&identity)
             .map_err(PublicAgentError::Runtime)?;
-        let deletion = self
-            .runtime_db()
-            .agent_deletions()
-            .latest_for_agent(agent_id)
-            .map_err(PublicAgentError::Runtime)?;
-        let bootstrap = self
-            .runtime_db()
-            .agent_bootstraps()
-            .latest(agent_id)
-            .map_err(PublicAgentError::Runtime)?
-            .map(|record| record.summary());
-        Ok(AgentDetail {
-            display_name: identity.display_name(),
-            name: identity.name.clone(),
-            created_at: identity.created_at,
-            updated_at: identity.updated_at,
-            identity: AgentIdentityView::from_record(&identity, &self.config().default_agent_id),
-            bootstrap,
-            deletion,
-        })
+        self.agent_detail_from_identity(identity)
+            .map_err(PublicAgentError::Runtime)
     }
 
-    pub(crate) async fn public_agent_state_projection(
+    pub(crate) async fn operator_agent_state_projection(
         &self,
         agent_id: &str,
         task_limit: usize,
         timer_limit: usize,
     ) -> std::result::Result<AgentStateReadProjection, PublicAgentError> {
-        let identity = self.public_agent_identity(agent_id)?;
+        let identity = self.active_agent_identity(agent_id)?;
         let runtime = {
             let registry = self.inner.runtimes.read().await;
             registry
@@ -2976,6 +3004,98 @@ impl RuntimeHost {
         }
         entries.sort_by(|left, right| left.identity.agent_id.cmp(&right.identity.agent_id));
         Ok(entries)
+    }
+
+    pub async fn operator_agent_tree(&self) -> Result<AgentTreeProjection> {
+        self.ensure_default_agent_identity()?;
+        let identities = self
+            .agent_identity_records()?
+            .into_iter()
+            .filter(|identity| identity.status == AgentRegistryStatus::Active)
+            .collect::<Vec<_>>();
+        let active_agent_ids = identities
+            .iter()
+            .map(|identity| identity.agent_id.clone())
+            .collect::<HashSet<_>>();
+        let mut nodes = HashMap::new();
+        let mut children_by_parent = HashMap::<String, Vec<String>>::new();
+        let mut root_ids = Vec::new();
+
+        for identity in identities {
+            let runtime = {
+                let registry = self.inner.runtimes.read().await;
+                registry
+                    .agents
+                    .get(&identity.agent_id)
+                    .filter(|entry| !entry.task.is_finished())
+                    .map(|entry| entry.runtime.clone())
+            };
+            let agent = if let Some(runtime) = runtime {
+                runtime.agent_list_entry().await?
+            } else {
+                self.agent_list_entry_from_storage(&identity)?
+            };
+            let canonical_relations = self
+                .runtime_db()
+                .agent_canonical_relations()
+                .latest(&identity.agent_id)?
+                .ok_or_else(|| {
+                    anyhow!(
+                        "missing canonical relations for active agent {}",
+                        identity.agent_id
+                    )
+                })?;
+            let parent_agent_id = canonical_relations
+                .lineage
+                .as_ref()
+                .map(|lineage| lineage.parent_agent_id.clone())
+                .filter(|parent_agent_id| active_agent_ids.contains(parent_agent_id));
+            if let Some(parent_agent_id) = parent_agent_id {
+                children_by_parent
+                    .entry(parent_agent_id)
+                    .or_default()
+                    .push(identity.agent_id.clone());
+            } else {
+                root_ids.push(identity.agent_id.clone());
+            }
+            nodes.insert(
+                identity.agent_id,
+                AgentTreeNode {
+                    agent,
+                    canonical_relations,
+                    children: Vec::new(),
+                },
+            );
+        }
+
+        root_ids.sort();
+        for child_ids in children_by_parent.values_mut() {
+            child_ids.sort();
+        }
+        let mut roots = Vec::new();
+        for root_id in root_ids {
+            if let Some(root) = build_agent_tree_node(
+                &root_id,
+                &mut nodes,
+                &children_by_parent,
+                &mut HashSet::new(),
+            ) {
+                roots.push(root);
+            }
+        }
+        let mut remaining_ids = nodes.keys().cloned().collect::<Vec<_>>();
+        remaining_ids.sort();
+        for agent_id in remaining_ids {
+            if let Some(root) = build_agent_tree_node(
+                &agent_id,
+                &mut nodes,
+                &children_by_parent,
+                &mut HashSet::new(),
+            ) {
+                roots.push(root);
+            }
+        }
+        Ok(AgentTreeProjection { roots })
     }
 
     fn agent_list_entry_from_storage(
@@ -4330,6 +4450,29 @@ impl RuntimeHost {
     }
 }
 
+fn build_agent_tree_node(
+    agent_id: &str,
+    nodes: &mut HashMap<String, AgentTreeNode>,
+    children_by_parent: &HashMap<String, Vec<String>>,
+    visiting: &mut HashSet<String>,
+) -> Option<AgentTreeNode> {
+    if !visiting.insert(agent_id.to_string()) {
+        return None;
+    }
+    let mut node = nodes.remove(agent_id)?;
+    if let Some(child_ids) = children_by_parent.get(agent_id) {
+        for child_id in child_ids {
+            if let Some(child) =
+                build_agent_tree_node(child_id, nodes, children_by_parent, visiting)
+            {
+                node.children.push(child);
+            }
+        }
+    }
+    visiting.remove(agent_id);
+    Some(node)
+}
+
 impl RuntimeHostBridge {
     fn host(&self) -> Result<RuntimeHost> {
         let inner = self
@@ -5263,7 +5406,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unloaded_public_agent_state_projection_reads_storage_without_starting_runtime() {
+    async fn unloaded_operator_agent_state_projection_reads_storage_without_starting_runtime() {
         let (_home, host) = test_host();
         let agent_id = host.config().default_agent_id.clone();
         let mut state = AgentState::new(&agent_id);
@@ -5277,7 +5420,7 @@ mod tests {
             .exists());
 
         let projection = host
-            .public_agent_state_projection(&agent_id, 10, 10)
+            .operator_agent_state_projection(&agent_id, 10, 10)
             .await
             .unwrap();
 
@@ -5291,13 +5434,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn loaded_public_agent_state_projection_prefers_runtime() {
+    async fn loaded_operator_agent_state_projection_prefers_runtime() {
         let (_home, host) = test_host();
         let agent_id = host.config().default_agent_id.clone();
         host.default_runtime().await.unwrap();
 
         let projection = host
-            .public_agent_state_projection(&agent_id, 10, 10)
+            .operator_agent_state_projection(&agent_id, 10, 10)
             .await
             .unwrap();
 
@@ -5715,6 +5858,150 @@ mod tests {
         assert_eq!(
             summary.identity.lineage_parent_agent_id.as_deref(),
             Some(host.config().default_agent_id.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_agent_tree_nests_supervised_child_and_allows_detail_navigation() {
+        let (_home, host) = test_host();
+        let parent = host.default_runtime().await.unwrap();
+        let parent_agent_id = host.config().default_agent_id.clone();
+
+        let spawned = parent
+            .spawn_agent(
+                Some("tree navigation work".into()),
+                AuthorityClass::OperatorInstruction,
+                AgentProfilePreset::PrivateChild,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let child_agent_id = spawned.agent_id.clone();
+        assert!(spawned.supervision_task_id.is_some());
+
+        let tree = host.operator_agent_tree().await.unwrap();
+        assert_eq!(
+            tree.roots.len(),
+            1,
+            "only the default agent should root the operator tree"
+        );
+        let root = &tree.roots[0];
+        assert_eq!(root.agent.identity.agent_id, parent_agent_id);
+        assert_eq!(root.children.len(), 1);
+        let child = &root.children[0];
+        assert_eq!(child.agent.identity.agent_id, child_agent_id);
+        assert_eq!(
+            child
+                .canonical_relations
+                .lineage
+                .as_ref()
+                .expect("child lineage")
+                .parent_agent_id,
+            parent_agent_id
+        );
+        assert!(
+            child.canonical_relations.supervision.is_some(),
+            "private child keeps its supervision attachment in the tree"
+        );
+        assert!(child.children.is_empty());
+        assert_eq!(
+            tree.into_agent_entries()
+                .iter()
+                .filter(|entry| entry.identity.agent_id == child_agent_id)
+                .count(),
+            1,
+            "each active child appears exactly once in the operator tree"
+        );
+
+        // The operator can open the private child directly even though peers cannot enumerate it.
+        let child_detail = host.operator_agent_detail(&child_agent_id).unwrap();
+        assert_eq!(
+            child_detail
+                .canonical_relations
+                .lineage
+                .as_ref()
+                .unwrap()
+                .parent_agent_id,
+            parent_agent_id
+        );
+        let parent_detail = host.operator_agent_detail(&parent_agent_id).unwrap();
+        assert!(parent_detail
+            .lineage_children
+            .iter()
+            .any(|record| record.child_agent_id == child_agent_id));
+    }
+
+    #[tokio::test]
+    async fn operator_agent_tree_keeps_unsupervised_public_named_lineage() {
+        let (_home, host) = test_host();
+        let parent = host.default_runtime().await.unwrap();
+        let parent_agent_id = host.config().default_agent_id.clone();
+
+        host.spawn_public_named_agent(
+            parent,
+            "release-bot",
+            Some("coordinate release work".into()),
+            AuthorityClass::OperatorInstruction,
+            None,
+            inherited_model_resolution("anthropic", "claude-sonnet-4-6"),
+        )
+        .await
+        .unwrap();
+
+        let tree = host.operator_agent_tree().await.unwrap();
+        assert_eq!(tree.roots.len(), 1);
+        let root = &tree.roots[0];
+        assert_eq!(root.agent.identity.agent_id, parent_agent_id);
+        let child = root
+            .children
+            .iter()
+            .find(|node| node.agent.identity.agent_id == "release-bot")
+            .expect("detached public named agent should stay nested under its lineage parent");
+        assert!(
+            child.canonical_relations.supervision.is_none(),
+            "public named agents keep lineage without a supervision attachment"
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_agent_tree_hides_deleted_agent_but_keeps_history() {
+        let (_home, host) = test_host();
+        let parent = host.default_runtime().await.unwrap();
+        host.spawn_public_named_agent(
+            parent,
+            "gone-bot",
+            Some("temporary work".into()),
+            AuthorityClass::OperatorInstruction,
+            None,
+            inherited_model_resolution("anthropic", "claude-sonnet-4-6"),
+        )
+        .await
+        .unwrap();
+
+        let (_, job, _) = host
+            .begin_public_agent_deletion("gone-bot", false, "operator")
+            .await
+            .unwrap();
+        host.execute_deletion_job(job).await.unwrap();
+
+        let tree = host.operator_agent_tree().await.unwrap();
+        assert!(
+            !tree
+                .into_agent_entries()
+                .iter()
+                .any(|entry| entry.identity.agent_id == "gone-bot"),
+            "deleted identities must be hidden from the operator tree"
+        );
+        assert!(
+            host.runtime_db()
+                .agent_canonical_relations()
+                .latest("gone-bot")
+                .unwrap()
+                .is_some(),
+            "canonical relation history must remain queryable after deletion"
         );
     }
 
@@ -8210,7 +8497,7 @@ mod tests {
         let agent_id = host.config().default_agent_id.clone();
 
         let _storage = host
-            .public_agent_read_storage(&agent_id)
+            .operator_agent_read_storage(&agent_id)
             .expect("read storage");
         assert!(host.inner.runtimes.read().await.agents.is_empty());
 

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -78,7 +78,7 @@ pub async fn scheduler_repair_apply(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     Ok(Json(
@@ -513,9 +513,23 @@ pub async fn agent_detail(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let detail = state
         .host
-        .public_agent_detail(&agent_id)
+        .operator_agent_detail(&agent_id)
         .map_err(agent_access_error)?;
     Ok(Json(detail))
+}
+
+pub async fn agent_tree(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    Ok(Json(
+        state
+            .host
+            .operator_agent_tree()
+            .await
+            .map_err(error_response)?,
+    ))
 }
 
 pub async fn repair_agent(
@@ -645,7 +659,7 @@ pub async fn abort_current_run(
     let provided_trust = request.authority_class.clone();
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let outcome = runtime
@@ -681,7 +695,7 @@ pub async fn attach_workspace(
         .map_err(error_response)?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let boundary = current_boundary_metadata(&runtime)
@@ -722,7 +736,7 @@ pub async fn exit_workspace(
     let provided_trust = request.authority_class;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let boundary = current_boundary_metadata(&runtime)
@@ -758,7 +772,7 @@ pub async fn detach_workspace(
     let workspace_id = request.workspace_id.trim().to_string();
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let boundary = current_boundary_metadata(&runtime)
@@ -798,7 +812,7 @@ pub async fn set_agent_model(
         .map_err(|error| bad_request(error.to_string()))?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let model_state = runtime
@@ -821,7 +835,7 @@ pub async fn clear_agent_model(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let model_state = runtime
@@ -843,7 +857,7 @@ pub async fn reset_callback(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let capability = runtime
@@ -1272,7 +1286,7 @@ pub async fn create_operator_transport_binding(
     }
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let delivery_auth = validate_operator_transport_delivery_auth(request.delivery_auth)?;

--- a/src/http/events.rs
+++ b/src/http/events.rs
@@ -11,13 +11,11 @@ pub async fn events(
         .unwrap_or(DEFAULT_EVENT_STREAM_WINDOW)
         .clamp(1, MAX_EVENT_STREAM_WINDOW);
     let order = query.order.unwrap_or(EventPageOrder::Desc);
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    if state.require_control_token {
-        authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    }
     let emit_projection_effect = projection_effect_emission_enabled(&state);
     let cursor_seq = storage.latest_event_seq().map_err(error_response)?;
     let event_log_epoch = storage.event_log_epoch().map_err(error_response)?;
@@ -71,13 +69,11 @@ pub async fn message(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    if state.require_control_token {
-        authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    }
     let Some(message) = storage
         .read_message_by_id(&message_id)
         .map_err(error_response)?
@@ -96,13 +92,11 @@ pub async fn messages_batch_get(
     headers: HeaderMap,
     Json(request): Json<BatchGetMessagesRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    if state.require_control_token {
-        authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    }
     let mut messages = Vec::new();
     let mut missing_message_ids = Vec::new();
     for message_id in request.message_ids {
@@ -131,13 +125,11 @@ pub async fn events_stream(
         .unwrap_or(DEFAULT_EVENT_STREAM_WINDOW)
         .clamp(1, MAX_EVENT_STREAM_WINDOW);
     let after_seq = query.after_seq;
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
-    if state.require_control_token {
-        authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    }
     let mut live_rx = state.host.subscribe_events();
     let event_log_epoch = storage.event_log_epoch().map_err(error_response)?;
     // Capability advertisement is captured once at stream open and applies

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -475,6 +475,7 @@ pub fn router(state: AppState) -> Router {
             "/control/agents/{agent_id}/create",
             post(control::create_agent),
         )
+        .route("/control/agents/tree", get(control::agent_tree))
         .route(
             "/control/agents/{agent_id}/detail",
             get(control::agent_detail),
@@ -1513,10 +1514,11 @@ mod tests {
         session_credential, AppState, ProjectionGate, ProjectionGateError,
     };
     use crate::{
-        config::AppConfig,
+        config::{AppConfig, ControlAuthMode},
         host::RuntimeHost,
         provider::StubProvider,
         runtime_error::{RuntimeError, RuntimeErrorDomain},
+        types::{AgentListEntry, AgentProfilePreset, AgentTreeProjection, AuthorityClass},
     };
     use axum::{
         body::{to_bytes, Body},
@@ -1557,6 +1559,21 @@ mod tests {
         )
         .unwrap();
         let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let host =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
+        (home, host)
+    }
+
+    fn control_token_test_host() -> (tempfile::TempDir, RuntimeHost) {
+        let home = tempdir().unwrap();
+        fs::write(
+            home.path().join("config.json"),
+            r#"{"model":{"default":"openai/gpt-5.4"}}"#,
+        )
+        .unwrap();
+        let mut config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        config.control_token = Some("secret".into());
+        config.control_auth_mode = ControlAuthMode::Required;
         let host =
             RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
         (home, host)
@@ -1806,6 +1823,148 @@ mod tests {
                     .unwrap();
             assert_eq!(body["code"], "auth_required", "{uri}");
         }
+    }
+
+    #[tokio::test]
+    async fn operator_agent_tree_requires_auth_and_does_not_expand_public_roster() {
+        let (_home, host) = control_token_test_host();
+        let parent = host.default_runtime().await.unwrap();
+        let spawned = parent
+            .spawn_agent(
+                Some("private tree navigation".into()),
+                AuthorityClass::OperatorInstruction,
+                AgentProfilePreset::PrivateChild,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let child_agent_id = spawned.agent_id;
+        let app = router(AppState::for_tcp(host));
+
+        for uri in [
+            format!("/api/control/agents/{child_agent_id}/detail"),
+            "/api/control/agents/unknown-agent/detail".to_string(),
+            format!("/api/agents/{child_agent_id}/events"),
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri(uri)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            let body: serde_json::Value =
+                serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                    .unwrap();
+            assert_eq!(body["code"], "auth_required");
+        }
+
+        let authorized = |uri: &str| {
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .header(header::AUTHORIZATION, "Bearer secret")
+                .body(Body::empty())
+                .unwrap()
+        };
+        let detail_response = app
+            .clone()
+            .oneshot(authorized(&format!(
+                "/api/control/agents/{child_agent_id}/detail"
+            )))
+            .await
+            .unwrap();
+        assert_eq!(detail_response.status(), StatusCode::OK);
+
+        let tree_response = app
+            .clone()
+            .oneshot(authorized("/api/control/agents/tree"))
+            .await
+            .unwrap();
+        assert_eq!(tree_response.status(), StatusCode::OK);
+        let tree: AgentTreeProjection = serde_json::from_slice(
+            &to_bytes(tree_response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            tree.into_agent_entries()
+                .iter()
+                .filter(|entry| entry.identity.agent_id == child_agent_id)
+                .count(),
+            1
+        );
+
+        let roster_response = app.oneshot(authorized("/api/agents/list")).await.unwrap();
+        assert_eq!(roster_response.status(), StatusCode::OK);
+        let roster: Vec<AgentListEntry> = serde_json::from_slice(
+            &to_bytes(roster_response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            roster
+                .iter()
+                .all(|entry| entry.identity.agent_id != child_agent_id),
+            "operator tree visibility must not expand the public roster"
+        );
+    }
+
+    #[tokio::test]
+    async fn oidc_event_reads_require_session_before_private_child_lookup() {
+        let (_home, host, session_secret) = oidc_test_host_with_session();
+        let parent = host.default_runtime().await.unwrap();
+        let child_agent_id = parent
+            .spawn_agent(
+                Some("private event navigation".into()),
+                AuthorityClass::OperatorInstruction,
+                AgentProfilePreset::PrivateChild,
+                None,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .agent_id;
+        let app = router(AppState::for_tcp(host));
+        let uri = format!("/api/agents/{child_agent_id}/events");
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .header(header::COOKIE, format!("holon_session={session_secret}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[test]

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -11,7 +11,7 @@ pub async fn list_skills(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let skills = state
         .host
-        .public_agent_skills_view(&agent_id)
+        .operator_agent_skills_view(&agent_id)
         .await
         .map_err(agent_access_error)?;
     Ok(Json(json!({
@@ -30,7 +30,7 @@ pub async fn install_skill(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let agent_home = runtime.agent_home();
@@ -178,7 +178,7 @@ pub async fn enable_skill(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let agent_home = runtime.agent_home();
@@ -216,7 +216,7 @@ pub async fn uninstall_skill(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let agent_home = runtime.agent_home();
@@ -247,7 +247,7 @@ pub async fn disable_skill(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let agent_home = runtime.agent_home();
@@ -390,7 +390,7 @@ async fn agent_scoped_skill_detail(
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let skills = state
         .host
-        .public_agent_skills_view(agent_id)
+        .operator_agent_skills_view(agent_id)
         .await
         .map_err(agent_access_error)?;
     let Some(skill) = skills

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -248,7 +248,7 @@ async fn build_agent_state_projection(
 ) -> Result<Bytes, ProjectionFailure> {
     let projection = state
         .host
-        .public_agent_state_projection(agent_id, STATE_BOOTSTRAP_TASK_LIMIT, 50)
+        .operator_agent_state_projection(agent_id, STATE_BOOTSTRAP_TASK_LIMIT, 50)
         .await
         .map_err(agent_access_error)
         .map_err(ProjectionFailure::from)?;
@@ -1040,7 +1040,7 @@ pub async fn briefs(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let briefs = storage
         .read_recent_briefs(query.limit.unwrap_or(20))
@@ -1056,7 +1056,7 @@ pub async fn brief(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let Some(brief) = storage
         .read_brief_by_id(&brief_id)
@@ -1077,7 +1077,7 @@ pub async fn briefs_batch_get(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let brief_ids = request
         .brief_ids
@@ -1145,7 +1145,7 @@ pub async fn transcript(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let transcript = storage
         .read_recent_transcript(query.limit.unwrap_or(50))
@@ -1161,7 +1161,7 @@ pub async fn transcript_entry(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let Some(entry) = storage
         .read_transcript_entry_by_id(&entry_id)
@@ -1182,7 +1182,7 @@ pub async fn transcript_batch_get(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let mut entries = Vec::new();
     let mut missing_entry_ids = Vec::new();

--- a/src/http/tasks.rs
+++ b/src/http/tasks.rs
@@ -17,7 +17,7 @@ pub async fn tasks(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     Ok(Json(
         storage
@@ -34,7 +34,7 @@ pub async fn task_status(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let Some(task) = storage
         .latest_task_record(&task_id)
@@ -45,7 +45,7 @@ pub async fn task_status(
     };
     let snapshot = match state
         .host
-        .try_get_public_loaded_runtime(&agent_id)
+        .try_get_operator_loaded_runtime(&agent_id)
         .await
         .map_err(agent_access_error)?
     {
@@ -68,7 +68,7 @@ pub async fn task_output(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     if !storage
         .latest_task_record(&task_id)
@@ -79,7 +79,7 @@ pub async fn task_output(
     }
     let runtime = state
         .host
-        .try_get_public_loaded_runtime(&agent_id)
+        .try_get_operator_loaded_runtime(&agent_id)
         .await
         .map_err(agent_access_error)?
         .ok_or_else(|| {
@@ -113,7 +113,7 @@ pub async fn tool_execution(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let Some(record) = storage
         .read_tool_execution_by_id(&tool_execution_id)
@@ -135,7 +135,7 @@ pub async fn tool_execution_artifact(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let Some(record) = storage
         .read_tool_execution_by_id(&tool_execution_id)
@@ -207,7 +207,7 @@ pub async fn task_input(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     if !runtime
@@ -239,7 +239,7 @@ pub async fn task_stop(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     if !runtime
@@ -294,7 +294,7 @@ pub async fn create_command_task(
         .unwrap_or(AuthorityClass::OperatorInstruction);
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let boundary = current_boundary_metadata(&runtime)
@@ -384,7 +384,7 @@ pub async fn pick_work_item(
     validate_invocation_context(request.invocation_context.as_ref(), provided_trust)?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let boundary = current_boundary_metadata(&runtime)
@@ -465,7 +465,7 @@ pub async fn update_work_item(
     }
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let boundary = current_boundary_metadata(&runtime)
@@ -514,7 +514,7 @@ pub async fn complete_work_item(
     validate_invocation_context(request.invocation_context.as_ref(), provided_trust)?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let boundary = current_boundary_metadata(&runtime)
@@ -587,7 +587,7 @@ pub async fn work_items(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let work_items = storage
         .work_queue_read_model()
@@ -607,7 +607,7 @@ pub async fn work_item(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let Some(work_item) = storage
         .work_queue_read_model()
@@ -637,7 +637,7 @@ pub async fn timers(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     Ok(Json(
         storage
@@ -654,7 +654,7 @@ pub async fn timer(
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let storage = state
         .host
-        .public_agent_read_storage(&agent_id)
+        .operator_agent_read_storage(&agent_id)
         .map_err(agent_access_error)?;
     let Some(timer) = storage
         .latest_timer_record(&timer_id)
@@ -681,7 +681,7 @@ pub async fn create_timer(
     let provided_trust = request.authority_class;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let boundary = current_boundary_metadata(&runtime)
@@ -717,7 +717,7 @@ pub async fn cancel_timer(
     let provided_trust = request.authority_class;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_operator_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let boundary = current_boundary_metadata(&runtime)

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -134,6 +134,7 @@ const ROUTES: &[RouteSpec] = &[
     route_with_response("post", "/control/agents/{agent_id}/timers", "createTimer", "control", "Create timer", "Schedule a timer for an agent.", Some("CreateTimerRequest"), "TimerRecord", AuthKind::Control),
     route_with_response("post", "/control/agents/{agent_id}/timers/{timer_id}/cancel", "cancelTimer", "control", "Cancel timer", "Cancel an active timer. Cancellation is idempotent for already-cancelled timers; completed or missing timers return a shared error envelope.", Some("CancelTimerRequest"), "TimerRecord", AuthKind::Control),
     route("post", "/control/agents/{agent_id}/create", "createAgent", "control", "Create named agent", "Create a public named agent, optionally from a template.", Some("CreateAgentRequest"), AuthKind::Control),
+    route_with_response("get", "/control/agents/tree", "agentTree", "control", "Agent tree", "Return the authenticated operator Agent tree built from canonical lineage.", None, "AgentTreeProjection", AuthKind::Control),
     route_with_response("get", "/control/agents/{agent_id}/detail", "agentDetail", "control", "Agent detail", "Return the canonical Agent identity, lifecycle, profile, and deletion detail.", None, "AgentDetail", AuthKind::Control),
     route_with_response("post", "/control/agents/{agent_id}/repair", "repairAgent", "control", "Repair agent bootstrap", "Retry incomplete post-create bootstrap steps without recreating the agent.", None, "AgentDetail", AuthKind::Control),
     route_with_response("patch", "/control/agents/{agent_id}/name", "renameAgent", "control", "Rename agent", "Update the public display name without changing the technical agent identity or lifecycle target.", Some("RenameAgentRequest"), "AgentDetail", AuthKind::Control),
@@ -699,6 +700,10 @@ fn component_schemas() -> Value {
     schemas.insert(
         "AgentDetail".into(),
         component_schema::<crate::types::AgentDetail>(),
+    );
+    schemas.insert(
+        "AgentTreeProjection".into(),
+        component_schema::<crate::types::AgentTreeProjection>(),
     );
     schemas.insert(
         "PickWorkItemRequest".into(),

--- a/src/runtime_db/agent_relations.rs
+++ b/src/runtime_db/agent_relations.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::{Context, Result};
 use rusqlite::{params, OptionalExtension, Transaction};
 
@@ -76,6 +78,47 @@ impl AgentCanonicalRelationRepository<'_> {
     pub fn latest(&self, agent_id: &str) -> Result<Option<AgentCanonicalRelationsProjection>> {
         let connection = self.db.connection()?;
         canonical_relations_from_connection(&connection, agent_id)
+    }
+
+    pub fn lineage_children(&self, parent_agent_id: &str) -> Result<Vec<AgentLineageRecord>> {
+        let connection = self.db.connection()?;
+        let mut records = HashMap::new();
+        let mut statement = connection.prepare(
+            "SELECT child_agent_id, payload_json
+             FROM agent_lineages
+             WHERE parent_agent_id = ?1
+             ORDER BY child_agent_id ASC",
+        )?;
+        let rows = statement.query_map([parent_agent_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        for row in rows {
+            let (child_agent_id, payload_json) = row?;
+            records.insert(
+                child_agent_id,
+                serde_json::from_str(&payload_json)
+                    .context("decoding canonical lineage child record")?,
+            );
+        }
+        let mut identity_statement = connection.prepare(
+            "SELECT payload_json
+             FROM agent_identities
+             ORDER BY agent_id ASC",
+        )?;
+        let identities = identity_statement.query_map([], |row| row.get::<_, String>(0))?;
+        for payload_json in identities {
+            let identity: AgentIdentityRecord = serde_json::from_str(&payload_json?)
+                .context("decoding agent identity for legacy lineage children")?;
+            let Some(lineage) = legacy_lineage(&identity, &mut Vec::new()) else {
+                continue;
+            };
+            if lineage.parent_agent_id == parent_agent_id {
+                records.entry(identity.agent_id).or_insert(lineage);
+            }
+        }
+        let mut records = records.into_values().collect::<Vec<_>>();
+        records.sort_by(|left, right| left.child_agent_id.cmp(&right.child_agent_id));
+        Ok(records)
     }
 }
 

--- a/src/runtime_db/agent_relations/tests.rs
+++ b/src/runtime_db/agent_relations/tests.rs
@@ -335,6 +335,72 @@ fn repository_round_trips_mixed_canonical_and_legacy_axes() -> Result<()> {
 }
 
 #[test]
+fn lineage_children_merges_canonical_and_legacy_records() -> Result<()> {
+    let temp_dir = tempdir()?;
+    let db_path = temp_dir.path().join("state/runtime.sqlite");
+    let lock_path = temp_dir.path().join("state/runtime.lock");
+    let db = crate::runtime_db::RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+    let parent = identity(
+        "parent",
+        AgentKind::Named,
+        AgentVisibility::Public,
+        AgentOwnership::SelfOwned,
+        AgentProfilePreset::PublicNamed,
+        None,
+        None,
+    );
+    let canonical_child = identity(
+        "canonical-child",
+        AgentKind::Named,
+        AgentVisibility::Public,
+        AgentOwnership::SelfOwned,
+        AgentProfilePreset::PublicNamed,
+        None,
+        None,
+    );
+    let legacy_child = identity(
+        "legacy-child",
+        AgentKind::Child,
+        AgentVisibility::Private,
+        AgentOwnership::ParentSupervised,
+        AgentProfilePreset::PrivateChild,
+        Some("parent"),
+        Some("task-legacy"),
+    );
+    for record in [&parent, &canonical_child, &legacy_child] {
+        db.agent_identities().upsert(record)?;
+    }
+    let repository = db.agent_canonical_relations();
+    repository.upsert_lineage(&AgentLineageRecord {
+        child_agent_id: "canonical-child".into(),
+        parent_agent_id: "parent".into(),
+        creation_cause: AgentLineageCreationCause::Migration,
+        revision: 1,
+        created_at: canonical_child.created_at,
+    })?;
+
+    let children = repository.lineage_children("parent")?;
+    assert_eq!(
+        children
+            .iter()
+            .map(|record| record.child_agent_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["canonical-child", "legacy-child"],
+        "canonical rows win over the legacy identity fallback and results stay sorted"
+    );
+    assert_eq!(children[1].parent_agent_id, "parent");
+    assert_eq!(
+        children[1].creation_cause,
+        AgentLineageCreationCause::LegacySpawn
+    );
+    assert!(
+        repository.lineage_children("other")?.is_empty(),
+        "children of an unrelated parent must not be returned"
+    );
+    Ok(())
+}
+
+#[test]
 fn repository_rejects_two_active_supervisors_for_one_child() -> Result<()> {
     let temp_dir = tempdir()?;
     let db_path = temp_dir.path().join("state/runtime.sqlite");

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -187,8 +187,9 @@ impl TuiApp {
         let tx = self.runtime_tx.clone();
         tokio::spawn(async move {
             let result = client
-                .list_agent_entries()
+                .operator_agent_tree()
                 .await
+                .map(crate::types::AgentTreeProjection::into_agent_entries)
                 .map_err(|err| err.to_string());
             let _ = tx.send(TuiRuntimeMessage::AgentListLoaded(result));
         });

--- a/src/types.rs
+++ b/src/types.rs
@@ -129,7 +129,7 @@ impl WorkspaceEntry {
 
 /// Typed metadata for workspace projections, replacing untyped `serde_json::Value`.
 /// Uses `untagged` serde for backward compatibility with previously serialized JSON.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum WorkspaceProjectionMetadata {
     ManagedWorktree {
@@ -183,7 +183,7 @@ pub struct WorktreeInfo {
     pub original_cwd: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct ActiveWorkspaceEntry {
     pub workspace_id: String,
     pub workspace_anchor: PathBuf,
@@ -666,10 +666,44 @@ pub struct AgentDetail {
     pub display_name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub canonical_relations: AgentCanonicalRelationsProjection,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lineage_children: Vec<AgentLineageRecord>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bootstrap: Option<AgentBootstrapSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deletion: Option<AgentDeletionJob>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct AgentTreeNode {
+    pub agent: AgentListEntry,
+    pub canonical_relations: AgentCanonicalRelationsProjection,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<AgentTreeNode>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct AgentTreeProjection {
+    #[serde(default)]
+    pub roots: Vec<AgentTreeNode>,
+}
+
+impl AgentTreeProjection {
+    pub fn into_agent_entries(self) -> Vec<AgentListEntry> {
+        fn append(node: AgentTreeNode, entries: &mut Vec<AgentListEntry>) {
+            entries.push(node.agent);
+            for child in node.children {
+                append(child, entries);
+            }
+        }
+
+        let mut entries = Vec::new();
+        for root in self.roots {
+            append(root, &mut entries);
+        }
+        entries
+    }
 }
 
 pub fn normalize_agent_name(value: &str) -> anyhow::Result<String> {
@@ -5559,20 +5593,26 @@ pub struct AgentSummary {
     pub recent_event_count: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct AgentListModelSummary {
     pub source: AgentModelSource,
+    #[schemars(with = "String")]
     pub runtime_default_model: ModelRouteRef,
+    #[schemars(with = "String")]
     pub effective_model: ModelRouteRef,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "Option<String>")]
     pub requested_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "Option<String>")]
     pub active_model: Option<ModelRouteRef>,
     #[serde(default)]
     pub fallback_active: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(with = "Vec<String>")]
     pub effective_fallback_models: Vec<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "Option<String>")]
     pub override_model: Option<ModelRouteRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub override_reasoning_effort: Option<String>,
@@ -5611,7 +5651,7 @@ impl AgentListModelSummary {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct AgentListEntry {
     pub identity: AgentIdentityView,
     pub status: AgentStatus,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -93,7 +93,7 @@ fn render_live_inventory() -> String {
             route
         })
         .collect();
-    assert_eq!(routes.len(), 113, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 114, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -666,6 +666,22 @@
   },
   {
     "method": "get",
+    "path": "/api/control/agents/tree",
+    "handler": "agent_tree",
+    "operation_id": "agentTree",
+    "tag": "control",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/api/control/agents/{agent_id}/delete-status",
     "handler": "agent_deletion_status",
     "operation_id": "agentDeleteStatus",


### PR DESCRIPTION
## 概要

- 为 authenticated operator 增加 canonical Agent detail 与树形 projection，暴露 lineage parent/children、supervision、durability 和 lifecycle attachment
- 允许 operator 直接读取 supervised child 的 detail、conversation 与管理资源，同时保持公开 roster 仅枚举 public Agent
- 将 operator/session 授权前置到私有 Agent 资源查找之前，避免通过 detail、events、tasks、skills 等读取路径扩大 peer 可见性
- 保留 Phase A legacy compatibility projection；lifecycle detach 不删除 lineage，tombstoned identity 不进入普通树
- 未增加任何跨 Agent 消息写能力

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib operator_agent_tree_requires_auth_and_does_not_expand_public_roster`
- `cargo test --lib oidc_event_reads_require_session_before_private_child_lookup`
- `cargo test --lib agent_tree`
- `cargo test --lib lineage_children`
- `cargo test --lib generated_openapi_includes_current_http_surface`
- `git diff --check`
