### PR TITLE
fix(web-gui): stabilize file browser source view rendering

### DIFF
--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowLeft,
   ArrowUp,
@@ -25,6 +25,7 @@ import { useRuntimeStore } from "../../runtime/runtime-store";
 import { useTranslation } from "react-i18next";
 import { parseWorkspaceImageRef, resolveWorkspaceRelativePath, WorkspaceImage } from "../../components/MarkdownContent";
 import { triggerBlobDownload } from "./download";
+import { buildPlainCodeHtml, normalizeShikiLineBreaks } from "./source-view";
 
 interface FileBrowserPanelProps {
   workspaceId: string;
@@ -129,34 +130,35 @@ function langForFile(name: string): string | undefined {
   return LANG_MAP[ext];
 }
 
-/** Async syntax highlighting via shiki. Returns highlighted HTML or null. */
+/**
+ * Async syntax highlighting via shiki. Returns highlighted HTML that matches
+ * the current content/path, or null while pending/stale so the caller renders
+ * a layout-compatible plain fallback instead of previously highlighted HTML.
+ */
 function useShikiHighlight(content: string | undefined, filePath: string | undefined): string | null {
-  const [highlighted, setHighlighted] = useState<string | null>(null);
+  const [state, setState] = useState<{ content: string; path: string; html: string | null } | null>(null);
 
   useEffect(() => {
-    if (!content || !filePath) {
-      setHighlighted(null);
-      return;
-    }
-    const lang = langForFile(filePath);
-    if (!lang) {
-      setHighlighted(null);
+    const lang = content && filePath ? langForFile(filePath) : undefined;
+    if (!content || !filePath || !lang) {
+      setState(null);
       return;
     }
     let cancelled = false;
     void getHighlighter().then((hl) => {
       if (cancelled) return;
       try {
-        const html = hl.codeToHtml(content, { lang, theme: "github-light" });
-        setHighlighted(html);
+        const html = normalizeShikiLineBreaks(hl.codeToHtml(content, { lang, theme: "github-light" }));
+        setState({ content, path: filePath, html });
       } catch {
-        setHighlighted(null);
+        setState(null);
       }
     });
     return () => { cancelled = true; };
   }, [content, filePath]);
 
-  return highlighted;
+  if (!state || state.content !== content || state.path !== filePath) return null;
+  return state.html;
 }
 
 export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, initialFilePath, workspaceLabel, onClose }: FileBrowserPanelProps) {
@@ -195,6 +197,12 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   }, [selectedFile?.path]);
 
   const highlightedHtml = useShikiHighlight(selectedFile?.content, selectedFile?.path);
+  // Plain fallback shares the shiki DOM skeleton so the async highlight swap
+  // never changes layout metrics; only token colors appear.
+  const plainCodeHtml = useMemo(
+    () => (selectedFile?.content != null ? buildPlainCodeHtml(selectedFile.content) : ""),
+    [selectedFile?.content],
+  );
 
   const loadDir = useCallback(
     async (path: string) => {
@@ -590,12 +598,12 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
                     {selectedFile.content}
                   </Markdown>
                 </div>
-              ) : highlightedHtml ? (
-                <div className="file-browser-code" ref={contentScrollRef} dangerouslySetInnerHTML={{ __html: highlightedHtml }} />
               ) : (
-                <pre className="file-browser-text" ref={contentScrollRef as React.Ref<HTMLPreElement>}>
-                  <code>{selectedFile.content}</code>
-                </pre>
+                <div
+                  className="file-browser-code"
+                  ref={contentScrollRef}
+                  dangerouslySetInnerHTML={{ __html: highlightedHtml ?? plainCodeHtml }}
+                />
               )}
             </>
           ) : (

--- a/web-gui/app/src/features/right-panel/source-view.test.ts
+++ b/web-gui/app/src/features/right-panel/source-view.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPlainCodeHtml, escapeHtml, normalizeShikiLineBreaks } from "./source-view";
+
+describe("escapeHtml", () => {
+  it("escapes characters that would break out of text nodes", () => {
+    expect(escapeHtml(`<b> & </b>`)).toBe("&lt;b&gt; &amp; &lt;/b&gt;");
+  });
+});
+
+describe("buildPlainCodeHtml", () => {
+  it("renders one span.line per source line without separator newlines", () => {
+    const html = buildPlainCodeHtml("let a = 1\nlet b = 2");
+    expect(html).toBe(
+      '<pre class="shiki file-browser-plain"><code>' +
+        '<span class="line">let a = 1</span>' +
+        '<span class="line">let b = 2</span>' +
+        "</code></pre>",
+    );
+    expect(html).not.toContain("\n");
+  });
+
+  it("escapes HTML-special content", () => {
+    const html = buildPlainCodeHtml("<script>alert('x')</script>");
+    expect(html).toContain("&lt;script&gt;alert('x')&lt;/script&gt;");
+    expect(html).not.toContain("<script>");
+  });
+
+  it("normalizes CRLF line endings and keeps empty lines as empty spans", () => {
+    const html = buildPlainCodeHtml("one\r\n\r\ntwo\r");
+    expect(html).toBe(
+      '<pre class="shiki file-browser-plain"><code>' +
+        '<span class="line">one</span>' +
+        '<span class="line"></span>' +
+        '<span class="line">two</span>' +
+        "</code></pre>",
+    );
+  });
+});
+
+describe("normalizeShikiLineBreaks", () => {
+  const shikiFixture =
+    '<pre class="shiki github-light" style="background-color:#fff"><code>' +
+    '<span class="line"><span style="color:#D73A49">let</span> a = 1</span>\n' +
+    '<span class="line"></span>\n' +
+    '<span class="line">  b(2)</span></code></pre>';
+
+  it("strips only the newlines shiki inserts between line spans", () => {
+    expect(normalizeShikiLineBreaks(shikiFixture)).toBe(
+      '<pre class="shiki github-light" style="background-color:#fff"><code>' +
+        '<span class="line"><span style="color:#D73A49">let</span> a = 1</span>' +
+        '<span class="line"></span>' +
+        '<span class="line">  b(2)</span></code></pre>',
+    );
+  });
+
+  it("keeps normalized output structurally identical to the plain fallback", () => {
+    const normalized = normalizeShikiLineBreaks(shikiFixture);
+    const lineCount = (html: string) => (html.match(/<span class="line[ "]/g) ?? []).length;
+    expect(lineCount(normalized)).toBe(3);
+    expect(normalized).not.toMatch(/\n(?=<span class="line")/);
+    expect(normalized.startsWith('<pre class="shiki')).toBe(true);
+    expect(buildPlainCodeHtml("x\n\ny")).toMatch(
+      /^<pre class="shiki file-browser-plain"><code><span class="line">/,
+    );
+  });
+});

