### PR TITLE
fix(provider): append placeholder user text for ollama tool-only rounds

### DIFF
--- a/docs/implementation-decisions/124-ollama-tool-only-round-placeholder-user-text.md
+++ b/docs/implementation-decisions/124-ollama-tool-only-round-placeholder-user-text.md
@@ -1,0 +1,28 @@
+# Ollama Tool-Only Round Placeholder User Text
+
+Decision:
+
+- keep the ollama `no user query found in messages` workaround inside the
+  Anthropic-compatible transport, gated on `route_provider == "ollama"`
+- when the whole request has no non-empty user text, append one placeholder
+  text block `"(continue)"` to the last user message (or push a new user
+  message when none exists) after cache marker computation
+- do not generalize this into a provider quirk configuration
+- remove the workaround once an upstream ollama release fixes
+  ollama/ollama#18303 and passes local regression
+
+Reason:
+
+- ollama rejects pure tool-result turns (`assistant tool_use` followed by
+  `user tool_result`) with HTTP 500, which makes agentic tool loops unusable
+  against ollama models
+- upstream fixes are unmerged and no release contains one, so a client-side
+  shim is the only near-term path
+- the placeholder lands after cache markers, so cache eligibility is unchanged
+
+Boundary:
+
+- only the ollama route is modified; real Anthropic and other compatible
+  providers keep byte-identical request bodies
+- the placeholder is visible to the model, so its text must stay a neutral
+  continuation cue rather than an instruction

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -116,3 +116,4 @@ Current decision notes:
 - [116 Universal macOS App DMG](./116-universal-macos-app-dmg.md)
 - [118 Explicit models.dev Provider Mapping](./118-explicit-models-dev-provider-mapping.md)
 - [119 models.dev Supplemental Catalog](./119-models-dev-supplemental-catalog.md)
+- [124 Ollama Tool-Only Round Placeholder User Text](./124-ollama-tool-only-round-placeholder-user-text.md)

--- a/src/provider/tests/anthropic_messages.rs
+++ b/src/provider/tests/anthropic_messages.rs
@@ -941,3 +941,149 @@ async fn anthropic_claude_code_prompt_cache_strategy_does_not_cache_mark_tool_re
         json!("tool_result")
     );
 }
