### PR TITLE
fix: support scheduler recovery on schema 46

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2024,44 +2024,42 @@ fn apply_scheduler_recovery_plan_with_options(
         if &current_entry == proposed_entry && candidate.proposed_commands.is_empty() {
             continue;
         }
-        let commit = runtime_db
-            .transitions()
-            .commit_queue_with_execution_protocol(
-                &crate::runtime_db::transitions::QueueTransitionCommand {
-                    agent_id: agent_id.to_string(),
-                    operation: if proposed_entry.status == QueueEntryStatus::Queued {
-                        crate::runtime_db::transitions::QueueOperation::Requeue
-                    } else {
-                        crate::runtime_db::transitions::QueueOperation::Settle
-                    },
-                    mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
-                        expected: current_entry,
-                        record: proposed_entry.clone(),
-                    },
-                    scheduler_claim_work_item: None,
-                    agent_state: None,
-                    message_evidence: Vec::new(),
-                    transcript_entries: Vec::new(),
-                    turn_record: None,
-                    audit_events: vec![AuditEvent::legacy(
-                        "scheduler_execution_recovered",
-                        serde_json::json!({
-                            "agent_id": agent_id,
-                            "message_id": candidate.message_id,
-                            "activation_id": candidate.activation_id,
-                            "work_item_id": candidate.work_item_id,
-                            "reason": candidate.reason,
-                        }),
-                    )],
-                    notify_scheduler: true,
-                    fault: None,
-                    brief_evidence: Vec::new(),
+        let commit = runtime_db.transitions().commit_scheduler_recovery(
+            &crate::runtime_db::transitions::QueueTransitionCommand {
+                agent_id: agent_id.to_string(),
+                operation: if proposed_entry.status == QueueEntryStatus::Queued {
+                    crate::runtime_db::transitions::QueueOperation::Requeue
+                } else {
+                    crate::runtime_db::transitions::QueueOperation::Settle
                 },
-                &crate::runtime_db::transitions::ExecutionProtocolTransition {
-                    bootstrap: None,
-                    commands: candidate.proposed_commands.clone(),
+                mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                    expected: current_entry,
+                    record: proposed_entry.clone(),
                 },
-            )?;
+                scheduler_claim_work_item: None,
+                agent_state: None,
+                message_evidence: Vec::new(),
+                transcript_entries: Vec::new(),
+                turn_record: None,
+                audit_events: vec![AuditEvent::legacy(
+                    "scheduler_execution_recovered",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "message_id": candidate.message_id,
+                        "activation_id": candidate.activation_id,
+                        "work_item_id": candidate.work_item_id,
+                        "reason": candidate.reason,
+                    }),
+                )],
+                notify_scheduler: true,
+                fault: None,
+                brief_evidence: Vec::new(),
+            },
+            &crate::runtime_db::transitions::ExecutionProtocolTransition {
+                bootstrap: None,
+                commands: candidate.proposed_commands.clone(),
+            },
+        )?;
         applied |= commit.applied;
     }
     for (candidate, expected_entry, proposed_entry, command) in task_result_claim_recovery {
@@ -2085,44 +2083,42 @@ fn apply_scheduler_recovery_plan_with_options(
                 candidate.message_id
             ));
         }