--- a/web-gui/app/src/features/right-panel/source-view.ts
+++ b/web-gui/app/src/features/right-panel/source-view.ts
@@ -1,0 +1,36 @@
+/**
+ * Source-view helpers that keep the plain-text fallback and the shiki
+ * highlight output structurally identical, so the async highlight swap only
+ * adds colors and never changes layout metrics.
+ */
+
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Build a plain-text fallback that mirrors the shiki output skeleton
+ * (`pre.shiki > code > span.line`) without separator newlines. The line spans
+ * are rendered as block boxes (see `.file-browser-code > .shiki .line`), so
+ * joining them without newlines keeps one span per visual line.
+ */
+export function buildPlainCodeHtml(content: string): string {
+  const lines = content
+    .split("\n")
+    .map((line) => `<span class="line">${escapeHtml(line.replace(/\r$/, ""))}</span>`);
+  return `<pre class="shiki file-browser-plain"><code>${lines.join("")}</code></pre>`;
+}
+
+/**
+ * shiki joins its `span.line` elements with literal newlines. Once lines are
+ * rendered as block boxes those separator newlines would render as extra
+ * blank lines inside the `pre-wrap` container, so strip them. Newlines cannot
+ * appear inside a line span's content (shiki splits by line first), which
+ * keeps this replacement safe.
+ */
+export function normalizeShikiLineBreaks(html: string): string {
+  return html.replace(/\n(?=<span class="line")/g, "");
+}

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -4407,25 +4407,6 @@ code {
   gap: 8px;
 }
 
-.file-browser-text {
-  background: var(--code-bg, #f5f5f5);
-  border-radius: 4px;
-  font-family: var(--mono-font, "SF Mono", "Fira Code", monospace);
-  font-size: 0.75rem;
-  line-height: 1.5;
-  flex: 1;
-  min-height: 0;
-  overflow: auto;
-  padding: 10px;
-  margin: 0;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.file-browser-text code {
-  font-family: inherit;
-}
-
 .file-browser-code {
   flex: 1;
   min-height: 0;
@@ -4450,10 +4431,20 @@ code {
 .file-browser-code > .shiki code {
   font-family: inherit;
   counter-reset: line;
+  display: block;
 }
 
+/*
+ * Lines render as block boxes with a hanging indent so wrapped continuation
+ * lines stay right of the line-number gutter instead of running under it.
+ * Separator newlines between line spans are stripped before insertion
+ * (see source-view.ts) so block layout shows exactly one box per line.
+ */
 .file-browser-code > .shiki .line {
   counter-increment: line;
+  display: block;
+  padding-left: 3.5rem;
+  text-indent: -3.5rem;
 }
 
 .file-browser-code > .shiki .line::before {
@@ -4464,6 +4455,7 @@ code {
   text-align: right;
   color: var(--text-muted, #999);
   user-select: none;
+  text-indent: 0;
 }
 
 .file-browser-image {


### PR DESCRIPTION
## Problem

Viewing a source file in the Web GUI file browser jittered: the plain-text preview (pre.file-browser-text, 0.75rem/1.5, 10px padding) was replaced wholesale by shiki's highlighted output (div.file-browser-code > pre.shiki, 0.8125rem/1.6, 12px 16px padding + line-number gutter) once async highlighting resolved. Different metrics meant a visible relayout on every open, refresh, and markdown rendered<->source toggle; wrapped lines also ran under the line-number gutter, and the highlight state could briefly show the previously selected file's HTML.

## Change

- New `source-view.ts`: builds an escaped plain-text fallback that mirrors the shiki skeleton (`pre.shiki > code > span.line`, no separator newlines) and strips shiki's inter-line newlines, so plain and highlighted states share one DOM structure and one set of metrics.
- `useShikiHighlight` keys its result by `{content, path}` and returns null while pending or stale, so the layout-compatible fallback renders instead of stale HTML.
- The viewer renders a single `.file-browser-code` container using `highlightedHtml ?? plainCodeHtml`; the old `file-browser-text` pre is removed.
- Line spans become block boxes with a hanging indent (`padding-left: 3.5rem; text-indent: -3.5rem`), so wrapped continuation lines stay right of the line-number gutter.

## Verification

- `npm test` (web-gui/app): 487 tests pass incl. new `source-view.test.ts` covering escaping, CRLF normalization, newline stripping, and structural parity with a shiki fixture.
- `npm run typecheck`, `npm run build` pass.
- Chromium check (dev-only, not committed): plain fallback and real shiki output render with identical geometry — same total height, same line tops, every visual row (including wrapped continuations) starting at the same x right of the gutter, identical wrap points. The highlight swap now only adds colors.

Part of the file browser upgrade plan (slice 1).