### PR TITLE
feat: linkify pure-URL code spans in web GUI markdown

### DIFF
--- a/web-gui/app/src/components/MarkdownContent.test.ts
+++ b/web-gui/app/src/components/MarkdownContent.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   markdownUrlTransform,
   parseWorkspaceImageRef,
+  remarkCodeSpanAutolink,
   remarkWorkspaceAutolink,
   resolveWorkspaceRelativePath,
   safeCitation,
@@ -104,6 +105,51 @@ describe("remarkWorkspaceAutolink", () => {
   it("does not modify text without workspace:// URLs", () => {
     const nodes = runPlugin("Just a regular http://example.com link");
     expect(nodes).toEqual([{ type: "text", value: "Just a regular http://example.com link" }]);
+  });
+});
+
+describe("remarkCodeSpanAutolink", () => {
+  function runPlugin(value: string) {
+    const tree = {
+      type: "root",
+      children: [
+        { type: "paragraph", children: [{ type: "inlineCode", value }] },
+      ],
+    } as any;
+    remarkCodeSpanAutolink()(tree);
+    return tree.children[0].children;
+  }
+
+  it("converts code spans whose entire content is one URL", () => {
+    for (const url of [
+      "workspace://agent_home:holon-test/notes/demo.pdf",
+      "https://example.com/page?x=1",
+      "mailto:user@example.com",
+    ]) {
+      expect(runPlugin(url)).toEqual([{ type: "link", url, children: [{ type: "inlineCode", value: url }] }]);
+    }
+  });
+
+  it("leaves code spans containing anything else untouched", () => {
+    for (const value of ["npm run build", "https://example.com and text", "workspace://invalid", "workspace://"]) {
+      expect(runPlugin(value)).toEqual([{ type: "inlineCode", value }]);
+    }
+  });
+
+  it("does not convert code spans inside existing link nodes", () => {
+    const tree = {
+      type: "root",
+      children: [
+        { type: "paragraph", children: [
+          { type: "link", url: "https://example.com", children: [
+            { type: "inlineCode", value: "https://other.example.com" },
+          ] },
+        ] },
+      ],
+    } as any;
+    remarkCodeSpanAutolink()(tree);
+    const linkNode = tree.children[0].children[0];
+    expect(linkNode.children[0]).toEqual({ type: "inlineCode", value: "https://other.example.com" });
   });
 });
 

--- a/web-gui/app/src/components/MarkdownContent.tsx
+++ b/web-gui/app/src/components/MarkdownContent.tsx
@@ -7,6 +7,8 @@ import { useRuntimeStore } from "../runtime/runtime-store";
 import type { RuntimeCitation } from "../runtime/types";
 
 const WORKSPACE_URL_RE = /workspace:\/\/[^\s<>"')\]]+/g;
+// Inline code spans only become links when the whole span is exactly one URL.
+const CODE_SPAN_URL_RE = /^(?:https?:\/\/|mailto:)\S+$/i;
 
 interface MarkdownContentProps {
   text: string;
@@ -209,6 +211,24 @@ export function remarkWorkspaceAutolink() {
   };
 }
 
+/**
+ * Markdown renders inline code spans (`` `…` ``) as plain text, so agents
+ * that wrap URLs in backticks lose clickable links. This plugin converts
+ * inline code spans whose entire content is exactly one allowlisted URL
+ * (http/https/mailto, or a valid `workspace://` ref) into links that keep
+ * their code styling. Code spans mixed with other text stay untouched.
+ */
+export function remarkCodeSpanAutolink() {
+  return (tree: import("unist").Node) => {
+    visit(tree, "inlineCode", (node: any, index: number | null, parent: any) => {
+      if (index === null || !parent || parent.type === "link") return;
+      const url: string = node.value;
+      if (!parseWorkspaceImageRef(url) && !CODE_SPAN_URL_RE.test(url)) return;
+      parent.children[index] = { type: "link", url, children: [node] };
+    });
+  };
+}
+
 export function stripOpenAiCitationSentinels(text: string): string {
   const start = "\uE200cite\uE202";
   let visible = "";
@@ -252,7 +272,7 @@ function MarkdownContentView({ text, citations, compact = false }: MarkdownConte
   return (
     <div className={`markdown-content${compact ? " compact" : ""}`}>
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkWorkspaceAutolink]}
+        remarkPlugins={[remarkGfm, remarkWorkspaceAutolink, remarkCodeSpanAutolink]}
         urlTransform={markdownUrlTransform}
         components={{
           a: ({ children, href, ...props }) => {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1381,6 +1381,10 @@ code {
   text-decoration: none;
 }
 
+.markdown-content a code {
+  color: inherit;
+}
+
 .markdown-content a:hover {
   text-decoration: underline;
 }


### PR DESCRIPTION
## 问题

agent 输出时习惯把链接（尤其是 `workspace://` 链接）放在反引号里以作区分，但 markdown 渲染规则下 inline code 是纯文本，不会渲染为可点击链接，用户只能手动复制。

## 方案

采用渲染层处理（与 operator 讨论确认）：在 remark 层新增 `remarkCodeSpanAutolink` 插件，**严格整串匹配**——仅当 inline code 的内容*整体恰好是*一个白名单链接时才转换为 link 节点：

- 白名单：`http(s)://`、`mailto:`、合法的 `workspace://` ref（复用 `parseWorkspaceImageRef` 校验）
- 转换后渲染为 `<a><code>…</code></a>`：保留等宽字体与 code 视觉样式，同时可点击
- `workspace://` 链接复用现有 `WorkspaceFileLink`（点击在文件浏览器内打开）
- 混有其他文字的 code span、fenced code block 完全不受影响
- 已在 link 节点内的 code span 不重复转换

CSS 补充 `.markdown-content a code { color: inherit; }`，让链接内的 code 继承链接颜色，保持可点击的可视线索。

相比提示词约束，渲染层是单一收敛点，确定生效且不依赖各模板遵守。

## 验证

- `npm test`：42 文件 / 509 用例全绿（含新增 3 个插件用例：URL 整串转换、非整串保持原样、link 内不转换）
- `npm run build`（typecheck + vite build）通过

