### PR TITLE
fix: resolve relative markdown links in web file browser previews

### DIFF
--- a/web-gui/app/src/components/MarkdownContent.tsx
+++ b/web-gui/app/src/components/MarkdownContent.tsx
@@ -148,7 +148,7 @@ interface WorkspaceFileLinkProps {
   children?: ReactNode;
 }
 
-function WorkspaceFileLink({ href, children }: WorkspaceFileLinkProps) {
+export function WorkspaceFileLink({ href, children }: WorkspaceFileLinkProps) {
   const showFileBrowser = useRuntimeStore((s) => s.showFileBrowser);
   const selectedAgentId = useRuntimeStore((s) => s.selectedAgentId);
   const workspaceRef = parseWorkspaceImageRef(href);

--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.test.ts
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.test.ts
@@ -7,6 +7,7 @@ import {
   isLargePreview,
   isPdfFile,
   isVideoFile,
+  markdownLinkTarget,
   type FileSortKey,
 } from "./FileBrowserPanel";
 import type { WorkspaceFileEntry } from "../../runtime/types";
@@ -79,5 +80,41 @@ describe("compareFileEntries", () => {
     const b = entry({ name: "b.txt", size: 10, modified: 100 });
     expect(compareFileEntries(a, b, "size", true)).toBeLessThan(0);
     expect(compareFileEntries(a, b, "size", false)).toBeLessThan(0);
+  });
+});
+
+describe("markdownLinkTarget", () => {
+  it("keeps page-internal anchors", () => {
+    expect(markdownLinkTarget("#section", "docs/readme.md")).toEqual({ kind: "anchor" });
+  });
+
+  it("routes workspace URIs to the workspace link flow", () => {
+    expect(markdownLinkTarget("workspace://ws_1/docs/a.md", "docs/readme.md")).toEqual({
+      kind: "workspace-uri",
+      workspaceId: "ws_1",
+      path: "docs/a.md",
+    });
+  });
+
+  it("resolves relative links against the directory of the rendered file", () => {
+    expect(markdownLinkTarget("sibling.md", "docs/readme.md")).toEqual({
+      kind: "workspace-relative",
+      path: "docs/sibling.md",
+    });
+    expect(markdownLinkTarget("../images/chart%201.png", "docs/nested/report.md")).toEqual({
+      kind: "workspace-relative",
+      path: "docs/images/chart 1.png",
+    });
+    expect(markdownLinkTarget("other.md", "readme.md")).toEqual({
+      kind: "workspace-relative",
+      path: "other.md",
+    });
+  });
+
+  it("leaves external and unresolvable links external", () => {
+    expect(markdownLinkTarget("https://example.com", "docs/readme.md")).toEqual({ kind: "external" });
+    expect(markdownLinkTarget("mailto:a@b.c", "docs/readme.md")).toEqual({ kind: "external" });
+    expect(markdownLinkTarget("../../../escape.md", "docs/readme.md")).toEqual({ kind: "external" });
+    expect(markdownLinkTarget(undefined, "docs/readme.md")).toEqual({ kind: "external" });
   });
 });

--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -23,9 +23,32 @@ import remarkGfm from "remark-gfm";
 import type { WorkspaceDirectoryListing, WorkspaceFileEntry } from "../../runtime/types";
 import { useRuntimeStore } from "../../runtime/runtime-store";
 import { useTranslation } from "react-i18next";
-import { parseWorkspaceImageRef, resolveWorkspaceRelativePath, WorkspaceImage } from "../../components/MarkdownContent";
+import { parseWorkspaceImageRef, resolveWorkspaceRelativePath, WorkspaceFileLink, WorkspaceImage } from "../../components/MarkdownContent";
 import { triggerHrefDownload } from "./download";
 import { buildPlainCodeHtml, normalizeShikiLineBreaks } from "./source-view";