-        let commit = runtime_db
-            .transitions()
-            .commit_queue_with_execution_protocol(
-                &crate::runtime_db::transitions::QueueTransitionCommand {
-                    agent_id: agent_id.to_string(),
-                    operation: if proposed_entry.status == QueueEntryStatus::Queued {
-                        crate::runtime_db::transitions::QueueOperation::Requeue
-                    } else {
-                        crate::runtime_db::transitions::QueueOperation::Settle
-                    },
-                    mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
-                        expected: expected_entry.clone(),
-                        record: proposed_entry.clone(),
-                    },
-                    scheduler_claim_work_item: None,
-                    agent_state: None,
-                    message_evidence: Vec::new(),
-                    transcript_entries: Vec::new(),
-                    turn_record: None,
-                    audit_events: vec![AuditEvent::legacy(
-                        "scheduler_task_result_claim_recovered",
-                        serde_json::json!({
-                            "agent_id": agent_id,
-                            "message_id": candidate.message_id,
-                            "activation_id": candidate.activation_id,
-                            "work_item_id": candidate.work_item_id,
-                            "reason": candidate.reason,
-                        }),
-                    )],
-                    notify_scheduler: true,
-                    fault: task_result_fault,
-                    brief_evidence: Vec::new(),
+        let commit = runtime_db.transitions().commit_scheduler_recovery(
+            &crate::runtime_db::transitions::QueueTransitionCommand {
+                agent_id: agent_id.to_string(),
+                operation: if proposed_entry.status == QueueEntryStatus::Queued {
+                    crate::runtime_db::transitions::QueueOperation::Requeue
+                } else {
+                    crate::runtime_db::transitions::QueueOperation::Settle
                 },
-                &crate::runtime_db::transitions::ExecutionProtocolTransition {
-                    bootstrap: None,
-                    commands: vec![command.clone()],
+                mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                    expected: expected_entry.clone(),
+                    record: proposed_entry.clone(),
                 },
-            )?;
+                scheduler_claim_work_item: None,
+                agent_state: None,
+                message_evidence: Vec::new(),
+                transcript_entries: Vec::new(),
+                turn_record: None,
+                audit_events: vec![AuditEvent::legacy(
+                    "scheduler_task_result_claim_recovered",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "message_id": candidate.message_id,
+                        "activation_id": candidate.activation_id,
+                        "work_item_id": candidate.work_item_id,
+                        "reason": candidate.reason,
+                    }),
+                )],
+                notify_scheduler: true,
+                fault: task_result_fault,
+                brief_evidence: Vec::new(),
+            },
+            &crate::runtime_db::transitions::ExecutionProtocolTransition {
+                bootstrap: None,
+                commands: vec![command.clone()],
+            },
+        )?;
         applied |= commit.applied;
         if commit.applied {
             crate::diagnostics::record_unsettled_claim_recovery();

--- a/src/runtime_db/agent_message_delivery.rs
+++ b/src/runtime_db/agent_message_delivery.rs
@@ -668,6 +668,34 @@ mod tests {
         Ok(())
     }
 
+    fn recovery_transition(
+        db: &RuntimeDb,
+        current: &QueueEntryRecord,
+        status: QueueEntryStatus,
+    ) -> Result<()> {
+        let mut next = current.clone();
+        next.status = status;
+        next.updated_at = Utc::now();
+        db.transitions().commit_scheduler_recovery(
+            &QueueTransitionCommand {
+                agent_id: current.agent_id.clone(),
+                operation: QueueOperation::Settle,
+                mutation: QueueMutation::Upsert(next),
+                scheduler_claim_work_item: None,
+                agent_state: None,
+                message_evidence: Vec::new(),
+                transcript_entries: Vec::new(),
+                turn_record: None,
+                audit_events: Vec::new(),
+                notify_scheduler: false,
+                fault: None,
+                brief_evidence: Vec::new(),
+            },
+            &crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
+        )?;
+        Ok(())
+    }
+
     #[test]
     fn accepted_delivery_is_idempotent_and_survives_restart() -> Result<()> {
         let (dir, db) = runtime_db()?;
@@ -857,6 +885,47 @@ mod tests {
                 .context("missing terminal delivery")?
                 .state,
             AgentMessageDeliveryState::CancelledByDeletion
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_recovery_advances_delivery_projection_when_available() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        seed_target(&db, AgentStatus::AwakeIdle)?;
+        let prepared = prepare("recovery-delivery", "recover")?;
+        let accepted = db.transitions().commit_delivery_admission(
+            &admission_command(&prepared),
+            None,
+            &prepared.record,
+        )?;
+        let delivery_id = accepted
+            .delivery_receipt
+            .context("missing delivery receipt")?
+            .delivery_id;
+        let queued = db
+            .queue_entries()
+            .latest(&prepared.message.id)?
+            .context("missing queue entry")?;
+        queue_transition(
+            &db,
+            &queued,
+            QueueOperation::Claim,
+            QueueEntryStatus::Dequeued,
+        )?;
+        let dequeued = db
+            .queue_entries()
+            .latest(&prepared.message.id)?
+            .context("missing dequeued entry")?;
+
+        recovery_transition(&db, &dequeued, QueueEntryStatus::Processed)?;
+
+        assert_eq!(
+            db.agent_message_deliveries()
+                .latest(&delivery_id)?
+                .context("missing recovered delivery")?
+                .state,
+            AgentMessageDeliveryState::Consumed
         );
         Ok(())
     }

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -1772,6 +1772,61 @@ INSERT INTO storage_domains (
     }
 
     #[test]
+    fn scheduler_recovery_commit_supports_schema_46_without_delivery_projection() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        {
+            let mut connection = open_connection(&db_path)?;
+            migrate_through(&mut connection, 46)?;
+        }
+
+        let recovery_db = RuntimeDb::open_for_scheduler_recovery(&db_path, &lock_path)?;
+        let now = Utc::now();
+        let dequeued = QueueEntryRecord {
+            message_id: "message-schema-46-recovery".into(),
+            agent_id: "agent-schema-46-recovery".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Dequeued,
+            created_at: now,
+            updated_at: now,
+        };
+        recovery_db.queue_entries().upsert(&dequeued)?;
+        let mut interrupted = dequeued.clone();
+        interrupted.status = QueueEntryStatus::Interrupted;
+        interrupted.updated_at = now + chrono::Duration::seconds(1);
+
+        let commit = recovery_db.transitions().commit_scheduler_recovery(
+            &crate::runtime_db::transitions::QueueTransitionCommand {
+                agent_id: dequeued.agent_id.clone(),
+                operation: crate::runtime_db::transitions::QueueOperation::Settle,
+                mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                    expected: dequeued.clone(),
+                    record: interrupted.clone(),
+                },
+                scheduler_claim_work_item: None,
+                agent_state: None,
+                message_evidence: Vec::new(),
+                transcript_entries: Vec::new(),
+                turn_record: None,
+                audit_events: Vec::new(),
+                notify_scheduler: false,
+                fault: None,
+                brief_evidence: Vec::new(),
+            },
+            &crate::runtime_db::transitions::ExecutionProtocolTransition::default(),
+        )?;
+
+        assert!(commit.applied);
+        assert_eq!(
+            recovery_db
+                .queue_entries()
+                .latest(&dequeued.message_id)?
+                .expect("recovered queue entry"),
+            interrupted
+        );
+        Ok(())
+    }
+
+    #[test]
     fn scheduler_recovery_open_rejects_older_schemas() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         {

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -55,6 +55,12 @@ pub(crate) enum TransitionFaultPoint {
     BeforeSchedulerNotification,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeliverySynchronization {
+    Required,
+    IfAvailable,
+}
+
 impl TransitionFaultPoint {
     fn is_post_commit(self) -> bool {
         matches!(
@@ -1012,7 +1018,7 @@ impl RuntimeTransitionRepository<'_> {
             &[],
             &[],
             None,
-            false,
+            DeliverySynchronization::IfAvailable,
         )
     }
 
@@ -1116,7 +1122,7 @@ impl RuntimeTransitionRepository<'_> {
             &[],
             &[],
             Some(delivery),
-            true,
+            DeliverySynchronization::Required,
         )
     }
 
@@ -1139,7 +1145,7 @@ impl RuntimeTransitionRepository<'_> {
             terminal_tool_executions,
             extra_wait_conditions,
             None,
-            true,
+            DeliverySynchronization::Required,
         )
     }
 
