### PR TITLE
feat: canonical workspace_uri in ViewImage results + web GUI consumption

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3250,6 +3250,29 @@ impl RuntimeHandle {
         workspace::workspace_view_for_root(&self.inner.storage, execution_root, cwd, worktree_root)
     }
 
+    /// Registered execution roots for the given workspaces. Used to populate
+    /// execution snapshots and to reverse-map resolved paths (for example
+    /// ViewImage results) into `workspace://` URIs with `?root=` parameters.
+    pub(crate) fn execution_root_refs_for_workspaces(
+        &self,
+        workspace_ids: &[String],
+    ) -> Vec<crate::system::ExecutionRootRef> {
+        let repo = self.inner.runtime_db.execution_root_entries();
+        let mut roots = Vec::new();
+        for ws_id in workspace_ids {
+            if let Ok(entries) = repo.active_for_workspace(ws_id) {
+                for entry in entries {
+                    roots.push(crate::system::ExecutionRootRef {
+                        execution_root_id: entry.execution_root_id,
+                        workspace_id: entry.workspace_id,
+                        filesystem_path: entry.filesystem_path,
+                    });
+                }
+            }
+        }
+        roots
+    }
+
     fn workspace_view_from_state(&self, state: &AgentState) -> Result<WorkspaceView> {
         workspace::workspace_view_from_state(state, self.inner.storage.data_dir().to_path_buf())
     }
@@ -3269,20 +3292,7 @@ impl RuntimeHandle {
         // Populate execution_roots from the runtime DB registry for all
         // attached workspaces, so the provider turn resolver can resolve
         // `?root=` parameters in workspace:// URIs.
-        let repo = self.inner.runtime_db.execution_root_entries();
-        let mut roots = Vec::new();
-        for ws_id in attached_workspace_ids {
-            if let Ok(entries) = repo.active_for_workspace(ws_id) {
-                for entry in entries {
-                    roots.push(crate::system::ExecutionRootRef {
-                        execution_root_id: entry.execution_root_id,
-                        workspace_id: entry.workspace_id,
-                        filesystem_path: entry.filesystem_path,
-                    });
-                }
-            }
-        }
-        snapshot.execution_roots = roots;
+        snapshot.execution_roots = self.execution_root_refs_for_workspaces(attached_workspace_ids);
         snapshot
     }
 

--- a/src/system/workspace.rs
+++ b/src/system/workspace.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{anyhow, Result};
 use thiserror::Error;
 