+
+/** How a rendered markdown link should be opened. */
+export type MarkdownLinkTarget =
+  | { kind: "workspace-uri"; workspaceId: string; path: string }
+  | { kind: "workspace-relative"; path: string }
+  | { kind: "anchor" }
+  | { kind: "external" };
+
+/**
+ * Classify a markdown link href for the file browser preview: page-internal
+ * anchors stay anchors, `workspace://` URIs reuse the workspace link flow,
+ * workspace-relative paths resolve against the directory of the rendered
+ * file, and everything else (http(s), mailto, data, invalid workspace URIs)
+ * stays an external link.
+ */
+export function markdownLinkTarget(href: string | undefined, baseFilePath: string | undefined): MarkdownLinkTarget {
+  if (href?.startsWith("#")) return { kind: "anchor" };
+  const workspaceRef = href ? parseWorkspaceImageRef(href) : undefined;
+  if (workspaceRef) return { kind: "workspace-uri", workspaceId: workspaceRef.workspaceId, path: workspaceRef.path };
+  const relativePath = resolveWorkspaceRelativePath(baseFilePath ?? "", href);
+  if (relativePath) return { kind: "workspace-relative", path: relativePath };
+  return { kind: "external" };
+}
 
 interface FileBrowserPanelProps {
   workspaceId: string;
@@ -230,6 +253,7 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   const { t } = useTranslation();
   const browseWorkspaceDir = useRuntimeStore((s) => s.browseWorkspaceDir);
   const readWorkspaceFile = useRuntimeStore((s) => s.readWorkspaceFile);
+  const fetchWorkspacePath = useRuntimeStore((s) => s.fetchWorkspacePath);
   const workspaceFileUrl = useRuntimeStore((s) => s.workspaceFileUrl);
 
   const effectiveInitialPath =
@@ -398,6 +422,57 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
     }
   };
 
