### PR TITLE
feat: add holon agent rename CLI command

### DIFF
--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -66,6 +66,7 @@ holon (v0.35.0)
 │   ├── list     List all agents
 │   ├── status   Show agent status
 │   ├── create   Create a new agent
+│   ├── rename   Rename a public self-owned agent
 │   ├── start    Start an agent
 │   ├── stop     Stop an agent
 │   ├── delete   Permanently delete an agent and its data
@@ -167,6 +168,11 @@ non-interactive mode.
 `holon agent repair <AGENT_ID>` retries incomplete post-create template,
 runtime, workspace, model, and initial-message steps. It does not recreate the
 Agent or overwrite conflicting user-managed state.
+
+`holon agent rename <AGENT_ID> --name <NAME>` updates the display name of a
+public self-owned agent and echoes the updated agent detail. The agent id is
+permanent; the configured default agent cannot be renamed, and duplicate names
+are rejected with a readable conflict error.
 
 ### Model selection
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -812,6 +812,14 @@ pub enum AgentCommands {
         #[arg(long)]
         template: Option<String>,
     },
+    /// Rename a public self-owned agent (display name only; the agent id is permanent)
+    #[command(name = "rename")]
+    Rename {
+        agent_id: String,
+        /// New display name (trimmed, 1-64 chars, no control characters or `/ \ :`)
+        #[arg(long = "name", value_name = "NAME")]
+        name: String,
+    },
     /// Retry incomplete post-create bootstrap steps
     Repair {
         agent_id: String,

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,8 +17,9 @@ use crate::{
         BatchGetTranscriptEntriesResponse, CancelTimerRequest, ClearAgentModelRequest,
         ControlPromptRequest, CreateAgentRequest, CreateTimerRequest, DebugPromptRequest,
         DeleteAgentRequest, DetachWorkspaceRequest, ExitWorkspaceRequest,
-        ModelConfigMigrationRequest, RuntimeConfigReadResponse, RuntimeConfigUpdateRequest,
-        RuntimeConfigUpdateResponse, SetAgentModelRequest, TaskInputRequest, TaskStopRequest,
+        ModelConfigMigrationRequest, RenameAgentRequest, RuntimeConfigReadResponse,
+        RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse, SetAgentModelRequest,
+        TaskInputRequest, TaskStopRequest,
     },
     http_dto::AgentStateSnapshotDto,
     model_catalog::BuiltInModelMetadata,
@@ -759,6 +760,18 @@ impl LocalClient {
         .await
     }
 
+    /// Rename a public self-owned agent. Only the display name changes; the
+    /// agent id stays permanent. Typed errors flow through `decode_or_error`.
+    pub async fn rename_agent(&self, agent_id: &str, name: &str) -> Result<AgentDetail> {
+        self.patch_control_json(
+            &format!("/control/agents/{agent_id}/name"),
+            &RenameAgentRequest {
+                name: name.to_string(),
+            },
+        )
+        .await
+    }
+
     pub async fn attach_workspace(
         &self,
         agent_id: &str,
@@ -1057,7 +1070,7 @@ impl LocalClient {
             .with_context(|| format!("failed to decode response body for DELETE {}", path))
     }
 
-    async fn patch_control_json<B: Serialize, T: DeserializeOwned>(
+    pub async fn patch_control_json<B: Serialize, T: DeserializeOwned>(
         &self,
         path: &str,
         payload: &B,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4573,6 +4573,11 @@ async fn handle_agent_command(config: &AppConfig, command: Option<AgentCommands>
                 client.repair_agent(&agent_id).await?,
             )?)
         }
+        Some(AgentCommands::Rename { agent_id, name }) => {
+            let client = LocalClient::new(config.clone())?;
+            let detail = client.rename_agent(&agent_id, &name).await?;
+            print_json(&serde_json::to_value(detail)?)
+        }
         Some(AgentCommands::Start { agent_id }) => {
             control_agent_lifecycle(config, agent_id, ControlAction::Start).await
         }

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -9,7 +9,7 @@ use std::{
     io::{BufRead, BufReader},
     path::PathBuf,
     process::{Child, Command, Output, Stdio},
-    sync::mpsc,
+    sync::{mpsc, Mutex, OnceLock},
     thread,
     time::{Duration, Instant},
 };
@@ -51,6 +51,14 @@ impl Drop for ServeChild {
     }
 }
 
+/// Serialize tests that spawn `holon serve`: concurrent instrumented servers
+/// (for example under llvm-cov) compete for CPU on CI runners and can exceed
+/// the startup deadline even though a single server starts well within it.
+fn serve_test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 fn spawn_local_serve(home: &tempfile::TempDir) -> (ServeChild, String) {
     let mut child = isolated_holon_command(home)
         .args(["serve", "--listen", "127.0.0.1:0"])
@@ -89,7 +97,7 @@ fn spawn_local_serve(home: &tempfile::TempDir) -> (ServeChild, String) {
         }
         let _ = stderr_tx.send(captured);
     });
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + Duration::from_secs(30);
     let mut addr = None;
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().expect("poll holon serve") {
@@ -396,6 +404,9 @@ fn config_set_unset_reports_offline_application_path_on_stderr() {
 
 #[test]
 fn config_set_prefers_running_daemon_runtime_config_api() {
+    let _serve_guard = serve_test_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
     let (_serve, addr) = spawn_local_serve(&home);
 
@@ -465,6 +476,9 @@ fn config_set_prefers_running_daemon_runtime_config_api() {
 
 #[test]
 fn config_set_surfaces_daemon_rejection_reason() {
+    let _serve_guard = serve_test_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
     let (_serve, addr) = spawn_local_serve(&home);
 
@@ -490,6 +504,9 @@ fn config_set_surfaces_daemon_rejection_reason() {
 
 #[test]
 fn config_set_rejects_runtime_scheduler_while_daemon_is_running() {
+    let _serve_guard = serve_test_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
     let (_serve, addr) = spawn_local_serve(&home);
 
@@ -572,6 +589,9 @@ fn onboard_defaults_to_scriptable_json_when_not_a_tty() {
 
 #[test]
 fn agent_rename_reports_detail_json_and_readable_errors() {
+    let _serve_guard = serve_test_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
     let (_serve, addr) = spawn_local_serve(&home);
     let envs = [("HOLON_HTTP_ADDR", addr.as_str())];

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -569,3 +569,53 @@ fn onboard_defaults_to_scriptable_json_when_not_a_tty() {
         "non-TTY onboard output should remain scriptable JSON: {value}"
     );
 }
+
+#[test]
+fn agent_rename_reports_detail_json_and_readable_errors() {
+    let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
+    let (_serve, addr) = spawn_local_serve(&home);
+    let envs = [("HOLON_HTTP_ADDR", addr.as_str())];
+
+    let created = run_json_with_env(&home, &["agent", "create", "rename-one"], &envs);
+    assert_eq!(created["identity"]["agent_id"], json!("rename-one"));
+
+    let renamed = run_json_with_env(
+        &home,
+        &["agent", "rename", "rename-one", "--name", "First Name"],
+        &envs,
+    );
+    assert_eq!(renamed["identity"]["agent_id"], json!("rename-one"));
+    assert_eq!(renamed["name"], json!("First Name"));
+    assert_eq!(renamed["identity"]["name"], json!("First Name"));
+    assert!(
+        renamed["display_name"]
+            .as_str()
+            .is_some_and(|value| value.contains("First Name")),
+        "rename should echo the updated agent detail: {renamed}"
+    );
+
+    // Duplicate names are rejected with the server's typed conflict message.
+    run_json_with_env(&home, &["agent", "create", "rename-two"], &envs);
+    let (conflict_stdout, conflict_stderr) = run_failure_with_env(
+        &home,
+        &["agent", "rename", "rename-two", "--name", "First Name"],
+        &envs,
+    );
+    assert!(
+        conflict_stdout.is_empty(),
+        "failed rename should not emit JSON stdout: {conflict_stdout}"
+    );
+    assert!(
+        conflict_stderr.contains("already in use"),
+        "conflict stderr should stay readable: {conflict_stderr}"
+    );
+
+    // The configured default agent keeps its identity.
+    let (default_stdout, default_stderr) =
+        run_failure_with_env(&home, &["agent", "rename", "main", "--name", "Nope"], &envs);
+    assert!(default_stdout.is_empty());
+    assert!(
+        default_stderr.contains("default agent cannot be renamed"),
+        "default-agent stderr should stay readable: {default_stderr}"
+    );
+}

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -158,6 +158,27 @@
     "aliases": []
   },
   {
+    "path": "agent.rename",
+    "positionals": [
+      {
+        "name": "agent_id",
+        "value_name": "AGENT_ID",
+        "index": null,
+        "required": true
+      }
+    ],
+    "flags": [
+      {
+        "long": "name",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": true
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "agent.repair",
     "positionals": [
       {


### PR DESCRIPTION
Closes #2841

## Summary

The rename capability already exists behind `PATCH /api/control/agents/{agent_id}/name` (#2801), but the CLI had no surface for it. This PR adds `holon agent rename <AGENT_ID> --name <NAME>` with no new backend semantics:

- **CLI**: new `AgentCommands::Rename` variant using a `--name` flag (as suggested in the issue) so the display name cannot be confused with the positional agent id.
- **Client**: `LocalClient::rename_agent` reuses the existing PATCH request plumbing (`RequestSpec::patch_json`); `patch_control_json` is promoted to public alongside the existing post/delete control helpers.
- **Errors**: all constraint cases (name conflict, default-agent rename, invalid names, private/deleting agents) stay typed via the existing control-plane error envelopes and `decode_or_error`, so the CLI prints readable messages instead of raw HTTP errors — no new error mapping layer.
- **Output**: success echoes the returned `AgentDetail` (including `name` / `display_name`), matching the issue's acceptance criteria.
- **Docs/snapshot**: CLI command-tree snapshot refreshed; the CLI reference documents the new subcommand and its constraints.

The Web GUI rename surface ships separately in #2842.

## Verification

- `cargo fmt --all -- --check` — clean.
- `RUSTFLAGS="-D warnings" cargo check --all-targets` — clean.
- `cargo test --test cli_snapshot` — snapshot matches.
- New `agent_rename_reports_detail_json_and_readable_errors` integration test (spawned daemon): rename success echoes detail JSON; duplicate name exits 1 with `already in use` on stderr; renaming the default agent exits 1 with `default agent cannot be renamed`.
- HTTP-layer semantics (invalid name, default-agent rename forbidden) were already covered by `control_agent_name_validation_and_default_rename_errors_are_typed`.