### PR TITLE
feat: enrich web file browser previews with media, metadata, and sorting

### DIFF
--- a/src/http/workspace_files.rs
+++ b/src/http/workspace_files.rs
@@ -34,6 +34,8 @@ struct DirectoryEntry {
     entry_type: &'static str,
     size: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    modified: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     mime_type: Option<String>,
 }
 
@@ -55,6 +57,10 @@ struct FileMetadata {
     size: u64,
     mime_type: String,
     truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    modified: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    line_count: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     total_size: Option<u64>,
 }
@@ -366,6 +372,17 @@ fn http_date(time: SystemTime) -> String {
         .to_string()
 }
 
+/// Convert a filesystem modification time to whole Unix-epoch seconds for
+/// JSON metadata responses. None when the platform does not report mtime.
+fn modified_unix_seconds(metadata: &std::fs::Metadata) -> Option<u64> {
+    metadata
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
+
 /// MIME types that execute scripts or host active content when rendered
 /// inline. Served with a sandboxing CSP so direct same-origin navigation
 /// cannot run workspace-controlled scripts.
@@ -618,6 +635,10 @@ async fn workspace_files_inner(
                 let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
                 ("file", size)
             };
+            let modified = entry
+                .metadata()
+                .ok()
+                .and_then(|m| modified_unix_seconds(&m));
             let mime_type = if file_type.is_file() {
                 Some(guess_mime(&entry.path()))
             } else {
@@ -627,6 +648,7 @@ async fn workspace_files_inner(
                 name,
                 entry_type,
                 size,
+                modified,
                 mime_type,
             });
         }
@@ -668,6 +690,8 @@ async fn workspace_files_inner(
             size: file_size,
             mime_type: mime_type.clone(),
             truncated: false,
+            modified: modified_unix_seconds(&metadata),
+            line_count: None,
             total_size: None,
         };
         return Ok(Json(json!(meta)).into_response());