@@ -1154,9 +1160,20 @@ impl RuntimeTransitionRepository<'_> {
         terminal_tool_executions: &[ToolExecutionRecord],
         extra_wait_conditions: &[crate::types::WaitConditionRecord],
         delivery: Option<&AgentMessageDeliveryRecord>,
-        synchronize_delivery: bool,
+        delivery_synchronization: DeliverySynchronization,
     ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
+            let synchronize_delivery = match delivery_synchronization {
+                DeliverySynchronization::Required => true,
+                DeliverySynchronization::IfAvailable => tx.query_row(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM sqlite_master
+                        WHERE type = 'table' AND name = 'agent_message_deliveries'
+                    )",
+                    [],
+                    |row| row.get::<_, bool>(0),
+                )?,
+            };
             let delivery = delivery
                 .map(|delivery| prepare_delivery_admission_tx(tx, delivery))
                 .transpose()?;

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -998,6 +998,24 @@ impl RuntimeTransitionRepository<'_> {
         self.commit_queue_transaction(command, execution_protocol, None, None, None, &[], &[])
     }
 
+    pub(crate) fn commit_scheduler_recovery(
+        &self,
+        command: &QueueTransitionCommand,
+        execution_protocol: &ExecutionProtocolTransition,
+    ) -> Result<TransitionCommit> {
+        self.commit_queue_transaction_with_delivery(
+            command,
+            execution_protocol,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            false,
+        )
+    }
+
     pub fn commit_queue_with_execution_protocol_and_terminal_tool_executions(
         &self,
         command: &QueueTransitionCommand,
@@ -1098,6 +1116,7 @@ impl RuntimeTransitionRepository<'_> {
             &[],
             &[],
             Some(delivery),
+            true,
         )
     }
 