+  /**
+   * Open an arbitrary workspace path, used by rendered markdown links:
+   * directories navigate the listing, and files preview exactly like a
+   * tree-clicked entry. Metadata is resolved first because no directory
+   * entry exists for the target.
+   */
+  const openWorkspacePath = useCallback(async (filePath: string) => {
+    setViewMode("preview");
+    setSelectedFile({ path: filePath, loading: true });
+    setError(undefined);
+    try {
+      const info = await fetchWorkspacePath(workspaceId, filePath, executionRootId);
+      if (info.type === "directory") {
+        setListing(info);
+        setCurrentPath(info.path);
+        setSelectedFile(null);
+        setViewMode("files");
+        setFilterText("");
+        return;
+      }
+      if (!isTextFile(info.mimeType, filePath)) {
+        setSelectedFile({
+          path: info.path,
+          loading: false,
+          mimeType: info.mimeType,
+          size: info.totalSize ?? info.size,
+          modified: info.modified,
+        });
+        return;
+      }
+      const content = await readWorkspaceFile(workspaceId, filePath, executionRootId);
+      setSelectedFile({
+        path: content.path,
+        content: content.content,
+        mimeType: content.mimeType,
+        truncated: content.truncated,
+        totalSize: content.totalSize ?? content.size,
+        modified: content.modified,
+        lineCount: content.lineCount,
+        size: content.totalSize ?? content.size,
+        loading: false,
+      });
+    } catch (err) {
+      setSelectedFile({
+        path: filePath,
+        loading: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [workspaceId, executionRootId, fetchWorkspacePath, readWorkspaceFile]);
+
   const downloadSelectedFile = () => {
     if (!selectedFile?.path) return;
     // Browser-native navigation: the raw byte endpoint responds with
@@ -434,7 +509,35 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, in
   const atRoot = !currentPath;
 
   const markdownComponents: Components = {
-    a: ({ href, children }) => <a href={href} target="_blank" rel="noreferrer">{children}</a>,
+    a: ({ href, children }) => {
+      const target = markdownLinkTarget(href, selectedFile?.path);
+      if (href && target.kind === "workspace-uri") {
+        return <WorkspaceFileLink href={href}>{children}</WorkspaceFileLink>;
+      }
+      if (target.kind === "anchor") {
+        return <a href={href}>{children}</a>;
+      }
+      if (target.kind === "workspace-relative") {
+        return (
+          <a
+            href={workspaceFileUrl(workspaceId, target.path, executionRootId)}
+            onClick={(e) => {
+              // Plain left clicks open the file inside the browser; modified
+              // and middle clicks keep browser semantics via the direct-link
+              // href, which is servable standalone.
+              if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+              e.preventDefault();
+              void openWorkspacePath(target.path);
+            }}
+            rel="noreferrer"
+            target="_blank"
+          >
+            {children}
+          </a>
+        );
+      }
+      return <a href={href} target="_blank" rel="noreferrer">{children}</a>;
+    },
     img: ({ src, alt, ...props }) => {
       const workspaceRef = parseWorkspaceImageRef(src);
       if (workspaceRef) {

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -628,6 +628,107 @@ describe("createRuntimeClient", () => {
     );
   });
 
+  it("stats workspace file paths through the meta endpoint", async () => {
+    const seen: string[] = [];
+    const fetchImpl = async (input: RequestInfo | URL) => {
+      seen.push(String(input));
+      return Response.json({
+        type: "file",
+        path: "docs/readme.md",
+        workspace_id: "ws/one",
+        size: 128,
+        mime_type: "text/markdown",
+        truncated: false,
+        modified: 1757000000,
+        line_count: 12,
+      });
+    };
+
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(client.fetchWorkspacePath("ws/one", "docs/readme.md", "root:ws")).resolves.toEqual({
+      type: "file",
+      path: "docs/readme.md",
+      workspaceId: "ws/one",
+      size: 128,
+      mimeType: "text/markdown",
+      truncated: false,
+      modified: 1757000000,
+      lineCount: 12,
+    });
+    expect(seen).toEqual([
+      "http://example.test:7878/api/workspaces/ws%2Fone/files/docs/readme.md?meta=true&execution_root_id=root%3Aws",
+    ]);
+  });
+
+  it("stats workspace directories through their listing", async () => {
+    const fetchImpl = async () =>
+      Response.json({
+        type: "directory",
+        path: "docs",
+        workspace_id: "ws/one",
+        entries: [
+          { name: "readme.md", type: "file", size: 10, modified: 1757000000, mime_type: "text/markdown" },
+          { name: "nested", type: "directory", size: 0 },
+        ],
+      });
+
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(client.fetchWorkspacePath("ws/one", "docs")).resolves.toEqual({
+      type: "directory",
+      path: "docs",
+      workspaceId: "ws/one",
+      entries: [
+        { name: "readme.md", type: "file", size: 10, modified: 1757000000, mimeType: "text/markdown" },
+        { name: "nested", type: "directory", size: 0 },
+      ],
+    });
+  });
+
+  it("reads workspace file text content with metadata mapping", async () => {
+    const fetchImpl = async () =>
+      Response.json({
+        type: "file",
+        path: "docs/readme.md",
+        workspace_id: "ws/one",
+        size: 8,
+        mime_type: "text/markdown",
+        truncated: true,
+        total_size: 2000,
+        content: "# Hello\n",
+        modified: 1757000000,
+        line_count: 120,
+      });
+
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(client.readWorkspaceFile("ws/one", "docs/readme.md")).resolves.toEqual({
+      type: "file",
+      path: "docs/readme.md",
+      workspaceId: "ws/one",
+      size: 8,
+      mimeType: "text/markdown",
+      truncated: true,
+      modified: 1757000000,
+      lineCount: 120,
+      totalSize: 2000,
+      content: "# Hello\n",
+    });
+  });
+
   it("reads tool execution artifacts through the scoped artifact endpoint", async () => {
     const seen: Array<{ url: string; authorization: string | null }> = [];
     const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -44,7 +44,9 @@ import type {
   DisplayLevel,
   WorkspaceDirectoryListing,
   WorkspaceFileContent,
+  WorkspaceFileMeta,
   WorkspaceFileEntry,
+  WorkspacePathInfo,
 } from "./types";
 
 export interface RuntimeClientOptions {
@@ -657,6 +659,7 @@ interface WorkspaceDirectoryEntryDto {
   name: string;
   type: string;
   size: number;
+  modified?: number;
   mime_type?: string;
 }
 
@@ -674,8 +677,26 @@ interface WorkspaceFileContentDto {
   size: number;
   mime_type: string;
   truncated: boolean;
+  modified?: number;
+  line_count?: number;
   total_size?: number;
   content?: string;
+}
+
+/**
+ * `?meta=true` metadata response. Directory paths respond with a listing
+ * regardless, so both DTO shapes arrive from the same endpoint.
+ */
+interface WorkspaceFileMetaDto {
+  type: string;
+  path: string;
+  workspace_id: string;
+  size: number;
+  mime_type: string;
+  truncated: boolean;
+  modified?: number;
+  line_count?: number;
+  total_size?: number;
 }
 
 interface ToolExecutionArtifactContentDto {
@@ -715,6 +736,39 @@ export function buildWorkspaceFileUrl(
   if (executionRootId) params.set("execution_root_id", executionRootId);
   const query = params.toString();
   return `${baseUrl ?? ""}/workspaces/${encodeURIComponent(workspaceId)}/files/${encodedPath}${query ? `?${query}` : ""}`;
+}
+
+function projectDirectoryEntry(entry: WorkspaceDirectoryEntryDto): WorkspaceFileEntry {
+  return {
+    name: entry.name,
+    type: entry.type as WorkspaceFileEntry["type"],
+    size: entry.size,
+    modified: entry.modified,
+    mimeType: entry.mime_type,
+  };
+}
+
+function projectDirectoryListing(response: WorkspaceDirectoryListingDto): WorkspaceDirectoryListing {
+  return {
+    type: "directory",
+    path: response.path,
+    workspaceId: response.workspace_id,
+    entries: (response.entries ?? []).map(projectDirectoryEntry),
+  };
+}
+
+function projectFileMeta(response: WorkspaceFileMetaDto): WorkspaceFileMeta {
+  return {
+    type: "file",
+    path: response.path,
+    workspaceId: response.workspace_id,
+    size: response.size,
+    mimeType: response.mime_type,
+    truncated: response.truncated,
+    modified: response.modified,
+    lineCount: response.line_count,
+    totalSize: response.total_size,
+  };
 }
 
 export function createRuntimeClient(options: RuntimeClientOptions = {}) {
@@ -1303,17 +1357,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         : `/workspaces/${encodeURIComponent(workspaceId)}/files`;
       const query = executionRootId ? `?execution_root_id=${encodeURIComponent(executionRootId)}` : "";
       const response = await getJson<WorkspaceDirectoryListingDto>(fetchImpl, baseUrl, `${urlPath}${query}`, { headers: requestHeaders });
-      return {
-        type: "directory",
-        path: response.path,
-        workspaceId: response.workspace_id,
-        entries: (response.entries ?? []).map((e) => ({
-          name: e.name,
-          type: e.type as WorkspaceFileEntry["type"],
-          size: e.size,
-          mimeType: e.mime_type,
-        })),
-      };
+      return projectDirectoryListing(response);
     },
     async readWorkspaceFile(workspaceId: string, path: string, executionRootId?: string): Promise<WorkspaceFileContent> {
       if (!baseUrl) {
@@ -1334,9 +1378,33 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         size: response.size,
         mimeType: response.mime_type,
         truncated: response.truncated,
+        modified: response.modified,
+        lineCount: response.line_count,
         totalSize: response.total_size,
         content: response.content,
       };
+    },
+    /**
+     * Stat an arbitrary workspace path without reading file content.
+     * Files answer with metadata (`?meta=true`); directories answer with
+     * their listing regardless of the meta flag.
+     */
+    async fetchWorkspacePath(workspaceId: string, path: string, executionRootId?: string): Promise<WorkspacePathInfo> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+      const params = new URLSearchParams({ meta: "true" });
+      if (executionRootId) params.set("execution_root_id", executionRootId);
+      const response = await getJson<WorkspaceDirectoryListingDto | WorkspaceFileMetaDto>(
+        fetchImpl,
+        baseUrl,
+        `/workspaces/${encodeURIComponent(workspaceId)}/files/${encodedPath}?${params.toString()}`,
+        { headers: requestHeaders },
+      );
+      return response.type === "directory"
+        ? projectDirectoryListing(response as WorkspaceDirectoryListingDto)
+        : projectFileMeta(response as WorkspaceFileMetaDto);
     },
     async readToolExecutionArtifact(
       agentId: string,

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -115,6 +115,7 @@ import type {
   SearchResponse,
   WorkspaceDirectoryListing,
   WorkspaceFileContent,
+  WorkspacePathInfo,
   ToolExecutionArtifactContent,
 } from "./types";
 
@@ -402,6 +403,7 @@ export interface RuntimeStoreState {
   showFileBrowser: (agentId: string, workspaceId: string, initialPath?: string, executionRootId?: string, initialFilePath?: string) => void;
   browseWorkspaceDir: (workspaceId: string, path?: string, executionRootId?: string) => Promise<WorkspaceDirectoryListing>;
   readWorkspaceFile: (workspaceId: string, path: string, executionRootId?: string) => Promise<WorkspaceFileContent>;
+  fetchWorkspacePath: (workspaceId: string, path: string, executionRootId?: string) => Promise<WorkspacePathInfo>;
   readToolExecutionArtifact: (
     agentId: string,
     toolExecutionId: string,
@@ -1933,6 +1935,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
     }),
   browseWorkspaceDir: (workspaceId, path, executionRootId) => runtimeClient.browseWorkspaceDir(workspaceId, path, executionRootId),
   readWorkspaceFile: (workspaceId, path, executionRootId) => runtimeClient.readWorkspaceFile(workspaceId, path, executionRootId),
+  fetchWorkspacePath: (workspaceId, path, executionRootId) => runtimeClient.fetchWorkspacePath(workspaceId, path, executionRootId),
   readToolExecutionArtifact: (agentId, toolExecutionId, artifactIndex) =>
     runtimeClient.readToolExecutionArtifact(agentId, toolExecutionId, artifactIndex),
   fetchWorkspaceFileBlob: (workspaceId, path, executionRootId, options) =>

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -748,6 +748,22 @@ export interface WorkspaceFileContent {
   content?: string;
 }
 
+/** Metadata-only view of a workspace file (`?meta=true` responses). */
+export interface WorkspaceFileMeta {
+  type: "file";
+  path: string;
+  workspaceId: string;
+  size: number;
+  mimeType: string;
+  truncated: boolean;
+  modified?: number;
+  lineCount?: number;
+  totalSize?: number;
+}
+
+/** A workspace path stat: a directory listing for directories, file metadata otherwise. */
+export type WorkspacePathInfo = WorkspaceDirectoryListing | WorkspaceFileMeta;
+
 export type RightPanelView =
   | {
       kind: "agent_overview";


### PR DESCRIPTION
## Summary

Rendered markdown in the file browser preview passed link hrefs through to a plain `<a target="_blank">`, so relative links resolved against the app origin (404), `workspace://` links lost the `WorkspaceFileLink` interception, and `#fragment` anchors opened a new tab. Fixes #2784.

The markdown `a` renderer now classifies each href (`markdownLinkTarget`):

- **`workspace://`** — renders the exported `WorkspaceFileLink`, matching chat markdown behavior (`showFileBrowser` flow with panel-stack back navigation).
- **Relative paths** — resolved against the directory of the rendered file via the existing `resolveWorkspaceRelativePath` (same resolver images already use), then opened inside the file browser by the new `openWorkspacePath`: directories navigate the listing, text files load content, media/PDF render from the direct-link endpoint. The rendered `href` is the servable direct-link URL, so middle/Ctrl/Shift clicks keep native browser semantics.
- **Absolute http(s)/mailto/etc.** — external, new tab, unchanged.
- **`#fragment`** — in-page anchor, no new tab.

To open an arbitrary path without a directory entry, the client gains `fetchWorkspacePath`: files answer `?meta=true` metadata (backend already supported since #2831), directories answer their listing. While wiring this, `modified`/`line_count` are now mapped through the workspace file DTOs so the mtime/line-count metadata the backend serves actually reaches the UI (listing entries and file content).

## Testing

- `npx vitest run`: 506 passed (new `markdownLinkTarget` classification tests; client tests for `fetchWorkspacePath` file/dir responses and content metadata mapping).
- `npm run typecheck` and `npm run build` pass.
- No Rust changes.