-use super::types::{WorkspaceAccessMode, WorkspaceProjectionKind};
+use super::types::{ExecutionRootRef, WorkspaceAccessMode, WorkspaceProjectionKind};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorkspacePathErrorKind {
@@ -295,6 +295,103 @@ pub fn normalize_path(path: &Path) -> Result<PathBuf> {
     Ok(normalized)
 }
 
+/// Reverse-map a resolved filesystem path to a canonical `workspace://` URI
+/// reference so results can embed durable workspace links instead of raw
+/// local paths.
+///
+/// Priority: active workspace canonical anchor, active execution root (for
+/// worktree projections this emits `?root=<execution_root_id>`), attached
+/// workspace anchors, then registered execution roots. Returns `None` when
+/// the path is outside every workspace (for example a system temp
+/// directory); callers should then keep the local path without a workspace
+/// reference.
+pub fn workspace_uri_for_path(
+    path: &Path,
+    workspace: &WorkspaceView,
+    attached_workspaces: &[(String, PathBuf)],
+    execution_roots: &[ExecutionRootRef],
+) -> Option<String> {
+    if let Some(workspace_id) = workspace.workspace_id() {
+        if let Some(relative) = relative_under_root(path, workspace.workspace_anchor()) {
+            return Some(format_workspace_uri(workspace_id, &relative, None));
+        }
+        if let Some(root_id) = workspace.execution_root_id() {
+            if let Some(relative) = relative_under_root(path, workspace.execution_root()) {
+                return Some(format_workspace_uri(workspace_id, &relative, Some(root_id)));
+            }
+        }
+    }
+    for (workspace_id, anchor) in attached_workspaces {
+        if let Some(relative) = relative_under_root(path, anchor) {
+            return Some(format_workspace_uri(workspace_id, &relative, None));
+        }
+    }
+    for root in execution_roots {
+        if let Some(relative) = relative_under_root(path, &root.filesystem_path) {
+            return Some(format_workspace_uri(
+                &root.workspace_id,
+                &relative,
+                Some(&root.execution_root_id),
+            ));
+        }
+    }
+    None
+}
+
+/// Compute the path relative to `root` when `path` lives inside `root`.
+/// Prefers symlink-resolved comparison when both exist on disk, falling back
+/// to the normalized lexical comparison.
+fn relative_under_root(path: &Path, root: &Path) -> Option<PathBuf> {
+    let normalized_path = normalize_path(path).ok()?;
+    let normalized_root = normalize_path(root).ok()?;
+    if let (Ok(canonical_path), Ok(canonical_root)) = (
+        fs::canonicalize(&normalized_path),
+        fs::canonicalize(&normalized_root),
+    ) {
+        return canonical_path
+            .strip_prefix(&canonical_root)
+            .ok()
+            .map(Path::to_path_buf);
+    }
+    normalized_path
+        .strip_prefix(&normalized_root)
+        .ok()
+        .map(Path::to_path_buf)
+}
+
+fn format_workspace_uri(
+    workspace_id: &str,
+    relative: &Path,
+    execution_root_id: Option<&str>,
+) -> String {
+    use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+    // Keep RFC 3986 pchar unreserved/sub-delims readable (`.` `-` `_` `~` etc.)
+    // and escape only characters that would break URI parsing.
+    const URI_SEGMENT: &AsciiSet = &CONTROLS
+        .add(b' ')
+        .add(b'"')
+        .add(b'#')
+        .add(b'%')
+        .add(b'?')
+        .add(b'\\')
+        .add(b'{')
+        .add(b'}');
+    let encoded_path = relative
+        .components()
+        .map(|component| {
+            utf8_percent_encode(&component.as_os_str().to_string_lossy(), URI_SEGMENT).to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("/");
+    match execution_root_id {
+        Some(root_id) => format!(
+            "workspace://{workspace_id}/{encoded_path}?root={}",
+            utf8_percent_encode(root_id, URI_SEGMENT)
+        ),
+        None => format!("workspace://{workspace_id}/{encoded_path}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
@@ -439,5 +536,123 @@ mod tests {
             discovered.projection_kind,
             WorkspaceProjectionKind::CanonicalRoot
         );
+    }
+
+    #[test]
+    fn workspace_uri_maps_canonical_workspace_path() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(root.join("docs")).unwrap();
+        let view = WorkspaceView::new(
+            Some("ws-1".into()),
+            root.clone(),
+            root.clone(),
+            root.clone(),
+            Some("canonical_root:ws-1".into()),
+            None,
+            WorkspaceProjectionKind::CanonicalRoot,
+            None,
+        )
+        .unwrap();
+
+        let uri = workspace_uri_for_path(&root.join("docs/chart.png"), &view, &[], &[]);
+
+        assert_eq!(uri.as_deref(), Some("workspace://ws-1/docs/chart.png"));
+    }
+
+    #[test]
+    fn workspace_uri_maps_worktree_path_with_root_param() {
+        let dir = tempdir().unwrap();
+        let anchor = dir.path().join("repo");
+        let worktree = dir.path().join("wt");
+        std::fs::create_dir_all(worktree.join("docs")).unwrap();
+        let view = WorkspaceView::new(
+            Some("ws-1".into()),
+            anchor,
+            worktree.clone(),
+            worktree.clone(),
+            Some("git_worktree_root:ws-1:/wt".into()),
+            None,
+            WorkspaceProjectionKind::GitWorktreeRoot,
+            Some(worktree.clone()),
+        )
+        .unwrap();
+
+        let uri = workspace_uri_for_path(&worktree.join("docs/chart.png"), &view, &[], &[]);
+
+        assert_eq!(
+            uri.as_deref(),
+            // root tokens stay readable; parsers percent-decode leniently.
+            Some("workspace://ws-1/docs/chart.png?root=git_worktree_root:ws-1:/wt")
+        );
+    }
+
+    #[test]
+    fn workspace_uri_maps_attached_workspace_and_registered_root() {
+        let dir = tempdir().unwrap();
+        let active = dir.path().join("active");
+        let other = dir.path().join("other");
+        let other_wt = dir.path().join("other-wt");
+        std::fs::create_dir_all(active.join("media")).unwrap();
+        std::fs::create_dir_all(other_wt.join("shots")).unwrap();
+        let view = WorkspaceView::new(
+            Some("ws-active".into()),
+            active.clone(),
+            active.clone(),
+            active.clone(),
+            Some("canonical_root:ws-active".into()),
+            None,
+            WorkspaceProjectionKind::CanonicalRoot,
+            None,
+        )
+        .unwrap();
+
+        let attached_uri = workspace_uri_for_path(
+            &other.join("media/logo.png"),
+            &view,
+            &[("ws-other".to_string(), other.clone())],
+            &[],
+        );
+        assert_eq!(
+            attached_uri.as_deref(),
+            Some("workspace://ws-other/media/logo.png")
+        );
+
+        let root_uri = workspace_uri_for_path(
+            &other_wt.join("shots/logo.png"),
+            &view,
+            &[("ws-other".to_string(), other.clone())],
+            &[ExecutionRootRef {
+                execution_root_id: "git_worktree_root:ws-other:/other-wt".to_string(),
+                workspace_id: "ws-other".to_string(),
+                filesystem_path: other_wt.clone(),
+            }],
+        );
+        assert_eq!(
+            root_uri.as_deref(),
+            Some("workspace://ws-other/shots/logo.png?root=git_worktree_root:ws-other:/other-wt")
+        );
+    }
+
+    #[test]
+    fn workspace_uri_returns_none_for_unmapped_path() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root).unwrap();
+        let outside = dir.path().join("tmp").join("scratch.png");
+        std::fs::create_dir_all(dir.path().join("tmp")).unwrap();
+        let view = WorkspaceView::new(
+            Some("ws-1".into()),
+            root.clone(),
+            root.clone(),
+            root.clone(),
+            Some("canonical_root:ws-1".into()),
+            None,
+            WorkspaceProjectionKind::CanonicalRoot,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(workspace_uri_for_path(&outside, &view, &[], &[]), None);
     }
 }

--- a/src/tool/tools/view_image.rs
+++ b/src/tool/tools/view_image.rs
@@ -62,7 +62,9 @@ pub(crate) async fn execute(
         .await?;
     let resolved_path = execution.workspace.resolve_read_path(&path)?;
     let image = read_visual_reference(&resolved_path)?;
-    let visual_reference = image.visual_reference;
+    let mut visual_reference = image.visual_reference;
+    visual_reference.workspace_uri =
+        workspace_uri_for_resolved_path(runtime, &execution, &resolved_path);
     let cache_key = observation_cache_key(&visual_reference, &prompt);
     let vision_selection = runtime.current_view_image_vision_selection().await?;
     if let Some(observation) = runtime.cached_view_image_observation(&cache_key).await {
@@ -119,6 +121,36 @@ pub(crate) async fn execute(
     )
 }
 
+/// Reverse-map the resolved image path into a canonical `workspace://` URI so
+/// consumers (for example the Web GUI) can render the image without guessing
+/// the workspace from the rendering-time active workspace. Returns `None`
+/// for paths outside every workspace (for example system temp files).
+fn workspace_uri_for_resolved_path(
+    runtime: &RuntimeHandle,
+    execution: &crate::system::EffectiveExecution,
+    resolved_path: &Path,
+) -> Option<String> {
+    let mut workspace_ids: Vec<String> = execution
+        .attached_workspaces
+        .iter()
+        .map(|(workspace_id, _)| workspace_id.clone())
+        .collect();
+    if let Some(active) = execution.workspace.workspace_id() {
+        if !workspace_ids
+            .iter()
+            .any(|workspace_id| workspace_id == active)
+        {
+            workspace_ids.push(active.to_string());
+        }
+    }
+    crate::system::workspace::workspace_uri_for_path(
+        resolved_path,
+        &execution.workspace,
+        &execution.attached_workspaces,
+        &runtime.execution_root_refs_for_workspaces(&workspace_ids),
+    )
+}
+
 pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
     let value = result
         .envelope
@@ -168,6 +200,12 @@ fn render_view_image_result(result: &ViewImageResult) -> String {
         format!("Prompt: {}", observation.prompt),
         format!("Summary: {}", observation.summary),
     ];
+
+    // Expose the canonical workspace URI when available so the model can
+    // embed durable references in later markdown output.
+    if let Some(uri) = &reference.workspace_uri {
+        lines.push(format!("Workspace URI: {uri}"));
+    }
 
     push_json_section(&mut lines, "OCR", &observation.ocr);
     push_json_section(&mut lines, "Elements", &observation.elements);
@@ -480,6 +518,7 @@ pub(crate) fn read_visual_reference(path: &Path) -> Result<ReadImage> {
         kind: "visual_reference".to_string(),
         id: format!("vis_{}", &sha256[..16]),
         path: path.to_path_buf(),
+        workspace_uri: None,
         sha256,
         mime: header.media_type.to_string(),
         byte_count: bytes.len() as u64,
@@ -991,6 +1030,7 @@ mod tests {
             kind: "visual_reference".to_string(),
             id: "vis_test".to_string(),
             path: Path::new("image.png").to_path_buf(),
+            workspace_uri: None,
             sha256: "sha256".to_string(),
             mime: "image/png".to_string(),
             byte_count: 10,

--- a/src/types.rs
+++ b/src/types.rs
@@ -4150,6 +4150,13 @@ pub struct ViewImageVisualReference {
     pub kind: String,
     pub id: String,
     pub path: PathBuf,
+    /// Canonical `workspace://` URI for the image when the resolved path maps
+    /// into an attached workspace or registered execution root (worktree
+    /// references carry `?root=`). Serialized as `null` when the path is
+    /// outside every workspace so consumers can distinguish "unmappable" from
+    /// legacy records that predate the field.
+    #[serde(default)]
+    pub workspace_uri: Option<String>,
     pub sha256: String,
     pub mime: String,
     pub byte_count: u64,

--- a/web-gui/app/src/components/MarkdownContent.test.ts
+++ b/web-gui/app/src/components/MarkdownContent.test.ts
@@ -30,6 +30,23 @@ describe("parseWorkspaceImageRef", () => {
     expect(parseWorkspaceImageRef("https://example.com/chart.png")).toBeUndefined();
     expect(parseWorkspaceImageRef("workspace://agent_home:holon-pm/../secret.png")).toBeUndefined();
   });
+
+  it("extracts the ?root= execution-root token and keeps it opaque", () => {
+    expect(parseWorkspaceImageRef("workspace://ws_1/docs/a.png?root=git_worktree_root:ws_1:/tmp/wt")).toEqual({
+      workspaceId: "ws_1",
+      path: "docs/a.png",
+      executionRootId: "git_worktree_root:ws_1:/tmp/wt",
+    });
+    expect(parseWorkspaceImageRef("workspace://ws_1/docs/a.png?root=git%5Fworktree%3Aws")).toEqual({
+      workspaceId: "ws_1",
+      path: "docs/a.png",
+      executionRootId: "git_worktree:ws",
+    });
+    expect(parseWorkspaceImageRef("workspace://ws_1/docs/a.png#frag")).toEqual({
+      workspaceId: "ws_1",
+      path: "docs/a.png",
+    });
+  });
 });
 
 describe("resolveWorkspaceRelativePath", () => {

--- a/web-gui/app/src/components/MarkdownContent.tsx
+++ b/web-gui/app/src/components/MarkdownContent.tsx
@@ -5,6 +5,7 @@ import { memo, useEffect, useState, type ImgHTMLAttributes, type ReactNode } fro
 
 import { useRuntimeStore } from "../runtime/runtime-store";
 import type { RuntimeCitation } from "../runtime/types";
+import { isHttpNotFoundError } from "../runtime/client";
 
 const WORKSPACE_URL_RE = /workspace:\/\/[^\s<>"')\]]+/g;
 // Inline code spans only become links when the whole span is exactly one URL.
@@ -19,6 +20,7 @@ interface MarkdownContentProps {
 export interface WorkspaceImageRef {
   workspaceId: string;
   path: string;
+  executionRootId?: string;
 }
 
 export function parseWorkspaceImageRef(src: string | undefined): WorkspaceImageRef | undefined {
@@ -28,8 +30,25 @@ export function parseWorkspaceImageRef(src: string | undefined): WorkspaceImageR
   if (pathStart <= 0) return undefined;
 
   const workspaceId = value.slice(0, pathStart);
-  const rawPath = value.slice(pathStart + 1).split(/[?#]/, 1)[0];
+  const remainder = value.slice(pathStart + 1).split("#", 1)[0];
+  const queryStart = remainder.indexOf("?");
+  const rawPath = queryStart >= 0 ? remainder.slice(0, queryStart) : remainder;
   if (!workspaceId || !rawPath) return undefined;
+
+  // Opaque execution-root token from `?root=`; percent-decode leniently the
+  // same way the runtime-side parser does.
+  let executionRootId: string | undefined;
+  if (queryStart >= 0) {
+    for (const pair of remainder.slice(queryStart + 1).split("&")) {
+      const eq = pair.indexOf("=");
+      if (eq <= 0 || pair.slice(0, eq) !== "root") continue;
+      try {
+        executionRootId = decodeURIComponent(pair.slice(eq + 1));
+      } catch {
+        return undefined;
+      }
+    }
+  }
 
   try {
     const path = rawPath
@@ -42,7 +61,7 @@ export function parseWorkspaceImageRef(src: string | undefined): WorkspaceImageR
       })
       .join("/");
     if (!path) return undefined;
-    return { workspaceId, path };
+    return executionRootId ? { workspaceId, path, executionRootId } : { workspaceId, path };
   } catch {
     return undefined;
   }
@@ -125,6 +144,13 @@ export function WorkspaceImage({
   }, [fetchWorkspaceFileBlob, workspaceId, path, executionRootId]);
 
   if (error) {
+    if (isHttpNotFoundError(error)) {
+      return (
+        <span className="workspace-image-error" title={error}>
+          {alt ?? path} image file not found (moved, cleaned up, or root removed)
+        </span>
+      );
+    }
     return (
       <span className="workspace-image-error" title={error}>
         {alt ?? path} image unavailable

--- a/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
+++ b/web-gui/app/src/features/right-panel/ToolExecutionRenderers.tsx
@@ -192,7 +192,12 @@ export function ImagePreview({ uri, alt }: { uri: string; alt?: string }) {
     <section className="tool-detail-field">
       <h3 className="tool-detail-field-label">Image preview</h3>
       <div className="tool-detail-image-preview">
-        <WorkspaceImage workspaceId={ref.workspaceId} path={ref.path} alt={alt ?? ref.path} />
+        <WorkspaceImage
+          workspaceId={ref.workspaceId}
+          path={ref.path}
+          executionRootId={ref.executionRootId}
+          alt={alt ?? ref.path}
+        />
       </div>
     </section>
   );
@@ -462,10 +467,6 @@ function ApplyPatchRenderer({ record }: { record: RuntimeToolExecutionRecord }) 
 
 function ViewImageRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
   const { t } = useTranslation();
-  const agentId = typeof record.agent_id === "string" ? record.agent_id : undefined;
-  const workspaceId = useRuntimeStore((s) =>
-    agentId ? s.sessionsByAgentId[agentId]?.detail?.agent?.workspaceSummary?.id : undefined,
-  );
 
   const output = unwrapToolOutput(record.output ?? record.result);
   const result = asResultRecord(output, "view_image_result");
@@ -476,6 +477,7 @@ function ViewImageRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
   const inputPath = nestedText(record.input, ["path", "image_path"]);
   const resultPath = nestedText(visualRef, ["path"]);
   const displayPath = inputPath || resultPath;
+  const workspaceUri = nestedText(visualRef, ["workspace_uri"]);
   const mime = nestedText(visualRef, ["mime"]);
   const byteCount = nestedValue(visualRef, ["byte_count"]);
   const sha256 = nestedText(visualRef, ["sha256"]);
@@ -499,12 +501,11 @@ function ViewImageRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
     : [];
   const summary = textField(result?.summary_text) || record.summary;
 
-  // Construct workspace URI for relative/absolute paths that aren't already workspace://
-  const imageUri = displayPath?.startsWith("workspace://")
-    ? displayPath
-    : displayPath && workspaceId
-      ? `workspace://${workspaceId}/${displayPath.replace(/^\/+/, "")}`
-      : displayPath;
+  // Consume the canonical reference recorded when the tool ran. Never
+  // reconstruct one from the render-time active workspace: the agent may
+  // have switched workspaces since, and absolute local paths (e.g. /tmp
+  // screenshots) are not workspace-relative anyway.
+  const imageUri = workspaceUri ?? (displayPath?.startsWith("workspace://") ? displayPath : undefined);
 
   return (
     <>
@@ -531,7 +532,11 @@ function ViewImageRenderer({ record }: { record: RuntimeToolExecutionRecord }) {
         <OutputField label="Uncertainties" value={uncertainties.join("; ")} />
       ) : null}
       {summary ? <OutputField label={t("inspector.result")} value={summary} /> : null}
-      {imageUri ? <ImagePreview uri={imageUri} alt={observationSummary ?? displayPath} /> : null}
+      {imageUri ? (
+        <ImagePreview uri={imageUri} alt={observationSummary ?? displayPath} />
+      ) : displayPath ? (
+        <SimpleField label="Image preview" value={`${displayPath} (no workspace reference recorded)`} />
+      ) : null}
       {record.error ? <OutputField label={t("inspector.error")} value={textField(record.error)} variant="error" /> : null}
     </>
   );

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -2699,6 +2699,11 @@ export function isProjectionBusyError(error: unknown): boolean {
   return error instanceof RuntimeHttpError && error.status === 429 && error.code === "projection_busy";
 }
 
+/** True when the request failed with HTTP 404 (resource missing or removed). */
+export function isHttpNotFoundError(error: unknown): boolean {
+  return error instanceof RuntimeHttpError && error.status === 404;
+}
+
 /** True when the snapshot target agent is unknown or not a member. */
 export function isSnapshotAgentMissingError(error: unknown): boolean {
   return error instanceof RuntimeHttpError && error.status === 404;


### PR DESCRIPTION
## Summary

Fixes the intermittent **"image unavailable"** for ViewImage results in the Web GUI right panel.

**Root cause:** the frontend reconstructed a `workspace://` URI at render time from the *then-current* active workspace plus `record.input.path`. That guess broke for absolute local paths (e.g. `/tmp` screenshots), worktree files (missing `?root=`), and records replayed after the agent switched workspaces; every 4xx collapsed into one opaque "image unavailable".

**Backend**
- `ViewImageVisualReference` gains `workspace_uri: Option<String>`: the resolved image path is reverse-mapped at execution time into a canonical `workspace://<ws>/<rel>` URI, with `?root=<execution_root_id>` for worktree files (`src/system/workspace.rs::workspace_uri_for_path`).
- Paths outside every workspace (e.g. system temp files) serialize the field as absent/null, so consumers can distinguish unmappable paths from legacy records.
- `render_for_model` surfaces `Workspace URI: …` so the model can embed durable references.
- URI percent-encoding keeps RFC 3986 pchar (incl. `. - _ ~`) readable and escapes only what breaks parsing; `?root=` tokens stay readable, matching the lenient decode already used by the runtime-side `split_root_query`.

**Frontend**
- `ViewImageRenderer` consumes `visual_reference.workspace_uri` directly and no longer guesses from the render-time active workspace; legacy records with no reference show the local path with a "no workspace reference recorded" note instead of a broken preview request.
- `parseWorkspaceImageRef` extracts the opaque `?root=` token (percent-decoded leniently) and `ImagePreview`/`WorkspaceImage` pass it through as `executionRootId`, so worktree images resolve to the right root.
- Image errors now distinguish HTTP 404 ("file not found — moved, cleaned up, or root removed") from other failures.

## Test plan
- `cargo test --lib system::workspace` (11 tests incl. canonical/worktree/unmappable URI mapping)
- `cargo test --lib tool::tools::view_image`, `provider_turn`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`, `cargo fmt --all -- --check`
- web: `npm run typecheck`, `npm test` (510 tests, incl. new `?root=` parser cases)