### PR TITLE
fix(web): render TaskOutput content in right panel tool detail

### DIFF
--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.test.tsx
@@ -305,4 +305,61 @@ describe("ToolExecutionContent", () => {
     expect(html).toContain("Hint:");
     expect(html).toContain("MemorySearch");
   });
+
+  it("renders TaskOutput snapshot content from the envelope result", () => {
+    const html = renderTool({
+      tool_name: "TaskOutput",
+      input: { task_id: "task_abc123", block: true },
+      output: {
+        envelope: {
+          status: "success",
+          result: {
+            retrieval_status: "success",
+            task: {
+              task_id: "task_abc123",
+              kind: "command_task",
+              status: "completed",
+              summary: "Run command: echo done",
+              output_preview: "done\n",
+              output_truncated: false,
+              exit_status: 0,
+            },
+          },
+        },
+      },
+    });
+
+    expect(html).toContain("task_abc123");
+    expect(html).toContain("completed");
+    expect(html).toContain("Run command: echo done");
+    expect(html).toContain("done");
+  });
+
+  it("renders TaskOutput retrieval timeout without swallowing task state", () => {
+    const html = renderTool({
+      tool_name: "TaskOutput",
+      input: { task_id: "task_slow456", block: true, timeout_ms: 1000 },
+      output: {
+        envelope: {
+          status: "success",
+          result: {
+            retrieval_status: "timeout",
+            task: {
+              task_id: "task_slow456",
+              kind: "command_task",
+              status: "running",
+              summary: "Run command: sleep 5",
+              output_preview: "",
+              output_truncated: false,
+            },
+          },
+        },
+      },
+    });
+
+    expect(html).toContain("task_slow456");
+    expect(html).toContain("running");
+    expect(html).toContain("timeout");
+    expect(html).toContain("Run command: sleep 5");
+  });
 });

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
@@ -1111,21 +1111,47 @@ function TaskOutputRenderer({ record }: { record: RuntimeToolExecutionRecord }) 
   const { t } = useTranslation();
   const input = isRecord(record.input) ? record.input : {};
   const output = unwrapToolOutput(record.output ?? record.result);
-  const taskId = nestedText(input, ["task_id"]);
-  const status = nestedText(output, ["status"]);
-  const disposition = nestedText(output, ["disposition"]);
-  const stdout = nestedText(output, ["stdout", "text"]);
-  const stderr = nestedText(output, ["stderr"]);
-  const truncated = nestedValue(output, ["truncated"]) === true;
+  // TaskOutput results are shaped {retrieval_status, task: TaskOutputSnapshot}
+  // where task.output_preview holds the actual output text; older records only
+  // exposed top-level stdout/stderr.
+  const result = asResultRecord(output, "task_output_result");
+  const taskValue = nestedValue(result, ["task", "task_record"]);
+  const task = isRecord(taskValue) ? taskValue : undefined;
+  const taskId = nestedText(input, ["task_id"]) || nestedText(task, ["task_id", "id"]);
+  const retrievalStatus = nestedText(result, ["retrieval_status"]);
+  const status = nestedText(task, ["status"]) || nestedText(result, ["status"]);
+  const summary = nestedText(task, ["summary"]);
+  const resultSummary = nestedText(task, ["result_summary"]) || nestedText(result, ["summary"]);
+  const exitStatus = nestedValue(task, ["exit_status"]) ?? nestedValue(result, ["exit_status"]);
+  const combinedOutput = nestedText(task, ["output_preview"]) || nestedText(result, ["output"]);
+  const stdout = combinedOutput ? "" : nestedText(task, ["stdout"]) || nestedText(result, ["stdout"]);
+  const stderr = combinedOutput ? "" : nestedText(task, ["stderr"]) || nestedText(result, ["stderr"]);
+  const truncated =
+    nestedValue(task, ["output_truncated"]) === true ||
+    nestedValue(result, ["output_truncated"]) === true ||
+    nestedValue(result, ["truncated"]) === true;
 
   return (
     <>
       <SimpleField label={t("inspector.taskId")} value={taskId} />
-      {status ? <SimpleField label={t("common.status")} value={status} /> : null}
-      {disposition ? <SimpleField label="Disposition" value={disposition} /> : null}
+      {status ? <SimpleField label={t("inspector.status")} value={status} /> : null}
+      {retrievalStatus && retrievalStatus !== "success" ? (
+        <SimpleField label={t("inspector.retrieval")} value={retrievalStatus} />
+      ) : null}
+      {exitStatus != null ? <SimpleField label={t("inspector.exit")} value={exitStatus} /> : null}
+      {summary ? <OutputField label={t("inspector.summary")} value={summary} /> : null}
+      {resultSummary && resultSummary.trim() !== "" && resultSummary !== summary ? (
+        <OutputField label={t("inspector.result")} value={resultSummary} />
+      ) : null}
+      {combinedOutput ? (
+        <OutputField
+          label={truncated ? t("inspector.outputTruncated") : t("inspector.output")}
+          value={truncatedText(combinedOutput, 8000)}
+        />
+      ) : null}
       {stdout ? <OutputField label={t("inspector.stdout")} value={truncatedText(stdout, 3000)} /> : null}
       {stderr ? <OutputField label={t("inspector.stderr")} value={truncatedText(stderr, 1000)} variant="error" /> : null}
-      {truncated ? <SimpleField label={t("inspector.truncated")} value={t("inspector.yes")} /> : null}
+      {truncated && !combinedOutput ? <SimpleField label={t("inspector.truncated")} value={t("inspector.yes")} /> : null}
       {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
     </>
   );


### PR DESCRIPTION
## What changed

Clicking a `TaskOutput` timeline item opens the right-panel tool execution detail, but `TaskOutputRenderer` only read legacy top-level fields (`status`, `disposition`, `stdout`, `stderr`). TaskOutput tool results are actually shaped `{retrieval_status, task: TaskOutputSnapshot}` with the real text in `task.output_preview`, so the panel showed nothing beyond the Task ID row.

- Rework `TaskOutputRenderer` to read the snapshot shape: task status, exit status, task summary, result summary, and the combined output preview (with the truncation flag reflected in the label).
- Keep legacy top-level `stdout`/`stderr`/`output` fallbacks for older records.
- Show `retrieval_status` only when it is not `success` (timeout / not_ready), since the record status row already conveys success.
- Add renderer tests for the success snapshot and the retrieval-timeout shape.

## Verification

- `npx vitest run` — 481 tests pass (40 files), including the two new TaskOutput renderer tests.
- `npx tsc --noEmit` and `npm run build` clean.