### PR TITLE
fix: preserve concurrent state after scheduler commits

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -57,7 +57,7 @@ pub(crate) use worktree::format_worktree_task_summary;
 #[cfg(test)]
 use std::sync::atomic::AtomicUsize;
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{hash_map::Entry, BTreeSet, HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
     sync::{
@@ -211,6 +211,54 @@ fn rebase_prepared_completion_agent_state(
     state.current_turn_work_item_id = committed.current_turn_work_item_id.clone();
     state.current_execution_binding = committed.current_execution_binding.clone();
     Ok(state)
+}
+
+fn rebase_committed_agent_state(
+    expected: &AgentState,
+    committed: &AgentState,
+    current: &AgentState,
+) -> Result<(AgentState, Vec<String>)> {
+    let expected = serde_json::to_value(expected)?;
+    let committed = serde_json::to_value(committed)?;
+    let mut current = serde_json::to_value(current)?;
+    let expected = expected
+        .as_object()
+        .context("expected agent state did not serialize as an object")?;
+    let committed = committed
+        .as_object()
+        .context("committed agent state did not serialize as an object")?;
+    let current_fields = current
+        .as_object_mut()
+        .context("current agent state did not serialize as an object")?;
+    let fields = expected
+        .keys()
+        .chain(committed.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut conflicts = Vec::new();
+
+    for field in fields {
+        let expected_value = expected.get(&field);
+        let committed_value = committed.get(&field);
+        if committed_value == expected_value {
+            continue;
+        }
+        let current_value = current_fields.get(&field);
+        if current_value == expected_value {
+            match committed_value {
+                Some(value) => {
+                    current_fields.insert(field, value.clone());
+                }
+                None => {
+                    current_fields.remove(&field);
+                }
+            }
+        } else if current_value != committed_value {
+            conflicts.push(field);
+        }
+    }
+
+    Ok((serde_json::from_value(current)?, conflicts))
 }
 
 #[derive(Debug, Clone)]
@@ -2791,6 +2839,34 @@ impl RuntimeHandle {
             {
                 guard.state = mutation.record.as_ref().clone();
                 guard.last_persisted_state = mutation.record.as_ref().clone();
+            } else if let Some(expected) = mutation.expected.as_deref() {
+                match rebase_committed_agent_state(expected, &mutation.record, &guard.state) {
+                    Ok((merged, conflicts)) => {
+                        guard.state = merged;
+                        if let Err(error) = guard.persist_state(&self.inner.storage) {
+                            warnings.push(PostCommitWarning {
+                                effect: "agent_state_projection_update",
+                                message: format!(
+                                    "failed to persist rebased post-commit agent state: {error}"
+                                ),
+                            });
+                        } else if !conflicts.is_empty() {
+                            warnings.push(PostCommitWarning {
+                                effect: "agent_state_projection_update",
+                                message: format!(
+                                    "retained newer in-memory agent state fields after transition commit: {}",
+                                    conflicts.join(",")
+                                ),
+                            });
+                        }
+                    }
+                    Err(error) => warnings.push(PostCommitWarning {
+                        effect: "agent_state_projection_update",
+                        message: format!(
+                            "failed to rebase post-commit agent state; retained newer in-memory state: {error}"
+                        ),
+                    }),
+                }
             } else {
                 warnings.push(PostCommitWarning {
                     effect: "agent_state_projection_update",

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -15536,7 +15536,7 @@ async fn post_commit_cache_fault_preserves_durable_transition_and_returns_warnin
 }
 
 #[tokio::test]
-async fn post_commit_agent_state_projection_does_not_overwrite_newer_memory() {
+async fn post_commit_agent_state_projection_rebases_onto_newer_memory() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -15549,9 +15549,14 @@ async fn post_commit_agent_state_projection_does_not_overwrite_newer_memory() {
         context_config(),
     )
     .unwrap();
+    let work_item = runtime
+        .create_work_item("agent state projection race".into(), None, None, Vec::new())
+        .await
+        .unwrap();
     let expected = runtime.agent_state().await.unwrap();
     let mut committed = expected.clone();
     committed.pending = 1;
+    committed.current_work_item_id = Some(work_item.id.clone());
     let commit = runtime
         .inner
         .runtime_db
@@ -15589,10 +15594,7 @@ async fn post_commit_agent_state_projection_does_not_overwrite_newer_memory() {
 
     let result = runtime.apply_transition_commit(commit).await;
 
-    assert!(result
-        .warnings
-        .iter()
-        .any(|warning| warning.effect == "agent_state_projection_update"));
+    assert!(result.warnings.is_empty(), "{:?}", result.warnings);
     assert_eq!(
         runtime
             .agent_state()
@@ -15601,6 +15603,16 @@ async fn post_commit_agent_state_projection_does_not_overwrite_newer_memory() {
             .last_wake_reason
             .as_deref(),
         Some("newer-memory-state")
+    );
+    assert_eq!(runtime.agent_state().await.unwrap().pending, 1);
+    assert_eq!(
+        runtime
+            .agent_state()
+            .await
+            .unwrap()
+            .current_work_item_id
+            .as_deref(),
+        Some(work_item.id.as_str())
     );
     assert_eq!(
         runtime


### PR DESCRIPTION
## Summary
- rebase committed scheduler state onto a newer in-memory `AgentState` instead of discarding the committed projection wholesale
- preserve concurrent, non-conflicting pending/focus updates while keeping committed fields authoritative
- add a regression test for the post-commit projection race that emptied `continue-active` ticks after provider failure

## Root cause
After the scheduler transition committed, a newer in-memory `AgentState` caused the entire committed projection to be skipped. The runner therefore missed non-conflicting committed pending/focus state, so provider-failure recovery produced no `continue-active` ticks.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test runtime_state --lib`
- `cargo test post_commit_agent_state_projection_rebases_onto_newer_memory --lib`
- local `scheduler-provider-failure-work-queue-retry`: PASS (the single-case command exits nonzero only because full-matrix coverage/acceptance reports are intentionally incomplete)
- E2E Scheduler Nightly run 34212673963: success, including the full deterministic scheduler matrix
