### PR TITLE
feat: cut over agent relation writes and backfill

### DIFF
--- a/docs/implementation-decisions/124-agent-relation-write-cutover-and-backfill.md
+++ b/docs/implementation-decisions/124-agent-relation-write-cutover-and-backfill.md
@@ -1,0 +1,27 @@
+# Agent relation write cutover and explicit backfill
+
+New Agent creation and terminal lifecycle writes commit the compatibility
+identity row and canonical relation/policy records in one SQLite transaction.
+The legacy identity fields remain populated so older readers can continue to
+read the database during Phase F, but no production create path may commit a
+legacy-only identity.
+
+Historical data is migrated only through
+`holon debug runtime-db agent-relations`. The default mode is a read-only
+report that does not upgrade the database schema; `--apply` requires the
+offline maintenance lock and creates a verified pre-migration database backup
+unless `--no-backup` is explicitly supplied. Backfill reuses the same per-axis
+projection used by compatibility reads, migrates only legacy axes without
+diagnostics, and records bounded unresolved evidence instead of guessing.
+
+An apply run commits each Agent and its checkpoint in one transaction. A
+restart reuses the durable `running` run and skips completed Agent checkpoints;
+an explicit failed run is retained for audit and a retry starts a new run.
+Backfill never rewrites Agent identity, AgentHome, history, tasks/results,
+workspace ownership, deletion jobs, or tombstones.
+
+Schema 61 is additive. Phase F rollback therefore means restoring a verified
+pre-upgrade database backup before starting an older binary: older binaries
+reject a newer schema version rather than silently ignoring canonical state.
+Mixed-version compatibility is provided at the data-contract level by the
+retained identity mirror, not by opening schema 61 with an older binary.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -759,6 +759,19 @@ pub enum ModelsDevCommands {
 
 #[derive(Debug, Subcommand)]
 pub enum RuntimeDbDebugCommands {
+    #[command(
+        about = "Report or backfill canonical agent relation and policy records from durable legacy evidence"
+    )]
+    AgentRelations {
+        #[arg(long)]
+        apply: bool,
+        #[arg(long, requires = "apply")]
+        no_backup: bool,
+        #[arg(long, default_value_t = 20, value_parser = parse_positive_usize)]
+        diagnostic_sample_limit: usize,
+        #[arg(long)]
+        json: bool,
+    },
     Audit {
         #[arg(long, value_enum, default_value_t = RuntimeDbAuditCheckArg::All)]
         check: RuntimeDbAuditCheckArg,

--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -123,9 +123,18 @@ impl RuntimeHost {
                 continue;
             }
 
-            let result = self.execute_deletion_phase(&agent_id, *phase, &job).await;
+            let result = if *phase == AgentDeletionPhase::Finalize {
+                self.deletion_phase_finalize(&job).await.map(Some)
+            } else {
+                self.execute_deletion_phase(&agent_id, *phase, &job)
+                    .await
+                    .map(|_| None)
+            };
             match result {
-                Ok(()) => {
+                Ok(finalized_job) => {
+                    if let Some(finalized_job) = finalized_job {
+                        job = finalized_job;
+                    }
                     // Advance to next phase.
                     if let Some(next) = phase.next() {
                         job.phase = next;
@@ -153,10 +162,12 @@ impl RuntimeHost {
         }
 
         // All phases completed.
-        job.status = AgentDeletionStatus::Completed;
-        job.completed_at = Some(Utc::now());
-        job.updated_at = Utc::now();
-        self.runtime_db().agent_deletions().update(&job)?;
+        if job.status != AgentDeletionStatus::Completed {
+            job.status = AgentDeletionStatus::Completed;
+            job.completed_at = Some(Utc::now());
+            job.updated_at = Utc::now();
+            self.runtime_db().agent_deletions().update(&job)?;
+        }
 
         info!(
             agent_id = %agent_id,
@@ -180,7 +191,9 @@ impl RuntimeHost {
             AgentDeletionPhase::Workspace => self.deletion_phase_workspace(agent_id).await,
             AgentDeletionPhase::Index => self.deletion_phase_index(agent_id).await,
             AgentDeletionPhase::Home => self.deletion_phase_home(agent_id).await,
-            AgentDeletionPhase::Finalize => self.deletion_phase_finalize(agent_id).await,
+            AgentDeletionPhase::Finalize => {
+                unreachable!("finalize uses the atomic repository path")
+            }
         }
     }
 
@@ -604,19 +617,11 @@ impl RuntimeHost {
     }
 
     /// Finalize: set identity to Deleted and emit audit event.
-    async fn deletion_phase_finalize(&self, agent_id: &str) -> Result<()> {
-        let mut identity = self
-            .agent_identity_record(agent_id)?
-            .ok_or_else(|| anyhow!("agent {agent_id} identity not found during finalize"))?;
-        if identity.status != AgentRegistryStatus::Deleted {
-            identity.status = AgentRegistryStatus::Deleted;
-            identity.deleted_at = Some(Utc::now());
-            identity.updated_at = Utc::now();
-            identity.revision = identity.revision.saturating_add(1);
-            self.append_agent_identity(&identity)?;
-        }
-        info!(agent_id, "agent identity finalized as Deleted");
-        Ok(())
+    async fn deletion_phase_finalize(&self, job: &AgentDeletionJob) -> Result<AgentDeletionJob> {
+        let (identity, completed_job) = self.runtime_db().agent_deletions().finalize(job)?;
+        self.cache_agent_identity(&identity)?;
+        info!(agent_id = %job.agent_id, "agent identity finalized as Deleted");
+        Ok(completed_job)
     }
 
     /// Cascade deletion to private children of the given agent.
@@ -653,7 +658,7 @@ impl RuntimeHost {
                         &parent_job.requested_by,
                         false, // Don't recurse further
                     )?;
-                    self.append_agent_identity(&updated_identity)?;
+                    self.cache_agent_identity(&updated_identity)?;
                     job
                 }
             };

--- a/src/domain/agent.rs
+++ b/src/domain/agent.rs
@@ -410,3 +410,36 @@ pub struct AgentCanonicalRecordSet {
     pub capability_policy: Option<AgentCapabilityPolicyRecord>,
     pub message_policy: Option<AgentMessagePolicyRecord>,
 }
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRelationBackfillOutcome {
+    Applied,
+    Unchanged,
+    Diagnostic,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct AgentRelationBackfillDiagnostic {
+    pub agent_id: String,
+    pub migrated_axes: Vec<AgentCanonicalRelationAxis>,
+    pub issues: Vec<AgentCanonicalProjectionIssue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct AgentRelationBackfillReport {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backup_path: Option<String>,
+    pub apply: bool,
+    pub scanned_agents: usize,
+    pub changed_agents: usize,
+    pub unchanged_agents: usize,
+    pub diagnostic_agents: usize,
+    pub migrated_axes: usize,
+    pub diagnostic_sample_limit: usize,
+    pub diagnostics: Vec<AgentRelationBackfillDiagnostic>,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: DateTime<Utc>,
+}

--- a/src/host.rs
+++ b/src/host.rs
@@ -40,7 +40,10 @@ use crate::{
         InitialWorkspaceBinding, LightweightAgentStateProjection, RuntimeHandle,
         SchedulerRepairInspection,
     },
-    runtime_db::RuntimeDb,
+    runtime_db::{
+        agent_relations::{independent_creation_records, supervised_creation_records},
+        RuntimeDb,
+    },
     runtime_error::{describe_runtime_error, RuntimeError},
     skills::{
         effective_skill_root_registrations, skills_runtime_view_from_catalog, SkillVisibility,
@@ -56,19 +59,20 @@ use crate::{
         normalize_agent_name, AdmissionContext, AgentBootstrapDesiredState,
         AgentBootstrapInitialMessage, AgentBootstrapRecord, AgentBootstrapStatus,
         AgentBootstrapStep, AgentBootstrapStepStatus, AgentBootstrapWorkspaceState,
-        AgentCreateReceipt, AgentCreateResult, AgentCreateStage, AgentDeletionJob, AgentDetail,
-        AgentDurability, AgentIdentityRecord, AgentIdentityView, AgentKind, AgentLifecycleHint,
-        AgentListEntry, AgentMessageCallerContext, AgentMessageDeliveryOutcome,
-        AgentMessageDeliveryRejectionCode, AgentMessagePrincipalKind, AgentMessageSendRequest,
-        AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState, AgentStatus,
-        AgentSummary, AgentSupervisionState, AgentTokenUsageSummary, AgentTreeNode,
-        AgentTreeProjection, AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome,
-        CreateAgentRequest, ExternalTriggerRecord, ExternalTriggerStatus, ExternalTriggerSummary,
-        LoadedAgentsMdView, MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind,
-        MessageOrigin, OperatorNotificationRecord, Priority, QueueEntryStatus,
-        RuntimeFailureSummary, SpawnAgentModelResolution, SpawnAgentModelResolutionStatus,
-        TaskKind, TaskRecord, TaskStatus, TimerRecord, TokenUsage, TranscriptEntry,
-        TranscriptEntryKind, WaitConditionSummary, WorkspaceEntry, WorkspaceOccupancyRecord,
+        AgentCanonicalDurability, AgentCreateReceipt, AgentCreateResult, AgentCreateStage,
+        AgentDeletionJob, AgentDetail, AgentDurability, AgentIdentityRecord, AgentIdentityView,
+        AgentKind, AgentLifecycleHint, AgentListEntry, AgentMessageCallerContext,
+        AgentMessageDeliveryOutcome, AgentMessageDeliveryRejectionCode, AgentMessagePrincipalKind,
+        AgentMessageSendRequest, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
+        AgentState, AgentStatus, AgentSummary, AgentSupervisionState, AgentTokenUsageSummary,
+        AgentTreeNode, AgentTreeProjection, AgentVisibility, AuthorityClass, ChildAgentSummary,
+        ClosureOutcome, CreateAgentRequest, ExternalTriggerRecord, ExternalTriggerStatus,
+        ExternalTriggerSummary, LoadedAgentsMdView, MessageBody, MessageDeliverySurface,
+        MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationRecord, Priority,
+        QueueEntryStatus, RuntimeFailureSummary, SpawnAgentModelResolution,
+        SpawnAgentModelResolutionStatus, TaskKind, TaskRecord, TaskStatus, TimerRecord, TokenUsage,
+        TranscriptEntry, TranscriptEntryKind, WaitConditionSummary, WorkspaceEntry,
+        WorkspaceOccupancyRecord,
     },
 };
 
@@ -1822,7 +1826,9 @@ impl RuntimeHost {
                 cascade_private_children,
             )
             .map_err(PublicAgentError::Runtime)?;
-        self.append_agent_identity(&updated_identity)
+        self.inner
+            .registry
+            .cache_agent_identity(&updated_identity)
             .map_err(PublicAgentError::Runtime)?;
         self.unload_runtime(agent_id).await;
         // Trigger the deletion coordinator inline for immediate progress.
@@ -2489,9 +2495,14 @@ impl RuntimeHost {
         .with_lineage_parent_agent_id(lineage_parent_agent_id.map(ToString::to_string));
         record.name = normalized_name;
         let bootstrap = AgentBootstrapRecord::new(agent_id, desired);
+        let relations = independent_creation_records(
+            &record,
+            lineage_parent_agent_id,
+            AgentCanonicalDurability::Persistent,
+        );
         self.runtime_db()
             .agent_identities()
-            .create_with_bootstrap(&record, &bootstrap)
+            .create_with_bootstrap_and_relations(&record, &bootstrap, &relations)
             .map_err(|error| {
                 if error.to_string().contains("agent_identity_conflict") {
                     return named_agent_already_exists_error(agent_id);
@@ -2930,7 +2941,12 @@ impl RuntimeHost {
             None,
         );
         identity.durability = Some(AgentDurability::Ephemeral);
-        self.append_agent_identity(&identity)?;
+        let relations =
+            independent_creation_records(&identity, None, AgentCanonicalDurability::Ephemeral);
+        self.runtime_db()
+            .agent_identities()
+            .create_with_relations(&identity, &relations)?;
+        self.cache_agent_identity(&identity)?;
         let (runtime, runtime_task, _phase) = match self.spawn_runtime(&agent_id, None) {
             Ok(spawned) => spawned,
             Err(error) => {
@@ -2945,15 +2961,15 @@ impl RuntimeHost {
         if !Self::is_temporary_agent_id(agent_id) {
             bail!("agent {agent_id} is not a temporary runtime");
         }
-        let Some(mut identity) = self.agent_identity_record(agent_id)? else {
+        let Some(identity) = self.agent_identity_record(agent_id)? else {
             bail!("temporary runtime {agent_id} is missing its host identity");
         };
         if identity.status != AgentRegistryStatus::Deleted {
-            identity.status = AgentRegistryStatus::Deleted;
-            identity.revision = identity.revision.saturating_add(1);
-            identity.deleted_at = Some(Utc::now());
-            identity.updated_at = Utc::now();
-            self.append_agent_identity(&identity)?;
+            let identity = self
+                .runtime_db()
+                .agent_identities()
+                .tombstone_with_closed_supervision(agent_id)?;
+            self.cache_agent_identity(&identity)?;
         }
         Ok(())
     }
@@ -2998,8 +3014,13 @@ impl RuntimeHost {
             .import_legacy(records)
     }
 
+    #[cfg(test)]
     pub(crate) fn append_agent_identity(&self, record: &AgentIdentityRecord) -> Result<()> {
         self.inner.registry.append_agent_identity(record)
+    }
+
+    pub(crate) fn cache_agent_identity(&self, record: &AgentIdentityRecord) -> Result<()> {
+        self.inner.registry.cache_agent_identity(record)
     }
 
     fn workspace_occupancy_by_id(
@@ -3832,7 +3853,7 @@ impl RuntimeHost {
     async fn create_child_identity(
         &self,
         parent_agent_id: &str,
-        task_id: &str,
+        task: &TaskRecord,
         template: Option<&str>,
         catalog_agent_home: &Path,
     ) -> Result<AgentIdentityRecord> {
@@ -3865,21 +3886,31 @@ impl RuntimeHost {
             AgentOwnership::ParentSupervised,
             AgentProfilePreset::PrivateChild,
             Some(parent_agent_id.to_string()),
-            Some(task_id.to_string()),
+            Some(task.id.clone()),
         )
         .with_lineage_parent_agent_id(Some(parent_agent_id.to_string()));
         record.durability = Some(AgentDurability::Ephemeral);
-        self.append_agent_identity(&record)?;
+        let relations = supervised_creation_records(
+            &record,
+            parent_agent_id,
+            &task.id,
+            task.effective_work_item_id(),
+        );
+        self.runtime_db()
+            .agent_identities()
+            .create_with_relations(&record, &relations)?;
+        self.inner.registry.cache_agent_identity(&record)?;
         Ok(record)
     }
 
     async fn archive_private_agent(&self, agent_id: &str) -> Result<()> {
-        if let Some(mut identity) = self.agent_identity_record(agent_id)? {
+        if let Some(identity) = self.agent_identity_record(agent_id)? {
             if identity.status != AgentRegistryStatus::Deleted {
-                identity.status = AgentRegistryStatus::Deleted;
-                identity.deleted_at = Some(chrono::Utc::now());
-                identity.updated_at = chrono::Utc::now();
-                self.append_agent_identity(&identity)?;
+                let identity = self
+                    .runtime_db()
+                    .agent_identities()
+                    .tombstone_with_closed_supervision(agent_id)?;
+                self.cache_agent_identity(&identity)?;
             }
         }
 
@@ -4005,12 +4036,13 @@ impl RuntimeHost {
     }
 
     fn archive_private_agent_identity_record(&self, agent_id: &str) -> Result<()> {
-        if let Some(mut identity) = self.agent_identity_record(agent_id)? {
+        if let Some(identity) = self.agent_identity_record(agent_id)? {
             if identity.status != AgentRegistryStatus::Deleted {
-                identity.status = AgentRegistryStatus::Deleted;
-                identity.deleted_at = Some(chrono::Utc::now());
-                identity.updated_at = chrono::Utc::now();
-                self.append_agent_identity(&identity)?;
+                let identity = self
+                    .runtime_db()
+                    .agent_identities()
+                    .tombstone_with_closed_supervision(agent_id)?;
+                self.cache_agent_identity(&identity)?;
             }
         }
         // Abort pending queue entries as a safety net for agents that were
@@ -4046,7 +4078,7 @@ impl RuntimeHost {
         let child_identity = self
             .create_child_identity(
                 &parent_state.id,
-                &task.id,
+                task,
                 template.as_deref(),
                 &parent_agent_home,
             )
@@ -5258,10 +5290,11 @@ mod tests {
         );
 
         let parent_state = recovered.agent_state().await.unwrap();
+        let task = test_child_supervision_task(&parent_state.id, "configured-home-task");
         let child_identity = host
             .create_child_identity(
                 &parent_state.id,
-                "configured-home-task",
+                &task,
                 None,
                 recovered.agent_home().as_path(),
             )
@@ -5383,6 +5416,23 @@ mod tests {
             resolved_parameters: None,
             resolution_status: SpawnAgentModelResolutionStatus::Inherited,
             policy_notes: Vec::new(),
+        }
+    }
+
+    fn test_child_supervision_task(agent_id: &str, task_id: &str) -> TaskRecord {
+        let now = chrono::Utc::now();
+        TaskRecord {
+            id: task_id.to_string(),
+            agent_id: agent_id.to_string(),
+            kind: crate::types::TaskKind::ChildAgentTask,
+            status: TaskStatus::Running,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: None,
+            summary: None,
+            detail: None,
+            recovery: None,
         }
     }
 
@@ -5513,6 +5563,28 @@ mod tests {
         assert_eq!(created.visibility, AgentVisibility::Public);
         assert_eq!(created.ownership(), AgentOwnership::SelfOwned);
         assert_eq!(created.profile_preset(), AgentProfilePreset::PublicNamed);
+        let relations = host
+            .runtime_db()
+            .agent_canonical_relations()
+            .latest("release-bot")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            relations.sources.durability,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
+        assert_eq!(
+            relations.sources.lifecycle_attachment,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
+        assert_eq!(
+            relations.sources.capability_policy,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
+        assert_eq!(
+            relations.sources.message_policy,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
         let agent_home = host.agent_data_dir("release-bot");
         assert!(agent_home.join("AGENTS.md").is_file());
         assert!(std::fs::read_to_string(agent_home.join("AGENTS.md"))
@@ -7201,10 +7273,41 @@ mod tests {
             .unwrap();
         let parent_state = parent.agent_state().await.unwrap();
         let parent_agent_home = host.agent_data_dir(&parent_state.id);
+        let task = test_child_supervision_task(&parent_state.id, "task-1");
         let child_identity = host
-            .create_child_identity(&parent_state.id, "task-1", None, &parent_agent_home)
+            .create_child_identity(&parent_state.id, &task, None, &parent_agent_home)
             .await
             .unwrap();
+        let relations = host
+            .runtime_db()
+            .agent_canonical_relations()
+            .latest(&child_identity.agent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            relations.sources.lineage,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
+        assert_eq!(
+            relations.sources.supervision,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
+        assert_eq!(
+            relations.sources.durability,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
+        assert_eq!(
+            relations.sources.lifecycle_attachment,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
+        assert_eq!(
+            relations.sources.capability_policy,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
+        assert_eq!(
+            relations.sources.message_policy,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
         let child_home = host.agent_data_dir(&child_identity.agent_id);
         assert!(child_home.join("AGENTS.md").is_file());
         assert!(std::fs::read_to_string(child_home.join("AGENTS.md"))
@@ -7249,13 +7352,9 @@ mod tests {
         fs::create_dir_all(&template_dir).unwrap();
         fs::write(template_dir.join("AGENTS.md"), "parent catalog worker").unwrap();
 
+        let task = test_child_supervision_task(&parent_state.id, "task-1");
         let child_identity = host
-            .create_child_identity(
-                &parent_state.id,
-                "task-1",
-                Some("worker"),
-                &parent_agent_home,
-            )
+            .create_child_identity(&parent_state.id, &task, Some("worker"), &parent_agent_home)
             .await
             .unwrap();
         let child_home = host.agent_data_dir(&child_identity.agent_id);
@@ -8964,6 +9063,14 @@ mod tests {
         );
         host.append_agent_identity(&child).unwrap();
         host.runtime_db().agent_identities().upsert(&child).unwrap();
+        host.runtime_db()
+            .agent_canonical_relations()
+            .upsert_supervision(
+                &supervised_creation_records(&child, parent_id, "task-queue-1", None)
+                    .supervision
+                    .unwrap(),
+            )
+            .unwrap();
 
         let now = Utc::now();
         host.runtime_db()
@@ -9010,6 +9117,17 @@ mod tests {
                 .unwrap()
                 .status,
             QueueEntryStatus::Aborted
+        );
+        assert_eq!(
+            host.runtime_db()
+                .agent_canonical_relations()
+                .latest(child_id)
+                .unwrap()
+                .unwrap()
+                .supervision
+                .unwrap()
+                .state,
+            AgentSupervisionState::Closed
         );
     }
 

--- a/src/host_registry.rs
+++ b/src/host_registry.rs
@@ -8,11 +8,12 @@ use arc_swap::ArcSwap;
 use crate::{
     config::AppConfig,
     ids,
-    runtime_db::RuntimeDb,
+    runtime_db::{agent_relations::independent_creation_records, RuntimeDb},
     storage::AppStorage,
     system::WorkspaceAccessMode,
     types::{
-        agent_home_workspace_id, AgentIdentityRecord, WorkspaceEntry, WorkspaceOccupancyRecord,
+        agent_home_workspace_id, AgentCanonicalDurability, AgentIdentityRecord, WorkspaceEntry,
+        WorkspaceOccupancyRecord,
     },
 };
 
@@ -94,6 +95,7 @@ impl RuntimeRegistry {
         Ok(records)
     }
 
+    #[cfg(test)]
     pub(crate) fn append_agent_identity(&self, record: &AgentIdentityRecord) -> Result<()> {
         self.inner.host_storage.append_agent_identity(record)?;
         self.cache_agent_identity(record)
@@ -346,7 +348,15 @@ impl RuntimeRegistry {
             None,
             None,
         );
-        self.append_agent_identity(&record)?;
+        let relations =
+            independent_creation_records(&record, None, AgentCanonicalDurability::Persistent);
+        self.inner
+            .host_storage
+            .runtime_db()?
+            .expect("host storage always has a runtime database")
+            .agent_identities()
+            .create_with_relations(&record, &relations)?;
+        self.cache_agent_identity(&record)?;
         Ok(record)
     }
 
@@ -769,7 +779,33 @@ mod tests {
     #[test]
     fn ensure_workspace_entry_recognizes_agent_home_path() {
         let (_home, registry) = test_registry();
-        registry.ensure_default_agent_identity().unwrap();
+        let identity = registry.ensure_default_agent_identity().unwrap();
+        let projection = registry
+            .inner
+            .host_storage
+            .runtime_db()
+            .unwrap()
+            .unwrap()
+            .agent_canonical_relations()
+            .latest(&identity.agent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            projection.sources.durability,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
+        assert_eq!(
+            projection.sources.lifecycle_attachment,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
+        assert_eq!(
+            projection.sources.capability_policy,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
+        assert_eq!(
+            projection.sources.message_policy,
+            Some(crate::types::AgentCanonicalValueSource::Canonical)
+        );
         let agent_id = registry.config().default_agent_id.clone();
         let agent_home = registry.config().agent_root_dir().join(&agent_id);
         std::fs::create_dir_all(&agent_home).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1118,6 +1118,7 @@ async fn dump_prompt(
 mod tests {
     use super::*;
     use holon::{
+        cli::RuntimeDbDebugCommands,
         config::{provider_registry_for_tests, AltScreenMode, ModelRouteRef},
         runtime_db::RuntimeDb,
     };
@@ -1661,6 +1662,71 @@ mod tests {
         };
         assert_eq!(agent.as_deref(), Some("pm"));
         assert_eq!(output, PathBuf::from("/tmp/scheduler-case"));
+    }
+
+    #[test]
+    fn debug_runtime_db_agent_relations_defaults_to_report_mode() {
+        let cli = Cli::parse_from(["holon", "debug", "runtime-db", "agent-relations", "--json"]);
+        let Commands::Debug {
+            command:
+                DebugCommands::RuntimeDb {
+                    command:
+                        RuntimeDbDebugCommands::AgentRelations {
+                            apply,
+                            no_backup,
+                            diagnostic_sample_limit,
+                            json,
+                        },
+                },
+        } = cli.command
+        else {
+            panic!("expected debug runtime-db agent-relations command");
+        };
+        assert!(!apply);
+        assert!(!no_backup);
+        assert_eq!(diagnostic_sample_limit, 20);
+        assert!(json);
+        assert!(Cli::try_parse_from([
+            "holon",
+            "debug",
+            "runtime-db",
+            "agent-relations",
+            "--no-backup",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn debug_runtime_db_agent_relations_parses_apply_options() {
+        let cli = Cli::parse_from([
+            "holon",
+            "debug",
+            "runtime-db",
+            "agent-relations",
+            "--apply",
+            "--no-backup",
+            "--diagnostic-sample-limit",
+            "7",
+        ]);
+        let Commands::Debug {
+            command:
+                DebugCommands::RuntimeDb {
+                    command:
+                        RuntimeDbDebugCommands::AgentRelations {
+                            apply,
+                            no_backup,
+                            diagnostic_sample_limit,
+                            json,
+                        },
+                },
+        } = cli.command
+        else {
+            panic!("expected debug runtime-db agent-relations command");
+        };
+        assert!(apply);
+        assert!(no_backup);
+        assert_eq!(diagnostic_sample_limit, 7);
+        assert!(!json);
     }
 
     #[test]
@@ -3316,6 +3382,71 @@ fn handle_runtime_db_debug_command(
     command: holon::cli::RuntimeDbDebugCommands,
 ) -> Result<()> {
     match command {
+        holon::cli::RuntimeDbDebugCommands::AgentRelations {
+            apply,
+            no_backup,
+            diagnostic_sample_limit,
+            json,
+        } => {
+            let _maintenance_lock = apply
+                .then(|| {
+                    RuntimeDbLock::try_lock(config.runtime_db_maintenance_lock_path())
+                        .context("runtime database maintenance is already running")
+                })
+                .transpose()?;
+            let inspection_db = RuntimeDb::open_for_agent_relation_backfill(
+                config.runtime_db_path(),
+                config.runtime_db_lock_path(),
+            )?;
+            let backup_path = if apply && !no_backup {
+                Some(inspection_db.create_agent_relation_backfill_backup()?)
+            } else {
+                None
+            };
+            let db = if apply {
+                drop(inspection_db);
+                RuntimeDb::open_and_migrate(
+                    config.runtime_db_path(),
+                    config.runtime_db_lock_path(),
+                )?
+            } else {
+                inspection_db
+            };
+            let report = db.agent_canonical_relations().backfill_with_backup(
+                apply,
+                diagnostic_sample_limit,
+                backup_path.map(|path| path.display().to_string()),
+            )?;
+            if json {
+                print_json(&serde_json::to_value(report)?)
+            } else {
+                println!(
+                    "agent relation backfill: mode={} scanned={} changed={} unchanged={} diagnostics={} migrated_axes={}",
+                    if report.apply { "apply" } else { "report" },
+                    report.scanned_agents,
+                    report.changed_agents,
+                    report.unchanged_agents,
+                    report.diagnostic_agents,
+                    report.migrated_axes
+                );
+                if let Some(backup_path) = &report.backup_path {
+                    println!("  backup: {backup_path}");
+                }
+                for diagnostic in &report.diagnostics {
+                    println!(
+                        "  agent={} migrated_axes={:?}",
+                        diagnostic.agent_id, diagnostic.migrated_axes
+                    );
+                    for issue in &diagnostic.issues {
+                        println!(
+                            "    axis={:?} resolution={:?} detail={}",
+                            issue.axis, issue.resolution, issue.detail
+                        );
+                    }
+                }
+                Ok(())
+            }
+        }
         holon::cli::RuntimeDbDebugCommands::Audit {
             check,
             baseline_through,

--- a/src/runtime_db/agent_relations.rs
+++ b/src/runtime_db/agent_relations.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::{Context, Result};
+use chrono::Utc;
 use rusqlite::{params, OptionalExtension, Transaction};
 
 use crate::runtime_db::types::AgentCanonicalRelationRepository;
@@ -13,7 +14,9 @@ use crate::types::{
     AgentLifecycleAttachmentRecord, AgentLifecycleFenceState, AgentLineageCreationCause,
     AgentLineageRecord, AgentMessagePolicyRecord, AgentMessagePolicyRule,
     AgentMessagePrincipalKind, AgentOwnership, AgentPolicyEffect, AgentProfilePreset,
-    AgentRegistryStatus, AgentSupervisionRecord, AgentSupervisionState, TaskKind, TaskRecord,
+    AgentRegistryStatus, AgentRelationBackfillDiagnostic, AgentRelationBackfillOutcome,
+    AgentRelationBackfillReport, AgentSupervisionRecord, AgentSupervisionState, TaskKind,
+    TaskRecord,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -120,6 +123,424 @@ impl AgentCanonicalRelationRepository<'_> {
         records.sort_by(|left, right| left.child_agent_id.cmp(&right.child_agent_id));
         Ok(records)
     }
+
+    pub fn backfill(
+        &self,
+        apply: bool,
+        diagnostic_sample_limit: usize,
+    ) -> Result<AgentRelationBackfillReport> {
+        self.backfill_with_backup(apply, diagnostic_sample_limit, None)
+    }
+
+    pub fn backfill_with_backup(
+        &self,
+        apply: bool,
+        diagnostic_sample_limit: usize,
+        backup_path: Option<String>,
+    ) -> Result<AgentRelationBackfillReport> {
+        let requested_at = Utc::now();
+        let run = if apply {
+            Some(self.db.transaction(|tx| {
+                let existing = tx
+                    .query_row(
+                        "SELECT run_id, started_at FROM agent_relation_backfill_runs
+                         WHERE status = 'running'
+                         ORDER BY started_at DESC LIMIT 1",
+                        [],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                    )
+                    .optional()?;
+                if let Some((run_id, started_at)) = existing {
+                    return Ok((
+                        run_id,
+                        parse_timestamp(&started_at, "relation backfill run")?,
+                    ));
+                }
+                let run_id = format!("agent-relations-{}", uuid::Uuid::new_v4().simple());
+                tx.execute(
+                    "INSERT INTO agent_relation_backfill_runs (
+                       run_id, status, started_at, updated_at
+                     ) VALUES (?1, 'running', ?2, ?2)",
+                    params![run_id, timestamp(requested_at)],
+                )?;
+                Ok((run_id, requested_at))
+            })?)
+        } else {
+            None
+        };
+        let run_id = run.as_ref().map(|(run_id, _)| run_id.clone());
+        let started_at = run
+            .as_ref()
+            .map(|(_, started_at)| *started_at)
+            .unwrap_or(requested_at);
+
+        let agent_ids = {
+            let connection = self.db.connection()?;
+            let mut statement = connection
+                .prepare("SELECT agent_id FROM agent_identities ORDER BY agent_id ASC")?;
+            let agent_ids = statement
+                .query_map([], |row| row.get::<_, String>(0))?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            agent_ids
+        };
+        let mut report = AgentRelationBackfillReport {
+            run_id: run_id.clone(),
+            backup_path,
+            apply,
+            scanned_agents: 0,
+            changed_agents: 0,
+            unchanged_agents: 0,
+            diagnostic_agents: 0,
+            migrated_axes: 0,
+            diagnostic_sample_limit,
+            diagnostics: Vec::new(),
+            started_at,
+            completed_at: started_at,
+        };
+
+        for agent_id in agent_ids {
+            let result = self.db.transaction(|tx| {
+                backfill_agent_relations_tx(tx, &agent_id, apply, run_id.as_deref())
+            });
+            let (migrated_axes, issues) = match result {
+                Ok(result) => result,
+                Err(error) => {
+                    if let Some(run_id) = run_id.as_deref() {
+                        let failed_at = Utc::now();
+                        report.completed_at = failed_at;
+                        self.db.transaction(|tx| {
+                            tx.execute(
+                                "UPDATE agent_relation_backfill_runs
+                                 SET status = 'failed', updated_at = ?1, completed_at = ?1,
+                                     report_json = ?2
+                                 WHERE run_id = ?3",
+                                params![
+                                    timestamp(failed_at),
+                                    serde_json::to_string(&report)?,
+                                    run_id
+                                ],
+                            )?;
+                            Ok(())
+                        })?;
+                    }
+                    return Err(error).with_context(|| {
+                        format!("backfilling canonical relations for agent {agent_id}")
+                    });
+                }
+            };
+            report.scanned_agents += 1;
+            report.migrated_axes += migrated_axes.len();
+            if migrated_axes.is_empty() {
+                report.unchanged_agents += 1;
+            } else {
+                report.changed_agents += 1;
+            }
+            if !issues.is_empty() {
+                report.diagnostic_agents += 1;
+                if report.diagnostics.len() < diagnostic_sample_limit {
+                    report.diagnostics.push(AgentRelationBackfillDiagnostic {
+                        agent_id,
+                        migrated_axes,
+                        issues,
+                    });
+                }
+            }
+        }
+
+        report.completed_at = Utc::now();
+        if let Some(run_id) = run_id.as_deref() {
+            self.db.transaction(|tx| {
+                tx.execute(
+                    "UPDATE agent_relation_backfill_runs
+                     SET status = 'completed', updated_at = ?1, completed_at = ?1,
+                         report_json = ?2
+                     WHERE run_id = ?3",
+                    params![
+                        timestamp(report.completed_at),
+                        serde_json::to_string(&report)?,
+                        run_id
+                    ],
+                )?;
+                Ok(())
+            })?;
+        }
+        Ok(report)
+    }
+}
+
+fn backfill_agent_relations_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    apply: bool,
+    run_id: Option<&str>,
+) -> Result<(
+    Vec<AgentCanonicalRelationAxis>,
+    Vec<AgentCanonicalProjectionIssue>,
+)> {
+    if let Some(run_id) = run_id.filter(|_| apply) {
+        let checkpoint = tx
+            .query_row(
+                "SELECT migrated_axes_json, issues_json
+                 FROM agent_relation_backfill_outcomes
+                 WHERE run_id = ?1 AND agent_id = ?2",
+                params![run_id, agent_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?;
+        if let Some((migrated_axes, issues)) = checkpoint {
+            return Ok((
+                serde_json::from_str(&migrated_axes)
+                    .context("decoding relation backfill checkpoint axes")?,
+                serde_json::from_str(&issues)
+                    .context("decoding relation backfill checkpoint issues")?,
+            ));
+        }
+    }
+    let payload = tx.query_row(
+        "SELECT payload_json FROM agent_identities WHERE agent_id = ?1",
+        [agent_id],
+        |row| row.get::<_, String>(0),
+    )?;
+    let identity: AgentIdentityRecord =
+        serde_json::from_str(&payload).context("decoding agent identity for relation backfill")?;
+    let canonical = AgentCanonicalRecordSet {
+        lineage: latest_lineage(tx, agent_id)?,
+        supervision: latest_supervision(tx, agent_id)?,
+        durability: latest_durability(tx, agent_id)?,
+        lifecycle_attachment: latest_lifecycle_attachment(tx, agent_id)?,
+        capability_policy: latest_capability_policy(tx, agent_id)?,
+        message_policy: latest_message_policy(tx, agent_id)?,
+    };
+    let task = identity
+        .delegated_from_task_id
+        .as_deref()
+        .map(|task_id| legacy_task_evidence(tx, task_id))
+        .transpose()?
+        .flatten();
+    let projection = project_agent_canonical_relations(&identity, canonical, task.as_ref());
+    let (records, migrated_axes) = legacy_axes_without_issues(&projection);
+    if apply {
+        upsert_canonical_record_set_tx(tx, &records)?;
+        let outcome = if projection.issues.is_empty() {
+            if migrated_axes.is_empty() {
+                AgentRelationBackfillOutcome::Unchanged
+            } else {
+                AgentRelationBackfillOutcome::Applied
+            }
+        } else {
+            AgentRelationBackfillOutcome::Diagnostic
+        };
+        tx.execute(
+            "INSERT INTO agent_relation_backfill_outcomes (
+               run_id, agent_id, identity_revision, outcome, migrated_axes_json,
+               issues_json, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(run_id, agent_id) DO UPDATE SET
+               identity_revision = excluded.identity_revision,
+               outcome = excluded.outcome,
+               migrated_axes_json = excluded.migrated_axes_json,
+               issues_json = excluded.issues_json,
+               updated_at = excluded.updated_at",
+            params![
+                run_id.context("apply backfill requires a run id")?,
+                agent_id,
+                sqlite_revision(identity.revision)?,
+                enum_string(&outcome)?,
+                serde_json::to_string(&migrated_axes)?,
+                serde_json::to_string(&projection.issues)?,
+                timestamp(Utc::now()),
+            ],
+        )?;
+    }
+    Ok((migrated_axes, projection.issues))
+}
+
+fn legacy_axes_without_issues(
+    projection: &AgentCanonicalRelationsProjection,
+) -> (AgentCanonicalRecordSet, Vec<AgentCanonicalRelationAxis>) {
+    let can_migrate = |axis| !projection.issues.iter().any(|issue| issue.axis == axis);
+    let mut records = AgentCanonicalRecordSet::default();
+    let mut axes = Vec::new();
+    if projection.sources.lineage == Some(AgentCanonicalValueSource::Legacy)
+        && can_migrate(AgentCanonicalRelationAxis::Lineage)
+    {
+        records.lineage = projection.lineage.clone();
+        axes.push(AgentCanonicalRelationAxis::Lineage);
+    }
+    if projection.sources.supervision == Some(AgentCanonicalValueSource::Legacy)
+        && can_migrate(AgentCanonicalRelationAxis::Supervision)
+    {
+        records.supervision = projection.supervision.clone();
+        axes.push(AgentCanonicalRelationAxis::Supervision);
+    }
+    if projection.sources.durability == Some(AgentCanonicalValueSource::Legacy)
+        && can_migrate(AgentCanonicalRelationAxis::Durability)
+    {
+        records.durability = projection.durability.clone();
+        axes.push(AgentCanonicalRelationAxis::Durability);
+    }
+    if projection.sources.lifecycle_attachment == Some(AgentCanonicalValueSource::Legacy)
+        && can_migrate(AgentCanonicalRelationAxis::LifecycleAttachment)
+    {
+        records.lifecycle_attachment = projection.lifecycle_attachment.clone();
+        axes.push(AgentCanonicalRelationAxis::LifecycleAttachment);
+    }
+    if projection.sources.capability_policy == Some(AgentCanonicalValueSource::Legacy)
+        && can_migrate(AgentCanonicalRelationAxis::CapabilityPolicy)
+    {
+        records.capability_policy = projection.capability_policy.clone();
+        axes.push(AgentCanonicalRelationAxis::CapabilityPolicy);
+    }
+    if projection.sources.message_policy == Some(AgentCanonicalValueSource::Legacy)
+        && can_migrate(AgentCanonicalRelationAxis::MessagePolicy)
+        && can_migrate(AgentCanonicalRelationAxis::Supervision)
+    {
+        records.message_policy = projection.message_policy.clone();
+        axes.push(AgentCanonicalRelationAxis::MessagePolicy);
+    }
+    (records, axes)
+}
+
+pub(crate) fn independent_creation_records(
+    identity: &AgentIdentityRecord,
+    lineage_parent_agent_id: Option<&str>,
+    durability: AgentCanonicalDurability,
+) -> AgentCanonicalRecordSet {
+    AgentCanonicalRecordSet {
+        lineage: lineage_parent_agent_id.map(|parent_agent_id| AgentLineageRecord {
+            child_agent_id: identity.agent_id.clone(),
+            parent_agent_id: parent_agent_id.to_string(),
+            creation_cause: AgentLineageCreationCause::CreateAgent,
+            revision: identity.revision,
+            created_at: identity.created_at,
+        }),
+        supervision: None,
+        durability: Some(AgentDurabilityRecord {
+            agent_id: identity.agent_id.clone(),
+            durability,
+            revision: identity.revision,
+            created_at: identity.created_at,
+        }),
+        lifecycle_attachment: Some(AgentLifecycleAttachmentRecord {
+            agent_id: identity.agent_id.clone(),
+            attachment: AgentLifecycleAttachment::Independent,
+            revision: identity.revision,
+            created_at: identity.created_at,
+        }),
+        capability_policy: Some(capability_policy_for_preset(
+            identity,
+            AgentProfilePreset::PublicNamed,
+        )),
+        message_policy: Some(message_policy_for_supervisor(identity, None)),
+    }
+}
+
+pub(crate) fn supervised_creation_records(
+    identity: &AgentIdentityRecord,
+    supervisor_agent_id: &str,
+    delegated_from_task_id: &str,
+    delegated_from_work_item_id: Option<&str>,
+) -> AgentCanonicalRecordSet {
+    AgentCanonicalRecordSet {
+        lineage: Some(AgentLineageRecord {
+            child_agent_id: identity.agent_id.clone(),
+            parent_agent_id: supervisor_agent_id.to_string(),
+            creation_cause: AgentLineageCreationCause::CreateAgent,
+            revision: identity.revision,
+            created_at: identity.created_at,
+        }),
+        supervision: Some(AgentSupervisionRecord {
+            supervision_id: format!("supervision:{delegated_from_task_id}"),
+            supervisor_agent_id: supervisor_agent_id.to_string(),
+            child_agent_id: identity.agent_id.clone(),
+            delegated_from_work_item_id: delegated_from_work_item_id.map(ToString::to_string),
+            delegated_from_task_id: Some(delegated_from_task_id.to_string()),
+            state: AgentSupervisionState::Active,
+            revision: identity.revision,
+            created_at: identity.created_at,
+            updated_at: identity.updated_at,
+        }),
+        durability: Some(AgentDurabilityRecord {
+            agent_id: identity.agent_id.clone(),
+            durability: AgentCanonicalDurability::Ephemeral,
+            revision: identity.revision,
+            created_at: identity.created_at,
+        }),
+        lifecycle_attachment: Some(AgentLifecycleAttachmentRecord {
+            agent_id: identity.agent_id.clone(),
+            attachment: AgentLifecycleAttachment::SupervisionAttached,
+            revision: identity.revision,
+            created_at: identity.created_at,
+        }),
+        capability_policy: Some(capability_policy_for_preset(
+            identity,
+            AgentProfilePreset::PrivateChild,
+        )),
+        message_policy: Some(message_policy_for_supervisor(
+            identity,
+            Some(supervisor_agent_id),
+        )),
+    }
+}
+
+pub(crate) fn upsert_canonical_record_set_tx(
+    tx: &Transaction<'_>,
+    records: &AgentCanonicalRecordSet,
+) -> Result<()> {
+    if let Some(record) = records.lineage.as_ref() {
+        upsert_lineage_tx(tx, record)?;
+    }
+    if let Some(record) = records.supervision.as_ref() {
+        upsert_supervision_tx(tx, record)?;
+    }
+    if let Some(record) = records.durability.as_ref() {
+        insert_versioned_record_tx(
+            tx,
+            "agent_durability_records",
+            &record.agent_id,
+            record.revision,
+            record.created_at,
+            record,
+            Some(("durability", enum_string(&record.durability)?)),
+        )?;
+    }
+    if let Some(record) = records.lifecycle_attachment.as_ref() {
+        insert_versioned_record_tx(
+            tx,
+            "agent_lifecycle_attachment_records",
+            &record.agent_id,
+            record.revision,
+            record.created_at,
+            record,
+            Some(("attachment", enum_string(&record.attachment)?)),
+        )?;
+    }
+    if let Some(record) = records.capability_policy.as_ref() {
+        upsert_capability_policy_tx(tx, record)?;
+    }
+    if let Some(record) = records.message_policy.as_ref() {
+        upsert_message_policy_tx(tx, record)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn transition_supervision_state_tx(
+    tx: &Transaction<'_>,
+    child_agent_id: &str,
+    state: AgentSupervisionState,
+    revision: u64,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> Result<()> {
+    let Some(mut supervision) = latest_supervision(tx, child_agent_id)? else {
+        return Ok(());
+    };
+    if supervision.state == state && supervision.revision >= revision {
+        return Ok(());
+    }
+    supervision.state = state;
+    supervision.revision = std::cmp::max(revision, supervision.revision.saturating_add(1));
+    supervision.updated_at = updated_at;
+    upsert_supervision_tx(tx, &supervision)
 }
 
 pub(crate) fn canonical_relations_from_connection(
@@ -795,6 +1216,7 @@ pub(crate) fn project_agent_canonical_relations(
         &mut issues,
     );
     validate_effective_relations(
+        identity,
         supervision.as_ref(),
         durability.as_ref(),
         lifecycle_attachment.as_ref(),
@@ -920,7 +1342,11 @@ fn legacy_supervision(
         child_agent_id: identity.agent_id.clone(),
         delegated_from_work_item_id: task.delegated_from_work_item_id.clone(),
         delegated_from_task_id: Some(task_id.to_string()),
-        state: AgentSupervisionState::Active,
+        state: match identity.status {
+            AgentRegistryStatus::Active => AgentSupervisionState::Active,
+            AgentRegistryStatus::Deleting => AgentSupervisionState::CleanupRequired,
+            AgentRegistryStatus::Deleted => AgentSupervisionState::Closed,
+        },
         revision: 0,
         created_at: identity.created_at,
         updated_at: identity.updated_at,
@@ -1087,6 +1513,82 @@ fn legacy_message_policy(
     }
 }
 
+fn capability_policy_for_preset(
+    identity: &AgentIdentityRecord,
+    preset: AgentProfilePreset,
+) -> AgentCapabilityPolicyRecord {
+    let families = [
+        AgentCapabilityFamily::CoreAgent,
+        AgentCapabilityFamily::LocalEnvironment,
+        AgentCapabilityFamily::Web,
+        AgentCapabilityFamily::AgentCreation,
+        AgentCapabilityFamily::AuthorityExpanding,
+        AgentCapabilityFamily::ExternalTrigger,
+    ];
+    let rules = families
+        .into_iter()
+        .map(|family| {
+            let allowed = match preset {
+                AgentProfilePreset::PublicNamed => true,
+                AgentProfilePreset::PrivateChild => !matches!(
+                    family,
+                    AgentCapabilityFamily::AgentCreation
+                        | AgentCapabilityFamily::AuthorityExpanding
+                ),
+            };
+            AgentCapabilityPolicyRule {
+                family,
+                effect: if allowed {
+                    AgentPolicyEffect::Allow
+                } else {
+                    AgentPolicyEffect::Deny
+                },
+            }
+        })
+        .collect();
+    AgentCapabilityPolicyRecord {
+        agent_id: identity.agent_id.clone(),
+        revision: identity.revision,
+        rules,
+        created_at: identity.created_at,
+    }
+}
+
+fn message_policy_for_supervisor(
+    identity: &AgentIdentityRecord,
+    supervisor_agent_id: Option<&str>,
+) -> AgentMessagePolicyRecord {
+    let mut rules = vec![
+        AgentMessagePolicyRule {
+            principal_kind: AgentMessagePrincipalKind::Operator,
+            principal_id: None,
+            route: Some("operator_control".into()),
+            effect: AgentPolicyEffect::Allow,
+        },
+        AgentMessagePolicyRule {
+            principal_kind: AgentMessagePrincipalKind::RuntimeCapability,
+            principal_id: Some("runtime:agent-invocation".into()),
+            route: Some("agent_invocation".into()),
+            effect: AgentPolicyEffect::Allow,
+        },
+    ];
+    if let Some(supervisor_agent_id) = supervisor_agent_id {
+        rules.push(AgentMessagePolicyRule {
+            principal_kind: AgentMessagePrincipalKind::SupervisingParent,
+            principal_id: Some(supervisor_agent_id.to_string()),
+            route: Some("supervision_follow_up".into()),
+            effect: AgentPolicyEffect::Allow,
+        });
+    }
+    AgentMessagePolicyRecord {
+        agent_id: identity.agent_id.clone(),
+        revision: identity.revision,
+        default_effect: AgentPolicyEffect::Deny,
+        rules,
+        created_at: identity.created_at,
+    }
+}
+
 fn validate_legacy_profile(
     identity: &AgentIdentityRecord,
     issues: &mut Vec<AgentCanonicalProjectionIssue>,
@@ -1198,11 +1700,30 @@ fn validate_canonical_legacy_drift(
 }
 
 fn validate_effective_relations(
+    identity: &AgentIdentityRecord,
     supervision: Option<&AgentSupervisionRecord>,
     durability: Option<&AgentDurabilityRecord>,
     attachment: Option<&AgentLifecycleAttachmentRecord>,
     issues: &mut Vec<AgentCanonicalProjectionIssue>,
 ) {
+    if let Some(supervision) = supervision {
+        let expected_state = match identity.status {
+            AgentRegistryStatus::Active => AgentSupervisionState::Active,
+            AgentRegistryStatus::Deleting => AgentSupervisionState::CleanupRequired,
+            AgentRegistryStatus::Deleted => AgentSupervisionState::Closed,
+        };
+        if supervision.state != expected_state {
+            issue(
+                issues,
+                AgentCanonicalRelationAxis::Supervision,
+                AgentCanonicalResolution::Contradictory,
+                format!(
+                    "supervision state {:?} conflicts with identity lifecycle {:?}",
+                    supervision.state, identity.status
+                ),
+            );
+        }
+    }
     let supervision_active = supervision.is_some_and(|record| {
         matches!(
             record.state,
@@ -1216,11 +1737,11 @@ fn validate_effective_relations(
             AgentCanonicalResolution::Contradictory,
             "independent lifecycle conflicts with active supervision",
         ),
-        Some(AgentLifecycleAttachment::SupervisionAttached) if !supervision_active => issue(
+        Some(AgentLifecycleAttachment::SupervisionAttached) if supervision.is_none() => issue(
             issues,
             AgentCanonicalRelationAxis::Supervision,
             AgentCanonicalResolution::MissingEvidence,
-            "supervision-attached lifecycle has no active supervision record",
+            "supervision-attached lifecycle has no supervision record",
         ),
         _ => {}
     }

--- a/src/runtime_db/agent_relations/tests.rs
+++ b/src/runtime_db/agent_relations/tests.rs
@@ -41,6 +41,26 @@ fn task_evidence(
     }
 }
 
+fn supervision_task(task_id: &str, owner_agent_id: &str, child_agent_id: &str) -> TaskRecord {
+    let created_at = Utc.with_ymd_and_hms(2026, 9, 6, 0, 0, 1).unwrap();
+    TaskRecord {
+        id: task_id.into(),
+        agent_id: owner_agent_id.into(),
+        kind: TaskKind::ChildAgentTask,
+        status: crate::types::TaskStatus::Running,
+        created_at,
+        updated_at: created_at,
+        parent_message_id: None,
+        work_item_id: Some("work-parent".into()),
+        summary: None,
+        detail: Some(serde_json::json!({
+            "child_agent_id": child_agent_id,
+            "created_new_subagent": true,
+        })),
+        recovery: None,
+    }
+}
+
 #[test]
 fn public_named_legacy_identity_maps_to_resolved_independent_projection() {
     let identity = identity(
@@ -464,5 +484,448 @@ fn repository_rejects_two_active_supervisors_for_one_child() -> Result<()> {
         })
         .unwrap_err();
     assert!(error.to_string().contains("UNIQUE constraint failed"));
+    Ok(())
+}
+
+#[test]
+fn backfill_dry_run_apply_and_retry_are_idempotent() -> Result<()> {
+    let temp_dir = tempdir()?;
+    let db_path = temp_dir.path().join("state/runtime.sqlite");
+    let lock_path = temp_dir.path().join("state/runtime.lock");
+    let db = crate::runtime_db::RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+    let worker = identity(
+        "worker",
+        AgentKind::Named,
+        AgentVisibility::Public,
+        AgentOwnership::SelfOwned,
+        AgentProfilePreset::PublicNamed,
+        None,
+        None,
+    );
+    db.agent_identities().upsert(&worker)?;
+    let original_identity_payload: String = db.connection()?.query_row(
+        "SELECT payload_json FROM agent_identities WHERE agent_id = 'worker'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    let dry_run = db.agent_canonical_relations().backfill(false, 5)?;
+    assert_eq!(dry_run.run_id, None);
+    assert_eq!(dry_run.scanned_agents, 1);
+    assert_eq!(dry_run.changed_agents, 1);
+    assert_eq!(dry_run.migrated_axes, 4);
+    assert_eq!(
+        db.agent_canonical_relations()
+            .latest("worker")?
+            .unwrap()
+            .sources
+            .durability,
+        Some(AgentCanonicalValueSource::Legacy)
+    );
+
+    let applied = db.agent_canonical_relations().backfill(true, 5)?;
+    assert!(applied.run_id.is_some());
+    assert_eq!(applied.changed_agents, 1);
+    assert_eq!(applied.diagnostic_agents, 0);
+    let projection = db.agent_canonical_relations().latest("worker")?.unwrap();
+    assert_eq!(
+        projection.sources.durability,
+        Some(AgentCanonicalValueSource::Canonical)
+    );
+    assert_eq!(
+        projection.sources.lifecycle_attachment,
+        Some(AgentCanonicalValueSource::Canonical)
+    );
+    assert_eq!(
+        projection.sources.capability_policy,
+        Some(AgentCanonicalValueSource::Canonical)
+    );
+    assert_eq!(
+        projection.sources.message_policy,
+        Some(AgentCanonicalValueSource::Canonical)
+    );
+
+    let retry = db.agent_canonical_relations().backfill(true, 5)?;
+    assert_eq!(retry.changed_agents, 0);
+    assert_eq!(retry.unchanged_agents, 1);
+    assert_eq!(retry.migrated_axes, 0);
+    let identity_payload: String = db.connection()?.query_row(
+        "SELECT payload_json FROM agent_identities WHERE agent_id = 'worker'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(identity_payload, original_identity_payload);
+    let outcome_count: i64 = db.connection()?.query_row(
+        "SELECT COUNT(*) FROM agent_relation_backfill_outcomes",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(outcome_count, 2);
+    Ok(())
+}
+
+#[test]
+fn backfill_resumes_running_run_from_per_agent_checkpoints_after_reopen() -> Result<()> {
+    let temp_dir = tempdir()?;
+    let db_path = temp_dir.path().join("state/runtime.sqlite");
+    let lock_path = temp_dir.path().join("state/runtime.lock");
+    let run_id = "agent-relations-interrupted";
+    let started_at = Utc.with_ymd_and_hms(2026, 9, 6, 1, 0, 0).unwrap();
+    {
+        let db = crate::runtime_db::RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        for agent_id in ["agent-a", "agent-b"] {
+            db.agent_identities().upsert(&identity(
+                agent_id,
+                AgentKind::Named,
+                AgentVisibility::Public,
+                AgentOwnership::SelfOwned,
+                AgentProfilePreset::PublicNamed,
+                None,
+                None,
+            ))?;
+        }
+        db.transaction(|tx| {
+            tx.execute(
+                "INSERT INTO agent_relation_backfill_runs (
+                   run_id, status, started_at, updated_at
+                 ) VALUES (?1, 'running', ?2, ?2)",
+                params![run_id, timestamp(started_at)],
+            )?;
+            backfill_agent_relations_tx(tx, "agent-a", true, Some(run_id))?;
+            Ok(())
+        })?;
+    }
+
+    let reopened = crate::runtime_db::RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+    let report = reopened.agent_canonical_relations().backfill(true, 5)?;
+    assert_eq!(report.run_id.as_deref(), Some(run_id));
+    assert_eq!(report.started_at, started_at);
+    assert_eq!(report.scanned_agents, 2);
+    assert_eq!(report.changed_agents, 2);
+    let run_status: String = reopened.connection()?.query_row(
+        "SELECT status FROM agent_relation_backfill_runs WHERE run_id = ?1",
+        [run_id],
+        |row| row.get(0),
+    )?;
+    assert_eq!(run_status, "completed");
+    let outcome_count: i64 = reopened.connection()?.query_row(
+        "SELECT COUNT(*) FROM agent_relation_backfill_outcomes WHERE run_id = ?1",
+        [run_id],
+        |row| row.get(0),
+    )?;
+    assert_eq!(outcome_count, 2);
+    for agent_id in ["agent-a", "agent-b"] {
+        let projection = reopened
+            .agent_canonical_relations()
+            .latest(agent_id)?
+            .unwrap();
+        assert_eq!(
+            projection.sources.durability,
+            Some(AgentCanonicalValueSource::Canonical)
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn backfill_report_does_not_migrate_and_apply_can_record_pre_migration_backup() -> Result<()> {
+    let temp_dir = tempdir()?;
+    let db_path = temp_dir.path().join("state/runtime.sqlite");
+    let lock_path = temp_dir.path().join("state/runtime.lock");
+    {
+        let db = crate::runtime_db::RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.agent_identities().upsert(&identity(
+            "worker",
+            AgentKind::Named,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        ))?;
+        db.connection()?.execute_batch(
+            "DROP TABLE agent_relation_backfill_outcomes;
+             DROP TABLE agent_relation_backfill_runs;
+             DROP TABLE agent_message_deliveries;
+             DELETE FROM schema_migrations WHERE version > 59;",
+        )?;
+    }
+
+    let inspection =
+        crate::runtime_db::RuntimeDb::open_for_agent_relation_backfill(&db_path, &lock_path)?;
+    assert_eq!(inspection.current_schema_version()?, 59);
+    let report = inspection.agent_canonical_relations().backfill(false, 5)?;
+    assert_eq!(report.scanned_agents, 1);
+    assert_eq!(inspection.current_schema_version()?, 59);
+    let backfill_table_count: i64 = inspection.connection()?.query_row(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type = 'table' AND name = 'agent_relation_backfill_runs'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(backfill_table_count, 0);
+
+    let backup_path = inspection.create_agent_relation_backfill_backup()?;
+    assert!(backup_path.is_file());
+    let backup_version: i64 = rusqlite::Connection::open(&backup_path)?.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(backup_version, 59);
+    drop(inspection);
+
+    let migrated = crate::runtime_db::RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+    let backup_path = backup_path.display().to_string();
+    let applied = migrated.agent_canonical_relations().backfill_with_backup(
+        true,
+        5,
+        Some(backup_path.clone()),
+    )?;
+    assert_eq!(migrated.current_schema_version()?, 61);
+    assert_eq!(applied.backup_path.as_deref(), Some(backup_path.as_str()));
+    Ok(())
+}
+
+#[test]
+fn backfill_isolates_missing_supervision_evidence_and_migrates_clear_axes() -> Result<()> {
+    let temp_dir = tempdir()?;
+    let db_path = temp_dir.path().join("state/runtime.sqlite");
+    let lock_path = temp_dir.path().join("state/runtime.lock");
+    let db = crate::runtime_db::RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+    let parent = identity(
+        "parent",
+        AgentKind::Named,
+        AgentVisibility::Public,
+        AgentOwnership::SelfOwned,
+        AgentProfilePreset::PublicNamed,
+        None,
+        None,
+    );
+    let child = identity(
+        "child",
+        AgentKind::Child,
+        AgentVisibility::Private,
+        AgentOwnership::ParentSupervised,
+        AgentProfilePreset::PrivateChild,
+        Some("parent"),
+        Some("missing-task"),
+    );
+    db.agent_identities().upsert(&parent)?;
+    db.agent_identities().upsert(&child)?;
+
+    let report = db.agent_canonical_relations().backfill(true, 10)?;
+    assert_eq!(report.scanned_agents, 2);
+    assert_eq!(report.diagnostic_agents, 1);
+    let diagnostic = report
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.agent_id == "child")
+        .unwrap();
+    assert!(diagnostic
+        .migrated_axes
+        .contains(&AgentCanonicalRelationAxis::Lineage));
+    assert!(diagnostic
+        .migrated_axes
+        .contains(&AgentCanonicalRelationAxis::CapabilityPolicy));
+    assert!(!diagnostic
+        .migrated_axes
+        .contains(&AgentCanonicalRelationAxis::MessagePolicy));
+    assert!(diagnostic.issues.iter().any(|issue| {
+        issue.axis == AgentCanonicalRelationAxis::Supervision
+            && issue.resolution == AgentCanonicalResolution::MissingEvidence
+    }));
+
+    let projection = db.agent_canonical_relations().latest("child")?.unwrap();
+    assert_eq!(
+        projection.sources.lineage,
+        Some(AgentCanonicalValueSource::Canonical)
+    );
+    assert_eq!(projection.supervision, None);
+    assert_eq!(
+        projection.resolution,
+        AgentCanonicalResolution::MissingEvidence
+    );
+    Ok(())
+}
+
+#[test]
+fn backfill_uses_durable_task_evidence_for_supervised_children() -> Result<()> {
+    let temp_dir = tempdir()?;
+    let db_path = temp_dir.path().join("state/runtime.sqlite");
+    let lock_path = temp_dir.path().join("state/runtime.lock");
+    let db = crate::runtime_db::RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+    let parent = identity(
+        "parent",
+        AgentKind::Named,
+        AgentVisibility::Public,
+        AgentOwnership::SelfOwned,
+        AgentProfilePreset::PublicNamed,
+        None,
+        None,
+    );
+    let child = identity(
+        "child",
+        AgentKind::Child,
+        AgentVisibility::Private,
+        AgentOwnership::ParentSupervised,
+        AgentProfilePreset::PrivateChild,
+        Some("parent"),
+        Some("task-child"),
+    );
+    db.agent_identities().upsert(&parent)?;
+    db.agent_identities().upsert(&child)?;
+    db.tasks()
+        .upsert(&supervision_task("task-child", "parent", "child"))?;
+
+    let report = db.agent_canonical_relations().backfill(true, 10)?;
+    assert_eq!(report.diagnostic_agents, 0);
+    let projection = db.agent_canonical_relations().latest("child")?.unwrap();
+    assert_eq!(projection.resolution, AgentCanonicalResolution::Resolved);
+    assert_eq!(
+        projection.sources.supervision,
+        Some(AgentCanonicalValueSource::Canonical)
+    );
+    assert_eq!(
+        projection
+            .supervision
+            .as_ref()
+            .and_then(|record| record.delegated_from_work_item_id.as_deref()),
+        Some("work-parent")
+    );
+    Ok(())
+}
+
+#[test]
+fn backfill_preserves_tombstoned_identity_and_task_while_closing_supervision() -> Result<()> {
+    let temp_dir = tempdir()?;
+    let db_path = temp_dir.path().join("state/runtime.sqlite");
+    let lock_path = temp_dir.path().join("state/runtime.lock");
+    let db = crate::runtime_db::RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+    let parent = identity(
+        "parent",
+        AgentKind::Named,
+        AgentVisibility::Public,
+        AgentOwnership::SelfOwned,
+        AgentProfilePreset::PublicNamed,
+        None,
+        None,
+    );
+    let mut child = identity(
+        "child",
+        AgentKind::Child,
+        AgentVisibility::Private,
+        AgentOwnership::ParentSupervised,
+        AgentProfilePreset::PrivateChild,
+        Some("parent"),
+        Some("task-child"),
+    );
+    child.status = AgentRegistryStatus::Deleted;
+    child.deleted_at = Some(child.updated_at);
+    let task = supervision_task("task-child", "parent", "child");
+    db.agent_identities().upsert(&parent)?;
+    db.agent_identities().upsert(&child)?;
+    db.tasks().upsert(&task)?;
+    let identity_payload_before: String = db.connection()?.query_row(
+        "SELECT payload_json FROM agent_identities WHERE agent_id = 'child'",
+        [],
+        |row| row.get(0),
+    )?;
+    let task_payload_before: String = db.connection()?.query_row(
+        "SELECT payload_json FROM tasks WHERE task_id = 'task-child'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    let report = db.agent_canonical_relations().backfill(true, 5)?;
+    assert_eq!(report.diagnostic_agents, 0);
+    let projection = db.agent_canonical_relations().latest("child")?.unwrap();
+    assert_eq!(
+        projection.identity_lifecycle,
+        AgentIdentityLifecycle::Deleted
+    );
+    assert_eq!(
+        projection.lifecycle_fence,
+        AgentLifecycleFenceState::Tombstoned
+    );
+    assert_eq!(
+        projection.supervision.as_ref().unwrap().state,
+        AgentSupervisionState::Closed
+    );
+    let identity_payload_after: String = db.connection()?.query_row(
+        "SELECT payload_json FROM agent_identities WHERE agent_id = 'child'",
+        [],
+        |row| row.get(0),
+    )?;
+    let task_payload_after: String = db.connection()?.query_row(
+        "SELECT payload_json FROM tasks WHERE task_id = 'task-child'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(identity_payload_after, identity_payload_before);
+    assert_eq!(task_payload_after, task_payload_before);
+    Ok(())
+}
+
+#[test]
+fn deletion_fence_and_finalize_transition_supervision_atomically() -> Result<()> {
+    let temp_dir = tempdir()?;
+    let db_path = temp_dir.path().join("state/runtime.sqlite");
+    let lock_path = temp_dir.path().join("state/runtime.lock");
+    let db = crate::runtime_db::RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+    let parent = identity(
+        "parent",
+        AgentKind::Named,
+        AgentVisibility::Public,
+        AgentOwnership::SelfOwned,
+        AgentProfilePreset::PublicNamed,
+        None,
+        None,
+    );
+    let child = identity(
+        "child",
+        AgentKind::Child,
+        AgentVisibility::Private,
+        AgentOwnership::ParentSupervised,
+        AgentProfilePreset::PrivateChild,
+        Some("parent"),
+        Some("task-child"),
+    );
+    db.agent_identities().upsert(&parent)?;
+    db.agent_identities().create_with_relations(
+        &child,
+        &supervised_creation_records(&child, "parent", "task-child", Some("work-parent")),
+    )?;
+
+    let (deleting, job, created) =
+        db.agent_deletions()
+            .begin("child", child.revision, "operator", false)?;
+    assert!(created);
+    assert_eq!(deleting.status, AgentRegistryStatus::Deleting);
+    let fenced = db.agent_canonical_relations().latest("child")?.unwrap();
+    assert_eq!(
+        fenced.supervision.as_ref().unwrap().state,
+        AgentSupervisionState::CleanupRequired
+    );
+    assert_eq!(
+        fenced.supervision.as_ref().unwrap().revision,
+        deleting.revision
+    );
+
+    let (deleted, completed_job) = db.agent_deletions().finalize(&job)?;
+    assert_eq!(deleted.status, AgentRegistryStatus::Deleted);
+    assert_eq!(
+        completed_job.status,
+        crate::types::AgentDeletionStatus::Completed
+    );
+    let tombstoned = db.agent_canonical_relations().latest("child")?.unwrap();
+    assert_eq!(
+        tombstoned.supervision.as_ref().unwrap().state,
+        AgentSupervisionState::Closed
+    );
+    assert_eq!(
+        tombstoned.supervision.as_ref().unwrap().revision,
+        deleted.revision
+    );
     Ok(())
 }

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -34,6 +34,7 @@ pub struct Migration {
 pub(crate) const PUBLISHED_MIGRATION_FLOOR: i64 = 25;
 pub(crate) const RELEASE_BASELINE_TARGET: i64 = 45;
 pub(crate) const RETIRED_SCHEDULER_SCHEMA_PREDECESSOR: i64 = 46;
+pub(crate) const AGENT_CANONICAL_RELATIONS_SCHEMA_VERSION: i64 = 59;
 const RELEASE_BASELINE_SCHEMA_TARGET: i64 = 42;
 const RELEASE_BASELINE_ID: &str = "v0.30.0-schema-25-to-schema-45";
 
@@ -3424,6 +3425,34 @@ CREATE INDEX IF NOT EXISTS idx_agent_message_deliveries_target_state
 CREATE INDEX IF NOT EXISTS idx_agent_message_deliveries_message
   ON agent_message_deliveries(message_id)
   WHERE message_id IS NOT NULL;
+"#,
+    },
+    Migration {
+        version: 61,
+        name: "agent_relation_backfill_audit",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS agent_relation_backfill_runs (
+  run_id TEXT PRIMARY KEY,
+  status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'failed')),
+  started_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  report_json TEXT
+);
+
+CREATE TABLE IF NOT EXISTS agent_relation_backfill_outcomes (
+  run_id TEXT NOT NULL REFERENCES agent_relation_backfill_runs(run_id),
+  agent_id TEXT NOT NULL REFERENCES agent_identities(agent_id),
+  identity_revision INTEGER NOT NULL CHECK (identity_revision >= 0),
+  outcome TEXT NOT NULL CHECK (outcome IN ('applied', 'unchanged', 'diagnostic')),
+  migrated_axes_json TEXT NOT NULL,
+  issues_json TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (run_id, agent_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_relation_backfill_outcomes_agent
+  ON agent_relation_backfill_outcomes(agent_id, updated_at);
 "#,
     },
 ];

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -89,8 +89,8 @@ use crate::runtime_db::connection::{
 use crate::runtime_db::migrations::{
     apply_migration, apply_release_baseline, backfill_wait_condition_payload_columns,
     backfill_work_item_recheck_columns, current_schema_version, ensure_migration_table,
-    max_known_migration_version, MIGRATIONS, PUBLISHED_MIGRATION_FLOOR, RELEASE_BASELINE_TARGET,
-    RETIRED_SCHEDULER_SCHEMA_PREDECESSOR,
+    max_known_migration_version, AGENT_CANONICAL_RELATIONS_SCHEMA_VERSION, MIGRATIONS,
+    PUBLISHED_MIGRATION_FLOOR, RELEASE_BASELINE_TARGET, RETIRED_SCHEDULER_SCHEMA_PREDECESSOR,
 };
 use crate::runtime_db::storage_domain::{
     read_storage_domain_connection, upsert_storage_domain, upsert_storage_domain_checkpoint_json,
@@ -344,6 +344,40 @@ impl RuntimeDb {
         Ok(db)
     }
 
+    /// Opens an existing database for an explicit Agent relation report or
+    /// pre-migration backup without applying schema migrations.
+    pub fn open_for_agent_relation_backfill(
+        path: impl Into<PathBuf>,
+        lock_path: impl Into<PathBuf>,
+    ) -> Result<Self> {
+        let path = path.into();
+        if !path.is_file() {
+            bail!(
+                "agent relation backfill requires an existing runtime database: {}",
+                path.display()
+            );
+        }
+        let writer = RuntimeDbWriter::open(path.clone(), open_connection(&path)?)?;
+        let db = Self {
+            writer,
+            path,
+            lock_path: lock_path.into(),
+        };
+        let current_version = db.current_schema_version()?;
+        let max_known_version = max_known_migration_version();
+        if !(AGENT_CANONICAL_RELATIONS_SCHEMA_VERSION..=max_known_version)
+            .contains(&current_version)
+        {
+            bail!(
+                "agent relation backfill supports runtime db schemas {} through {}, found {}",
+                AGENT_CANONICAL_RELATIONS_SCHEMA_VERSION,
+                max_known_version,
+                current_version
+            );
+        }
+        Ok(db)
+    }
+
     pub fn path(&self) -> &Path {
         &self.path
     }
@@ -393,6 +427,10 @@ impl RuntimeDb {
 
     pub fn create_scheduler_recovery_backup(&self) -> Result<PathBuf> {
         self.create_verified_backup("scheduler-recovery")
+    }
+
+    pub fn create_agent_relation_backfill_backup(&self) -> Result<PathBuf> {
+        self.create_verified_backup("agent-relation-backfill")
     }
 
     pub fn transaction<T>(&self, f: impl FnMut(&Transaction<'_>) -> Result<T>) -> Result<T> {

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -7,6 +7,9 @@ use chrono::{DateTime, Utc};
 use rusqlite::{params, OptionalExtension, ToSql, Transaction};
 use sha2::{Digest, Sha256};
 
+use crate::runtime_db::agent_relations::{
+    transition_supervision_state_tx, upsert_canonical_record_set_tx,
+};
 use crate::runtime_db::evidence::*;
 use crate::runtime_db::index_outbox::RuntimeIndexChange;
 use crate::runtime_db::types::*;
@@ -396,6 +399,19 @@ impl AgentIdentityRepository<'_> {
         identity: &AgentIdentityRecord,
         bootstrap: &AgentBootstrapRecord,
     ) -> Result<()> {
+        self.create_with_bootstrap_and_relations(
+            identity,
+            bootstrap,
+            &AgentCanonicalRecordSet::default(),
+        )
+    }
+
+    pub fn create_with_bootstrap_and_relations(
+        &self,
+        identity: &AgentIdentityRecord,
+        bootstrap: &AgentBootstrapRecord,
+        relations: &AgentCanonicalRecordSet,
+    ) -> Result<()> {
         self.db.transaction(|tx| {
             let existing = tx
                 .query_row(
@@ -410,7 +426,64 @@ impl AgentIdentityRepository<'_> {
                 identity.agent_id
             );
             upsert_agent_identity_tx(tx, identity)?;
-            upsert_agent_bootstrap_tx(tx, bootstrap)
+            upsert_agent_bootstrap_tx(tx, bootstrap)?;
+            upsert_canonical_record_set_tx(tx, relations)
+        })
+    }
+
+    pub fn create_with_relations(
+        &self,
+        identity: &AgentIdentityRecord,
+        relations: &AgentCanonicalRecordSet,
+    ) -> Result<()> {
+        self.db.transaction(|tx| {
+            let existing = tx
+                .query_row(
+                    "SELECT agent_id FROM agent_identities WHERE agent_id = ?1",
+                    [&identity.agent_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            anyhow::ensure!(
+                existing.is_none(),
+                "agent_identity_conflict: agent {} already exists",
+                identity.agent_id
+            );
+            upsert_agent_identity_tx(tx, identity)?;
+            upsert_canonical_record_set_tx(tx, relations)
+        })
+    }
+
+    pub fn tombstone_with_closed_supervision(&self, agent_id: &str) -> Result<AgentIdentityRecord> {
+        self.db.transaction(|tx| {
+            let payload = tx
+                .query_row(
+                    "SELECT payload_json FROM agent_identities WHERE agent_id = ?1",
+                    [agent_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .ok_or_else(|| anyhow!("agent {agent_id} not found"))?;
+            let mut identity = decode_agent_identity_payload(&payload)?;
+            if identity.status != AgentRegistryStatus::Deleted {
+                let now = std::cmp::max(
+                    Utc::now(),
+                    identity.updated_at + chrono::Duration::nanoseconds(1),
+                );
+                identity.status = AgentRegistryStatus::Deleted;
+                identity.deleted_at = Some(now);
+                identity.updated_at = now;
+                identity.revision = identity.revision.saturating_add(1);
+                upsert_agent_identity_tx(tx, &identity)?;
+            }
+            transition_supervision_state_tx(
+                tx,
+                agent_id,
+                AgentSupervisionState::Closed,
+                identity.revision,
+                identity.updated_at,
+            )?;
+            Ok(identity)
         })
     }
 
@@ -559,6 +632,19 @@ impl AgentDeletionRepository<'_> {
             let mut identity = decode_agent_identity_payload(&payload)?;
 
             if identity.status != AgentRegistryStatus::Active {
+                transition_supervision_state_tx(
+                    tx,
+                    agent_id,
+                    match identity.status {
+                        AgentRegistryStatus::Active => unreachable!(),
+                        AgentRegistryStatus::Deleting => {
+                            AgentSupervisionState::CleanupRequired
+                        }
+                        AgentRegistryStatus::Deleted => AgentSupervisionState::Closed,
+                    },
+                    identity.revision,
+                    identity.updated_at,
+                )?;
                 let job = tx
                     .query_row(
                         "SELECT payload_json FROM agent_deletion_jobs WHERE agent_id = ?1",
@@ -607,11 +693,101 @@ impl AgentDeletionRepository<'_> {
             identity.revision = identity.revision.saturating_add(1);
             identity.updated_at = now;
             upsert_agent_identity_tx(tx, &identity)?;
+            transition_supervision_state_tx(
+                tx,
+                agent_id,
+                AgentSupervisionState::CleanupRequired,
+                identity.revision,
+                now,
+            )?;
             insert_agent_deletion_job_tx(tx, &job)?;
             crate::runtime_db::agent_message_delivery::cancel_active_deliveries_for_target_tx(
                 tx, agent_id,
             )?;
             Ok((identity, job, true))
+        })
+    }
+
+    pub fn finalize(
+        &self,
+        job: &AgentDeletionJob,
+    ) -> Result<(AgentIdentityRecord, AgentDeletionJob)> {
+        self.db.transaction(|tx| {
+            let job_payload = tx
+                .query_row(
+                    "SELECT payload_json FROM agent_deletion_jobs WHERE deletion_id = ?1",
+                    [&job.deletion_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .ok_or_else(|| anyhow!("deletion job {} not found", job.deletion_id))?;
+            let mut completed_job: AgentDeletionJob = serde_json::from_str(&job_payload)
+                .context("decoding deletion job for finalization")?;
+            let payload = tx
+                .query_row(
+                    "SELECT payload_json FROM agent_identities WHERE agent_id = ?1",
+                    [&completed_job.agent_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .ok_or_else(|| anyhow!("agent {} not found", completed_job.agent_id))?;
+            let mut identity = decode_agent_identity_payload(&payload)?;
+            if completed_job.status == AgentDeletionStatus::Completed {
+                transition_supervision_state_tx(
+                    tx,
+                    &completed_job.agent_id,
+                    AgentSupervisionState::Closed,
+                    identity.revision,
+                    identity.updated_at,
+                )?;
+                return Ok((identity, completed_job));
+            }
+            let now = std::cmp::max(
+                Utc::now(),
+                std::cmp::max(identity.updated_at, completed_job.updated_at)
+                    + chrono::Duration::nanoseconds(1),
+            );
+            if identity.status != AgentRegistryStatus::Deleted {
+                identity.status = AgentRegistryStatus::Deleted;
+                identity.deleted_at = Some(now);
+                identity.updated_at = now;
+                identity.revision = identity.revision.saturating_add(1);
+                upsert_agent_identity_tx(tx, &identity)?;
+            }
+            transition_supervision_state_tx(
+                tx,
+                &completed_job.agent_id,
+                AgentSupervisionState::Closed,
+                identity.revision,
+                identity.updated_at,
+            )?;
+            completed_job.status = AgentDeletionStatus::Completed;
+            completed_job.phase = AgentDeletionPhase::Finalize;
+            completed_job.last_error = None;
+            completed_job.updated_at = now;
+            completed_job.completed_at = Some(now);
+            let payload_json = serde_json::to_string(&completed_job)?;
+            let updated = tx.execute(
+                "UPDATE agent_deletion_jobs
+                 SET status = ?1, phase = ?2, updated_at = ?3,
+                     completed_at = ?4, payload_json = ?5
+                 WHERE deletion_id = ?6 AND agent_id = ?7",
+                params![
+                    enum_string(&completed_job.status)?,
+                    enum_string(&completed_job.phase)?,
+                    timestamp(completed_job.updated_at),
+                    completed_job.completed_at.map(timestamp),
+                    payload_json,
+                    completed_job.deletion_id,
+                    completed_job.agent_id,
+                ],
+            )?;
+            anyhow::ensure!(
+                updated == 1,
+                "deletion job {} not found for finalization",
+                completed_job.deletion_id
+            );
+            Ok((identity, completed_job))
         })
     }
 

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -841,6 +841,50 @@
     "aliases": []
   },
   {
+    "path": "debug.runtime-db.agent-relations",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "apply",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
+        "long": "diagnostic-sample-limit",
+        "short": null,
+        "default_value": "20",
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "json",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
+        "long": "no-backup",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "debug.runtime-db.audit",
     "positionals": [],
     "flags": [


### PR DESCRIPTION
## 概要

- 将 Agent create 与 terminal deletion/lifecycle 写入收敛为同一事务内的 canonical relation/policy + legacy compatibility identity mirror，避免产生 legacy-only records
- 新增 schema 61 的 restart-safe、幂等 Agent relation backfill ledger/checkpoint/diagnostics，以及默认只读的 `holon debug runtime-db agent-relations` report surface
- `--apply` 要求 offline maintenance lock，默认创建并校验迁移前备份；ambiguous evidence 仅记录 bounded diagnostics，不猜测或阻塞其他可确定记录
- 保留 mixed-version 读取所需 legacy identity，不重写 Agent ID、AgentHome、history、task/result、lineage、workspace ownership、deletion job 或 tombstone
- 记录 Phase F cutover、rollback 与 compatibility 边界

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test runtime_db::agent_relations::tests --lib --no-fail-fast`
- `cargo test deletion_ --lib --no-fail-fast`
- `cargo test --lib --no-fail-fast`（最终：3047 passed, 0 failed, 2 ignored）
- 独立只读 code review：无 findings
