### PR TITLE
feat: add canonical agent creation and invocation services

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -2780,6 +2780,7 @@
                 },
                 "kind": {
                   "enum": [
+                    "actor_invocation",
                     "command_task",
                     "child_agent_task",
                     "sleep_job",
@@ -8676,6 +8677,7 @@
           },
           "kind": {
             "enum": [
+              "actor_invocation",
               "command_task",
               "child_agent_task",
               "sleep_job",

--- a/src/host.rs
+++ b/src/host.rs
@@ -6084,6 +6084,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn canonical_new_subagent_rejects_missing_model_before_task_creation() {
+        let (_home, host) = test_host();
+        let parent = host.default_runtime().await.unwrap();
+        let tasks_before = parent.storage().latest_task_records().unwrap();
+
+        let error = parent
+            .agent_invocation_service()
+            .invoke(InvokeAgentRequest {
+                target: InvokeAgentTarget::NewSubagent {
+                    template: None,
+                    workspace_mode: ChildAgentWorkspaceMode::Inherit,
+                    model_resolution: None,
+                },
+                message: "invalid invocation".into(),
+                authority_class: AuthorityClass::OperatorInstruction,
+            })
+            .await
+            .expect_err("missing model resolution must reject the invocation");
+
+        assert_eq!(
+            error.to_string(),
+            "new subagent invocation requires model resolution"
+        );
+        assert_eq!(
+            parent.storage().latest_task_records().unwrap(),
+            tasks_before,
+            "invalid invocation must not persist an orphaned queued task"
+        );
+    }
+
+    #[tokio::test]
     async fn canonical_existing_invocation_preserves_target_configuration_and_relations() {
         let (_home, host) = test_host();
         let parent = host.default_runtime().await.unwrap();

--- a/src/host.rs
+++ b/src/host.rs
@@ -60,9 +60,9 @@ use crate::{
         AgentDurability, AgentIdentityRecord, AgentIdentityView, AgentKind, AgentLifecycleHint,
         AgentListEntry, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState,
         AgentStatus, AgentSummary, AgentTokenUsageSummary, AgentTreeNode, AgentTreeProjection,
-        AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord,
-        ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMdView, MessageBody,
-        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
+        AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome, CreateAgentRequest,
+        ExternalTriggerRecord, ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMdView,
+        MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
         OperatorNotificationRecord, Priority, QueueEntryStatus, RuntimeFailureSummary,
         SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, TaskKind, TaskRecord,
         TaskStatus, TimerRecord, TokenUsage, TranscriptEntry, TranscriptEntryKind,
@@ -2331,6 +2331,84 @@ impl RuntimeHost {
         })
     }
 
+    async fn create_agent(
+        &self,
+        parent_runtime: RuntimeHandle,
+        request: CreateAgentRequest,
+    ) -> Result<AgentCreateResult> {
+        if let Some(identity) = self.agent_identity_record(&request.agent_id)? {
+            anyhow::ensure!(
+                identity.status == AgentRegistryStatus::Active
+                    && identity.kind == AgentKind::Named
+                    && identity.visibility == AgentVisibility::Public
+                    && identity.ownership() == AgentOwnership::SelfOwned,
+                "agent {} already exists with an incompatible identity or lifecycle",
+                request.agent_id
+            );
+            let bootstrap = self.reconcile_agent_bootstrap(&request.agent_id).await?;
+            let bootstrap_summary = bootstrap.summary();
+            return Ok(AgentCreateResult {
+                receipt: AgentCreateReceipt {
+                    receipt_id: ids::runtime_id("agent_create"),
+                    agent_id: identity.agent_id.clone(),
+                    name: identity.name.clone(),
+                    display_name: identity.display_name(),
+                    preset: AgentProfilePreset::PublicNamed,
+                    stage: if bootstrap_summary.status == AgentBootstrapStatus::Ready {
+                        AgentCreateStage::Bootstrapped
+                    } else {
+                        AgentCreateStage::Degraded
+                    },
+                    lifecycle: identity.status,
+                    created: false,
+                    bootstrap: bootstrap_summary,
+                },
+                identity,
+            });
+        }
+
+        let parent_state = parent_runtime.agent_state().await?;
+        let catalog_agent_home = request
+            .inherit_parent_runtime
+            .then(|| self.agent_data_dir(&parent_state.id));
+        let workspace = request
+            .inherit_parent_runtime
+            .then(|| AgentBootstrapWorkspaceState {
+                attached_workspaces:
+                    crate::runtime::workspace::inherited_attached_workspaces_for_agent(
+                        &parent_state,
+                        &request.agent_id,
+                    ),
+                execution_profile: parent_state.execution_profile.clone(),
+                inherited_model_override: parent_state.model_override.clone(),
+                inherited_model_override_reasoning_effort: parent_state
+                    .model_override_reasoning_effort
+                    .clone(),
+            });
+        let initial_message = request
+            .initial_message
+            .map(|text| AgentBootstrapInitialMessage {
+                message_id: format!("agent_bootstrap_message:{}", request.agent_id),
+                text,
+                authority_class: request.authority_class,
+                creator_agent_id: parent_state.id,
+            });
+        let desired = AgentBootstrapDesiredState {
+            template: request.template,
+            catalog_agent_home,
+            workspace,
+            model_resolution: request.model_resolution,
+            initial_message,
+        };
+        self.create_public_named_agent_with_bootstrap(
+            &request.agent_id,
+            request.lineage_parent_agent_id.as_deref(),
+            request.name.as_deref(),
+            desired,
+        )
+        .await
+    }
+
     async fn ensure_named_agent(
         &self,
         agent_id: &str,
@@ -3778,7 +3856,7 @@ impl RuntimeHost {
             )
             .await?;
         }
-        let record = AgentIdentityRecord::new(
+        let mut record = AgentIdentityRecord::new(
             child_agent_id,
             AgentKind::Child,
             AgentVisibility::Private,
@@ -3788,6 +3866,7 @@ impl RuntimeHost {
             Some(task_id.to_string()),
         )
         .with_lineage_parent_agent_id(Some(parent_agent_id.to_string()));
+        record.durability = Some(AgentDurability::Ephemeral);
         self.append_agent_identity(&record)?;
         Ok(record)
     }
@@ -3912,6 +3991,10 @@ impl RuntimeHost {
         let Some(task) = parent_storage.latest_task_record(task_id)? else {
             return Ok(true);
         };
+
+        if task.kind == TaskKind::ActorInvocation {
+            return Ok(false);
+        }
 
         Ok(matches!(
             task.status,
@@ -4049,6 +4132,59 @@ impl RuntimeHost {
         })
     }
 
+    async fn invoke_existing_agent(
+        &self,
+        task: &TaskRecord,
+        target_agent_id: &str,
+        message_text: String,
+        authority_class: AuthorityClass,
+    ) -> Result<ChildTaskSpawn> {
+        let identity = self
+            .active_agent_identity(target_agent_id)
+            .map_err(anyhow::Error::from)?;
+        let runtime = self.get_or_create_agent(target_agent_id).await?;
+        let child_turn_baseline = runtime.agent_state().await?.turn_index;
+        let mut message = crate::types::MessageEnvelope::new(
+            target_agent_id.to_string(),
+            crate::types::MessageKind::InternalFollowup,
+            crate::types::MessageOrigin::Task {
+                task_id: task.id.clone(),
+            },
+            authority_class.clone(),
+            crate::types::Priority::Normal,
+            crate::types::MessageBody::Text { text: message_text },
+        )
+        .with_admission(
+            crate::types::MessageDeliverySurface::RuntimeSystem,
+            crate::types::AdmissionContext::RuntimeOwned,
+        );
+        message.metadata = Some(json!({
+            "invocation_task_id": task.id,
+            "target_agent_id": target_agent_id,
+            "delegated_authority_class": authority_class,
+        }));
+        runtime.enqueue(message).await?;
+
+        let mut task_detail = json!({
+            "target_agent_id": target_agent_id,
+            "target_agent_kind": identity.kind,
+            "target_agent_visibility": identity.visibility,
+            "target_agent_ownership": identity.ownership(),
+            "target_agent_profile_preset": identity.profile_preset(),
+            "child_turn_baseline": child_turn_baseline,
+            "created_new_subagent": false,
+        });
+        if identity.kind == AgentKind::Child {
+            task_detail["child_agent_id"] = json!(target_agent_id);
+        }
+        Ok(ChildTaskSpawn {
+            child_agent_id: target_agent_id.to_string(),
+            child_turn_baseline,
+            task_detail,
+        })
+    }
+
+    #[cfg(test)]
     async fn spawn_public_named_agent(
         &self,
         parent_runtime: RuntimeHandle,
@@ -4098,13 +4234,19 @@ impl RuntimeHost {
         child_agent_id: &str,
         child_turn_baseline: u64,
         worktree: bool,
+        cleanup_agent_on_terminal: bool,
     ) -> Result<ChildTaskTerminalResult> {
         let storage = self.agent_storage(child_agent_id)?;
+        let identity = self
+            .active_agent_identity(child_agent_id)
+            .map_err(anyhow::Error::from)?;
         if let Some(result) = self
-            .completed_child_terminal_from_storage(&storage, child_agent_id, child_turn_baseline)
+            .completed_child_terminal_from_storage(&storage, &identity, child_turn_baseline)
             .await?
         {
-            self.archive_private_agent(child_agent_id).await?;
+            if cleanup_agent_on_terminal {
+                self.archive_private_agent(child_agent_id).await?;
+            }
             return Ok(result);
         }
         let runtime = self.get_or_create_agent(child_agent_id).await?;
@@ -4187,18 +4329,25 @@ impl RuntimeHost {
             };
 
             let mut metadata = json!({
-                "child_agent_id": child_agent_id,
-                "child_kind": AgentKind::Child,
-                "child_visibility": AgentVisibility::Private,
-                "child_ownership": AgentOwnership::ParentSupervised,
-                "child_profile_preset": AgentProfilePreset::PrivateChild,
-                "child_observability": runtime.child_agent_observability().await?,
+                "target_agent_id": child_agent_id,
+                "target_agent_kind": identity.kind,
+                "target_agent_visibility": identity.visibility,
+                "target_agent_ownership": identity.ownership(),
+                "target_agent_profile_preset": identity.profile_preset(),
                 "token_usage": json!({
                     "total": crate::types::TokenUsage::new(state.total_input_tokens, state.total_output_tokens),
                     "last_turn": state.last_turn_token_usage.clone(),
                     "total_model_rounds": state.total_model_rounds,
                 }),
             });
+            if identity.kind == AgentKind::Child {
+                metadata["child_agent_id"] = json!(child_agent_id);
+                metadata["child_kind"] = json!(identity.kind);
+                metadata["child_visibility"] = json!(identity.visibility);
+                metadata["child_ownership"] = json!(identity.ownership());
+                metadata["child_profile_preset"] = json!(identity.profile_preset());
+                metadata["child_observability"] = json!(runtime.child_agent_observability().await?);
+            }
             if worktree {
                 if let Some(worktree) = state.worktree_session.as_ref() {
                     let changed_files =
@@ -4214,7 +4363,9 @@ impl RuntimeHost {
             }
             let task_detail = Some(metadata);
 
-            self.archive_private_agent(child_agent_id).await?;
+            if cleanup_agent_on_terminal {
+                self.archive_private_agent(child_agent_id).await?;
+            }
             return Ok(ChildTaskTerminalResult {
                 status,
                 text,
@@ -4226,7 +4377,7 @@ impl RuntimeHost {
     async fn completed_child_terminal_from_storage(
         &self,
         storage: &AppStorage,
-        child_agent_id: &str,
+        identity: &AgentIdentityRecord,
         child_turn_baseline: u64,
     ) -> Result<Option<ChildTaskTerminalResult>> {
         let Some(state) = storage.read_agent()? else {
@@ -4243,7 +4394,7 @@ impl RuntimeHost {
         };
         if state.current_run_id.is_some()
             || state.pending > 0
-            || child_has_active_lifecycle_blockers(storage, child_agent_id)?
+            || child_has_active_lifecycle_blockers(storage, &identity.agent_id)?
         {
             return Ok(None);
         }
@@ -4282,12 +4433,19 @@ impl RuntimeHost {
             text,
             task_detail: {
                 let mut detail = json!( {
-                    "child_agent_id": child_agent_id,
-                    "child_kind": AgentKind::Child,
-                    "child_visibility": AgentVisibility::Private,
-                    "child_ownership": AgentOwnership::ParentSupervised,
-                    "child_profile_preset": AgentProfilePreset::PrivateChild,
+                    "target_agent_id": identity.agent_id,
+                    "target_agent_kind": identity.kind,
+                    "target_agent_visibility": identity.visibility,
+                    "target_agent_ownership": identity.ownership(),
+                    "target_agent_profile_preset": identity.profile_preset(),
                 });
+                if identity.kind == AgentKind::Child {
+                    detail["child_agent_id"] = json!(identity.agent_id);
+                    detail["child_kind"] = json!(identity.kind);
+                    detail["child_visibility"] = json!(identity.visibility);
+                    detail["child_ownership"] = json!(identity.ownership());
+                    detail["child_profile_preset"] = json!(identity.profile_preset());
+                }
                 detail["token_usage"] = json!({
                     "total": crate::types::TokenUsage::new(state.total_input_tokens, state.total_output_tokens),
                     "last_turn": state.last_turn_token_usage.clone(),
@@ -4571,25 +4729,24 @@ impl RuntimeHostBridge {
             .await
     }
 
-    pub(crate) async fn spawn_public_named_agent(
+    pub(crate) async fn invoke_existing_agent(
+        &self,
+        task: &TaskRecord,
+        target_agent_id: &str,
+        message_text: String,
+        authority_class: AuthorityClass,
+    ) -> Result<ChildTaskSpawn> {
+        self.host()?
+            .invoke_existing_agent(task, target_agent_id, message_text, authority_class)
+            .await
+    }
+
+    pub(crate) async fn create_agent(
         &self,
         parent_runtime: RuntimeHandle,
-        agent_id: &str,
-        initial_message: Option<String>,
-        authority_class: AuthorityClass,
-        template: Option<String>,
-        model_resolution: SpawnAgentModelResolution,
+        request: CreateAgentRequest,
     ) -> Result<AgentCreateResult> {
-        self.host()?
-            .spawn_public_named_agent(
-                parent_runtime,
-                agent_id,
-                initial_message,
-                authority_class,
-                template,
-                model_resolution,
-            )
-            .await
+        self.host()?.create_agent(parent_runtime, request).await
     }
 
     pub(crate) async fn child_turn_index(&self, agent_id: &str) -> Result<u64> {
@@ -4623,9 +4780,15 @@ impl RuntimeHostBridge {
         child_agent_id: &str,
         child_turn_baseline: u64,
         worktree: bool,
+        cleanup_agent_on_terminal: bool,
     ) -> Result<ChildTaskTerminalResult> {
         self.host()?
-            .await_child_terminal_result(child_agent_id, child_turn_baseline, worktree)
+            .await_child_terminal_result(
+                child_agent_id,
+                child_turn_baseline,
+                worktree,
+                cleanup_agent_on_terminal,
+            )
             .await
     }
 
@@ -4798,10 +4961,12 @@ mod tests {
         types::{
             AgentDeletionPhase, AgentDeletionStatus, AgentKind, AgentOwnership, AgentProfilePreset,
             AgentRegistryStatus, AgentStatus, AgentVisibility, AuthorityClass, BriefKind,
-            BriefRecord, ControlAction, DeliverySummaryRecord, MessageBody, MessageEnvelope,
-            MessageKind, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus, TaskRecord,
+            BriefRecord, ChildAgentWorkspaceMode, ControlAction, DeliverySummaryRecord,
+            InvokeAgentRequest, InvokeAgentTarget, MessageBody, MessageEnvelope, MessageKind,
+            MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus, TaskRecord,
             TaskRecoverySpec, TaskStatus, TurnTerminalKind, WaitConditionKind, WaitConditionRecord,
             WaitConditionStatus, WakeSource, WorkItemRecord, WorkItemState,
+            ACTOR_INVOCATION_TASK_KIND,
         },
     };
 
@@ -5107,6 +5272,24 @@ mod tests {
             resolution_status: SpawnAgentModelResolutionStatus::Inherited,
             policy_notes: Vec::new(),
         }
+    }
+
+    async fn wait_for_terminal_task(runtime: &RuntimeHandle, task_id: &str) -> TaskRecord {
+        for _ in 0..100 {
+            let task = runtime
+                .storage()
+                .latest_task_record(task_id)
+                .unwrap()
+                .expect("task should remain persisted");
+            if matches!(
+                task.status,
+                TaskStatus::Completed | TaskStatus::Failed | TaskStatus::Cancelled
+            ) {
+                return task;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("timed out waiting for task {task_id} to become terminal");
     }
 
     struct BlockingProvider {
@@ -5814,6 +5997,230 @@ mod tests {
                 .is_empty(),
             "duplicate creation must not inject a follow-up message into the default agent"
         );
+    }
+
+    #[tokio::test]
+    async fn canonical_create_reuses_committed_agent_without_supervision_or_reconfiguration() {
+        let (_home, host) = test_host();
+        let parent = host.default_runtime().await.unwrap();
+        let parent_agent_id = parent.agent_summary().await.unwrap().identity.agent_id;
+
+        let created = parent
+            .agent_creation_service()
+            .create(CreateAgentRequest {
+                agent_id: "canonical-create".into(),
+                name: Some("Canonical Create".into()),
+                template: None,
+                initial_message: Some("initial work".into()),
+                authority_class: AuthorityClass::OperatorInstruction,
+                model_resolution: Some(inherited_model_resolution(
+                    "anthropic",
+                    "claude-sonnet-4-6",
+                )),
+                lineage_parent_agent_id: Some(parent_agent_id),
+                inherit_parent_runtime: true,
+            })
+            .await
+            .unwrap();
+        assert!(created.receipt.created);
+        assert!(
+            parent.storage().latest_task_records().unwrap().is_empty(),
+            "independent create must not create a supervision task"
+        );
+
+        let target = host.get_public_agent("canonical-create").await.unwrap();
+        let before = target.agent_summary().await.unwrap();
+        let before_bootstrap = host
+            .runtime_db()
+            .agent_bootstraps()
+            .latest("canonical-create")
+            .unwrap()
+            .unwrap();
+        let before_messages = target.storage().read_recent_messages(100).unwrap().len();
+
+        let duplicate = parent
+            .agent_creation_service()
+            .create(CreateAgentRequest {
+                agent_id: "canonical-create".into(),
+                name: Some("Ignored Rename".into()),
+                template: Some("ignored-template".into()),
+                initial_message: Some("must not be delivered".into()),
+                authority_class: AuthorityClass::ExternalEvidence,
+                model_resolution: Some(inherited_model_resolution("openai", "gpt-5.4")),
+                lineage_parent_agent_id: None,
+                inherit_parent_runtime: false,
+            })
+            .await
+            .unwrap();
+        assert!(!duplicate.receipt.created);
+
+        let after = target.agent_summary().await.unwrap();
+        let after_bootstrap = host
+            .runtime_db()
+            .agent_bootstraps()
+            .latest("canonical-create")
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.identity, before.identity);
+        assert_eq!(after.agent.model_override, before.agent.model_override);
+        assert_eq!(
+            after.agent.model_override_reasoning_effort,
+            before.agent.model_override_reasoning_effort
+        );
+        assert_eq!(
+            after.agent.attached_workspaces,
+            before.agent.attached_workspaces
+        );
+        assert_eq!(after_bootstrap.desired, before_bootstrap.desired);
+        assert_eq!(
+            target.storage().read_recent_messages(100).unwrap().len(),
+            before_messages,
+            "duplicate create must not deliver its initial message"
+        );
+        assert!(
+            parent.storage().latest_task_records().unwrap().is_empty(),
+            "duplicate create must not create an invocation task"
+        );
+    }
+
+    #[tokio::test]
+    async fn canonical_existing_invocation_preserves_target_configuration_and_relations() {
+        let (_home, host) = test_host();
+        let parent = host.default_runtime().await.unwrap();
+        parent
+            .agent_creation_service()
+            .create(CreateAgentRequest {
+                agent_id: "canonical-existing".into(),
+                name: None,
+                template: None,
+                initial_message: None,
+                authority_class: AuthorityClass::OperatorInstruction,
+                model_resolution: Some(inherited_model_resolution(
+                    "anthropic",
+                    "claude-sonnet-4-6",
+                )),
+                lineage_parent_agent_id: Some(
+                    parent.agent_summary().await.unwrap().identity.agent_id,
+                ),
+                inherit_parent_runtime: true,
+            })
+            .await
+            .unwrap();
+
+        let target = host.get_public_agent("canonical-existing").await.unwrap();
+        let before_summary = target.agent_summary().await.unwrap();
+        let before_relations = host
+            .operator_agent_detail("canonical-existing")
+            .unwrap()
+            .canonical_relations;
+        let receipt = parent
+            .agent_invocation_service()
+            .invoke(InvokeAgentRequest {
+                target: InvokeAgentTarget::ExistingAgent {
+                    agent_id: "canonical-existing".into(),
+                },
+                message: "continue existing work".into(),
+                authority_class: AuthorityClass::ExternalEvidence,
+            })
+            .await
+            .unwrap();
+
+        assert!(!receipt.created);
+        assert_eq!(receipt.agent_id, "canonical-existing");
+        assert_eq!(receipt.task_handle.task_kind, ACTOR_INVOCATION_TASK_KIND);
+        let task = parent
+            .storage()
+            .latest_task_record(&receipt.task_handle.task_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.kind, TaskKind::ActorInvocation);
+
+        let after_summary = target.agent_summary().await.unwrap();
+        let after_relations = host
+            .operator_agent_detail("canonical-existing")
+            .unwrap()
+            .canonical_relations;
+        assert_eq!(after_summary.identity, before_summary.identity);
+        assert_eq!(
+            after_summary.agent.model_override,
+            before_summary.agent.model_override
+        );
+        assert_eq!(
+            after_summary.agent.model_override_reasoning_effort,
+            before_summary.agent.model_override_reasoning_effort
+        );
+        assert_eq!(
+            after_summary.agent.attached_workspaces,
+            before_summary.agent.attached_workspaces
+        );
+        assert_eq!(
+            after_summary.agent.worktree_session,
+            before_summary.agent.worktree_session
+        );
+        assert_eq!(after_relations, before_relations);
+
+        let terminal = wait_for_terminal_task(&parent, &receipt.task_handle.task_id).await;
+        assert_eq!(terminal.status, TaskStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn canonical_new_subagent_remains_reusable_after_invocation_and_restart() {
+        let (_home, host) = test_host();
+        let config = host.config().as_ref().clone();
+        let parent = host.default_runtime().await.unwrap();
+
+        let created = parent
+            .agent_invocation_service()
+            .invoke(InvokeAgentRequest {
+                target: InvokeAgentTarget::NewSubagent {
+                    template: None,
+                    workspace_mode: ChildAgentWorkspaceMode::Inherit,
+                    model_resolution: Some(inherited_model_resolution("openai", "gpt-5.4")),
+                },
+                message: "first invocation".into(),
+                authority_class: AuthorityClass::OperatorInstruction,
+            })
+            .await
+            .unwrap();
+        assert!(created.created);
+        assert_eq!(created.task_handle.task_kind, ACTOR_INVOCATION_TASK_KIND);
+        let first_terminal = wait_for_terminal_task(&parent, &created.task_handle.task_id).await;
+        assert_eq!(first_terminal.status, TaskStatus::Completed);
+
+        let child_identity = host
+            .agent_identity_record(&created.agent_id)
+            .unwrap()
+            .expect("new subagent identity should remain recorded");
+        assert_eq!(child_identity.status, AgentRegistryStatus::Active);
+        assert_eq!(child_identity.durability, Some(AgentDurability::Ephemeral));
+        assert!(host.agent_data_dir(&created.agent_id).exists());
+
+        let reused = parent
+            .agent_invocation_service()
+            .invoke(InvokeAgentRequest {
+                target: InvokeAgentTarget::ExistingAgent {
+                    agent_id: created.agent_id.clone(),
+                },
+                message: "second invocation".into(),
+                authority_class: AuthorityClass::OperatorInstruction,
+            })
+            .await
+            .unwrap();
+        assert!(!reused.created);
+        assert_eq!(reused.agent_id, created.agent_id);
+        let second_terminal = wait_for_terminal_task(&parent, &reused.task_handle.task_id).await;
+        assert_eq!(second_terminal.status, TaskStatus::Completed);
+
+        host.shutdown().await.unwrap();
+        drop(host);
+        let restarted =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
+        let restarted_identity = restarted
+            .agent_identity_record(&created.agent_id)
+            .unwrap()
+            .expect("terminal invocation must not delete its target during restart convergence");
+        assert_eq!(restarted_identity.status, AgentRegistryStatus::Active);
+        assert!(restarted.agent_data_dir(&created.agent_id).exists());
     }
 
     #[tokio::test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,3 +1,4 @@
+mod agent_services;
 mod bootstrap;
 mod callback;
 mod clock;

--- a/src/runtime/agent_services.rs
+++ b/src/runtime/agent_services.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 
 use super::RuntimeHandle;
+use crate::runtime_error::{collect_runtime_error_source_chain, RuntimeError, RuntimeErrorDomain};
 use crate::types::{
     AgentCreateResult, AgentInvocationReceipt, ChildAgentWorkspaceMode, CreateAgentRequest,
     InvokeAgentRequest, InvokeAgentTarget, SpawnAgentModelResolution, TaskHandle, TaskRecord,
@@ -42,8 +43,8 @@ impl AgentInvocationService<'_> {
         &self,
         request: InvokeAgentRequest,
     ) -> Result<AgentInvocationReceipt> {
-        let message = request.message.trim().to_string();
-        if message.is_empty() {
+        let message = request.message;
+        if message.trim().is_empty() {
             return Err(anyhow!("agent invocation requires a non-empty message"));
         }
         let bridge = self
@@ -52,14 +53,25 @@ impl AgentInvocationService<'_> {
             .host_bridge
             .clone()
             .ok_or_else(|| anyhow!("agent invocation requires a host bridge"))?;
-        let (target_agent_id, created_new_subagent, workspace_mode) = match &request.target {
-            InvokeAgentTarget::ExistingAgent { agent_id } => (
-                Some(agent_id.clone()),
-                false,
-                ChildAgentWorkspaceMode::Inherit,
-            ),
-            InvokeAgentTarget::NewSubagent { workspace_mode, .. } => (None, true, *workspace_mode),
-        };
+        let (target_agent_id, created_new_subagent, workspace_mode, model_resolution) =
+            match &request.target {
+                InvokeAgentTarget::ExistingAgent { agent_id } => (
+                    Some(agent_id.clone()),
+                    false,
+                    ChildAgentWorkspaceMode::Inherit,
+                    None,
+                ),
+                InvokeAgentTarget::NewSubagent {
+                    workspace_mode,
+                    model_resolution,
+                    ..
+                } => (
+                    None,
+                    true,
+                    *workspace_mode,
+                    Some(required_model_resolution(model_resolution.clone())?),
+                ),
+            };
         let summary = super::tasks::spawn_agent_task_label(&message);
         let task = self
             .runtime
@@ -87,7 +99,7 @@ impl AgentInvocationService<'_> {
             InvokeAgentTarget::NewSubagent {
                 template,
                 workspace_mode,
-                model_resolution,
+                ..
             } => {
                 bridge
                     .spawn_child_task(
@@ -97,7 +109,9 @@ impl AgentInvocationService<'_> {
                         request.authority_class.clone(),
                         workspace_mode.is_worktree(),
                         template,
-                        required_model_resolution(model_resolution)?,
+                        model_resolution.expect(
+                            "new subagent model resolution was validated before task creation",
+                        ),
                     )
                     .await
             }
@@ -108,7 +122,21 @@ impl AgentInvocationService<'_> {
                 self.runtime
                     .fail_agent_invocation_task(&task, &error)
                     .await?;
-                return Err(error);
+                let direct_cause = collect_runtime_error_source_chain(&error)
+                    .last()
+                    .cloned()
+                    .unwrap_or_else(|| "agent invocation admission failed".to_string());
+                return Err(error.context(
+                    RuntimeError::new(
+                        RuntimeErrorDomain::Task,
+                        "agent_invocation_failed",
+                        format!("failed to invoke agent: {direct_cause}"),
+                    )
+                    .with_safe_context("task_id", &task.id)
+                    .with_recovery_hint(
+                        "correct the target agent, template, model, or workspace configuration and retry",
+                    ),
+                ));
             }
         };
         admitted.task_detail["created_new_subagent"] = serde_json::json!(created_new_subagent);

--- a/src/runtime/agent_services.rs
+++ b/src/runtime/agent_services.rs
@@ -1,0 +1,149 @@
+use anyhow::{anyhow, Result};
+
+use super::RuntimeHandle;
+use crate::types::{
+    AgentCreateResult, AgentInvocationReceipt, ChildAgentWorkspaceMode, CreateAgentRequest,
+    InvokeAgentRequest, InvokeAgentTarget, SpawnAgentModelResolution, TaskHandle, TaskRecord,
+    TaskStatus,
+};
+
+pub(crate) struct AgentCreationService<'a> {
+    runtime: &'a RuntimeHandle,
+}
+
+pub(crate) struct AgentInvocationService<'a> {
+    runtime: &'a RuntimeHandle,
+}
+
+impl RuntimeHandle {
+    pub(crate) fn agent_creation_service(&self) -> AgentCreationService<'_> {
+        AgentCreationService { runtime: self }
+    }
+
+    pub(crate) fn agent_invocation_service(&self) -> AgentInvocationService<'_> {
+        AgentInvocationService { runtime: self }
+    }
+}
+
+impl AgentCreationService<'_> {
+    pub(crate) async fn create(&self, request: CreateAgentRequest) -> Result<AgentCreateResult> {
+        let bridge = self
+            .runtime
+            .inner
+            .host_bridge
+            .clone()
+            .ok_or_else(|| anyhow!("agent creation requires a host bridge"))?;
+        bridge.create_agent(self.runtime.clone(), request).await
+    }
+}
+
+impl AgentInvocationService<'_> {
+    pub(crate) async fn invoke(
+        &self,
+        request: InvokeAgentRequest,
+    ) -> Result<AgentInvocationReceipt> {
+        let message = request.message.trim().to_string();
+        if message.is_empty() {
+            return Err(anyhow!("agent invocation requires a non-empty message"));
+        }
+        let bridge = self
+            .runtime
+            .inner
+            .host_bridge
+            .clone()
+            .ok_or_else(|| anyhow!("agent invocation requires a host bridge"))?;
+        let (target_agent_id, created_new_subagent, workspace_mode) = match &request.target {
+            InvokeAgentTarget::ExistingAgent { agent_id } => (
+                Some(agent_id.clone()),
+                false,
+                ChildAgentWorkspaceMode::Inherit,
+            ),
+            InvokeAgentTarget::NewSubagent { workspace_mode, .. } => (None, true, *workspace_mode),
+        };
+        let summary = super::tasks::spawn_agent_task_label(&message);
+        let task = self
+            .runtime
+            .create_agent_invocation_task(
+                summary,
+                message.clone(),
+                request.authority_class.clone(),
+                target_agent_id,
+                created_new_subagent,
+                workspace_mode,
+            )
+            .await?;
+
+        let admitted = match request.target {
+            InvokeAgentTarget::ExistingAgent { agent_id } => {
+                bridge
+                    .invoke_existing_agent(
+                        &task,
+                        &agent_id,
+                        message,
+                        request.authority_class.clone(),
+                    )
+                    .await
+            }
+            InvokeAgentTarget::NewSubagent {
+                template,
+                workspace_mode,
+                model_resolution,
+            } => {
+                bridge
+                    .spawn_child_task(
+                        self.runtime.clone(),
+                        &task,
+                        message,
+                        request.authority_class.clone(),
+                        workspace_mode.is_worktree(),
+                        template,
+                        required_model_resolution(model_resolution)?,
+                    )
+                    .await
+            }
+        };
+        let mut admitted = match admitted {
+            Ok(admitted) => admitted,
+            Err(error) => {
+                self.runtime
+                    .fail_agent_invocation_task(&task, &error)
+                    .await?;
+                return Err(error);
+            }
+        };
+        admitted.task_detail["created_new_subagent"] = serde_json::json!(created_new_subagent);
+        let queued_task = self
+            .runtime
+            .start_agent_invocation_monitor(
+                task,
+                request.authority_class,
+                workspace_mode.is_worktree(),
+                admitted.child_agent_id.clone(),
+                admitted.child_turn_baseline,
+                admitted.task_detail,
+            )
+            .await?;
+        Ok(AgentInvocationReceipt {
+            agent_id: admitted.child_agent_id,
+            created: created_new_subagent,
+            task_handle: TaskHandle::from_task_record(&queued_task, None),
+        })
+    }
+}
+
+pub(super) fn required_model_resolution(
+    resolution: Option<SpawnAgentModelResolution>,
+) -> Result<SpawnAgentModelResolution> {
+    resolution.ok_or_else(|| anyhow!("new subagent invocation requires model resolution"))
+}
+
+pub(super) fn failed_invocation_task(task: &TaskRecord, error: &anyhow::Error) -> TaskRecord {
+    let mut detail = task.detail.clone().unwrap_or_else(|| serde_json::json!({}));
+    detail["error"] = serde_json::json!(error.to_string());
+    TaskRecord {
+        status: TaskStatus::Failed,
+        updated_at: chrono::Utc::now(),
+        detail: Some(detail),
+        ..task.clone()
+    }
+}

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -3,7 +3,8 @@ use super::waiting::WorkItemBlockerClearance;
 use super::{task_state_reducer, *};
 use crate::config::{ModelRef, ProviderId};
 use crate::runtime_error::{
-    sanitize_runtime_error_text, RuntimeError, RuntimeErrorContext, RuntimeErrorDomain,
+    describe_runtime_error, sanitize_runtime_error_text, RuntimeError, RuntimeErrorContext,
+    RuntimeErrorDomain,
 };
 use crate::tool::helpers::truncate_output_to_char_budget;
 use crate::tool::ToolError;
@@ -661,7 +662,7 @@ impl RuntimeHandle {
                         "private_child spawn requires non-empty initial_message"
                     ));
                 }
-                let receipt = self
+                let receipt = match self
                     .agent_invocation_service()
                     .invoke(InvokeAgentRequest {
                         target: InvokeAgentTarget::NewSubagent {
@@ -676,7 +677,40 @@ impl RuntimeHandle {
                         message: initial_message,
                         authority_class,
                     })
-                    .await?;
+                    .await
+                {
+                    Ok(receipt) => receipt,
+                    Err(error) => {
+                        let descriptor = describe_runtime_error(&error);
+                        let Some(task_id) = descriptor.safe_context.get("task_id") else {
+                            return Err(error);
+                        };
+                        if descriptor.code != "agent_invocation_failed" {
+                            return Err(error);
+                        }
+                        let direct_cause = descriptor
+                            .source_chain
+                            .last()
+                            .cloned()
+                            .unwrap_or_else(|| descriptor.operator_message.clone());
+                        return Err(anyhow::Error::from(
+                            ToolError::new(
+                                "spawn_agent_failed",
+                                format!("failed to spawn child agent: {direct_cause}"),
+                            )
+                            .with_domain(RuntimeErrorDomain::Task)
+                            .with_details(serde_json::json!({
+                                "task_id": task_id,
+                                "preset": AgentProfilePreset::PrivateChild,
+                                "workspace_mode": if worktree { "worktree" } else { "inherit" },
+                            }))
+                            .with_recovery_hint(
+                                "correct the child template, model, or workspace configuration and retry SpawnAgent",
+                            )
+                            .with_source_chain(descriptor.source_chain),
+                        ));
+                    }
+                };
                 let task = self
                     .task_record(&receipt.task_handle.task_id)
                     .await?

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -3,21 +3,21 @@ use super::waiting::WorkItemBlockerClearance;
 use super::{task_state_reducer, *};
 use crate::config::{ModelRef, ProviderId};
 use crate::runtime_error::{
-    collect_runtime_error_source_chain, sanitize_runtime_error_text, RuntimeError,
-    RuntimeErrorContext, RuntimeErrorDomain,
+    sanitize_runtime_error_text, RuntimeError, RuntimeErrorContext, RuntimeErrorDomain,
 };
 use crate::tool::helpers::truncate_output_to_char_budget;
 use crate::tool::ToolError;
 use crate::types::{
     brief_created_event_for, AgentProfilePreset, BriefKind, BriefRecord, ChildAgentWorkspaceMode,
-    CommandTaskStatusSnapshot, CompletionReportRequirement, CompletionReportState, FailureArtifact,
-    FailureArtifactCategory, SpawnAgentModelRequest, SpawnAgentModelResolution,
-    SpawnAgentModelResolutionStatus, SpawnAgentResult, TaskHandle, TaskInputResult, TaskKind,
-    TaskListEntry, TaskOutputResult, TaskOutputRetrievalStatus, TaskOutputSnapshot,
-    TaskStatusSnapshot, TodoItem, ToolArtifactRef, WaitConditionRecord, WaitConditionStatus,
-    WorkItemCompletionIntent, WorkItemContinuationFrame, WorkItemContinuationReturnPolicy,
-    WorkItemContinuationState, WorkItemDelegationRecord, WorkItemDelegationState,
-    WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState, CHILD_AGENT_TASK_KIND,
+    CommandTaskStatusSnapshot, CompletionReportRequirement, CompletionReportState,
+    CreateAgentRequest, FailureArtifact, FailureArtifactCategory, InvokeAgentRequest,
+    InvokeAgentTarget, SpawnAgentModelRequest, SpawnAgentModelResolution,
+    SpawnAgentModelResolutionStatus, SpawnAgentResult, TaskInputResult, TaskKind, TaskListEntry,
+    TaskOutputResult, TaskOutputRetrievalStatus, TaskOutputSnapshot, TaskStatusSnapshot, TodoItem,
+    ToolArtifactRef, WaitConditionRecord, WaitConditionStatus, WorkItemCompletionIntent,
+    WorkItemContinuationFrame, WorkItemContinuationReturnPolicy, WorkItemContinuationState,
+    WorkItemDelegationRecord, WorkItemDelegationState, WorkItemPlanStatus, WorkItemReadiness,
+    WorkItemRecord, WorkItemState, CHILD_AGENT_TASK_KIND,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -122,7 +122,7 @@ pub(super) fn task_rejoin_fence(
     task.rejoin_fence().map_err(anyhow::Error::msg)
 }
 
-fn spawn_agent_task_label(initial_message: &str) -> String {
+pub(super) fn spawn_agent_task_label(initial_message: &str) -> String {
     let collapsed = initial_message
         .split_whitespace()
         .collect::<Vec<_>>()
@@ -318,6 +318,114 @@ impl RuntimeHandle {
             .current_turn_work_item_id
             .clone()
             .or_else(|| guard.state.current_work_item_id.clone())
+    }
+
+    pub(super) async fn create_agent_invocation_task(
+        &self,
+        summary: String,
+        prompt: String,
+        authority_class: AuthorityClass,
+        target_agent_id: Option<String>,
+        created_new_subagent: bool,
+        workspace_mode: ChildAgentWorkspaceMode,
+    ) -> Result<TaskRecord> {
+        self.ensure_background_tasks_allowed(crate::types::ACTOR_INVOCATION_TASK_KIND)
+            .await?;
+        let agent_id = self.agent_id().await?;
+        let work_item_id = self.task_work_item_binding().await;
+        let recovery = TaskRecoverySpec::AgentInvocation {
+            summary: summary.clone(),
+            prompt,
+            authority_class,
+            target_agent_id,
+            created_new_subagent,
+            workspace_mode,
+        };
+        let task_id = crate::ids::task_id();
+        let detail = self
+            .task_creation_detail(
+                &task_id,
+                serde_json::json!({
+                    "wait_policy": crate::types::TaskWaitPolicy::Background,
+                    "workspace_mode": workspace_mode,
+                    "created_new_subagent": created_new_subagent,
+                }),
+            )
+            .await?;
+        let task = TaskRecord {
+            id: task_id,
+            agent_id,
+            kind: TaskKind::ActorInvocation,
+            status: TaskStatus::Queued,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            work_item_id,
+            summary: Some(summary),
+            detail: Some(detail),
+            recovery: Some(recovery),
+        };
+        self.apply_task_transition(task_state_reducer::TaskTransition::new(
+            &task,
+            "task_created",
+        ))
+        .await?;
+        Ok(task)
+    }
+
+    pub(super) async fn start_agent_invocation_monitor(
+        &self,
+        task: TaskRecord,
+        authority_class: AuthorityClass,
+        worktree: bool,
+        child_agent_id: String,
+        child_turn_baseline: u64,
+        task_detail: serde_json::Value,
+    ) -> Result<TaskRecord> {
+        let queued_task = TaskRecord {
+            updated_at: Utc::now(),
+            detail: Some(self.task_detail_preserving_rejoin_contract(&task, task_detail.clone())),
+            ..task
+        };
+        self.apply_task_transition(task_state_reducer::TaskTransition::new(
+            &queued_task,
+            "task_agent_invocation_admitted",
+        ))
+        .await?;
+
+        let runtime = self.clone();
+        let task_record = queued_task.clone();
+        let task_id = queued_task.id.clone();
+        let handle = tokio::spawn(async move {
+            let _ = runtime
+                .monitor_spawned_child_agent_task(
+                    task_record,
+                    authority_class,
+                    worktree,
+                    false,
+                    false,
+                    child_agent_id,
+                    child_turn_baseline,
+                    task_detail,
+                )
+                .await;
+            runtime.inner.task_handles.lock().await.remove(&task_id);
+        });
+        self.inner.task_handles.lock().await.insert(
+            queued_task.id.clone(),
+            command_task::ManagedTaskHandle::Async(handle),
+        );
+        Ok(queued_task)
+    }
+
+    pub(super) async fn fail_agent_invocation_task(
+        &self,
+        task: &TaskRecord,
+        error: &anyhow::Error,
+    ) -> Result<()> {
+        let failed = super::agent_services::failed_invocation_task(task, error);
+        self.persist_task_status_direct(&failed, "task_agent_invocation_failed")
+            .await
     }
 
     pub(crate) fn supports_child_agent_spawning(&self) -> bool {
@@ -544,12 +652,6 @@ impl RuntimeHandle {
         let model_resolution = self
             .resolve_spawn_agent_model_request(model_request)
             .await?;
-        let bridge = self
-            .inner
-            .host_bridge
-            .clone()
-            .expect("spawn agent support should imply host bridge");
-
         match preset {
             AgentProfilePreset::PrivateChild => {
                 let initial_message = initial_message
@@ -559,117 +661,41 @@ impl RuntimeHandle {
                         "private_child spawn requires non-empty initial_message"
                     ));
                 }
-                let task_label = spawn_agent_task_label(&initial_message);
-                let task = self
-                    .create_child_supervision_task(
-                        task_label,
-                        initial_message.clone(),
-                        authority_class.clone(),
-                        worktree,
-                    )
+                let receipt = self
+                    .agent_invocation_service()
+                    .invoke(InvokeAgentRequest {
+                        target: InvokeAgentTarget::NewSubagent {
+                            template,
+                            workspace_mode: if worktree {
+                                ChildAgentWorkspaceMode::Worktree
+                            } else {
+                                ChildAgentWorkspaceMode::Inherit
+                            },
+                            model_resolution: Some(model_resolution.clone()),
+                        },
+                        message: initial_message,
+                        authority_class,
+                    })
                     .await?;
-
-                let spawned = match bridge
-                    .spawn_child_task(
-                        self.clone(),
-                        &task,
-                        initial_message,
-                        authority_class.clone(),
-                        worktree,
-                        template.clone(),
-                        model_resolution.clone(),
-                    )
-                    .await
-                {
-                    Ok(spawned) => spawned,
-                    Err(err) => {
-                        let source_chain = collect_runtime_error_source_chain(&err);
-                        let direct_cause = source_chain
-                            .last()
-                            .cloned()
-                            .unwrap_or_else(|| "child agent initialization failed".to_string());
-                        let mut detail =
-                            task.detail.clone().unwrap_or_else(|| serde_json::json!({}));
-                        detail["error"] = serde_json::json!(direct_cause);
-                        let failed_task = TaskRecord {
-                            status: TaskStatus::Failed,
-                            updated_at: Utc::now(),
-                            detail: Some(detail),
-                            ..task.clone()
-                        };
-                        self.persist_task_status_direct(&failed_task, "task_spawn_failed")
-                            .await?;
-                        return Err(anyhow::Error::from(
-                            ToolError::new(
-                                "spawn_agent_failed",
-                                format!("failed to spawn child agent: {direct_cause}"),
-                            )
-                            .with_domain(RuntimeErrorDomain::Task)
-                            .with_details(serde_json::json!({
-                                "task_id": task.id,
-                                "preset": AgentProfilePreset::PrivateChild,
-                                "workspace_mode": if worktree { "worktree" } else { "inherit" },
-                            }))
-                            .with_recovery_hint(
-                                "correct the child template, model, or workspace configuration and retry SpawnAgent",
-                            )
-                            .with_source_chain(source_chain),
-                        ));
-                    }
-                };
-
-                let queued_task = TaskRecord {
-                    updated_at: Utc::now(),
-                    detail: Some(self.task_detail_preserving_rejoin_contract(
-                        &task,
-                        spawned.task_detail.clone(),
-                    )),
-                    ..task.clone()
-                };
-                self.apply_task_transition(task_state_reducer::TaskTransition::new(
-                    &queued_task,
-                    "task_child_spawned",
-                ))
-                .await?;
-
-                let runtime = self.clone();
-                let task_record = queued_task.clone();
-                let task_id = queued_task.id.clone();
-                let child_agent_id = spawned.child_agent_id.clone();
-                let child_turn_baseline = spawned.child_turn_baseline;
-                let task_detail = spawned.task_detail.clone();
-                let handle = tokio::spawn(async move {
-                    let _ = runtime
-                        .monitor_spawned_child_agent_task(
-                            task_record.clone(),
-                            authority_class,
-                            worktree,
-                            false,
-                            child_agent_id,
-                            child_turn_baseline,
-                            task_detail,
-                        )
-                        .await;
-                    runtime.inner.task_handles.lock().await.remove(&task_id);
-                });
-                self.inner.task_handles.lock().await.insert(
-                    queued_task.id.clone(),
-                    command_task::ManagedTaskHandle::Async(handle),
-                );
-
+                let task = self
+                    .task_record(&receipt.task_handle.task_id)
+                    .await?
+                    .ok_or_else(|| anyhow!("invocation task disappeared after admission"))?;
                 let child_supervision =
-                    crate::types::ChildSupervisionProjection::from_task_record(&queued_task);
+                    crate::types::ChildSupervisionProjection::from_task_record(&task);
+                let mut task_handle = receipt.task_handle.clone();
+                task_handle.task_kind = CHILD_AGENT_TASK_KIND.to_string();
 
                 Ok(SpawnAgentResult {
-                    agent_id: spawned.child_agent_id.clone(),
+                    agent_id: receipt.agent_id.clone(),
                     create_receipt: None,
-                    child_agent_id: Some(spawned.child_agent_id.clone()),
-                    task_handle: Some(TaskHandle::from_task_record(&queued_task, None)),
-                    supervision_task_id: Some(queued_task.id.clone()),
+                    child_agent_id: Some(receipt.agent_id.clone()),
+                    task_handle: Some(task_handle),
+                    supervision_task_id: Some(receipt.task_handle.task_id.clone()),
                     child_supervision,
                     summary_text: Some(format!(
                         "delegated child {} started under supervision task {}",
-                        spawned.child_agent_id, queued_task.id
+                        receipt.agent_id, receipt.task_handle.task_id
                     )),
                     delegation_id: None,
                     parent_work_item_id: None,
@@ -686,16 +712,36 @@ impl RuntimeHandle {
                     ));
                 }
 
-                let spawned_agent_id = bridge
-                    .spawn_public_named_agent(
-                        self.clone(),
-                        &agent_id,
+                let parent_agent_id = self.agent_id().await?;
+                let spawned_agent_id = self
+                    .agent_creation_service()
+                    .create(CreateAgentRequest {
+                        agent_id: agent_id.clone(),
+                        name: None,
+                        template,
                         initial_message,
                         authority_class,
-                        template,
-                        model_resolution.clone(),
-                    )
+                        model_resolution: Some(model_resolution.clone()),
+                        lineage_parent_agent_id: Some(parent_agent_id),
+                        inherit_parent_runtime: true,
+                    })
                     .await?;
+                if !spawned_agent_id.receipt.created {
+                    return Err(anyhow::Error::from(
+                        ToolError::new(
+                            "already_exists",
+                            format!("public named agent {agent_id} already exists"),
+                        )
+                        .with_domain(RuntimeErrorDomain::Conflict)
+                        .with_details(serde_json::json!({
+                            "agent_id": agent_id,
+                            "preset": AgentProfilePreset::PublicNamed,
+                        }))
+                        .with_recovery_hint(
+                            "use an explicit agent invocation or enqueue operation to deliver work to an existing agent",
+                        ),
+                    ));
+                }
 
                 Ok(SpawnAgentResult {
                     agent_id: spawned_agent_id.identity.agent_id.clone(),
@@ -1170,6 +1216,7 @@ impl RuntimeHandle {
                     authority_class,
                     worktree,
                     recovered,
+                    true,
                     child_agent_id,
                     child_turn_baseline,
                     task_detail,
@@ -1190,82 +1237,13 @@ impl RuntimeHandle {
         Ok(())
     }
 
-    async fn create_child_supervision_task(
-        &self,
-        summary: String,
-        prompt: String,
-        authority_class: AuthorityClass,
-        worktree: bool,
-    ) -> Result<TaskRecord> {
-        let workspace_mode = if worktree {
-            ChildAgentWorkspaceMode::Worktree
-        } else {
-            ChildAgentWorkspaceMode::Inherit
-        };
-        self.ensure_background_tasks_allowed(CHILD_AGENT_TASK_KIND)
-            .await?;
-        if worktree {
-            let state = self.agent_state().await?;
-            crate::system::ensure_workspace_projection_allowed(
-                &crate::system::HostLocalBoundary::from_parts(
-                    &state.execution_profile,
-                    state
-                        .active_workspace_entry
-                        .as_ref()
-                        .map(|entry| entry.projection_kind),
-                    state
-                        .active_workspace_entry
-                        .as_ref()
-                        .map(|entry| entry.access_mode),
-                    state
-                        .active_workspace_entry
-                        .as_ref()
-                        .map(|entry| entry.execution_root_id.clone()),
-                ),
-                WorkspaceProjectionKind::GitWorktreeRoot,
-                CHILD_AGENT_TASK_KIND,
-            )?;
-        }
-
-        let agent_id = self.agent_id().await?;
-        let work_item_id = self.task_work_item_binding().await;
-        let recovery = TaskRecoverySpec::ChildAgentTask {
-            summary: summary.clone(),
-            prompt,
-            authority_class: authority_class.clone(),
-            workspace_mode,
-        };
-        let task_id = crate::ids::task_id();
-        let detail = self
-            .task_creation_detail(&task_id, child_agent_task_detail(workspace_mode))
-            .await?;
-        let task = TaskRecord {
-            id: task_id,
-            agent_id,
-            kind: TaskKind::ChildAgentTask,
-            status: TaskStatus::Queued,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            parent_message_id: None,
-            work_item_id,
-            summary: Some(summary),
-            detail: Some(detail),
-            recovery: Some(recovery),
-        };
-        self.apply_task_transition(task_state_reducer::TaskTransition::new(
-            &task,
-            "task_created",
-        ))
-        .await?;
-        Ok(task)
-    }
-
-    async fn monitor_spawned_child_agent_task(
+    pub(super) async fn monitor_spawned_child_agent_task(
         &self,
         task_record: TaskRecord,
         authority_class: AuthorityClass,
         worktree: bool,
         recovered: bool,
+        cleanup_agent_on_terminal: bool,
         child_agent_id: String,
         child_turn_baseline: u64,
         task_detail: serde_json::Value,
@@ -1326,14 +1304,27 @@ impl RuntimeHandle {
 
         let task_detail_for_result = task_detail.clone();
         let result = bridge
-            .await_child_terminal_result(&child_agent_id, child_turn_baseline, worktree)
+            .await_child_terminal_result(
+                &child_agent_id,
+                child_turn_baseline,
+                worktree,
+                cleanup_agent_on_terminal,
+            )
             .await;
         let (mut text, status, mut task_detail) = match result {
-            Ok(result) => (
-                result.text,
-                result.status,
-                result.task_detail.unwrap_or(task_detail_for_result.clone()),
-            ),
+            Ok(result) => {
+                let mut detail = task_detail_for_result.clone();
+                if let Some(result_detail) = result.task_detail {
+                    if let (Some(detail), Some(result_detail)) =
+                        (detail.as_object_mut(), result_detail.as_object())
+                    {
+                        detail.extend(result_detail.clone());
+                    } else {
+                        detail = result_detail;
+                    }
+                }
+                (result.text, result.status, detail)
+            }
             Err(err) => (
                 format!("child agent failed: {err:#}"),
                 TaskStatus::Failed,
@@ -1490,55 +1481,96 @@ impl RuntimeHandle {
         let mut remaining = Vec::new();
 
         for task in tasks {
-            let (prompt, authority_class, worktree) = match task.recovery.as_ref() {
-                Some(TaskRecoverySpec::ChildAgentTask {
-                    prompt,
-                    authority_class,
-                    workspace_mode,
-                    ..
-                }) => (
-                    prompt.clone(),
-                    authority_class.clone(),
-                    workspace_mode.is_worktree(),
-                ),
-                Some(TaskRecoverySpec::SubagentTask {
-                    prompt,
-                    authority_class,
-                    ..
-                }) => (prompt.clone(), authority_class.clone(), false),
-                Some(TaskRecoverySpec::WorktreeSubagentTask {
-                    prompt,
-                    authority_class,
-                    ..
-                }) => (prompt.clone(), authority_class.clone(), true),
-                _ => {
-                    remaining.push(task);
-                    continue;
-                }
-            };
+            let (prompt, authority_class, worktree, invocation_target) =
+                match task.recovery.as_ref() {
+                    Some(TaskRecoverySpec::AgentInvocation {
+                        prompt,
+                        authority_class,
+                        target_agent_id,
+                        workspace_mode,
+                        ..
+                    }) => {
+                        let target_agent_id = target_agent_id
+                            .clone()
+                            .or_else(|| detail_string(&task.detail, "target_agent_id"))
+                            .or_else(|| detail_string(&task.detail, "child_agent_id"));
+                        (
+                            prompt.clone(),
+                            authority_class.clone(),
+                            workspace_mode.is_worktree(),
+                            target_agent_id,
+                        )
+                    }
+                    Some(TaskRecoverySpec::ChildAgentTask {
+                        prompt,
+                        authority_class,
+                        workspace_mode,
+                        ..
+                    }) => (
+                        prompt.clone(),
+                        authority_class.clone(),
+                        workspace_mode.is_worktree(),
+                        None,
+                    ),
+                    Some(TaskRecoverySpec::SubagentTask {
+                        prompt,
+                        authority_class,
+                        ..
+                    }) => (prompt.clone(), authority_class.clone(), false, None),
+                    Some(TaskRecoverySpec::WorktreeSubagentTask {
+                        prompt,
+                        authority_class,
+                        ..
+                    }) => (prompt.clone(), authority_class.clone(), true, None),
+                    _ => {
+                        remaining.push(task);
+                        continue;
+                    }
+                };
 
-            let child_agent_id = detail_string(&task.detail, "child_agent_id");
-            let Some(child_agent_id) = child_agent_id else {
+            let target_agent_id = invocation_target
+                .clone()
+                .or_else(|| detail_string(&task.detail, "child_agent_id"));
+            let Some(target_agent_id) = target_agent_id else {
                 remaining.push(task);
                 continue;
             };
 
-            if !bridge.reusable_agent_exists(&child_agent_id).await? {
+            if !bridge.reusable_agent_exists(&target_agent_id).await? {
                 remaining.push(task);
                 continue;
             }
 
-            match self
-                .spawn_child_agent_task(task.clone(), prompt, authority_class, worktree, true)
+            let recovery_result = if invocation_target.is_some() {
+                let child_turn_baseline = task
+                    .detail
+                    .as_ref()
+                    .and_then(|detail| detail.get("child_turn_baseline"))
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(bridge.child_turn_index(&target_agent_id).await?);
+                let task_detail = task.detail.clone().unwrap_or_else(|| serde_json::json!({}));
+                self.start_agent_invocation_monitor(
+                    task.clone(),
+                    authority_class,
+                    worktree,
+                    target_agent_id.clone(),
+                    child_turn_baseline,
+                    task_detail,
+                )
                 .await
-            {
+                .map(|_| ())
+            } else {
+                self.spawn_child_agent_task(task.clone(), prompt, authority_class, worktree, true)
+                    .await
+            };
+            match recovery_result {
                 Ok(()) => reattached.push(task),
                 Err(error) => {
                     self.inner.storage.append_event(&AuditEvent::legacy(
                         "supervised_child_task_recovery_failed",
                         serde_json::json!({
                             "task_id": task.id,
-                            "child_agent_id": child_agent_id,
+                            "target_agent_id": target_agent_id,
                             "error": error.to_string(),
                         }),
                     ))?;

--- a/src/runtime_db/agent_relations.rs
+++ b/src/runtime_db/agent_relations.rs
@@ -658,8 +658,16 @@ fn legacy_task_evidence(
                 Ok(LegacySupervisionTaskEvidence {
                     task_id: task_id.to_string(),
                     owner_agent_id,
+                    is_child_agent_task: kind.is_child_agent()
+                        || (kind == TaskKind::ActorInvocation
+                            && child_agent_id.is_some()
+                            && task
+                                .detail
+                                .as_ref()
+                                .and_then(|detail| detail.get("created_new_subagent"))
+                                .and_then(serde_json::Value::as_bool)
+                                .unwrap_or(false)),
                     child_agent_id,
-                    is_child_agent_task: kind.is_child_agent(),
                     delegated_from_work_item_id: task.effective_work_item_id().map(str::to_string),
                 })
             },

--- a/src/runtime_error.rs
+++ b/src/runtime_error.rs
@@ -146,19 +146,21 @@ impl std::error::Error for RuntimeError {}
 pub fn describe_runtime_error(error: &AnyhowError) -> RuntimeErrorDescriptor {
     let source_chain = collect_runtime_error_source_chain(error);
 
-    if let Some(runtime_error) = error
-        .chain()
-        .find_map(|source| source.downcast_ref::<RuntimeError>())
-    {
+    if let Some(runtime_error) = error.downcast_ref::<RuntimeError>().or_else(|| {
+        error
+            .chain()
+            .find_map(|source| source.downcast_ref::<RuntimeError>())
+    }) {
         let mut descriptor = runtime_error.descriptor().clone();
         descriptor.source_chain = merge_source_chains(descriptor.source_chain, source_chain);
         return descriptor;
     }
 
-    if let Some(tool_error) = error
-        .chain()
-        .find_map(|source| source.downcast_ref::<ToolError>())
-    {
+    if let Some(tool_error) = error.downcast_ref::<ToolError>().or_else(|| {
+        error
+            .chain()
+            .find_map(|source| source.downcast_ref::<ToolError>())
+    }) {
         return descriptor_from_tool_error(tool_error, source_chain);
     }
 
@@ -551,6 +553,28 @@ mod tests {
             .source_chain
             .iter()
             .any(|message| message == "failed to read task status"));
+    }
+
+    #[test]
+    fn typed_runtime_error_is_detected_when_used_as_anyhow_context() {
+        let error = AnyhowError::msg("template selector is invalid").context(
+            RuntimeError::new(
+                RuntimeErrorDomain::Task,
+                "agent_invocation_failed",
+                "failed to invoke agent",
+            )
+            .with_safe_context("task_id", "task_123"),
+        );
+
+        let descriptor = describe_runtime_error(&error);
+
+        assert_eq!(descriptor.domain, RuntimeErrorDomain::Task);
+        assert_eq!(descriptor.code, "agent_invocation_failed");
+        assert_eq!(descriptor.safe_context["task_id"], "task_123");
+        assert!(descriptor
+            .source_chain
+            .iter()
+            .any(|message| message == "template selector is invalid"));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -658,6 +658,54 @@ pub struct AgentCreateResult {
     pub receipt: AgentCreateReceipt,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct CreateAgentRequest {
+    pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initial_message: Option<String>,
+    pub authority_class: AuthorityClass,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_resolution: Option<SpawnAgentModelResolution>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lineage_parent_agent_id: Option<String>,
+    #[serde(default)]
+    pub inherit_parent_runtime: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum InvokeAgentTarget {
+    ExistingAgent {
+        agent_id: String,
+    },
+    NewSubagent {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        template: Option<String>,
+        #[serde(default)]
+        workspace_mode: ChildAgentWorkspaceMode,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model_resolution: Option<SpawnAgentModelResolution>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct InvokeAgentRequest {
+    pub target: InvokeAgentTarget,
+    pub message: String,
+    pub authority_class: AuthorityClass,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct AgentInvocationReceipt {
+    pub agent_id: String,
+    pub created: bool,
+    pub task_handle: TaskHandle,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct AgentDetail {
     pub identity: AgentIdentityView,
@@ -1395,12 +1443,14 @@ pub enum TaskWaitPolicy {
 }
 
 pub const CHILD_AGENT_TASK_KIND: &str = "child_agent_task";
+pub const ACTOR_INVOCATION_TASK_KIND: &str = "actor_invocation";
 pub const LEGACY_SUBAGENT_TASK_KIND: &str = "subagent_task";
 pub const LEGACY_WORKTREE_SUBAGENT_TASK_KIND: &str = "worktree_subagent_task";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskKind {
+    ActorInvocation,
     CommandTask,
     ChildAgentTask,
     SleepJob,
@@ -1411,6 +1461,7 @@ pub enum TaskKind {
 impl TaskKind {
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::ActorInvocation => ACTOR_INVOCATION_TASK_KIND,
             Self::CommandTask => "command_task",
             Self::ChildAgentTask => CHILD_AGENT_TASK_KIND,
             Self::SleepJob => "sleep_job",
@@ -1442,6 +1493,12 @@ impl std::fmt::Display for TaskKind {
 pub enum ChildAgentWorkspaceMode {
     Inherit,
     Worktree,
+}
+
+impl Default for ChildAgentWorkspaceMode {
+    fn default() -> Self {
+        Self::Inherit
+    }
 }
 
 impl ChildAgentWorkspaceMode {
@@ -3432,6 +3489,9 @@ impl TaskRecord {
 
     pub fn is_child_agent_task(&self) -> bool {
         self.kind.is_child_agent()
+            || (self.kind == TaskKind::ActorInvocation
+                && task_detail_bool(&self.detail, "created_new_subagent").unwrap_or(false)
+                && task_detail_string(&self.detail, "child_agent_id").is_some())
     }
 
     pub fn effective_work_item_id(&self) -> Option<&str> {
@@ -4345,6 +4405,16 @@ fn is_false(value: &bool) -> bool {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TaskRecoverySpec {
+    AgentInvocation {
+        summary: String,
+        prompt: String,
+        #[serde(alias = "trust")]
+        authority_class: AuthorityClass,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target_agent_id: Option<String>,
+        created_new_subagent: bool,
+        workspace_mode: ChildAgentWorkspaceMode,
+    },
     ChildAgentTask {
         summary: String,
         prompt: String,
@@ -4417,6 +4487,7 @@ impl TaskRecoverySpec {
 
     pub fn child_agent_workspace_mode(&self) -> Option<ChildAgentWorkspaceMode> {
         match self {
+            TaskRecoverySpec::AgentInvocation { workspace_mode, .. } => Some(*workspace_mode),
             TaskRecoverySpec::ChildAgentTask { workspace_mode, .. } => Some(*workspace_mode),
             TaskRecoverySpec::SubagentTask { .. } => Some(ChildAgentWorkspaceMode::Inherit),
             TaskRecoverySpec::WorktreeSubagentTask { .. } => {
@@ -4428,6 +4499,7 @@ impl TaskRecoverySpec {
 
     pub fn wait_policy(&self) -> TaskWaitPolicy {
         match self {
+            TaskRecoverySpec::AgentInvocation { .. } => TaskWaitPolicy::Background,
             TaskRecoverySpec::ChildAgentTask { .. } => TaskWaitPolicy::Background,
             TaskRecoverySpec::SubagentTask { .. } => TaskWaitPolicy::Background,
             TaskRecoverySpec::WorktreeSubagentTask { .. } => TaskWaitPolicy::Background,
@@ -4438,7 +4510,8 @@ impl TaskRecoverySpec {
     pub fn terminal_reentry(&self) -> bool {
         match self {
             TaskRecoverySpec::CommandTask { spec, .. } => spec.terminal_reentry,
-            TaskRecoverySpec::ChildAgentTask { .. }
+            TaskRecoverySpec::AgentInvocation { .. }
+            | TaskRecoverySpec::ChildAgentTask { .. }
             | TaskRecoverySpec::SubagentTask { .. }
             | TaskRecoverySpec::WorktreeSubagentTask { .. } => false,
         }

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -1105,7 +1105,7 @@ async fn assert_run_once_prefers_parent_final_result_over_delegated_task_briefs(
     assert_eq!(response.final_status, RunFinalStatus::Completed);
     assert_eq!(response.final_text, "parent final result");
     assert_eq!(response.tasks.len(), 1);
-    assert_eq!(response.tasks[0].task.kind, "child_agent_task");
+    assert_eq!(response.tasks[0].task.kind, "actor_invocation");
     assert_eq!(response.tasks[0].task.status, TaskStatus::Completed);
     assert!(
         !response.final_text.contains("child delegated result"),


### PR DESCRIPTION
## Summary

- add canonical `AgentCreationService` and `AgentInvocationService` application boundaries
- define `CreateAgentRequest`, `InvokeAgentRequest`, `InvokeAgentTarget`, and invocation receipts
- route the existing agent-facing `SpawnAgent` behavior through the canonical invocation service without changing its public tool schema
- reuse the existing committed identity creation and post-commit reconcile path, while preserving existing-agent configuration and supervised-child reuse semantics

## Runtime boundary

This change separates identity creation from invocation admission. Existing-agent invocation only creates and monitors a result-bearing invocation task; new-subagent invocation creates the supervised identity through the existing host commit boundary, admits the first turn, and leaves the child reusable after the invocation task completes.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test canonical_ --lib -- --nocapture` (56 passed)
- `cargo test spawn_agent --lib -- --nocapture` (8 passed)
- `cargo test spawn_agent_receipt_projects_child_supervision_boundary --test runtime_subagents -- --nocapture` (1 passed)