+
+#[tokio::test]
+async fn ollama_tool_only_round_appends_placeholder_user_text() {
+    let captured_body = Arc::new(Mutex::new(None::<serde_json::Value>));
+    let captured_body_for_server = captured_body.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/v1/messages",
+        post(move |Json(body): Json<serde_json::Value>| {
+            let captured_body = captured_body_for_server.clone();
+            async move {
+                *captured_body.lock().unwrap() = Some(body);
+                Json(json!({
+                    "content": [{ "type": "text", "text": "ok" }],
+                    "stop_reason": "end_turn",
+                    "usage": { "input_tokens": 4, "output_tokens": 2 }
+                }))
+            }
+        }),
+    ))
+    .await;
+    let provider_config = ProviderRuntimeConfig {
+        id: ProviderId::parse("ollama").unwrap(),
+        route_provider: ProviderId::parse("ollama").unwrap(),
+        route_endpoint: ProviderEndpointId::default_endpoint(),
+        transport: ProviderTransportKind::AnthropicMessages,
+        base_url,
+        auth: Default::default(),
+        credential: None,
+        credential_store_path: None,
+        codex_home: None,
+        originator: None,
+        reasoning_effort: None,
+        context_management: Default::default(),
+        builtin_web_search: None,
+    };
+    let provider = AnthropicProvider::from_runtime_config(
+        &provider_config,
+        "qwen3.8:latest",
+        1024,
+        Path::new("."),
+        true,
+    )
+    .unwrap();
+
+    let request = ProviderTurnRequest::plain(
+        "system",
+        vec![
+            ConversationMessage::AssistantBlocks(vec![ModelBlock::ToolUse {
+                id: "exec-1".into(),
+                name: "ExecCommand".into(),
+                input: json!({ "cmd": "ls /tmp" }),
+                kind: crate::provider::ModelToolCallKind::Function,
+            }]),
+            ConversationMessage::UserToolResults(vec![ToolResultBlock {
+                tool_use_id: "exec-1".into(),
+                content: "stdout:\na.txt\nb.txt".into(),
+                is_error: false,
+                error: None,
+            }]),
+        ],
+        Vec::new(),
+    );
+    provider.complete_turn(request).await.unwrap();
+
+    let body = captured_body
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("server should capture request body");
+    let messages = body["messages"].as_array().unwrap();
+    let last = messages.last().unwrap();
+    assert_eq!(last["role"], json!("user"));
+    let blocks = last["content"].as_array().unwrap();
+    let placeholder = blocks.last().unwrap();
+    assert_eq!(placeholder["type"], json!("text"));
+    assert!(!placeholder["text"].as_str().unwrap().trim().is_empty());
+}
+
+#[tokio::test]
+async fn anthropic_tool_only_round_does_not_append_placeholder_user_text() {
+    let captured_body = Arc::new(Mutex::new(None::<serde_json::Value>));
+    let captured_body_for_server = captured_body.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/v1/messages",
+        post(move |Json(body): Json<serde_json::Value>| {
+            let captured_body = captured_body_for_server.clone();
+            async move {
+                *captured_body.lock().unwrap() = Some(body);
+                Json(json!({
+                    "content": [{ "type": "text", "text": "ok" }],
+                    "stop_reason": "end_turn",
+                    "usage": { "input_tokens": 4, "output_tokens": 2 }
+                }))
+            }
+        }),
+    ))
+    .await;
+    let mut fixture = test_config(
+        "anthropic/claude-sonnet-4-6",
+        &[],
+        None,
+        Some("anthropic-token"),
+        false,
+    );
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::anthropic())
+        .unwrap()
+        .base_url = base_url;
+    let provider = AnthropicProvider::from_config(&fixture.config).unwrap();
+
+    let request = ProviderTurnRequest::plain(
+        "system",
+        vec![
+            ConversationMessage::AssistantBlocks(vec![ModelBlock::ToolUse {
+                id: "exec-1".into(),
+                name: "ExecCommand".into(),
+                input: json!({ "cmd": "ls /tmp" }),
+                kind: crate::provider::ModelToolCallKind::Function,
+            }]),
+            ConversationMessage::UserToolResults(vec![ToolResultBlock {
+                tool_use_id: "exec-1".into(),
+                content: "stdout:\na.txt\nb.txt".into(),
+                is_error: false,
+                error: None,
+            }]),
+        ],
+        Vec::new(),
+    );
+    provider.complete_turn(request).await.unwrap();
+
+    let body = captured_body
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("server should capture request body");
+    let messages = body["messages"].as_array().unwrap();
+    for message in messages {
+        if message["role"] == json!("user") {
+            for block in message["content"].as_array().unwrap() {
+                assert_ne!(block["type"], json!("text"));
+            }
+        }
+    }
+}

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -294,7 +294,10 @@ impl AgentProvider for AnthropicProvider {
         let wire_conversation = build_anthropic_wire_conversation(&request, cache_strategy);
         let rolling_cache_marker =
             rolling_conversation_cache_marker(&wire_conversation, cache_strategy);
-        let messages = build_anthropic_messages(&wire_conversation, rolling_cache_marker);
+        let mut messages = build_anthropic_messages(&wire_conversation, rolling_cache_marker);
+        if needs_placeholder_user_text(&self.route_provider) {
+            ensure_placeholder_user_text(&mut messages);
+        }
         let response_format_tool_choice = anthropic_response_format_tool_choice(&request);
         let (thinking, output_config) = anthropic_reasoning_controls(
             &self.route_provider,
@@ -1502,6 +1505,57 @@ fn build_anthropic_messages(
         .collect()
 }
 
+/// Ollama's Anthropic-compatible `/v1/messages` endpoint rejects message
+/// lists without any user text (e.g. pure tool-result rounds) with
+/// `500 no user query found in messages`; see ollama/ollama#18303. Until
+/// upstream ships a fix, append a non-empty placeholder user text block so
+/// tool-only rounds stay usable against ollama deployments.
+fn needs_placeholder_user_text(route_provider: &str) -> bool {
+    route_provider == "ollama"
+}
+
+fn ensure_placeholder_user_text(messages: &mut Vec<ApiMessage>) {
+    const PLACEHOLDER_USER_TEXT: &str = "(continue)";
+    if messages
+        .iter()
+        .any(|message| api_message_has_nonempty_user_text(message))
+    {
+        return;
+    }
+    let placeholder_block = || json!({ "type": "text", "text": PLACEHOLDER_USER_TEXT });
+    if let Some(message) = messages
+        .iter_mut()
+        .rev()
+        .find(|message| message.role == "user")
+    {
+        if let Some(blocks) = message.content.as_array_mut() {
+            blocks.push(placeholder_block());
+            return;
+        }
+    }
+    messages.push(ApiMessage {
+        role: "user",
+        content: Value::Array(vec![placeholder_block()]),
+    });
+}
+
+fn api_message_has_nonempty_user_text(message: &ApiMessage) -> bool {
+    if message.role != "user" {
+        return false;
+    }
+    match &message.content {
+        Value::String(text) => !text.trim().is_empty(),
+        Value::Array(blocks) => blocks.iter().any(|block| {
+            block.get("type").and_then(Value::as_str) == Some("text")
+                && block
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .is_some_and(|text| !text.trim().is_empty())
+        }),
+        _ => false,
+    }
+}
+
 fn conversation_message_has_content(message: &ConversationMessage) -> bool {
     match message {
         ConversationMessage::UserText(text) => !text.trim().is_empty(),
@@ -2616,6 +2670,35 @@ mod tests {
         ProviderPromptFrame, ToolResultBlock,
     };
     use serde_json::json;
+
+    #[test]
+    fn ensure_placeholder_user_text_appends_to_tool_only_user_turn() {
+        let mut messages = vec![ApiMessage {
+            role: "user",
+            content: json!([{ "type": "tool_result", "tool_use_id": "toolu_1" }]),
+        }];
+        ensure_placeholder_user_text(&mut messages);
+        let blocks = messages[0].content.as_array().unwrap();
+        let placeholder = blocks.last().unwrap();
+        assert_eq!(placeholder["type"], json!("text"));
+        assert!(!placeholder["text"].as_str().unwrap().trim().is_empty());
+    }
+
+    #[test]
+    fn ensure_placeholder_user_text_pushes_user_message_when_no_user_turn() {
+        let mut messages = vec![ApiMessage {
+            role: "assistant",
+            content: json!([{ "type": "text", "text": "working" }]),
+        }];
+        ensure_placeholder_user_text(&mut messages);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1].role, "user");
+        assert!(!messages[1].content[0]["text"]
+            .as_str()
+            .unwrap()
+            .trim()
+            .is_empty());
+    }
 
     #[test]
     fn build_anthropic_messages_marks_latest_tool_result_as_rolling_cache_tail() {


### PR DESCRIPTION
## Problem

ollama's Anthropic-compatible `/v1/messages` endpoint (and the OpenAI-compatible `/v1/chat/completions`) rejects any request whose `messages` contain no non-empty user text with HTTP 500:

```
chat prompt error: no user query found in messages
```

Agentic tool loops inherently produce such turns (`assistant` `tool_use` followed by a `user` message with only `tool_result` blocks), so any holon agent driving an ollama model fails as soon as it consumes one tool result. An empty-string placeholder does not help; ollama requires non-empty user text somewhere in the request.

- Upstream issue: ollama/ollama#18303 (includes a minimal repro and test matrix)
- Upstream fix PRs #17813 / #17894 are unmerged; v0.33.3 does not contain a fix

## Fix

Client-side mitigation in the Anthropic-compatible transport (`src/provider/transports/anthropic.rs`):

- When `route_provider == "ollama"` and the whole request has no non-empty user text (string content or non-empty text block), append a single placeholder text block `"(continue)"` to the **last user message**; push a new user message containing only the placeholder when no user message exists.
- The placeholder is appended **after** cache marker computation, so cache eligibility is unchanged.
- All other providers (including real Anthropic) keep byte-identical request bodies.

The trigger stays hardcoded to the ollama route instead of becoming a provider quirk config: it is a single known upstream bug with a clear removal condition, documented in `docs/implementation-decisions/124-ollama-tool-only-round-placeholder-user-text.md` (remove once an upstream release fixes ollama/ollama#18303 and passes regression).

## Tests

- 2 unit tests: placeholder appends to the tool-only user turn; placeholder pushes a user message when none exists.
- 2 end-to-end tests against a mock server capturing the `/v1/messages` body: the ollama route appends the placeholder block; the anthropic route does not.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib placeholder` (4 new tests pass)
- Live regression against local ollama 0.33.0 with `qwen3.8:latest`: replaying the exact request shape this transport now emits (tool-only user turn + trailing `"(continue)"` text block) returns HTTP 200, where the unmodified shape returns 500.

Closes #2829