@@ -1120,6 +1139,7 @@ impl RuntimeTransitionRepository<'_> {
             terminal_tool_executions,
             extra_wait_conditions,
             None,
+            true,
         )
     }
 
@@ -1134,6 +1154,7 @@ impl RuntimeTransitionRepository<'_> {
         terminal_tool_executions: &[ToolExecutionRecord],
         extra_wait_conditions: &[crate::types::WaitConditionRecord],
         delivery: Option<&AgentMessageDeliveryRecord>,
+        synchronize_delivery: bool,
     ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             let delivery = delivery
@@ -1193,12 +1214,17 @@ impl RuntimeTransitionRepository<'_> {
                 terminal_tool_executions,
             )?;
             let queue_record = queue_mutation_record(&command.mutation);
-            if delivery_by_message_id_tx(tx, &queue_record.message_id)?.is_some_and(|delivery| {
-                !matches!(
-                    delivery.state,
-                    AgentMessageDeliveryState::Queued | AgentMessageDeliveryState::Dispatched
+            if synchronize_delivery
+                && delivery_by_message_id_tx(tx, &queue_record.message_id)?.is_some_and(
+                    |delivery| {
+                        !matches!(
+                            delivery.state,
+                            AgentMessageDeliveryState::Queued
+                                | AgentMessageDeliveryState::Dispatched
+                        )
+                    },
                 )
-            }) {
+            {
                 return Ok(TransitionCommit::default());
             }
             if let QueueMutation::Consume(record) = &command.mutation {
@@ -1287,7 +1313,9 @@ impl RuntimeTransitionRepository<'_> {
             if !matches!(&command.mutation, QueueMutation::Upsert(_)) && !mutation_applied {
                 return Ok(TransitionCommit::default());
             }
-            advance_delivery_for_queue_transition_tx(tx, command)?;
+            if synchronize_delivery {
+                advance_delivery_for_queue_transition_tx(tx, command)?;
+            }
             let agent_state_applied =
                 apply_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
             let execution_protocol_applied = execution_protocol


### PR DESCRIPTION
## 背景

v0.38.0 受保护 Release E2E 的 `runtime-upgrade-interrupted-schema47` 场景从 schema 46 数据库恢复 interrupted scheduler state 时失败。schema 46 尚未包含 delivery projection 表，但恢复提交路径无条件写入该表。

## 修复

- 为 scheduler recovery 增加 schema-aware transition 入口。
- schema 47+ 继续使用 queue + execution protocol + delivery projection 的完整原子提交。
- schema 46 使用相同 queue CAS、execution protocol、audit/fault/brief 语义，但跳过尚不存在的 delivery projection 写入。
- 增加 schema 46 interrupted recovery 回归测试，覆盖 CAS 生效、命令持久化及无 delivery 表场景。

## 验证

- `cargo test --lib runtime_db::tests::tests -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`

此 PR 仅修复 v0.38.0 Release E2E 门禁；合并后将重跑受保护 Release E2E，再继续 tag/Release/资产发布。