@@ -702,6 +726,7 @@ async fn workspace_files_inner(
         .map_err(|err| error_response(anyhow!(err)))?;
     let total_size = bytes.len();
     let truncated = total_size > READ_LIMIT_BYTES;
+    let line_count = bytes.iter().filter(|&&b| b == b'\n').count() as u64;
     let read_bytes = if truncated {
         &bytes[..READ_LIMIT_BYTES]
     } else {
@@ -738,6 +763,8 @@ async fn workspace_files_inner(
             size: content.len() as u64,
             mime_type: mime_type.clone(),
             truncated,
+            modified: modified_unix_seconds(&metadata),
+            line_count: Some(line_count),
             total_size: if truncated {
                 Some(total_size as u64)
             } else {

--- a/tests/support/http_workspace.rs
+++ b/tests/support/http_workspace.rs
@@ -189,6 +189,10 @@ pub async fn workspace_files_lists_directory() -> Result<()> {
     for entry in entries {
         assert!(entry["name"].is_string(), "entry has name");
         assert!(entry["type"].is_string(), "entry has type");
+        assert!(
+            entry["modified"].is_u64(),
+            "entry has unix-seconds modified timestamp"
+        );
     }
 
     server.abort();
@@ -227,6 +231,11 @@ pub async fn workspace_files_reads_text_file() -> Result<()> {
     assert!(body["content"].is_string(), "content field present");
     assert!(body["mime_type"].is_string(), "mime_type field present");
     assert_eq!(body["truncated"], false);
+    assert!(body["modified"].is_u64(), "modified present for text file");
+    assert!(
+        body["line_count"].is_u64(),
+        "line_count present for text file"
+    );
 
     server.abort();
     Ok(())
@@ -296,6 +305,7 @@ pub async fn workspace_files_metadata_only() -> Result<()> {
     assert_eq!(body["type"], "file");
     assert!(body["size"].is_number(), "size present");
     assert!(body["mime_type"].is_string(), "mime_type present");
+    assert!(body["modified"].is_u64(), "modified present in meta mode");
     assert!(
         body.get("content").is_none(),
         "content must be absent in meta mode"

--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.test.ts
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareFileEntries,
+  formatSize,
+  isAudioFile,
+  isLargePreview,
+  isPdfFile,
+  isVideoFile,
+  type FileSortKey,
+} from "./FileBrowserPanel";
+import type { WorkspaceFileEntry } from "../../runtime/types";
+
+function entry(partial: Partial<WorkspaceFileEntry> & { name: string }): WorkspaceFileEntry {
+  return { type: "file", size: 0, ...partial };
+}
+
+describe("media type detection", () => {
+  it("detects video by mime type and extension", () => {
+    expect(isVideoFile("video/mp4")).toBe(true);
+    expect(isVideoFile(undefined, "clip.webm")).toBe(true);
+    expect(isVideoFile(undefined, "clip.MOV")).toBe(true);
+    expect(isVideoFile("text/plain", "notes.txt")).toBe(false);
+  });
+
+  it("detects audio by mime type and extension", () => {
+    expect(isAudioFile("audio/mpeg")).toBe(true);
+    expect(isAudioFile(undefined, "track.flac")).toBe(true);
+    expect(isAudioFile(undefined, "track.ogg")).toBe(true);
+    expect(isAudioFile("video/mp4", "clip.mp4")).toBe(false);
+  });
+
+  it("detects pdf by mime type and extension", () => {
+    expect(isPdfFile("application/pdf")).toBe(true);
+    expect(isPdfFile(undefined, "report.PDF")).toBe(true);
+    expect(isPdfFile("text/plain", "report.txt")).toBe(false);
+  });
+});
+
+describe("formatSize", () => {
+  it("renders byte, kilobyte, megabyte, and gigabyte tiers", () => {
+    expect(formatSize(512)).toBe("512 B");
+    expect(formatSize(2048)).toBe("2.0 KB");
+    expect(formatSize(3 * 1024 * 1024)).toBe("3.0 MB");
+    expect(formatSize(2.5 * 1024 * 1024 * 1024)).toBe("2.50 GB");
+  });
+
+  it("flags previews over one gigabyte as large", () => {
+    expect(isLargePreview(1024 * 1024 * 1024)).toBe(false);
+    expect(isLargePreview(1024 * 1024 * 1024 + 1)).toBe(true);
+    expect(isLargePreview(undefined)).toBe(false);
+  });
+});
+
+describe("compareFileEntries", () => {
+  const dir = entry({ name: "zzz", type: "directory" });
+  const small = entry({ name: "big.txt", size: 900, modified: 200 });
+  const big = entry({ name: "small.txt", size: 100, modified: 400 });
+
+  it("keeps directories before files regardless of sort key", () => {
+    for (const key of ["name", "size", "modified"] as FileSortKey[]) {
+      expect(compareFileEntries(big, dir, key, true)).toBeGreaterThan(0);
+      expect(compareFileEntries(dir, big, key, false)).toBeLessThan(0);
+    }
+  });
+
+  it("sorts by size with descending inversion", () => {
+    expect(compareFileEntries(small, big, "size", true)).toBeGreaterThan(0);
+    expect(compareFileEntries(small, big, "size", false)).toBeLessThan(0);
+  });
+
+  it("sorts by modified timestamp", () => {
+    expect(compareFileEntries(small, big, "modified", true)).toBeLessThan(0);
+    expect(compareFileEntries(small, big, "modified", false)).toBeGreaterThan(0);
+  });
+
+  it("falls back to name when keys tie", () => {
+    const a = entry({ name: "a.txt", size: 10, modified: 100 });
+    const b = entry({ name: "b.txt", size: 10, modified: 100 });
+    expect(compareFileEntries(a, b, "size", true)).toBeLessThan(0);
+    expect(compareFileEntries(a, b, "size", false)).toBeLessThan(0);
+  });
+});

--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -42,6 +42,9 @@ interface SelectedFile {
   mimeType?: string;
   truncated?: boolean;
   totalSize?: number;
+  modified?: number;
+  lineCount?: number;
+  size?: number;
   loading: boolean;
   error?: string;
 }
@@ -90,10 +93,74 @@ function isImageFile(mimeType?: string): boolean {
   return Boolean(mimeType?.startsWith("image/"));
 }
 
-function formatSize(bytes: number): string {
+const VIDEO_EXTENSIONS = ["mp4", "webm", "ogv", "mov", "mkv", "m4v"];
+const AUDIO_EXTENSIONS = ["mp3", "wav", "ogg", "oga", "flac", "m4a", "aac", "opus"];
+
+function fileExtension(name: string): string {
+  return name.split(".").pop()?.toLowerCase() ?? "";
+}
+
+export function isVideoFile(mimeType?: string, name?: string): boolean {
+  if (mimeType?.startsWith("video/")) return true;
+  return Boolean(name && VIDEO_EXTENSIONS.includes(fileExtension(name)));
+}
+
+export function isAudioFile(mimeType?: string, name?: string): boolean {
+  if (mimeType?.startsWith("audio/")) return true;
+  return Boolean(name && AUDIO_EXTENSIONS.includes(fileExtension(name)));
+}
+
+export function isPdfFile(mimeType?: string, name?: string): boolean {
+  if (mimeType === "application/pdf") return true;
+  return Boolean(name && fileExtension(name) === "pdf");
+}
+
+function formatDateTime(unixSeconds?: number): string | undefined {
+  if (!unixSeconds) return undefined;
+  return new Date(unixSeconds * 1000).toLocaleString(undefined, {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+}
+
+function formatDate(unixSeconds?: number): string | undefined {
+  if (!unixSeconds) return undefined;
+  return new Date(unixSeconds * 1000).toLocaleDateString();
+}
+
+const GIGABYTE = 1024 * 1024 * 1024;
+
+export function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes < GIGABYTE) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / GIGABYTE).toFixed(2)} GB`;
+}
+
+export function isLargePreview(totalBytes?: number): boolean {
+  return Boolean(totalBytes && totalBytes > GIGABYTE);
+}
+
+export type FileSortKey = "name" | "size" | "modified";
+
+// Containers (directories and symlinks) always sort before plain files;
+// equal keys fall back to name order.
+export function compareFileEntries(
+  a: WorkspaceFileEntry,
+  b: WorkspaceFileEntry,
+  key: FileSortKey,
+  ascending: boolean,
+): number {
+  const aContainer = a.type === "directory" || a.type === "symlink";
+  const bContainer = b.type === "directory" || b.type === "symlink";
+  if (aContainer !== bContainer) return aContainer ? -1 : 1;
+  let cmp: number;
+  if (key === "size") cmp = a.size - b.size;
+  else if (key === "modified") cmp = (a.modified ?? 0) - (b.modified ?? 0);
+  else cmp = a.name.localeCompare(b.name);
+  if (cmp !== 0) return ascending ? cmp : -cmp;
+  // Ties fall back to name order so descending sorts stay stable.
+  return a.name.localeCompare(b.name);
 }
 
 // --- Shiki syntax highlighting ---
@@ -179,6 +246,9 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   const [showRendered, setShowRendered] = useState(true);
   const [viewMode, setViewMode] = useState<"files" | "preview">("files");
   const [filterText, setFilterText] = useState("");
+  const [sortKey, setSortKey] = useState<"name" | "size" | "modified">("name");
+  const [sortAsc, setSortAsc] = useState(true);
+  const [imageDims, setImageDims] = useState<{ width: number; height: number }>();
 
   // Determine whether the selected file is markdown.
   const isMarkdownFile = selectedFile?.path?.toLowerCase().endsWith(".md") ?? false;
@@ -189,6 +259,7 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
       contentScrollRef.current.scrollTop = 0;
     }
     setShowRendered(true);
+    setImageDims(undefined);
   }, [selectedFile?.path]);
 
   const highlightedHtml = useShikiHighlight(selectedFile?.content, selectedFile?.path);
@@ -222,9 +293,14 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   const reloadFile = useCallback(async () => {
     if (!selectedFile?.path) return;
     const filePath = selectedFile.path;
-    if (isImageFile(selectedFile.mimeType)) {
-      // Image files are served via URL, force re-render by re-setting state
-      setSelectedFile({ path: filePath, loading: false, mimeType: selectedFile.mimeType });
+    if (
+      isImageFile(selectedFile.mimeType) ||
+      isVideoFile(selectedFile.mimeType, selectedFile.path) ||
+      isAudioFile(selectedFile.mimeType, selectedFile.path) ||
+      isPdfFile(selectedFile.mimeType, selectedFile.path)
+    ) {
+      // URL-backed previews: force re-render by re-setting state.
+      setSelectedFile({ ...selectedFile, path: filePath, loading: false });
       return;
     }
     setSelectedFile({ path: filePath, loading: true });
@@ -236,6 +312,9 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
         mimeType: content.mimeType,
         truncated: content.truncated,
         totalSize: content.totalSize ?? content.size,
+        modified: content.modified,
+        lineCount: content.lineCount,
+        size: content.totalSize ?? content.size,
         loading: false,
       });
     } catch (err) {
@@ -283,13 +362,16 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
     const filePath = currentPath ? `${currentPath}/${entry.name}` : entry.name;
     setViewMode("preview");
 
-    if (isImageFile(entry.mimeType)) {
-      setSelectedFile({ path: filePath, loading: false, mimeType: entry.mimeType });
-      return;
-    }
-
     if (!isTextFile(entry.mimeType, entry.name)) {
-      setSelectedFile({ path: filePath, loading: false, mimeType: entry.mimeType });
+      // URL-backed previews (image, video, audio, PDF) and other binary
+      // files render from entry metadata without reading content.
+      setSelectedFile({
+        path: filePath,
+        loading: false,
+        mimeType: entry.mimeType,
+        size: entry.size,
+        modified: entry.modified,
+      });
       return;
     }
 
@@ -302,6 +384,9 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
         mimeType: content.mimeType,
         truncated: content.truncated,
         totalSize: content.totalSize ?? content.size,
+        modified: content.modified,
+        lineCount: content.lineCount,
+        size: content.totalSize ?? content.size,
         loading: false,
       });
     } catch (err) {
@@ -383,12 +468,30 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   const visibleEntries = showHidden
     ? entries
     : entries.filter((e) => !e.name.startsWith("."));
-  const dirs = visibleEntries.filter((e) => e.type === "directory" || e.type === "symlink");
-  const files = visibleEntries.filter((e) => e.type === "file");
-  const sortedEntries = [...dirs, ...files];
+  const toggleSort = (key: "name" | "size" | "modified") => {
+    if (sortKey === key) {
+      setSortAsc((v) => !v);
+    } else {
+      setSortKey(key);
+      setSortAsc(true);
+    }
+  };
+  const sortedEntries = [...visibleEntries].sort((a, b) =>
+    compareFileEntries(a, b, sortKey, sortAsc),
+  );
   const filteredEntries = filterText
     ? sortedEntries.filter((e) => e.name.toLowerCase().includes(filterText.toLowerCase()))
     : sortedEntries;
+
+  const selectedFileUrl = selectedFile
+    ? workspaceFileUrl(workspaceId, selectedFile.path, executionRootId)
+    : undefined;
+  const selectedFileTotalBytes =
+    selectedFile?.totalSize ?? selectedFile?.size;
+  const largePreviewHint =
+    selectedFileTotalBytes != null && isLargePreview(selectedFileTotalBytes)
+      ? t("fileBrowser.largeFileHint", { size: formatSize(selectedFileTotalBytes) })
+      : undefined;
 
   return (
     <div className="file-browser">
@@ -510,8 +613,35 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
               {filterText ? t("fileBrowser.noMatch") : t("fileBrowser.emptyDir")}
             </p>
       ) : (
-        <ul className="file-browser-list">
-          {filteredEntries.map((entry) => (
+        <div className="file-browser-listing">
+          <div className="file-browser-columns">
+            <button
+              type="button"
+              className={`file-browser-column file-browser-column-name${sortKey === "name" ? " active" : ""}`}
+              onClick={() => toggleSort("name")}
+            >
+              {t("fileBrowser.columnName")}
+              {sortKey === "name" ? (sortAsc ? " ▲" : " ▼") : ""}
+            </button>
+            <button
+              type="button"
+              className={`file-browser-column file-browser-column-size${sortKey === "size" ? " active" : ""}`}
+              onClick={() => toggleSort("size")}
+            >
+              {t("fileBrowser.columnSize")}
+              {sortKey === "size" ? (sortAsc ? " ▲" : " ▼") : ""}
+            </button>
+            <button
+              type="button"
+              className={`file-browser-column file-browser-column-time${sortKey === "modified" ? " active" : ""}`}
+              onClick={() => toggleSort("modified")}
+            >
+              {t("fileBrowser.columnModified")}
+              {sortKey === "modified" ? (sortAsc ? " ▲" : " ▼") : ""}
+            </button>
+          </div>
+          <ul className="file-browser-list">
+            {filteredEntries.map((entry) => (
             <li key={entry.name}>
               <button
                 type="button"
@@ -524,10 +654,12 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
                 {entry.type === "file" ? (
                   <small className="file-browser-entry-size">{formatSize(entry.size)}</small>
                 ) : null}
+                <small className="file-browser-entry-time">{formatDate(entry.modified)}</small>
               </button>
             </li>
-          ))}
-        </ul>
+            ))}
+          </ul>
+        </div>
       )}
 
         </>
@@ -578,6 +710,27 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
               <button type="button" className="file-browser-close-btn" aria-label={t("fileBrowser.closeFile")} onClick={() => { setSelectedFile(null); setViewMode("files"); }}>{t("fileBrowser.closeFile")}</button>
             </div>
           </div>
+          <div className="file-browser-meta-bar">
+            {selectedFile.mimeType ? <span className="file-browser-meta-item">{selectedFile.mimeType}</span> : null}
+            {selectedFileTotalBytes != null ? (
+              <span className="file-browser-meta-item">{formatSize(selectedFileTotalBytes)}</span>
+            ) : null}
+            {selectedFile.modified ? (
+              <span className="file-browser-meta-item">
+                {t("fileBrowser.modifiedAt", { time: formatDateTime(selectedFile.modified) })}
+              </span>
+            ) : null}
+            {selectedFile.lineCount != null ? (
+              <span className="file-browser-meta-item">
+                {t("fileBrowser.lineCount", { count: selectedFile.lineCount })}
+              </span>
+            ) : null}
+            {imageDims ? (
+              <span className="file-browser-meta-item">
+                {t("fileBrowser.imageDimensions", { width: imageDims.width, height: imageDims.height })}
+              </span>
+            ) : null}
+          </div>
           {selectedFile.loading ? (
             <p className="inspector-muted">{t("fileBrowser.loadingFile")}</p>
           ) : selectedFile.error ? (
@@ -589,14 +742,42 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
               path={selectedFile.path}
               executionRootId={executionRootId}
               alt={selectedFile.path}
+              onLoad={(e) => {
+                const img = e.currentTarget;
+                if (img.naturalWidth && img.naturalHeight) {
+                  setImageDims({ width: img.naturalWidth, height: img.naturalHeight });
+                }
+              }}
             />
+          ) : isVideoFile(selectedFile.mimeType, selectedFile.path) ? (
+            <div className="file-browser-media">
+              {largePreviewHint ? <p className="inspector-muted">{largePreviewHint}</p> : null}
+              <video className="file-browser-video" controls preload="metadata" src={selectedFileUrl} />
+            </div>
+          ) : isAudioFile(selectedFile.mimeType, selectedFile.path) ? (
+            <div className="file-browser-media">
+              {largePreviewHint ? <p className="inspector-muted">{largePreviewHint}</p> : null}
+              <audio className="file-browser-audio" controls preload="metadata" src={selectedFileUrl} />
+            </div>
+          ) : isPdfFile(selectedFile.mimeType, selectedFile.path) ? (
+            <div className="file-browser-media">
+              {largePreviewHint ? <p className="inspector-muted">{largePreviewHint}</p> : null}
+              <iframe className="file-browser-pdf" src={selectedFileUrl} title={selectedFile.path} />
+            </div>
           ) : selectedFile.content != null ? (
             <>
               {selectedFile.truncated ? (
-                <p className="inspector-muted">
+                <p className="inspector-muted file-browser-truncated">
                   {selectedFile.totalSize
                     ? t("fileBrowser.fileTruncated", { size: formatSize(selectedFile.totalSize) })
                     : t("fileBrowser.fileTruncatedNoSize")}
+                  {" "}
+                  <button type="button" className="file-browser-truncated-action" onClick={openSelectedFileInNewTab}>
+                    {t("fileBrowser.openInNewTab")}
+                  </button>
+                  <button type="button" className="file-browser-truncated-action" onClick={downloadSelectedFile}>
+                    {t("fileBrowser.download")}
+                  </button>
                 </p>
               ) : null}
               {isMarkdownFile && showRendered ? (

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -768,6 +768,13 @@ const en = {
     openInFileBrowser: "Open in file browser",
     markdownView: "Markdown view mode",
     pathBreadcrumb: "Path breadcrumb",
+    columnName: "Name",
+    columnSize: "Size",
+    columnModified: "Modified",
+    modifiedAt: "Modified {{time}}",
+    lineCount: "{{count}} lines",
+    imageDimensions: "{{width}}×{{height}} px",
+    largeFileHint: "Large file ({{size}}). Consider downloading it to view locally.",
   },
   inspector: {
     fullDetail: "Full detail",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -769,6 +769,13 @@ const zh: Record<string, any> = {
     openInFileBrowser: "在文件浏览器中打开",
     markdownView: "Markdown 查看模式",
     pathBreadcrumb: "路径面包屑导航",
+    columnName: "名称",
+    columnSize: "大小",
+    columnModified: "修改时间",
+    modifiedAt: "修改于 {{time}}",
+    lineCount: "{{count}} 行",
+    imageDimensions: "{{width}}×{{height}} 像素",
+    largeFileHint: "大文件（{{size}}），建议下载后本地查看。",
   },
   inspector: {
     fullDetail: "完整详情",

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -724,6 +724,7 @@ export interface WorkspaceFileEntry {
   name: string;
   type: "directory" | "file" | "symlink";
   size: number;
+  modified?: number;
   mimeType?: string;
 }
 
@@ -741,6 +742,8 @@ export interface WorkspaceFileContent {
   size: number;
   mimeType: string;
   truncated: boolean;
+  modified?: number;
+  lineCount?: number;
   totalSize?: number;
   content?: string;
 }

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -4390,6 +4390,68 @@ code {
   font-size: 0.75rem;
 }
 
+.file-browser-listing {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.file-browser-columns {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-bottom: 1px solid var(--border, #ddd);
+  flex-shrink: 0;
+}
+
+.file-browser-column {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--text-muted, #888);
+  padding: 2px 0;
+}
+
+.file-browser-column:hover,
+.file-browser-column.active {
+  color: var(--text, inherit);
+}
+
+.file-browser-column-name {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+}
+
+.file-browser-column-size,
+.file-browser-entry-size {
+  width: 56px;
+}
+
+.file-browser-column-size {
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.file-browser-column-time,
+.file-browser-entry-time {
+  width: 84px;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.file-browser-column.active {
+  font-weight: 600;
+}
+
+.file-browser-entry-time {
+  color: var(--text-muted, #888);
+  font-size: 0.75rem;
+}
+
 .file-browser-viewer {
   background: var(--surface);
   display: flex;
@@ -4462,6 +4524,71 @@ code {
   max-width: 100%;
   height: auto;
   border-radius: 4px;
+}
+
+.file-browser-meta-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px 12px;
+  font-size: 0.75rem;
+  color: var(--text-muted, #888);
+  flex-shrink: 0;
+}
+
+.file-browser-meta-item {
+  white-space: nowrap;
+}
+
+.file-browser-media {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  overflow: auto;
+}
+
+.file-browser-media > .inspector-muted {
+  flex-shrink: 0;
+  margin: 0;
+}
+
+.file-browser-video {
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: 6px;
+  background: #000;
+}
+
+.file-browser-audio {
+  width: 100%;
+  margin: auto 0;
+}
+
+.file-browser-pdf {
+  flex: 1;
+  width: 100%;
+  min-height: 420px;
+  border: 1px solid var(--border, #ddd);
+  border-radius: 6px;
+  background: #fff;
+}
+
+.file-browser-truncated-action {
+  background: none;
+  border: 1px solid var(--border, #ccc);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 1px 6px;
+  color: inherit;
+  margin-left: 6px;
+}
+
+.file-browser-truncated-action:hover {
+  background: var(--hover-bg, #f0f0f0);
 }
 
 .file-browser-viewer-actions {


### PR DESCRIPTION
## Summary

Slice 3 of the Web GUI file browser upgrade (follows #2820, builds on the direct-link/Range support merged in #2823):

- **Media previews**: video (`mp4/webm/ogg/mov/...`) and audio (`mp3/wav/ogg/flac/m4a/...`) render native `<video controls preload="metadata">` / `<audio controls>` elements pointing at the direct file URL, so playback streams with Range support instead of buffering through `fetch`.
- **PDF preview**: embedded via `<iframe>` using the browser's native viewer.
- **Metadata bar**: human-readable size, mime type, modified time, text line count, and image dimensions (`naturalWidth`/`naturalHeight`).
- **Sortable directory listing**: backend listing and `?meta=1` now include `mtime`; the frontend table supports sorting by name, size, and modified time.
- **Truncation UX**: text previews beyond the 1 MB limit surface the existing `truncated` flag with inline download / open-in-new-tab actions; previews over 1 GB suggest downloading the file instead of inline viewing.

## Testing

- `cargo test --test http_workspace` — updated fixtures + assertions for `mtime` (all passing)
- New `FileBrowserPanel.test.ts` covering preview-kind selection, metadata formatting, and sorting
- `web-gui` vitest suite green; full `make test` (Rust suite) green
