### PR TITLE
feat: add reliable agent message delivery ledger

### DIFF
--- a/src/domain/agent.rs
+++ b/src/domain/agent.rs
@@ -2,6 +2,10 @@ use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::types::{
+    AdmissionContext, AuthorityClass, MessageBody, MessageDeliverySurface, MessageOrigin, Priority,
+};
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentIdentityLifecycle {
@@ -147,6 +151,181 @@ pub struct AgentMessagePolicyRecord {
     pub default_effect: AgentPolicyEffect,
     pub rules: Vec<AgentMessagePolicyRule>,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentMessageDeliveryOutcome {
+    Accepted,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentMessageDeliveryState {
+    Queued,
+    Dispatched,
+    Consumed,
+    Failed,
+    CancelledByDeletion,
+    Rejected,
+}
+
+impl AgentMessageDeliveryState {
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Consumed | Self::Failed | Self::CancelledByDeletion | Self::Rejected
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentMessageDeliveryRejectionCode {
+    TargetNotFound,
+    MessageNotAuthorized,
+    InvalidMessage,
+    InvalidCorrelation,
+    InvalidPriority,
+    IdempotencyConflict,
+    AgentStopped,
+    AgentDeleting,
+    AgentDeleted,
+    QueueUnavailable,
+}
+
+impl AgentMessageDeliveryRejectionCode {
+    pub fn retryable(self) -> bool {
+        matches!(self, Self::AgentStopped | Self::QueueUnavailable)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct AgentMessageSendRequest {
+    pub target_agent_id: String,
+    pub content: MessageBody,
+    pub client_idempotency_key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_priority: Option<Priority>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct AgentMessageCallerContext {
+    pub caller_principal: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caller_agent_id: Option<String>,
+    pub principal_kind: AgentMessagePrincipalKind,
+    pub route: String,
+    pub origin: MessageOrigin,
+    pub authority_class: AuthorityClass,
+    pub delivery_surface: MessageDeliverySurface,
+    pub admission_context: AdmissionContext,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_work_item_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct AgentMessageAdmissionEvidence {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_revision: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_status: Option<AgentIdentityLifecycle>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_policy_revision: Option<u64>,
+    pub principal_kind: AgentMessagePrincipalKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub principal_id: Option<String>,
+    pub route: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub matched_rule_index: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct AgentMessageDeliveryRecord {
+    pub delivery_id: String,
+    pub target_agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causation_id: Option<String>,
+    pub idempotency_scope: String,
+    pub idempotency_key_digest: String,
+    pub request_digest: String,
+    pub caller: AgentMessageCallerContext,
+    pub outcome: AgentMessageDeliveryOutcome,
+    pub state: AgentMessageDeliveryState,
+    pub state_version: u64,
+    pub admission_evidence: AgentMessageAdmissionEvidence,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejection_code: Option<AgentMessageDeliveryRejectionCode>,
+    pub retryable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct AgentMessageDeliveryReceipt {
+    pub delivery_id: String,
+    pub target_agent_id: String,
+    pub outcome: AgentMessageDeliveryOutcome,
+    pub state: AgentMessageDeliveryState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_at: Option<DateTime<Utc>>,
+    pub idempotent_replay: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejection_code: Option<AgentMessageDeliveryRejectionCode>,
+    pub retryable: bool,
+    pub lifecycle_snapshot: AgentMessageAdmissionEvidence,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+}
+
+impl AgentMessageDeliveryRecord {
+    pub fn receipt(&self, idempotent_replay: bool) -> AgentMessageDeliveryReceipt {
+        AgentMessageDeliveryReceipt {
+            delivery_id: self.delivery_id.clone(),
+            target_agent_id: self.target_agent_id.clone(),
+            outcome: self.outcome,
+            state: self.state,
+            accepted_at: self.accepted_at,
+            terminal_at: self.terminal_at,
+            idempotent_replay,
+            rejection_code: self.rejection_code,
+            retryable: self.retryable,
+            lifecycle_snapshot: self.admission_evidence.clone(),
+            correlation_id: self.correlation_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum AgentMessageDeliveryError {
+    #[error("agent message idempotency key was reused with different request semantics")]
+    IdempotencyConflict {
+        idempotency_scope: String,
+        idempotency_key_digest: String,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/src/host.rs
+++ b/src/host.rs
@@ -58,15 +58,17 @@ use crate::{
         AgentBootstrapStep, AgentBootstrapStepStatus, AgentBootstrapWorkspaceState,
         AgentCreateReceipt, AgentCreateResult, AgentCreateStage, AgentDeletionJob, AgentDetail,
         AgentDurability, AgentIdentityRecord, AgentIdentityView, AgentKind, AgentLifecycleHint,
-        AgentListEntry, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState,
-        AgentStatus, AgentSummary, AgentTokenUsageSummary, AgentTreeNode, AgentTreeProjection,
-        AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome, CreateAgentRequest,
-        ExternalTriggerRecord, ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMdView,
-        MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
-        OperatorNotificationRecord, Priority, QueueEntryStatus, RuntimeFailureSummary,
-        SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, TaskKind, TaskRecord,
-        TaskStatus, TimerRecord, TokenUsage, TranscriptEntry, TranscriptEntryKind,
-        WaitConditionSummary, WorkspaceEntry, WorkspaceOccupancyRecord,
+        AgentListEntry, AgentMessageCallerContext, AgentMessageDeliveryOutcome,
+        AgentMessagePrincipalKind, AgentMessageSendRequest, AgentOwnership, AgentProfilePreset,
+        AgentRegistryStatus, AgentState, AgentStatus, AgentSummary, AgentTokenUsageSummary,
+        AgentTreeNode, AgentTreeProjection, AgentVisibility, AuthorityClass, ChildAgentSummary,
+        ClosureOutcome, CreateAgentRequest, ExternalTriggerRecord, ExternalTriggerStatus,
+        ExternalTriggerSummary, LoadedAgentsMdView, MessageBody, MessageDeliverySurface,
+        MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationRecord, Priority,
+        QueueEntryStatus, RuntimeFailureSummary, SpawnAgentModelResolution,
+        SpawnAgentModelResolutionStatus, TaskKind, TaskRecord, TaskStatus, TimerRecord, TokenUsage,
+        TranscriptEntry, TranscriptEntryKind, WaitConditionSummary, WorkspaceEntry,
+        WorkspaceOccupancyRecord,
     },
 };
 
@@ -4139,31 +4141,90 @@ impl RuntimeHost {
         message_text: String,
         authority_class: AuthorityClass,
     ) -> Result<ChildTaskSpawn> {
-        let identity = self
-            .active_agent_identity(target_agent_id)
-            .map_err(anyhow::Error::from)?;
-        let runtime = self.get_or_create_agent(target_agent_id).await?;
-        let child_turn_baseline = runtime.agent_state().await?.turn_index;
-        let mut message = crate::types::MessageEnvelope::new(
-            target_agent_id.to_string(),
-            crate::types::MessageKind::InternalFollowup,
-            crate::types::MessageOrigin::Task {
+        let caller = AgentMessageCallerContext {
+            caller_principal: "runtime:agent-invocation".into(),
+            caller_agent_id: Some(task.agent_id.clone()),
+            principal_kind: AgentMessagePrincipalKind::RuntimeCapability,
+            route: "agent_invocation".into(),
+            origin: MessageOrigin::Task {
                 task_id: task.id.clone(),
             },
-            authority_class.clone(),
-            crate::types::Priority::Normal,
-            crate::types::MessageBody::Text { text: message_text },
-        )
-        .with_admission(
-            crate::types::MessageDeliverySurface::RuntimeSystem,
-            crate::types::AdmissionContext::RuntimeOwned,
-        );
-        message.metadata = Some(json!({
-            "invocation_task_id": task.id,
-            "target_agent_id": target_agent_id,
-            "delegated_authority_class": authority_class,
-        }));
-        runtime.enqueue(message).await?;
+            authority_class,
+            delivery_surface: MessageDeliverySurface::RuntimeSystem,
+            admission_context: AdmissionContext::RuntimeOwned,
+            current_turn_id: task
+                .detail
+                .as_ref()
+                .and_then(|detail| detail.get("parent_turn_id"))
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            current_task_id: Some(task.id.clone()),
+            current_work_item_id: task.work_item_id.clone(),
+        };
+        let prepared = crate::runtime::AgentMessageDeliveryService::prepare(
+            AgentMessageSendRequest {
+                target_agent_id: target_agent_id.to_string(),
+                content: MessageBody::Text { text: message_text },
+                client_idempotency_key: task.id.clone(),
+                correlation_id: Some(task.id.clone()),
+                causation_id: task.parent_message_id.clone(),
+                requested_priority: Some(Priority::Normal),
+            },
+            caller,
+        )?;
+        let identity = self.agent_identity_record(target_agent_id)?;
+        let (identity, runtime, receipt) = match identity {
+            Some(identity) if identity.status == AgentRegistryStatus::Active => {
+                match self.get_or_create_agent(target_agent_id).await {
+                    Ok(runtime) => {
+                        let receipt = runtime
+                            .agent_message_delivery_service()
+                            .deliver(&prepared)
+                            .await?;
+                        (identity, Some(runtime), receipt)
+                    }
+                    Err(activation_error) => {
+                        let latest_identity = self.agent_identity_record(target_agent_id)?;
+                        if latest_identity
+                            .as_ref()
+                            .is_none_or(|latest| latest.status != AgentRegistryStatus::Active)
+                        {
+                            let receipt = self
+                                .runtime_db()
+                                .agent_message_deliveries()
+                                .admit_without_queue(&prepared.record)?;
+                            (latest_identity.unwrap_or(identity), None, receipt)
+                        } else {
+                            return Err(activation_error);
+                        }
+                    }
+                }
+            }
+            _ => {
+                let receipt = self
+                    .runtime_db()
+                    .agent_message_deliveries()
+                    .admit_without_queue(&prepared.record)?;
+                let identity = identity.ok_or_else(|| {
+                    anyhow!("agent message delivery target {target_agent_id} was not found")
+                })?;
+                (identity, None, receipt)
+            }
+        };
+        if receipt.outcome != AgentMessageDeliveryOutcome::Accepted {
+            return Err(anyhow!(
+                "agent message delivery {} was rejected: {:?}",
+                receipt.delivery_id,
+                receipt.rejection_code
+            ));
+        }
+        let runtime = runtime.ok_or_else(|| {
+            anyhow!(
+                "accepted delivery {} targets an inactive agent",
+                receipt.delivery_id
+            )
+        })?;
+        let child_turn_baseline = runtime.agent_state().await?.turn_index;
 
         let mut task_detail = json!({
             "target_agent_id": target_agent_id,
@@ -4173,6 +4234,8 @@ impl RuntimeHost {
             "target_agent_profile_preset": identity.profile_preset(),
             "child_turn_baseline": child_turn_baseline,
             "created_new_subagent": false,
+            "delivery_id": receipt.delivery_id,
+            "delivery_state": receipt.state,
         });
         if identity.kind == AgentKind::Child {
             task_detail["child_agent_id"] = json!(target_agent_id);
@@ -4531,8 +4594,7 @@ impl RuntimeHost {
             let runtime = runtime.clone();
             let agent_id = agent_id.to_string();
             async move {
-                let run = runtime.clone().run();
-                tokio::pin!(run);
+                let mut run = Box::pin(runtime.clone().run());
                 let result = tokio::select! {
                     result = &mut run => result,
                     bootstrap = runtime.wait_for_bootstrap() => {
@@ -4736,9 +4798,13 @@ impl RuntimeHostBridge {
         message_text: String,
         authority_class: AuthorityClass,
     ) -> Result<ChildTaskSpawn> {
-        self.host()?
-            .invoke_existing_agent(task, target_agent_id, message_text, authority_class)
-            .await
+        Box::pin(self.host()?.invoke_existing_agent(
+            task,
+            target_agent_id,
+            message_text,
+            authority_class,
+        ))
+        .await
     }
 
     pub(crate) async fn create_agent(

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -24,6 +24,16 @@ pub fn message_id() -> String {
     runtime_id("msg")
 }
 
+pub fn agent_message_delivery_id(idempotency_scope: &str, idempotency_key_digest: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"holon.agent-message-delivery.v1\x00");
+    hasher.update(idempotency_scope.as_bytes());
+    hasher.update(b"\x00");
+    hasher.update(idempotency_key_digest.as_bytes());
+    let digest = hasher.finalize();
+    format!("delivery1_{}", hex(&digest[..16]))
+}
+
 pub fn task_id() -> String {
     runtime_id("task")
 }

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    future::Future,
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
@@ -215,7 +216,14 @@ pub async fn run_once(config: AppConfig, request: RunOnceRequest) -> Result<RunO
     run_once_with_host(host, request).await
 }
 
-pub async fn run_once_with_host(
+pub fn run_once_with_host(
+    host: RuntimeHost,
+    request: RunOnceRequest,
+) -> impl Future<Output = Result<RunOnceResponse>> + Send {
+    Box::pin(run_once_with_host_inner(host, request))
+}
+
+async fn run_once_with_host_inner(
     host: RuntimeHost,
     request: RunOnceRequest,
 ) -> Result<RunOnceResponse> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,3 +1,4 @@
+mod agent_message_delivery;
 mod agent_services;
 mod bootstrap;
 mod callback;
@@ -32,6 +33,9 @@ pub(crate) mod workspace;
 pub(crate) mod workspace_control;
 mod worktree;
 
+pub(crate) use agent_message_delivery::AgentMessageDeliveryService;
+#[cfg(test)]
+pub(crate) use agent_message_delivery::PreparedAgentMessageDelivery;
 pub use first_run_intro::maybe_enqueue_first_run_intro;
 pub(crate) use lifecycle::LightweightAgentStateProjection;
 pub(crate) use repair::is_wake_only_message;
@@ -118,14 +122,15 @@ use crate::{
     types::LoadedAgentMemory,
     types::{
         brief_created_event_for, ActiveWorkspaceEntry, AdmissionContext, AgentIdentityView,
-        AgentKind, AgentModelOverrideAuditEvent, AgentModelSource, AgentModelState, AgentState,
-        AgentStateChangedEvent, AgentStatus, AgentSummary, AuditEvent, AuthorityClass,
-        BriefCreatedAuditEvent, BriefRecord, CallbackDeliveryMode, CallbackDeliveryPayload,
-        CallbackDeliveryResult, CallbackIngressDisposition, ClosureDecision,
-        ContinuationResolution, ControlAction, ExecCommandBatchItemStatus, ExecCommandBatchResult,
-        ExecutionAdmissionProvenance, ExternalTriggerCapability, ExternalTriggerRecord,
-        ExternalTriggerScope, ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMd,
-        MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind,
+        AgentKind, AgentMessageDeliveryOutcome, AgentMessageDeliveryReceipt,
+        AgentMessageDeliveryRecord, AgentModelOverrideAuditEvent, AgentModelSource,
+        AgentModelState, AgentState, AgentStateChangedEvent, AgentStatus, AgentSummary, AuditEvent,
+        AuthorityClass, BriefCreatedAuditEvent, BriefRecord, CallbackDeliveryMode,
+        CallbackDeliveryPayload, CallbackDeliveryResult, CallbackIngressDisposition,
+        ClosureDecision, ContinuationResolution, ControlAction, ExecCommandBatchItemStatus,
+        ExecCommandBatchResult, ExecutionAdmissionProvenance, ExternalTriggerCapability,
+        ExternalTriggerRecord, ExternalTriggerScope, ExternalTriggerStatus, ExternalTriggerSummary,
+        LoadedAgentsMd, MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind,
         MessageLifecycleAuditEvent, MessageOrigin, PendingWakeHint, Priority, QueueEntryRecord,
         QueueEntryStatus, RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture,
         SkillActivationSource, SkillActivationState, SkillCatalogEntry, SkillLoadReason,
@@ -3884,18 +3889,41 @@ impl RuntimeHandle {
         Ok(())
     }
 
-    pub async fn enqueue(&self, mut message: MessageEnvelope) -> Result<MessageEnvelope> {
+    pub async fn enqueue(&self, message: MessageEnvelope) -> Result<MessageEnvelope> {
+        let (message, _) = self.enqueue_internal(message, None).await?;
+        Ok(message)
+    }
+
+    pub(crate) async fn enqueue_delivery(
+        &self,
+        message: MessageEnvelope,
+        delivery: &AgentMessageDeliveryRecord,
+    ) -> Result<AgentMessageDeliveryReceipt> {
+        let (_, receipt) = self.enqueue_internal(message, Some(delivery)).await?;
+        receipt.context("delivery admission completed without a receipt")
+    }
+
+    async fn enqueue_internal(
+        &self,
+        mut message: MessageEnvelope,
+        delivery: Option<&AgentMessageDeliveryRecord>,
+    ) -> Result<(MessageEnvelope, Option<AgentMessageDeliveryReceipt>)> {
         message.normalize_admission_fields();
         message.turn_id = normalized_turn_id(message.turn_id.as_deref());
         if message.turn_id.is_none() {
             message.turn_id = Some(crate::ids::turn_id());
         }
         for attempt in 0..ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
-            match self.enqueue_attempt(&message).await {
+            match self.enqueue_attempt(&message, delivery).await {
                 Ok(mut commit) => {
-                    commit.effects.notify_scheduler = true;
+                    commit.effects.notify_scheduler =
+                        commit.delivery_receipt.as_ref().is_none_or(|receipt| {
+                            receipt.outcome == AgentMessageDeliveryOutcome::Accepted
+                                && !receipt.idempotent_replay
+                        });
+                    let receipt = commit.delivery_receipt.clone();
                     self.apply_transition_commit(commit).await;
-                    return Ok(message);
+                    return Ok((message, receipt));
                 }
                 Err(error) => {
                     let can_retry = attempt + 1 < ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
@@ -3913,7 +3941,11 @@ impl RuntimeHandle {
         unreachable!("enqueue attempts always return or retry")
     }
 
-    async fn enqueue_attempt(&self, message: &MessageEnvelope) -> Result<TransitionCommit> {
+    async fn enqueue_attempt(
+        &self,
+        message: &MessageEnvelope,
+        delivery: Option<&AgentMessageDeliveryRecord>,
+    ) -> Result<TransitionCommit> {
         let wait_trigger = self.wait_trigger_transition_for_message(message)?;
         let message_is_new = self
             .inner
@@ -4005,47 +4037,55 @@ impl RuntimeHandle {
                     }),
                 ));
             }
-            let mut commit = self
-                .inner
-                .runtime_db
-                .transitions()
-                .commit_queue_with_wait_trigger(
-                    &crate::runtime_db::transitions::QueueTransitionCommand {
-                        agent_id: message.agent_id.clone(),
-                        operation: crate::runtime_db::transitions::QueueOperation::Admit,
-                        mutation: crate::runtime_db::transitions::QueueMutation::Upsert(
-                            QueueEntryRecord {
-                                message_id: message.id.clone(),
-                                agent_id: message.agent_id.clone(),
-                                priority: message.priority.clone(),
-                                status: QueueEntryStatus::Queued,
-                                created_at: existing_queue_entry
-                                    .as_ref()
-                                    .map_or(message.created_at, |entry| entry.created_at),
-                                updated_at: Utc::now(),
-                            },
-                        ),
-                        scheduler_claim_work_item: None,
-                        agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
-                            expected: Some(Box::new(expected_persisted_state)),
-                            record: Box::new(committed_state.clone()),
-                        }),
-                        message_evidence: vec![message.clone()],
-                        transcript_entries: Vec::new(),
-                        turn_record: None,
-                        audit_events,
-                        notify_scheduler: true,
-                        fault: self.take_transition_fault(),
-                        brief_evidence: Vec::new(),
-                    },
-                    wait_trigger.as_ref(),
-                )?;
-            if queue_needs_push {
+            let command = crate::runtime_db::transitions::QueueTransitionCommand {
+                agent_id: message.agent_id.clone(),
+                operation: crate::runtime_db::transitions::QueueOperation::Admit,
+                mutation: crate::runtime_db::transitions::QueueMutation::Upsert(QueueEntryRecord {
+                    message_id: message.id.clone(),
+                    agent_id: message.agent_id.clone(),
+                    priority: message.priority.clone(),
+                    status: QueueEntryStatus::Queued,
+                    created_at: existing_queue_entry
+                        .as_ref()
+                        .map_or(message.created_at, |entry| entry.created_at),
+                    updated_at: Utc::now(),
+                }),
+                scheduler_claim_work_item: None,
+                agent_state: Some(crate::runtime_db::transitions::AgentStateMutation {
+                    expected: Some(Box::new(expected_persisted_state)),
+                    record: Box::new(committed_state.clone()),
+                }),
+                message_evidence: vec![message.clone()],
+                transcript_entries: Vec::new(),
+                turn_record: None,
+                audit_events,
+                notify_scheduler: true,
+                fault: self.take_transition_fault(),
+                brief_evidence: Vec::new(),
+            };
+            let mut commit = if let Some(delivery) = delivery {
+                self.inner
+                    .runtime_db
+                    .transitions()
+                    .commit_delivery_admission(&command, wait_trigger.as_ref(), delivery)?
+            } else {
+                self.inner
+                    .runtime_db
+                    .transitions()
+                    .commit_queue_with_wait_trigger(&command, wait_trigger.as_ref())?
+            };
+            let queue_admitted = commit.delivery_receipt.as_ref().is_none_or(|receipt| {
+                receipt.outcome == AgentMessageDeliveryOutcome::Accepted
+                    && !receipt.idempotent_replay
+            });
+            if queue_admitted && queue_needs_push {
                 guard.queue.push(message.clone());
             }
-            guard.state = committed_state.clone();
-            guard.last_persisted_state = committed_state;
-            commit.effects.agent_state = None;
+            if queue_admitted {
+                guard.state = committed_state.clone();
+                guard.last_persisted_state = committed_state;
+                commit.effects.agent_state = None;
+            }
             commit
         };
         Ok(commit)

--- a/src/runtime/agent_message_delivery.rs
+++ b/src/runtime/agent_message_delivery.rs
@@ -1,0 +1,161 @@
+use anyhow::{bail, Result};
+use chrono::Utc;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use super::RuntimeHandle;
+use crate::types::{
+    AgentMessageAdmissionEvidence, AgentMessageCallerContext, AgentMessageDeliveryOutcome,
+    AgentMessageDeliveryReceipt, AgentMessageDeliveryRecord, AgentMessageDeliveryState,
+    AgentMessageSendRequest, MessageEnvelope, MessageKind, Priority,
+};
+
+const DELIVERY_IDEMPOTENCY_NAMESPACE: &str = "agent_message_delivery";
+
+pub(crate) struct AgentMessageDeliveryService<'a> {
+    runtime: &'a RuntimeHandle,
+}
+
+pub(crate) struct PreparedAgentMessageDelivery {
+    pub(crate) message: MessageEnvelope,
+    pub(crate) record: AgentMessageDeliveryRecord,
+}
+
+impl RuntimeHandle {
+    pub(crate) fn agent_message_delivery_service(&self) -> AgentMessageDeliveryService<'_> {
+        AgentMessageDeliveryService { runtime: self }
+    }
+}
+
+impl AgentMessageDeliveryService<'_> {
+    pub(crate) async fn deliver(
+        &self,
+        prepared: &PreparedAgentMessageDelivery,
+    ) -> Result<AgentMessageDeliveryReceipt> {
+        self.runtime
+            .enqueue_delivery(prepared.message.clone(), &prepared.record)
+            .await
+    }
+
+    pub(crate) fn prepare(
+        request: AgentMessageSendRequest,
+        caller: AgentMessageCallerContext,
+    ) -> Result<PreparedAgentMessageDelivery> {
+        if request.target_agent_id.trim().is_empty() {
+            bail!("agent message delivery requires a target agent");
+        }
+        if request.client_idempotency_key.trim().is_empty() {
+            bail!("agent message delivery requires an idempotency key");
+        }
+
+        let priority = request
+            .requested_priority
+            .clone()
+            .unwrap_or(Priority::Normal);
+        let idempotency_scope = format!(
+            "{DELIVERY_IDEMPOTENCY_NAMESPACE}:{}:{}",
+            caller.caller_principal, request.target_agent_id
+        );
+        let idempotency_key_digest = digest(
+            b"holon.agent-message-delivery.idempotency-key.v1",
+            &request.client_idempotency_key,
+        )?;
+        let request_digest = digest(
+            b"holon.agent-message-delivery.request.v1",
+            &DeliverySemanticRequest {
+                target_agent_id: &request.target_agent_id,
+                content: &request.content,
+                correlation_id: request.correlation_id.as_deref(),
+                causation_id: request.causation_id.as_deref(),
+                priority: &priority,
+                caller: &caller,
+            },
+        )?;
+        let delivery_id =
+            crate::ids::agent_message_delivery_id(&idempotency_scope, &idempotency_key_digest);
+        let now = Utc::now();
+        let mut message = MessageEnvelope::new(
+            request.target_agent_id.clone(),
+            MessageKind::InternalFollowup,
+            caller.origin.clone(),
+            caller.authority_class,
+            priority,
+            request.content,
+        )
+        .with_admission(caller.delivery_surface, caller.admission_context);
+        message.turn_id.clone_from(&caller.current_turn_id);
+        message.task_id.clone_from(&caller.current_task_id);
+        message
+            .work_item_id
+            .clone_from(&caller.current_work_item_id);
+        message.correlation_id.clone_from(&request.correlation_id);
+        message.causation_id.clone_from(&request.causation_id);
+        message.metadata = Some(serde_json::json!({
+            "agent_message_delivery": {
+                "delivery_id": delivery_id,
+                "caller_principal": caller.caller_principal,
+                "caller_agent_id": caller.caller_agent_id,
+                "principal_kind": caller.principal_kind,
+                "route": caller.route,
+            }
+        }));
+        let principal_id = caller
+            .caller_agent_id
+            .clone()
+            .unwrap_or_else(|| caller.caller_principal.clone());
+        let record = AgentMessageDeliveryRecord {
+            delivery_id,
+            target_agent_id: request.target_agent_id,
+            message_id: Some(message.id.clone()),
+            correlation_id: request.correlation_id,
+            causation_id: request.causation_id,
+            idempotency_scope,
+            idempotency_key_digest,
+            request_digest,
+            caller: caller.clone(),
+            outcome: AgentMessageDeliveryOutcome::Rejected,
+            state: AgentMessageDeliveryState::Rejected,
+            state_version: 1,
+            admission_evidence: AgentMessageAdmissionEvidence {
+                identity_revision: None,
+                identity_status: None,
+                runtime_status: None,
+                message_policy_revision: None,
+                principal_kind: caller.principal_kind,
+                principal_id: Some(principal_id),
+                route: caller.route,
+                matched_rule_index: None,
+            },
+            rejection_code: None,
+            retryable: false,
+            diagnostic: None,
+            accepted_at: None,
+            terminal_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+        Ok(PreparedAgentMessageDelivery { message, record })
+    }
+}
+
+#[derive(Serialize)]
+struct DeliverySemanticRequest<'a> {
+    target_agent_id: &'a str,
+    content: &'a crate::types::MessageBody,
+    correlation_id: Option<&'a str>,
+    causation_id: Option<&'a str>,
+    priority: &'a Priority,
+    caller: &'a AgentMessageCallerContext,
+}
+
+fn digest<T: Serialize>(domain: &[u8], value: &T) -> Result<String> {
+    let mut hasher = Sha256::new();
+    hasher.update(domain);
+    hasher.update(b"\0");
+    hasher.update(serde_json::to_vec(value)?);
+    Ok(hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
+}

--- a/src/runtime/agent_services.rs
+++ b/src/runtime/agent_services.rs
@@ -1,4 +1,6 @@
 use anyhow::{anyhow, Result};
+use std::future::Future;
+use std::pin::Pin;
 
 use super::RuntimeHandle;
 use crate::runtime_error::{collect_runtime_error_source_chain, RuntimeError, RuntimeErrorDomain};
@@ -39,122 +41,119 @@ impl AgentCreationService<'_> {
 }
 
 impl AgentInvocationService<'_> {
-    pub(crate) async fn invoke(
-        &self,
+    pub(crate) fn invoke<'a>(
+        &'a self,
         request: InvokeAgentRequest,
-    ) -> Result<AgentInvocationReceipt> {
-        let message = request.message;
-        if message.trim().is_empty() {
-            return Err(anyhow!("agent invocation requires a non-empty message"));
-        }
-        let bridge = self
-            .runtime
-            .inner
-            .host_bridge
-            .clone()
-            .ok_or_else(|| anyhow!("agent invocation requires a host bridge"))?;
-        let (target_agent_id, created_new_subagent, workspace_mode, model_resolution) =
-            match &request.target {
-                InvokeAgentTarget::ExistingAgent { agent_id } => (
-                    Some(agent_id.clone()),
-                    false,
-                    ChildAgentWorkspaceMode::Inherit,
-                    None,
-                ),
-                InvokeAgentTarget::NewSubagent {
-                    workspace_mode,
-                    model_resolution,
-                    ..
-                } => (
-                    None,
-                    true,
-                    *workspace_mode,
-                    Some(required_model_resolution(model_resolution.clone())?),
-                ),
-            };
-        let summary = super::tasks::spawn_agent_task_label(&message);
-        let task = self
-            .runtime
-            .create_agent_invocation_task(
-                summary,
-                message.clone(),
-                request.authority_class.clone(),
-                target_agent_id,
-                created_new_subagent,
-                workspace_mode,
-            )
-            .await?;
-
-        let admitted = match request.target {
-            InvokeAgentTarget::ExistingAgent { agent_id } => {
-                bridge
-                    .invoke_existing_agent(
-                        &task,
-                        &agent_id,
-                        message,
-                        request.authority_class.clone(),
-                    )
-                    .await
+    ) -> Pin<Box<dyn Future<Output = Result<AgentInvocationReceipt>> + Send + 'a>> {
+        Box::pin(async move {
+            let message = request.message;
+            if message.trim().is_empty() {
+                return Err(anyhow!("agent invocation requires a non-empty message"));
             }
-            InvokeAgentTarget::NewSubagent {
-                template,
-                workspace_mode,
-                ..
-            } => {
-                bridge
-                    .spawn_child_task(
-                        self.runtime.clone(),
-                        &task,
-                        message,
-                        request.authority_class.clone(),
-                        workspace_mode.is_worktree(),
-                        template,
-                        model_resolution.expect(
-                            "new subagent model resolution was validated before task creation",
-                        ),
-                    )
-                    .await
-            }
-        };
-        let mut admitted = match admitted {
-            Ok(admitted) => admitted,
-            Err(error) => {
-                self.runtime
-                    .fail_agent_invocation_task(&task, &error)
-                    .await?;
-                let direct_cause = collect_runtime_error_source_chain(&error)
-                    .last()
-                    .cloned()
-                    .unwrap_or_else(|| "agent invocation admission failed".to_string());
-                return Err(error.context(
-                    RuntimeError::new(
-                        RuntimeErrorDomain::Task,
-                        "agent_invocation_failed",
-                        format!("failed to invoke agent: {direct_cause}"),
-                    )
-                    .with_safe_context("task_id", &task.id)
-                    .with_recovery_hint(
-                        "correct the target agent, template, model, or workspace configuration and retry",
+            let bridge = self
+                .runtime
+                .inner
+                .host_bridge
+                .clone()
+                .ok_or_else(|| anyhow!("agent invocation requires a host bridge"))?;
+            let (target_agent_id, created_new_subagent, workspace_mode, model_resolution) =
+                match &request.target {
+                    InvokeAgentTarget::ExistingAgent { agent_id } => (
+                        Some(agent_id.clone()),
+                        false,
+                        ChildAgentWorkspaceMode::Inherit,
+                        None,
                     ),
-                ));
-            }
-        };
-        admitted.task_detail["created_new_subagent"] = serde_json::json!(created_new_subagent);
-        let queued_task = self
-            .runtime
-            .start_agent_invocation_monitor(
-                task,
-                request.authority_class,
-                workspace_mode.is_worktree(),
-                admitted.child_agent_id.clone(),
-                admitted.child_turn_baseline,
-                admitted.task_detail,
-            )
-            .await?;
-        Ok(AgentInvocationReceipt {
-            agent_id: admitted.child_agent_id,
-            created: created_new_subagent,
-            task_handle: TaskHandle::from_task_record(&queued_task, None),
+                    InvokeAgentTarget::NewSubagent {
+                        workspace_mode,
+                        model_resolution,
+                        ..
+                    } => (
+                        None,
+                        true,
+                        *workspace_mode,
+                        Some(required_model_resolution(model_resolution.clone())?),
+                    ),
+                };
+            let summary = super::tasks::spawn_agent_task_label(&message);
+            let task = self
+                .runtime
+                .create_agent_invocation_task(
+                    summary,
+                    message.clone(),
+                    request.authority_class,
+                    target_agent_id,
+                    created_new_subagent,
+                    workspace_mode,
+                )
+                .await?;
+
+            let admitted = match request.target {
+                InvokeAgentTarget::ExistingAgent { agent_id } => {
+                    bridge
+                        .invoke_existing_agent(&task, &agent_id, message, request.authority_class)
+                        .await
+                }
+                InvokeAgentTarget::NewSubagent {
+                    template,
+                    workspace_mode,
+                    ..
+                } => {
+                    bridge
+                        .spawn_child_task(
+                            self.runtime.clone(),
+                            &task,
+                            message,
+                            request.authority_class,
+                            workspace_mode.is_worktree(),
+                            template,
+                            model_resolution.expect(
+                                "new subagent model resolution was validated before task creation",
+                            ),
+                        )
+                        .await
+                }
+            };
+            let mut admitted = match admitted {
+                Ok(admitted) => admitted,
+                Err(error) => {
+                    self.runtime
+                        .fail_agent_invocation_task(&task, &error)
+                        .await?;
+                    let direct_cause = collect_runtime_error_source_chain(&error)
+                        .last()
+                        .cloned()
+                        .unwrap_or_else(|| "agent invocation admission failed".to_string());
+                    return Err(error.context(
+                        RuntimeError::new(
+                            RuntimeErrorDomain::Task,
+                            "agent_invocation_failed",
+                            format!("failed to invoke agent: {direct_cause}"),
+                        )
+                        .with_safe_context("task_id", &task.id)
+                        .with_recovery_hint(
+                            "correct the target agent, template, model, or workspace configuration and retry",
+                        ),
+                    ));
+                }
+            };
+            admitted.task_detail["created_new_subagent"] = serde_json::json!(created_new_subagent);
+            let queued_task = self
+                .runtime
+                .start_agent_invocation_monitor(
+                    task,
+                    request.authority_class,
+                    workspace_mode.is_worktree(),
+                    admitted.child_agent_id.clone(),
+                    admitted.child_turn_baseline,
+                    admitted.task_detail,
+                )
+                .await?;
+            Ok(AgentInvocationReceipt {
+                agent_id: admitted.child_agent_id,
+                created: created_new_subagent,
+                task_handle: TaskHandle::from_task_record(&queued_task, None),
+            })
         })
     }
 }

--- a/src/runtime_db/agent_message_delivery.rs
+++ b/src/runtime_db/agent_message_delivery.rs
@@ -1,0 +1,904 @@
+//! Durable internal Agent message delivery ledger.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use rusqlite::{params, OptionalExtension, Transaction};
+
+use crate::{
+    runtime_db::agent_relations::canonical_relations_from_connection,
+    runtime_db::AgentMessageDeliveryRepository,
+    types::{
+        AgentIdentityLifecycle, AgentIdentityRecord, AgentMessageAdmissionEvidence,
+        AgentMessageDeliveryError, AgentMessageDeliveryOutcome, AgentMessageDeliveryReceipt,
+        AgentMessageDeliveryRecord, AgentMessageDeliveryRejectionCode, AgentMessageDeliveryState,
+        AgentPolicyEffect, AgentRegistryStatus, AgentState, AgentStatus,
+    },
+};
+
+const DELIVERY_DIAGNOSTIC_LIMIT: usize = 512;
+
+pub(crate) enum AgentMessageDeliveryAdmissionDecision {
+    Queue {
+        record: AgentMessageDeliveryRecord,
+        replace_existing: bool,
+    },
+    Complete {
+        record: AgentMessageDeliveryRecord,
+        insert: bool,
+        replay: bool,
+    },
+}
+
+impl AgentMessageDeliveryAdmissionDecision {
+    pub(crate) fn receipt(&self) -> AgentMessageDeliveryReceipt {
+        match self {
+            Self::Queue { record, .. } => record.receipt(false),
+            Self::Complete { record, replay, .. } => record.receipt(*replay),
+        }
+    }
+}
+
+impl AgentMessageDeliveryRepository<'_> {
+    pub fn latest(&self, delivery_id: &str) -> Result<Option<AgentMessageDeliveryRecord>> {
+        let connection = self.db.connection()?;
+        delivery_by_id(&connection, delivery_id)
+    }
+
+    pub fn latest_for_message(
+        &self,
+        message_id: &str,
+    ) -> Result<Option<AgentMessageDeliveryRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT payload_json
+                 FROM agent_message_deliveries
+                 WHERE message_id = ?1",
+                [message_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| decode_delivery(&payload))
+            .transpose()
+    }
+
+    pub fn receipt(&self, delivery_id: &str) -> Result<Option<AgentMessageDeliveryReceipt>> {
+        Ok(self
+            .latest(delivery_id)?
+            .map(|record| record.receipt(false)))
+    }
+
+    pub(crate) fn admit_without_queue(
+        &self,
+        candidate: &AgentMessageDeliveryRecord,
+    ) -> Result<AgentMessageDeliveryReceipt> {
+        self.db.transaction(|tx| {
+            let decision = prepare_delivery_admission_tx(tx, candidate)?;
+            match &decision {
+                AgentMessageDeliveryAdmissionDecision::Complete { .. } => {
+                    persist_completed_admission_tx(tx, &decision)?;
+                    Ok(decision.receipt())
+                }
+                AgentMessageDeliveryAdmissionDecision::Queue { .. } => {
+                    anyhow::bail!("active delivery admission requires a target queue transaction")
+                }
+            }
+        })
+    }
+}
+
+pub(crate) fn delivery_by_id(
+    connection: &rusqlite::Connection,
+    delivery_id: &str,
+) -> Result<Option<AgentMessageDeliveryRecord>> {
+    connection
+        .query_row(
+            "SELECT payload_json
+             FROM agent_message_deliveries
+             WHERE delivery_id = ?1",
+            [delivery_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| decode_delivery(&payload))
+        .transpose()
+}
+
+pub(crate) fn delivery_by_idempotency_scope_tx(
+    tx: &Transaction<'_>,
+    idempotency_scope: &str,
+    idempotency_key_digest: &str,
+) -> Result<Option<AgentMessageDeliveryRecord>> {
+    tx.query_row(
+        "SELECT payload_json
+         FROM agent_message_deliveries
+         WHERE idempotency_scope = ?1 AND idempotency_key_digest = ?2",
+        params![idempotency_scope, idempotency_key_digest],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()?
+    .map(|payload| decode_delivery(&payload))
+    .transpose()
+}
+
+pub(crate) fn delivery_by_message_id_tx(
+    tx: &Transaction<'_>,
+    message_id: &str,
+) -> Result<Option<AgentMessageDeliveryRecord>> {
+    tx.query_row(
+        "SELECT payload_json
+         FROM agent_message_deliveries
+         WHERE message_id = ?1",
+        [message_id],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()?
+    .map(|payload| decode_delivery(&payload))
+    .transpose()
+}
+
+pub(crate) fn prepare_delivery_admission_tx(
+    tx: &Transaction<'_>,
+    candidate: &AgentMessageDeliveryRecord,
+) -> Result<AgentMessageDeliveryAdmissionDecision> {
+    let existing = delivery_by_idempotency_scope_tx(
+        tx,
+        &candidate.idempotency_scope,
+        &candidate.idempotency_key_digest,
+    )?;
+    if let Some(existing) = existing.as_ref() {
+        if existing.request_digest != candidate.request_digest {
+            return Err(AgentMessageDeliveryError::IdempotencyConflict {
+                idempotency_scope: candidate.idempotency_scope.clone(),
+                idempotency_key_digest: candidate.idempotency_key_digest.clone(),
+            }
+            .into());
+        }
+        if existing.outcome == AgentMessageDeliveryOutcome::Accepted || !existing.retryable {
+            return Ok(AgentMessageDeliveryAdmissionDecision::Complete {
+                record: existing.clone(),
+                insert: false,
+                replay: true,
+            });
+        }
+    }
+
+    let identity = tx
+        .query_row(
+            "SELECT payload_json FROM agent_identities WHERE agent_id = ?1",
+            [&candidate.target_agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| {
+            serde_json::from_str::<AgentIdentityRecord>(&payload)
+                .context("decoding delivery target identity")
+        })
+        .transpose()?;
+    let state = tx
+        .query_row(
+            "SELECT payload_json FROM agent_states WHERE agent_id = ?1",
+            [&candidate.target_agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|payload| {
+            serde_json::from_str::<AgentState>(&payload)
+                .context("decoding delivery target agent state")
+        })
+        .transpose()?;
+    let relations = canonical_relations_from_connection(tx, &candidate.target_agent_id)?;
+    let policy = relations
+        .as_ref()
+        .and_then(|projection| projection.message_policy.as_ref());
+    let principal_id = match candidate.caller.principal_kind {
+        crate::types::AgentMessagePrincipalKind::SupervisingParent
+        | crate::types::AgentMessagePrincipalKind::PeerAgent => candidate
+            .caller
+            .caller_agent_id
+            .as_deref()
+            .unwrap_or(&candidate.caller.caller_principal),
+        crate::types::AgentMessagePrincipalKind::Operator
+        | crate::types::AgentMessagePrincipalKind::ExternalIngress
+        | crate::types::AgentMessagePrincipalKind::RuntimeCapability => {
+            &candidate.caller.caller_principal
+        }
+    };
+    let matched_rule = policy.and_then(|policy| {
+        policy.rules.iter().enumerate().find(|(_, rule)| {
+            rule.principal_kind == candidate.caller.principal_kind
+                && rule
+                    .principal_id
+                    .as_deref()
+                    .is_none_or(|expected| expected == principal_id)
+                && rule
+                    .route
+                    .as_deref()
+                    .is_none_or(|expected| expected == candidate.caller.route)
+        })
+    });
+    let allowed = matched_rule.map_or_else(
+        || policy.is_some_and(|policy| policy.default_effect == AgentPolicyEffect::Allow),
+        |(_, rule)| rule.effect == AgentPolicyEffect::Allow,
+    );
+    let evidence = AgentMessageAdmissionEvidence {
+        identity_revision: identity.as_ref().map(|identity| identity.revision),
+        identity_status: identity.as_ref().map(|identity| match identity.status {
+            AgentRegistryStatus::Active => AgentIdentityLifecycle::Active,
+            AgentRegistryStatus::Deleting => AgentIdentityLifecycle::Deleting,
+            AgentRegistryStatus::Deleted => AgentIdentityLifecycle::Deleted,
+        }),
+        runtime_status: state
+            .as_ref()
+            .map(|state| enum_string(&state.status))
+            .transpose()?,
+        message_policy_revision: policy.map(|policy| policy.revision),
+        principal_kind: candidate.caller.principal_kind,
+        principal_id: Some(principal_id.to_string()),
+        route: candidate.caller.route.clone(),
+        matched_rule_index: matched_rule.map(|(index, _)| index),
+    };
+    let rejection = match identity.as_ref().map(|identity| identity.status) {
+        None => Some((
+            AgentMessageDeliveryRejectionCode::TargetNotFound,
+            "target agent identity was not found",
+        )),
+        Some(AgentRegistryStatus::Deleting) => Some((
+            AgentMessageDeliveryRejectionCode::AgentDeleting,
+            "target agent is deletion-fenced",
+        )),
+        Some(AgentRegistryStatus::Deleted) => Some((
+            AgentMessageDeliveryRejectionCode::AgentDeleted,
+            "target agent is deleted",
+        )),
+        Some(AgentRegistryStatus::Active)
+            if state
+                .as_ref()
+                .is_some_and(|state| state.status == AgentStatus::Stopped) =>
+        {
+            Some((
+                AgentMessageDeliveryRejectionCode::AgentStopped,
+                "target agent is stopped",
+            ))
+        }
+        Some(AgentRegistryStatus::Active) if !allowed => Some((
+            AgentMessageDeliveryRejectionCode::MessageNotAuthorized,
+            "caller is not authorized by the target message policy",
+        )),
+        Some(AgentRegistryStatus::Active) => None,
+    };
+    let now = Utc::now();
+    let replace_existing = existing.is_some();
+    let mut record = existing.unwrap_or_else(|| candidate.clone());
+    record.admission_evidence = evidence;
+    record.updated_at = now;
+    record.state_version = record
+        .state_version
+        .saturating_add(u64::from(replace_existing));
+    if let Some((code, diagnostic)) = rejection {
+        record.message_id = None;
+        record.outcome = AgentMessageDeliveryOutcome::Rejected;
+        record.state = AgentMessageDeliveryState::Rejected;
+        record.rejection_code = Some(code);
+        record.retryable = code.retryable();
+        record.diagnostic = Some(bounded_diagnostic(diagnostic));
+        record.accepted_at = None;
+        record.terminal_at = Some(now);
+        return Ok(AgentMessageDeliveryAdmissionDecision::Complete {
+            record,
+            insert: !replace_existing,
+            replay: replace_existing,
+        });
+    }
+
+    record.message_id.clone_from(&candidate.message_id);
+    record.correlation_id.clone_from(&candidate.correlation_id);
+    record.causation_id.clone_from(&candidate.causation_id);
+    record.outcome = AgentMessageDeliveryOutcome::Accepted;
+    record.state = AgentMessageDeliveryState::Queued;
+    record.rejection_code = None;
+    record.retryable = false;
+    record.diagnostic = None;
+    record.accepted_at = Some(now);
+    record.terminal_at = None;
+    Ok(AgentMessageDeliveryAdmissionDecision::Queue {
+        record,
+        replace_existing,
+    })
+}
+
+pub(crate) fn insert_delivery_tx(
+    tx: &Transaction<'_>,
+    record: &AgentMessageDeliveryRecord,
+) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    tx.execute(
+        "INSERT INTO agent_message_deliveries (
+           delivery_id, target_agent_id, message_id, idempotency_scope,
+           idempotency_key_digest, request_digest, outcome, state, state_version,
+           rejection_code, retryable, accepted_at, terminal_at, created_at,
+           updated_at, payload_json
+         ) VALUES (
+           ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16
+         )",
+        params![
+            record.delivery_id,
+            record.target_agent_id,
+            record.message_id,
+            record.idempotency_scope,
+            record.idempotency_key_digest,
+            record.request_digest,
+            enum_string(&record.outcome)?,
+            enum_string(&record.state)?,
+            i64::try_from(record.state_version).context("delivery state version exceeds SQLite")?,
+            record
+                .rejection_code
+                .as_ref()
+                .map(enum_string)
+                .transpose()?,
+            i64::from(record.retryable),
+            record.accepted_at.map(timestamp),
+            record.terminal_at.map(timestamp),
+            timestamp(record.created_at),
+            timestamp(record.updated_at),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn persist_completed_admission_tx(
+    tx: &Transaction<'_>,
+    decision: &AgentMessageDeliveryAdmissionDecision,
+) -> Result<()> {
+    let AgentMessageDeliveryAdmissionDecision::Complete { record, insert, .. } = decision else {
+        return Ok(());
+    };
+    if *insert {
+        insert_delivery_tx(tx, record)
+    } else {
+        replace_delivery_tx(tx, record)
+    }
+}
+
+pub(crate) fn persist_queued_admission_tx(
+    tx: &Transaction<'_>,
+    decision: &AgentMessageDeliveryAdmissionDecision,
+) -> Result<()> {
+    let AgentMessageDeliveryAdmissionDecision::Queue {
+        record,
+        replace_existing,
+    } = decision
+    else {
+        return Ok(());
+    };
+    if *replace_existing {
+        replace_delivery_tx(tx, record)
+    } else {
+        insert_delivery_tx(tx, record)
+    }
+}
+
+fn replace_delivery_tx(tx: &Transaction<'_>, record: &AgentMessageDeliveryRecord) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let changed = tx.execute(
+        "UPDATE agent_message_deliveries
+         SET message_id = ?1, outcome = ?2, state = ?3, state_version = ?4,
+             rejection_code = ?5, retryable = ?6, accepted_at = ?7,
+             terminal_at = ?8, updated_at = ?9, payload_json = ?10
+         WHERE delivery_id = ?11",
+        params![
+            record.message_id,
+            enum_string(&record.outcome)?,
+            enum_string(&record.state)?,
+            i64::try_from(record.state_version).context("delivery state version exceeds SQLite")?,
+            record
+                .rejection_code
+                .as_ref()
+                .map(enum_string)
+                .transpose()?,
+            i64::from(record.retryable),
+            record.accepted_at.map(timestamp),
+            record.terminal_at.map(timestamp),
+            timestamp(record.updated_at),
+            payload_json,
+            record.delivery_id,
+        ],
+    )?;
+    anyhow::ensure!(changed == 1, "delivery {} not found", record.delivery_id);
+    Ok(())
+}
+
+pub(crate) fn compare_and_set_delivery_state_tx(
+    tx: &Transaction<'_>,
+    delivery_id: &str,
+    expected_state: AgentMessageDeliveryState,
+    next: &AgentMessageDeliveryRecord,
+) -> Result<bool> {
+    let payload_json = serde_json::to_string(next)?;
+    let changed = tx.execute(
+        "UPDATE agent_message_deliveries
+         SET state = ?1, state_version = ?2, terminal_at = ?3,
+             updated_at = ?4, payload_json = ?5
+         WHERE delivery_id = ?6 AND state = ?7 AND state_version = ?8",
+        params![
+            enum_string(&next.state)?,
+            i64::try_from(next.state_version).context("delivery state version exceeds SQLite")?,
+            next.terminal_at.map(timestamp),
+            timestamp(next.updated_at),
+            payload_json,
+            delivery_id,
+            enum_string(&expected_state)?,
+            i64::try_from(next.state_version.saturating_sub(1))
+                .context("delivery state version exceeds SQLite")?,
+        ],
+    )?;
+    Ok(changed == 1)
+}
+
+pub(crate) fn advance_delivery_state_for_message_tx(
+    tx: &Transaction<'_>,
+    message_id: &str,
+    next_state: AgentMessageDeliveryState,
+    diagnostic: Option<&str>,
+) -> Result<bool> {
+    let Some(mut record) = delivery_by_message_id_tx(tx, message_id)? else {
+        return Ok(false);
+    };
+    let valid = matches!(
+        (record.state, next_state),
+        (
+            AgentMessageDeliveryState::Queued,
+            AgentMessageDeliveryState::Dispatched
+                | AgentMessageDeliveryState::Consumed
+                | AgentMessageDeliveryState::Failed
+                | AgentMessageDeliveryState::CancelledByDeletion
+        ) | (
+            AgentMessageDeliveryState::Dispatched,
+            AgentMessageDeliveryState::Consumed
+                | AgentMessageDeliveryState::Failed
+                | AgentMessageDeliveryState::CancelledByDeletion
+        )
+    );
+    if !valid {
+        return Ok(false);
+    }
+
+    let expected_state = record.state;
+    let now = Utc::now();
+    record.state = next_state;
+    record.state_version = record.state_version.saturating_add(1);
+    record.updated_at = now;
+    record.terminal_at = next_state.is_terminal().then_some(now);
+    if let Some(diagnostic) = diagnostic {
+        record.diagnostic = Some(bounded_diagnostic(diagnostic));
+    }
+    compare_and_set_delivery_state_tx(tx, &record.delivery_id, expected_state, &record)
+}
+
+pub(crate) fn cancel_active_deliveries_for_target_tx(
+    tx: &Transaction<'_>,
+    target_agent_id: &str,
+) -> Result<usize> {
+    let queued = enum_string(&AgentMessageDeliveryState::Queued)?;
+    let dispatched = enum_string(&AgentMessageDeliveryState::Dispatched)?;
+    let records = {
+        let mut statement = tx.prepare(
+            "SELECT payload_json
+             FROM agent_message_deliveries
+             WHERE target_agent_id = ?1 AND state IN (?2, ?3)
+             ORDER BY created_at ASC, delivery_id ASC",
+        )?;
+        let rows = statement.query_map(params![target_agent_id, queued, dispatched], |row| {
+            row.get::<_, String>(0)
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+            .into_iter()
+            .map(|payload| decode_delivery(&payload))
+            .collect::<Result<Vec<_>>>()?
+    };
+
+    let mut cancelled = 0;
+    for record in records {
+        cancelled += usize::from(advance_delivery_state_for_message_tx(
+            tx,
+            record
+                .message_id
+                .as_deref()
+                .context("accepted delivery is missing its message id")?,
+            AgentMessageDeliveryState::CancelledByDeletion,
+            Some("target agent entered the deletion fence"),
+        )?);
+    }
+    Ok(cancelled)
+}
+
+fn decode_delivery(payload: &str) -> Result<AgentMessageDeliveryRecord> {
+    serde_json::from_str(payload).context("decoding agent message delivery payload")
+}
+
+fn enum_string<T: serde::Serialize>(value: &T) -> Result<String> {
+    Ok(serde_json::to_value(value)?
+        .as_str()
+        .context("delivery enum serialized to a non-string value")?
+        .to_string())
+}
+
+fn timestamp(value: chrono::DateTime<chrono::Utc>) -> String {
+    value.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+fn bounded_diagnostic(value: &str) -> String {
+    value.chars().take(DELIVERY_DIAGNOSTIC_LIMIT).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        runtime::AgentMessageDeliveryService,
+        runtime_db::{
+            transitions::{QueueMutation, QueueOperation, QueueTransitionCommand},
+            RuntimeDb,
+        },
+        types::{
+            AdmissionContext, AgentKind, AgentMessageCallerContext, AgentMessageDeliveryError,
+            AgentMessageDeliveryOutcome, AgentMessageDeliveryRejectionCode,
+            AgentMessagePrincipalKind, AgentMessageSendRequest, AgentOwnership, AgentProfilePreset,
+            AgentState, AgentStatus, AgentVisibility, AuthorityClass, MessageBody,
+            MessageDeliverySurface, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus,
+        },
+    };
+    use tempfile::TempDir;
+
+    fn runtime_db() -> Result<(TempDir, RuntimeDb)> {
+        let dir = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            dir.path().join("state/runtime.sqlite"),
+            dir.path().join("state/runtime.lock"),
+        )?;
+        Ok((dir, db))
+    }
+
+    fn seed_target(db: &RuntimeDb, status: AgentStatus) -> Result<()> {
+        db.agent_identities().upsert(&AgentIdentityRecord::new(
+            "target-agent",
+            AgentKind::Named,
+            AgentVisibility::Private,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        ))?;
+        let mut state = AgentState::new("target-agent");
+        state.status = status;
+        db.agent_states().upsert(&state)
+    }
+
+    fn caller() -> AgentMessageCallerContext {
+        AgentMessageCallerContext {
+            caller_principal: "runtime:agent-invocation".into(),
+            caller_agent_id: Some("caller-agent".into()),
+            principal_kind: AgentMessagePrincipalKind::RuntimeCapability,
+            route: "agent_invocation".into(),
+            origin: MessageOrigin::Task {
+                task_id: "task-delivery".into(),
+            },
+            authority_class: AuthorityClass::RuntimeInstruction,
+            delivery_surface: MessageDeliverySurface::RuntimeSystem,
+            admission_context: AdmissionContext::RuntimeOwned,
+            current_turn_id: Some("turn-delivery".into()),
+            current_task_id: Some("task-delivery".into()),
+            current_work_item_id: Some("work-delivery".into()),
+        }
+    }
+
+    fn request(key: &str, text: &str) -> AgentMessageSendRequest {
+        AgentMessageSendRequest {
+            target_agent_id: "target-agent".into(),
+            content: MessageBody::Text { text: text.into() },
+            client_idempotency_key: key.into(),
+            correlation_id: Some("correlation-delivery".into()),
+            causation_id: Some("message-parent".into()),
+            requested_priority: Some(Priority::Normal),
+        }
+    }
+
+    fn prepare(key: &str, text: &str) -> Result<crate::runtime::PreparedAgentMessageDelivery> {
+        AgentMessageDeliveryService::prepare(request(key, text), caller())
+    }
+
+    fn admission_command(
+        prepared: &crate::runtime::PreparedAgentMessageDelivery,
+    ) -> QueueTransitionCommand {
+        let now = Utc::now();
+        QueueTransitionCommand {
+            agent_id: prepared.message.agent_id.clone(),
+            operation: QueueOperation::Admit,
+            mutation: QueueMutation::Upsert(QueueEntryRecord {
+                message_id: prepared.message.id.clone(),
+                agent_id: prepared.message.agent_id.clone(),
+                priority: prepared.message.priority.clone(),
+                status: QueueEntryStatus::Queued,
+                created_at: now,
+                updated_at: now,
+            }),
+            scheduler_claim_work_item: None,
+            agent_state: None,
+            message_evidence: vec![prepared.message.clone()],
+            transcript_entries: Vec::new(),
+            turn_record: None,
+            audit_events: Vec::new(),
+            notify_scheduler: true,
+            fault: None,
+            brief_evidence: Vec::new(),
+        }
+    }
+
+    fn queue_transition(
+        db: &RuntimeDb,
+        current: &QueueEntryRecord,
+        operation: QueueOperation,
+        status: QueueEntryStatus,
+    ) -> Result<()> {
+        let mut next = current.clone();
+        next.status = status;
+        next.updated_at = Utc::now();
+        let mutation = match operation {
+            QueueOperation::Claim | QueueOperation::Interject => QueueMutation::Consume(next),
+            QueueOperation::Settle | QueueOperation::RepairDrop => QueueMutation::Upsert(next),
+            QueueOperation::Admit | QueueOperation::Requeue => {
+                unreachable!("test helper only advances admitted deliveries")
+            }
+        };
+        db.transitions().commit_queue(&QueueTransitionCommand {
+            agent_id: current.agent_id.clone(),
+            operation,
+            mutation,
+            scheduler_claim_work_item: None,
+            agent_state: None,
+            message_evidence: Vec::new(),
+            transcript_entries: Vec::new(),
+            turn_record: None,
+            audit_events: Vec::new(),
+            notify_scheduler: false,
+            fault: None,
+            brief_evidence: Vec::new(),
+        })?;
+        Ok(())
+    }
+
+    #[test]
+    fn accepted_delivery_is_idempotent_and_survives_restart() -> Result<()> {
+        let (dir, db) = runtime_db()?;
+        seed_target(&db, AgentStatus::AwakeIdle)?;
+        let prepared = prepare("stable-key", "hello")?;
+        assert_eq!(prepared.message.turn_id.as_deref(), Some("turn-delivery"));
+        let first = db.transitions().commit_delivery_admission(
+            &admission_command(&prepared),
+            None,
+            &prepared.record,
+        )?;
+        let first = first.delivery_receipt.context("missing delivery receipt")?;
+        assert_eq!(first.outcome, AgentMessageDeliveryOutcome::Accepted);
+        assert_eq!(first.state, AgentMessageDeliveryState::Queued);
+        assert!(!first.idempotent_replay);
+
+        let replay = prepare("stable-key", "hello")?;
+        let replay = db.transitions().commit_delivery_admission(
+            &admission_command(&replay),
+            None,
+            &replay.record,
+        )?;
+        let replay = replay.delivery_receipt.context("missing replay receipt")?;
+        assert_eq!(replay.delivery_id, first.delivery_id);
+        assert!(replay.idempotent_replay);
+        assert_eq!(db.queue_entries().latest_all()?.len(), 1);
+
+        let stored = db
+            .agent_message_deliveries()
+            .latest(&first.delivery_id)?
+            .context("missing delivery ledger record")?;
+        assert_eq!(
+            stored.admission_evidence.principal_id.as_deref(),
+            Some("runtime:agent-invocation")
+        );
+        assert_eq!(stored.admission_evidence.matched_rule_index, Some(1));
+        assert_eq!(
+            stored.caller.caller_agent_id.as_deref(),
+            Some("caller-agent")
+        );
+
+        let database_path = dir.path().join("state/runtime.sqlite");
+        let lock_path = dir.path().join("state/runtime.lock");
+        drop(db);
+        let reopened = RuntimeDb::open_and_migrate(database_path, lock_path)?;
+        let receipt = reopened
+            .agent_message_deliveries()
+            .receipt(&first.delivery_id)?
+            .context("delivery receipt did not survive restart")?;
+        assert_eq!(receipt.state, AgentMessageDeliveryState::Queued);
+        assert_eq!(
+            receipt.correlation_id.as_deref(),
+            Some("correlation-delivery")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn idempotency_conflict_is_typed_and_does_not_admit_twice() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        seed_target(&db, AgentStatus::AwakeIdle)?;
+        let first = prepare("conflict-key", "first")?;
+        db.transitions().commit_delivery_admission(
+            &admission_command(&first),
+            None,
+            &first.record,
+        )?;
+
+        let conflicting = prepare("conflict-key", "different")?;
+        let error = db
+            .transitions()
+            .commit_delivery_admission(&admission_command(&conflicting), None, &conflicting.record)
+            .unwrap_err();
+        assert!(error.downcast_ref::<AgentMessageDeliveryError>().is_some());
+        assert_eq!(db.queue_entries().latest_all()?.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn retryable_rejection_can_succeed_with_the_same_key() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        seed_target(&db, AgentStatus::Stopped)?;
+        let rejected = prepare("retry-key", "retry me")?;
+        let rejected = db
+            .agent_message_deliveries()
+            .admit_without_queue(&rejected.record)?;
+        assert_eq!(rejected.outcome, AgentMessageDeliveryOutcome::Rejected);
+        assert_eq!(
+            rejected.rejection_code,
+            Some(AgentMessageDeliveryRejectionCode::AgentStopped)
+        );
+        assert!(rejected.retryable);
+
+        let mut state = db
+            .agent_states()
+            .latest("target-agent")?
+            .context("missing target state")?;
+        state.status = AgentStatus::AwakeIdle;
+        db.agent_states().upsert(&state)?;
+        let retry = prepare("retry-key", "retry me")?;
+        let accepted = db.transitions().commit_delivery_admission(
+            &admission_command(&retry),
+            None,
+            &retry.record,
+        )?;
+        let accepted = accepted
+            .delivery_receipt
+            .context("missing accepted retry receipt")?;
+        assert_eq!(accepted.delivery_id, rejected.delivery_id);
+        assert_eq!(accepted.outcome, AgentMessageDeliveryOutcome::Accepted);
+        assert_eq!(accepted.state, AgentMessageDeliveryState::Queued);
+        assert!(!accepted.idempotent_replay);
+        Ok(())
+    }
+
+    #[test]
+    fn queue_lifecycle_and_deletion_fence_are_linearized() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        seed_target(&db, AgentStatus::AwakeIdle)?;
+        let prepared = prepare("delete-race", "race")?;
+        let accepted = db.transitions().commit_delivery_admission(
+            &admission_command(&prepared),
+            None,
+            &prepared.record,
+        )?;
+        let delivery_id = accepted
+            .delivery_receipt
+            .context("missing delivery receipt")?
+            .delivery_id;
+        let queued = db
+            .queue_entries()
+            .latest(&prepared.message.id)?
+            .context("missing queue entry")?;
+        queue_transition(
+            &db,
+            &queued,
+            QueueOperation::Claim,
+            QueueEntryStatus::Dequeued,
+        )?;
+        assert_eq!(
+            db.agent_message_deliveries()
+                .latest(&delivery_id)?
+                .context("missing dispatched delivery")?
+                .state,
+            AgentMessageDeliveryState::Dispatched
+        );
+
+        let identity = db
+            .agent_identities()
+            .latest("target-agent")?
+            .context("missing target identity")?;
+        db.agent_deletions()
+            .begin("target-agent", identity.revision, "test", false)?;
+        let cancelled = db
+            .agent_message_deliveries()
+            .latest(&delivery_id)?
+            .context("missing cancelled delivery")?;
+        assert_eq!(
+            cancelled.state,
+            AgentMessageDeliveryState::CancelledByDeletion
+        );
+        assert!(cancelled.terminal_at.is_some());
+
+        let deleting = prepare("after-fence", "late")?;
+        let rejected = db
+            .agent_message_deliveries()
+            .admit_without_queue(&deleting.record)?;
+        assert_eq!(
+            rejected.rejection_code,
+            Some(AgentMessageDeliveryRejectionCode::AgentDeleting)
+        );
+        assert!(!rejected.retryable);
+
+        let dequeued = db
+            .queue_entries()
+            .latest(&prepared.message.id)?
+            .context("missing dequeued entry")?;
+        queue_transition(
+            &db,
+            &dequeued,
+            QueueOperation::Settle,
+            QueueEntryStatus::Processed,
+        )?;
+        assert_eq!(
+            db.agent_message_deliveries()
+                .latest(&delivery_id)?
+                .context("missing terminal delivery")?
+                .state,
+            AgentMessageDeliveryState::CancelledByDeletion
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn failed_delivery_diagnostic_is_bounded() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        seed_target(&db, AgentStatus::AwakeIdle)?;
+        let prepared = prepare("diagnostic-key", "fail")?;
+        let accepted = db.transitions().commit_delivery_admission(
+            &admission_command(&prepared),
+            None,
+            &prepared.record,
+        )?;
+        let delivery_id = accepted
+            .delivery_receipt
+            .context("missing delivery receipt")?
+            .delivery_id;
+        let diagnostic = "x".repeat(DELIVERY_DIAGNOSTIC_LIMIT + 100);
+        db.transaction(|tx| {
+            anyhow::ensure!(advance_delivery_state_for_message_tx(
+                tx,
+                &prepared.message.id,
+                AgentMessageDeliveryState::Failed,
+                Some(&diagnostic),
+            )?);
+            Ok(())
+        })?;
+        let failed = db
+            .agent_message_deliveries()
+            .latest(&delivery_id)?
+            .context("missing failed delivery")?;
+        assert_eq!(failed.state, AgentMessageDeliveryState::Failed);
+        assert_eq!(
+            failed
+                .diagnostic
+                .as_deref()
+                .context("missing failure diagnostic")?
+                .chars()
+                .count(),
+            DELIVERY_DIAGNOSTIC_LIMIT
+        );
+        Ok(())
+    }
+}

--- a/src/runtime_db/agent_relations.rs
+++ b/src/runtime_db/agent_relations.rs
@@ -1051,12 +1051,20 @@ fn legacy_message_policy(
     identity: &AgentIdentityRecord,
     supervision: Option<&AgentSupervisionRecord>,
 ) -> AgentMessagePolicyRecord {
-    let mut rules = vec![AgentMessagePolicyRule {
-        principal_kind: AgentMessagePrincipalKind::Operator,
-        principal_id: None,
-        route: Some("operator_control".into()),
-        effect: AgentPolicyEffect::Allow,
-    }];
+    let mut rules = vec![
+        AgentMessagePolicyRule {
+            principal_kind: AgentMessagePrincipalKind::Operator,
+            principal_id: None,
+            route: Some("operator_control".into()),
+            effect: AgentPolicyEffect::Allow,
+        },
+        AgentMessagePolicyRule {
+            principal_kind: AgentMessagePrincipalKind::RuntimeCapability,
+            principal_id: Some("runtime:agent-invocation".into()),
+            route: Some("agent_invocation".into()),
+            effect: AgentPolicyEffect::Allow,
+        },
+    ];
     if let Some(supervision) = supervision.filter(|record| {
         matches!(
             record.state,

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3389,6 +3389,43 @@ CREATE TABLE IF NOT EXISTS agent_message_policy_rules (
 );
 "#,
     },
+    Migration {
+        version: 60,
+        name: "agent_message_delivery_ledger",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS agent_message_deliveries (
+  delivery_id TEXT PRIMARY KEY,
+  target_agent_id TEXT NOT NULL,
+  message_id TEXT UNIQUE,
+  idempotency_scope TEXT NOT NULL,
+  idempotency_key_digest TEXT NOT NULL,
+  request_digest TEXT NOT NULL,
+  outcome TEXT NOT NULL CHECK (outcome IN ('accepted', 'rejected')),
+  state TEXT NOT NULL CHECK (
+    state IN (
+      'queued', 'dispatched', 'consumed', 'failed',
+      'cancelled_by_deletion', 'rejected'
+    )
+  ),
+  state_version INTEGER NOT NULL CHECK (state_version >= 0),
+  rejection_code TEXT,
+  retryable INTEGER NOT NULL CHECK (retryable IN (0, 1)),
+  accepted_at TEXT,
+  terminal_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  UNIQUE (idempotency_scope, idempotency_key_digest)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_message_deliveries_target_state
+  ON agent_message_deliveries(target_agent_id, state, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_agent_message_deliveries_message
+  ON agent_message_deliveries(message_id)
+  WHERE message_id IS NOT NULL;
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -10,6 +10,7 @@
 //! - [`repositories`]: domain repository implementations.
 //! - [`index_outbox`]: runtime index outbox repository.
 
+pub mod agent_message_delivery;
 pub mod agent_relations;
 pub mod audit;
 pub mod authentication;
@@ -58,13 +59,13 @@ pub use crate::runtime_db::retired_scheduler_cleanup::{
 pub use crate::runtime_db::storage_domain::{ExpectedStorageDomain, StorageDomainSnapshot};
 pub use crate::runtime_db::types::{
     AgentBootstrapRepository, AgentCanonicalRelationRepository, AgentDeletionRepository,
-    AgentIdentityRepository, AgentStateRepository, AuditEventSink, ContextEpisodeRepository,
-    EvidenceRepository, ExecutionRootEntryRepository, ExternalTriggerRepository, MessageRepository,
-    OperatorDeliveryRepository, OperatorNotificationRepository, OperatorTransportBindingRepository,
-    QueueEntryRepository, TaskRepository, TimerRepository, TranscriptRepository,
-    TurnRecordRepository, WaitConditionRepository, WorkItemContinuationRepository,
-    WorkItemDelegationRepository, WorkItemRepository, WorkspaceEntryRepository,
-    WorkspaceOccupancyRepository,
+    AgentIdentityRepository, AgentMessageDeliveryRepository, AgentStateRepository, AuditEventSink,
+    ContextEpisodeRepository, EvidenceRepository, ExecutionRootEntryRepository,
+    ExternalTriggerRepository, MessageRepository, OperatorDeliveryRepository,
+    OperatorNotificationRepository, OperatorTransportBindingRepository, QueueEntryRepository,
+    TaskRepository, TimerRepository, TranscriptRepository, TurnRecordRepository,
+    WaitConditionRepository, WorkItemContinuationRepository, WorkItemDelegationRepository,
+    WorkItemRepository, WorkspaceEntryRepository, WorkspaceOccupancyRepository,
 };
 #[cfg(test)]
 mod tests;
@@ -538,6 +539,10 @@ impl RuntimeDb {
 
     pub fn agent_deletions(&self) -> AgentDeletionRepository<'_> {
         AgentDeletionRepository { db: self }
+    }
+
+    pub fn agent_message_deliveries(&self) -> AgentMessageDeliveryRepository<'_> {
+        AgentMessageDeliveryRepository { db: self }
     }
 
     pub fn work_item_delegations(&self) -> WorkItemDelegationRepository<'_> {

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -608,6 +608,9 @@ impl AgentDeletionRepository<'_> {
             identity.updated_at = now;
             upsert_agent_identity_tx(tx, &identity)?;
             insert_agent_deletion_job_tx(tx, &job)?;
+            crate::runtime_db::agent_message_delivery::cancel_active_deliveries_for_target_tx(
+                tx, agent_id,
+            )?;
             Ok((identity, job, true))
         })
     }

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -7,13 +7,18 @@ mod execution_protocol_fixture_repository;
 pub(crate) mod execution_protocol_repository;
 pub(crate) use execution_protocol_repository::{authority_fences_tx, persist_state_tx};
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use chrono::Utc;
 use rusqlite::{OptionalExtension, Transaction};
 use std::collections::BTreeMap;
 
 use crate::{
     runtime_db::{
+        agent_message_delivery::{
+            advance_delivery_state_for_message_tx, delivery_by_message_id_tx,
+            persist_completed_admission_tx, persist_queued_admission_tx,
+            prepare_delivery_admission_tx, AgentMessageDeliveryAdmissionDecision,
+        },
         evidence::{
             append_audit_event_tx, append_message_tx, append_transcript_entry_tx,
             insert_brief_evidence_tx, insert_runtime_index_changes_tx, insert_tool_evidence_tx,
@@ -30,6 +35,7 @@ use crate::{
     },
     runtime_error::RuntimeError,
     types::{
+        AgentMessageDeliveryReceipt, AgentMessageDeliveryRecord, AgentMessageDeliveryState,
         AgentState, AuditEvent, BriefRecord, MessageEnvelope, QueueEntryRecord, QueueEntryStatus,
         TaskRecord, ToolExecutionRecord, TranscriptEntry, TurnRecord, WaitConditionRecord,
         WorkItemContinuationFrame, WorkItemRecord, WorkItemSchedulingState, WorkItemState,
@@ -126,6 +132,7 @@ pub(crate) struct AgentStateMutation {
 pub(crate) struct TransitionCommit {
     pub applied: bool,
     pub effects: PostCommitEffects,
+    pub delivery_receipt: Option<AgentMessageDeliveryReceipt>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1076,6 +1083,24 @@ impl RuntimeTransitionRepository<'_> {
         )
     }
 
+    pub fn commit_delivery_admission(
+        &self,
+        command: &QueueTransitionCommand,
+        wait_trigger: Option<&QueueWaitTransition>,
+        delivery: &AgentMessageDeliveryRecord,
+    ) -> Result<TransitionCommit> {
+        self.commit_queue_transaction_with_delivery(
+            command,
+            &ExecutionProtocolTransition::default(),
+            wait_trigger,
+            None,
+            None,
+            &[],
+            &[],
+            Some(delivery),
+        )
+    }
+
     fn commit_queue_transaction(
         &self,
         command: &QueueTransitionCommand,
@@ -1086,7 +1111,49 @@ impl RuntimeTransitionRepository<'_> {
         terminal_tool_executions: &[ToolExecutionRecord],
         extra_wait_conditions: &[crate::types::WaitConditionRecord],
     ) -> Result<TransitionCommit> {
+        self.commit_queue_transaction_with_delivery(
+            command,
+            execution_protocol,
+            wait_transition,
+            task_expectation,
+            completion,
+            terminal_tool_executions,
+            extra_wait_conditions,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn commit_queue_transaction_with_delivery(
+        &self,
+        command: &QueueTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+        wait_transition: Option<&QueueWaitTransition>,
+        task_expectation: Option<&TaskExpectation>,
+        completion: Option<&CompletionTransition>,
+        terminal_tool_executions: &[ToolExecutionRecord],
+        extra_wait_conditions: &[crate::types::WaitConditionRecord],
+        delivery: Option<&AgentMessageDeliveryRecord>,
+    ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
+            let delivery = delivery
+                .map(|delivery| prepare_delivery_admission_tx(tx, delivery))
+                .transpose()?;
+            if let Some(decision @ AgentMessageDeliveryAdmissionDecision::Complete { .. }) =
+                delivery.as_ref()
+            {
+                persist_completed_admission_tx(tx, decision)?;
+                return Ok(TransitionCommit {
+                    applied: true,
+                    effects: PostCommitEffects::default(),
+                    delivery_receipt: Some(decision.receipt()),
+                });
+            }
+            if let Some(AgentMessageDeliveryAdmissionDecision::Queue { record, .. }) =
+                delivery.as_ref()
+            {
+                validate_delivery_queue_admission(command, record)?;
+            }
             validate_queue_operation(command)?;
             validate_queue_mutation_tx(tx, &command.mutation)?;
             if let Some(wait_transition) = wait_transition {
@@ -1125,6 +1192,15 @@ impl RuntimeTransitionRepository<'_> {
                 &command.agent_id,
                 terminal_tool_executions,
             )?;
+            let queue_record = queue_mutation_record(&command.mutation);
+            if delivery_by_message_id_tx(tx, &queue_record.message_id)?.is_some_and(|delivery| {
+                !matches!(
+                    delivery.state,
+                    AgentMessageDeliveryState::Queued | AgentMessageDeliveryState::Dispatched
+                )
+            }) {
+                return Ok(TransitionCommit::default());
+            }
             if let QueueMutation::Consume(record) = &command.mutation {
                 let include_interrupted = match command.operation {
                     QueueOperation::Claim => true,
@@ -1211,6 +1287,7 @@ impl RuntimeTransitionRepository<'_> {
             if !matches!(&command.mutation, QueueMutation::Upsert(_)) && !mutation_applied {
                 return Ok(TransitionCommit::default());
             }
+            advance_delivery_for_queue_transition_tx(tx, command)?;
             let agent_state_applied =
                 apply_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
             let execution_protocol_applied = execution_protocol
@@ -1312,6 +1389,10 @@ impl RuntimeTransitionRepository<'_> {
                 || wait_work_item_applied
                 || completion_applied
                 || terminal_tool_execution_applied;
+            if let Some(decision) = delivery.as_ref() {
+                persist_queued_admission_tx(tx, decision)?;
+                applied = true;
+            }
             let mut message_index_changes = Vec::new();
             for message in &command.message_evidence {
                 let (message, inserted) = append_message_tx(tx, message)?;
@@ -1363,7 +1444,10 @@ impl RuntimeTransitionRepository<'_> {
                 &command.brief_evidence,
                 &commit.effects.audit_events,
             )?;
-            Ok(commit)
+            Ok(TransitionCommit {
+                delivery_receipt: delivery.as_ref().map(|decision| decision.receipt()),
+                ..commit
+            })
         })
     }
 
@@ -1577,6 +1661,7 @@ fn finish_transition_tx(
     Ok(TransitionCommit {
         applied: true,
         effects,
+        delivery_receipt: None,
     })
 }
 
@@ -2130,10 +2215,7 @@ fn validate_wait_condition_tx(tx: &Transaction<'_>, incoming: &WaitConditionReco
 }
 
 fn validate_queue_mutation_tx(tx: &Transaction<'_>, mutation: &QueueMutation) -> Result<()> {
-    let incoming = match mutation {
-        QueueMutation::Consume(record) | QueueMutation::Upsert(record) => record,
-        QueueMutation::CompareAndSet { record, .. } => record,
-    };
+    let incoming = queue_mutation_record(mutation);
     let existing = tx
         .query_row(
             "SELECT payload_json FROM queue_entries WHERE message_id = ?1",
@@ -2152,6 +2234,70 @@ fn validate_queue_mutation_tx(tx: &Transaction<'_>, mutation: &QueueMutation) ->
         }
         _ => {}
     }
+    Ok(())
+}
+
+fn queue_mutation_record(mutation: &QueueMutation) -> &QueueEntryRecord {
+    match mutation {
+        QueueMutation::Consume(record) | QueueMutation::Upsert(record) => record,
+        QueueMutation::CompareAndSet { record, .. } => record,
+    }
+}
+
+fn advance_delivery_for_queue_transition_tx(
+    tx: &Transaction<'_>,
+    command: &QueueTransitionCommand,
+) -> Result<bool> {
+    let record = queue_mutation_record(&command.mutation);
+    let next = match (command.operation, &record.status) {
+        (QueueOperation::Claim, QueueEntryStatus::Dequeued) => {
+            Some(AgentMessageDeliveryState::Dispatched)
+        }
+        (QueueOperation::Interject, QueueEntryStatus::Interjected)
+        | (QueueOperation::Settle, QueueEntryStatus::Processed) => {
+            Some(AgentMessageDeliveryState::Consumed)
+        }
+        (
+            QueueOperation::Settle | QueueOperation::RepairDrop,
+            QueueEntryStatus::Aborted | QueueEntryStatus::Dropped | QueueEntryStatus::Quarantined,
+        ) => Some(AgentMessageDeliveryState::Failed),
+        _ => None,
+    };
+    next.map(|next| {
+        advance_delivery_state_for_message_tx(
+            tx,
+            &record.message_id,
+            next,
+            (next == AgentMessageDeliveryState::Failed)
+                .then_some("message queue processing terminated before consumption"),
+        )
+    })
+    .transpose()
+    .map(Option::unwrap_or_default)
+}
+
+fn validate_delivery_queue_admission(
+    command: &QueueTransitionCommand,
+    delivery: &AgentMessageDeliveryRecord,
+) -> Result<()> {
+    let queue_record = match &command.mutation {
+        QueueMutation::Consume(record) | QueueMutation::Upsert(record) => record,
+        QueueMutation::CompareAndSet { record, .. } => record,
+    };
+    let message_id = delivery
+        .message_id
+        .as_deref()
+        .context("accepted delivery is missing message identity")?;
+    anyhow::ensure!(
+        message_id == queue_record.message_id,
+        "delivery message identity does not match queue admission"
+    );
+    anyhow::ensure!(
+        command.message_evidence.iter().any(|message| {
+            message.id == message_id && message.agent_id == delivery.target_agent_id
+        }),
+        "delivery message identity does not match message evidence"
+    );
     Ok(())
 }
 

--- a/src/runtime_db/types.rs
+++ b/src/runtime_db/types.rs
@@ -78,6 +78,10 @@ pub struct AgentDeletionRepository<'a> {
     pub(crate) db: &'a RuntimeDb,
 }
 
+pub struct AgentMessageDeliveryRepository<'a> {
+    pub(crate) db: &'a RuntimeDb,
+}
+
 pub struct WorkItemDelegationRepository<'a> {
     pub(crate) db: &'a RuntimeDb,
 }

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -142,135 +142,251 @@ pub(crate) fn execute_builtin_tool_with_context<'a>(
     call: &'a ToolCall,
     context: &'a ToolExecutionContext,
 ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
-    Box::pin(execute_builtin_tool_inner(
-        runtime,
-        agent_id,
-        authority_class,
-        call,
-        context,
-    ))
+    execute_builtin_tool_inner(runtime, agent_id, authority_class, call, context)
 }
 
-async fn execute_builtin_tool_inner(
-    runtime: &RuntimeHandle,
-    agent_id: &str,
-    authority_class: &AuthorityClass,
-    call: &ToolCall,
-    context: &ToolExecutionContext,
-) -> Result<ToolResult> {
+fn execute_builtin_tool_inner<'a>(
+    runtime: &'a RuntimeHandle,
+    agent_id: &'a str,
+    authority_class: &'a AuthorityClass,
+    call: &'a ToolCall,
+    context: &'a ToolExecutionContext,
+) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
     match call.name.as_str() {
-        sleep::NAME => sleep::execute(runtime, agent_id, authority_class, &call.input).await,
-        wait_for::NAME => wait_for::execute(runtime, agent_id, authority_class, &call.input).await,
-        timer::CREATE_NAME => timer::create(runtime, &call.input).await,
-        timer::LIST_NAME => timer::list(runtime, &call.input).await,
-        timer::GET_NAME => timer::get(runtime, &call.input).await,
-        timer::CANCEL_NAME => timer::cancel(runtime, &call.input).await,
-        agent_get::NAME => {
-            agent_get::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        enqueue::NAME => enqueue::execute(runtime, agent_id, authority_class, &call.input).await,
-        spawn_agent::NAME => {
-            spawn_agent::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        task_list::NAME => {
-            task_list::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        task_list::LEGACY_NAME => {
-            task_list::execute_legacy(runtime, agent_id, authority_class, &call.input).await
-        }
-        task_status::NAME => {
-            task_status::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        task_input::NAME => {
-            task_input::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        task_output::NAME => {
-            task_output::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        task_stop::NAME => {
-            task_stop::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        list_model_providers::NAME => {
-            list_model_providers::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        list_provider_models::NAME => {
-            list_provider_models::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        create_work_item::NAME => {
-            create_work_item::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        pick_work_item::NAME => {
-            pick_work_item::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        get_work_item::NAME => {
-            get_work_item::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        generate_image::NAME => {
-            generate_image::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        list_work_items::NAME => {
-            list_work_items::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        update_work_item::NAME => {
-            update_work_item::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        complete_work_item::NAME => {
-            complete_work_item::execute(runtime, agent_id, authority_class, &call.input, context)
-                .await
-        }
-        memory_search::NAME => {
-            memory_search::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        memory_get::NAME => {
-            memory_get::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        get_workspace_state::NAME => {
-            get_workspace_state::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        attach_workspace::NAME => {
-            attach_workspace::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        detach_workspace::NAME => {
-            detach_workspace::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        switch_workspace::NAME => {
-            switch_workspace::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        create_worktree::NAME => {
-            create_worktree::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        remove_worktree::NAME => {
-            remove_worktree::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        create_external_trigger::NAME => {
-            create_external_trigger::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        cancel_external_trigger::NAME => {
-            cancel_external_trigger::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        apply_patch_tool::NAME => {
-            apply_patch_tool::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        exec_command::NAME => {
-            exec_command::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        exec_command_batch::NAME => {
-            exec_command_batch::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        use_workspace::NAME => {
-            use_workspace::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        view_image::NAME => {
-            view_image::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        web_fetch::NAME => {
-            web_fetch::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        web_search::NAME => {
-            web_search::execute(runtime, agent_id, authority_class, &call.input).await
-        }
-        x_search::NAME => x_search::execute(runtime, agent_id, authority_class, &call.input).await,
-        _ => Err(anyhow!("unknown builtin tool {}", call.name)),
+        sleep::NAME => Box::pin(sleep::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        wait_for::NAME => Box::pin(wait_for::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        timer::CREATE_NAME => Box::pin(timer::create(runtime, &call.input)),
+        timer::LIST_NAME => Box::pin(timer::list(runtime, &call.input)),
+        timer::GET_NAME => Box::pin(timer::get(runtime, &call.input)),
+        timer::CANCEL_NAME => Box::pin(timer::cancel(runtime, &call.input)),
+        agent_get::NAME => Box::pin(agent_get::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        enqueue::NAME => Box::pin(enqueue::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        spawn_agent::NAME => Box::pin(spawn_agent::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        task_list::NAME => Box::pin(task_list::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        task_list::LEGACY_NAME => Box::pin(task_list::execute_legacy(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        task_status::NAME => Box::pin(task_status::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        task_input::NAME => Box::pin(task_input::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        task_output::NAME => Box::pin(task_output::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        task_stop::NAME => Box::pin(task_stop::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        list_model_providers::NAME => Box::pin(list_model_providers::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        list_provider_models::NAME => Box::pin(list_provider_models::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        create_work_item::NAME => Box::pin(create_work_item::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        pick_work_item::NAME => Box::pin(pick_work_item::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        get_work_item::NAME => Box::pin(get_work_item::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        generate_image::NAME => Box::pin(generate_image::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        list_work_items::NAME => Box::pin(list_work_items::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        update_work_item::NAME => Box::pin(update_work_item::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        complete_work_item::NAME => Box::pin(complete_work_item::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+            context,
+        )),
+        memory_search::NAME => Box::pin(memory_search::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        memory_get::NAME => Box::pin(memory_get::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        get_workspace_state::NAME => Box::pin(get_workspace_state::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        attach_workspace::NAME => Box::pin(attach_workspace::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        detach_workspace::NAME => Box::pin(detach_workspace::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        switch_workspace::NAME => Box::pin(switch_workspace::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        create_worktree::NAME => Box::pin(create_worktree::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        remove_worktree::NAME => Box::pin(remove_worktree::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        create_external_trigger::NAME => Box::pin(create_external_trigger::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        cancel_external_trigger::NAME => Box::pin(cancel_external_trigger::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        apply_patch_tool::NAME => Box::pin(apply_patch_tool::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        exec_command::NAME => Box::pin(exec_command::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        exec_command_batch::NAME => Box::pin(exec_command_batch::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        use_workspace::NAME => Box::pin(use_workspace::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        view_image::NAME => Box::pin(view_image::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        web_fetch::NAME => Box::pin(web_fetch::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        web_search::NAME => Box::pin(web_search::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        x_search::NAME => Box::pin(x_search::execute(
+            runtime,
+            agent_id,
+            authority_class,
+            &call.input,
+        )),
+        _ => Box::pin(async move { Err(anyhow!("unknown builtin tool {}", call.name)) }),
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1704,7 +1704,7 @@ pub enum Priority {
     Background,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MessageOrigin {
     Operator {
@@ -1735,7 +1735,7 @@ pub enum MessageOrigin {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MessageBody {
     Text {
@@ -2102,7 +2102,7 @@ fn collect_source_ref(metadata: &Value, refs: &mut BTreeMap<String, String>, key
     refs.entry(key.to_string()).or_insert(value);
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum MessageDeliverySurface {
     CliPrompt,
@@ -2118,7 +2118,7 @@ pub enum MessageDeliverySurface {
     TaskRejoin,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AdmissionContext {
     PublicUnauthenticated,


### PR DESCRIPTION
## Summary

- add an internal `AgentMessageDeliveryService` and SQLite-backed delivery repository with durable request, idempotency, provenance, admission evidence, lifecycle status, and bounded diagnostics
- linearize target lifecycle checks, authorization, idempotency decisions, delivery records, and queue admission in one database transaction
- integrate post-commit wake reconciliation, monotonic delivery lifecycle updates, and deletion fencing so accepted work cannot reactivate deleting agents
- preserve the Phase D boundary: no public `SendAgentMessage` tool or operator invoke surface is added
- move large built-in tool execution branches behind heap boundaries to keep default test-thread stack usage bounded

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- exact default-stack regressions for `run_once` and `scripted_agent_provider`
- `RUSTFLAGS="-D warnings" make test`
- `make snapshots-check`
- `make test-resource-lint`
- `make lint`

`make lint` reports the repository's existing Clippy warnings but exits successfully under the CI command.
