### PR TITLE
fix: 深化 work_item_scoped 历史窗口

### DIFF
--- a/docs/implementation-decisions/context-history-selector-boundary.md
+++ b/docs/implementation-decisions/context-history-selector-boundary.md
@@ -3,15 +3,22 @@
 ## Decision
 
 The context projection exposes `recent_turns` and `work_item_scoped` as
-request-scoped history selectors. Both selectors are evaluated from the same
-`EffectivePrompt`/canonical runtime snapshot and produce diagnostics and
-manifests; only one projection is sent to a provider.
+request-scoped history selectors. `work_item_scoped` is the default;
+`recent_turns` remains an explicit compatibility override and the fallback
+when request-scoped provider projection is unavailable.
+
+The baseline prompt keeps the existing agent-recent window. When scoped
+projection is adopted, the runtime may query a deeper owner-scoped TurnRecord
+window from the same canonical persisted state and hydrate only evidence
+referenced by those turns. This is still one request-scoped projection and one
+provider request, not a second context build or provider comparison.
 
 ## Preserved boundary
 
 Selector evaluation is model-free and must not mutate scheduler, queue,
 settlement, replay, audit, or persisted transcript state. Comparing selectors
 must not issue a second provider request or compare provider outputs. The
-existing `recent_turns` projection remains the compatibility default while
-`work_item_scoped` is introduced as an observable candidate for later,
-independently gated rollout.
+agent-recent baseline remains isolated from the deeper scoped evidence so
+fallback cost does not grow. Owner-scoped output remains subject to the same
+turn projection token budget, and projection diagnostics record the selected
+window, fallback or no-op outcome, and evaluated safety invariants.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -117,9 +117,24 @@ pub(crate) struct RecentTurnsReprojection {
     initial_budget: usize,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum WorkItemScopedReprojection {
+    NoCurrentWorkItem,
+    NoOwnedTurnRecords,
+    Rendered {
+        section: PromptSection,
+        evidence: Vec<ProjectionEvidenceRef>,
+        turns_loaded: usize,
+    },
+}
+
 impl RecentTurnsReprojection {
     pub(crate) fn initial_budget(&self) -> usize {
         self.initial_budget
+    }
+
+    pub(crate) fn turn_count(&self) -> usize {
+        self.turn_records.len()
     }
 }
 
@@ -142,33 +157,64 @@ pub(crate) fn reproject_recent_turns(
     .map(|content| turn_section("recent_turns", content))
 }
 
-pub(crate) fn reproject_work_item_scoped(
+pub(crate) fn reproject_work_item_scoped_with_limit(
     storage: &AppStorage,
     reprojection: &RecentTurnsReprojection,
     budget: usize,
-) -> Option<PromptSection> {
-    let work_item_id = reprojection.current_work_item.as_ref()?.id.as_str();
-    let turn_records = reprojection
-        .turn_records
-        .iter()
-        .filter(|record| record.effective_owner().work_item_id() == Some(work_item_id))
-        .cloned()
-        .collect::<Vec<_>>();
+    window_limit: usize,
+) -> Result<WorkItemScopedReprojection> {
+    let Some(work_item) = reprojection.current_work_item.as_ref() else {
+        return Ok(WorkItemScopedReprojection::NoCurrentWorkItem);
+    };
+    let owner = crate::types::TurnOwner::WorkItem {
+        work_item_id: work_item.id.clone(),
+    };
+    let turn_records = storage.read_recent_turns_for_owner(&owner, window_limit)?;
     if turn_records.is_empty() {
-        return None;
+        return Ok(WorkItemScopedReprojection::NoOwnedTurnRecords);
     }
-    render_turn_records_with_budget(
+    let mut messages = Vec::new();
+    let mut briefs = Vec::new();
+    let mut tools = Vec::new();
+    hydrate_recent_turn_references(
         storage,
         &turn_records,
-        &reprojection.messages,
-        &reprojection.briefs,
-        &reprojection.tools,
-        &reprojection.transcript,
+        &mut messages,
+        &mut briefs,
+        &mut tools,
+    )?;
+    let turn_ids = turn_records
+        .iter()
+        .map(|record| record.turn_id.clone())
+        .collect::<Vec<_>>();
+    let transcript = storage.read_transcript_for_turns(&turn_ids)?;
+    let Some(content) = render_turn_records_with_budget(
+        storage,
+        &turn_records,
+        &messages,
+        &briefs,
+        &tools,
+        &transcript,
         &reprojection.current_message,
-        reprojection.current_work_item.as_ref(),
+        Some(work_item),
         budget,
-    )
-    .map(|content| turn_section("recent_turns", content))
+    ) else {
+        return Ok(WorkItemScopedReprojection::NoOwnedTurnRecords);
+    };
+    let evidence = build_recent_turn_projection_evidence(
+        &turn_records,
+        &messages,
+        &briefs,
+        &tools,
+        ProjectionOwner::WorkItem {
+            work_item_id: work_item.id.clone(),
+        },
+    );
+    Ok(WorkItemScopedReprojection::Rendered {
+        section: turn_section("recent_turns", content),
+        evidence,
+        turns_loaded: turn_records.len(),
+    })
 }
 
 pub fn build_context(
@@ -685,10 +731,6 @@ fn build_projection_evidence(
         .and_then(|binding| binding.owner.as_ref())
         .map(ProjectionOwner::from)
         .unwrap_or_else(|| projection_owner(current_message.work_item_id.as_deref(), &agent.id));
-    let turn_owners = turn_records
-        .iter()
-        .map(|turn| (turn.turn_id.as_str(), turn.effective_owner()))
-        .collect::<std::collections::BTreeMap<_, _>>();
     evidence.insert(
         "current_input".into(),
         vec![ProjectionEvidenceRef::new(
@@ -723,14 +765,20 @@ fn build_projection_evidence(
         }
     }
 
-    let mut recent_turn_refs = Vec::new();
-    for turn in turn_records {
-        recent_turn_refs.push(ProjectionEvidenceRef::new(
-            format!("turn:{}", turn.turn_id),
-            ProjectionEvidenceRole::Turn,
-            ProjectionOwner::from(&turn.effective_owner()),
-        ));
-    }
+    let turn_owners = turn_records
+        .iter()
+        .map(|turn| (turn.turn_id.as_str(), turn.effective_owner()))
+        .collect::<BTreeMap<_, _>>();
+    let mut recent_turn_refs = turn_records
+        .iter()
+        .map(|turn| {
+            ProjectionEvidenceRef::new(
+                format!("turn:{}", turn.turn_id),
+                ProjectionEvidenceRole::Turn,
+                ProjectionOwner::from(&turn.effective_owner()),
+            )
+        })
+        .collect::<Vec<_>>();
     let direct_predecessor_id = messages
         .iter()
         .max_by(|left, right| compare_message_recency(left, right))
@@ -782,6 +830,67 @@ fn build_projection_evidence(
     if !recent_turn_refs.is_empty() {
         evidence.insert("recent_turns".into(), recent_turn_refs);
     }
+    evidence
+}
+
+fn build_recent_turn_projection_evidence(
+    turn_records: &[TurnRecord],
+    messages: &[MessageEnvelope],
+    briefs: &[BriefRecord],
+    tools: &[ToolExecutionRecord],
+    fallback_owner: ProjectionOwner,
+) -> Vec<ProjectionEvidenceRef> {
+    let turn_owners = turn_records
+        .iter()
+        .map(|turn| (turn.turn_id.as_str(), turn.effective_owner()))
+        .collect::<BTreeMap<_, _>>();
+    let owner_for_turn = |turn_id: Option<&str>| {
+        turn_id
+            .and_then(|turn_id| turn_owners.get(turn_id))
+            .map(ProjectionOwner::from)
+            .unwrap_or_else(|| fallback_owner.clone())
+    };
+    let mut evidence = turn_records
+        .iter()
+        .map(|turn| {
+            ProjectionEvidenceRef::new(
+                format!("turn:{}", turn.turn_id),
+                ProjectionEvidenceRole::Turn,
+                ProjectionOwner::from(&turn.effective_owner()),
+            )
+        })
+        .collect::<Vec<_>>();
+    let direct_predecessor_id = messages
+        .iter()
+        .max_by(|left, right| compare_message_recency(left, right))
+        .map(|message| message.id.as_str());
+    evidence.extend(messages.iter().map(|message| {
+        ProjectionEvidenceRef::new(
+            format!("message:{}", message.id),
+            if direct_predecessor_id == Some(message.id.as_str()) {
+                ProjectionEvidenceRole::DirectPredecessor
+            } else {
+                ProjectionEvidenceRole::Input
+            },
+            owner_for_turn(message.turn_id.as_deref()),
+        )
+    }));
+    evidence.extend(briefs.iter().map(|brief| {
+        ProjectionEvidenceRef::new(
+            format!("brief:{}", brief.id),
+            ProjectionEvidenceRole::Result,
+            owner_for_turn(brief.turn_id.as_deref()),
+        )
+    }));
+    evidence.extend(tools.iter().map(|tool| {
+        ProjectionEvidenceRef::new(
+            format!("tool_execution:{}", tool.id),
+            ProjectionEvidenceRole::ToolResult,
+            owner_for_turn(tool.turn_id.as_deref()),
+        )
+    }));
+    evidence.sort();
+    evidence.dedup();
     evidence
 }
 
@@ -3448,6 +3557,139 @@ mod tests {
             storage.data_dir(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn work_item_scoped_reprojection_reads_deeper_owner_history_and_hydrates_evidence() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let mut work_item =
+            WorkItemRecord::new("default", "deep scoped history", WorkItemState::Open);
+        work_item.id = "work-current".into();
+        let owner = crate::types::TurnOwner::WorkItem {
+            work_item_id: work_item.id.clone(),
+        };
+
+        for index in 1..=20u64 {
+            let turn_id = format!("turn-owned-{index:02}");
+            let mut message = MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator {
+                    actor_id: None,
+                    actor_display_name: None,
+                },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: format!("owned request {index:02}"),
+                },
+            );
+            message.turn_id = Some(turn_id.clone());
+            message.work_item_id = Some(work_item.id.clone());
+            storage.append_message(&message).unwrap();
+
+            let mut turn = TurnRecord::new("default", &turn_id, index * 2);
+            turn.owner = Some(owner.clone());
+            turn.current_work_item_id = Some(work_item.id.clone());
+            turn.input_message_ids = vec![message.id.clone()];
+            turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(&message));
+
+            if index == 1 {
+                let tool = ToolExecutionRecord {
+                    id: "tool-owned-oldest".into(),
+                    agent_id: "default".into(),
+                    work_item_id: Some(work_item.id.clone()),
+                    turn_index: turn.turn_index,
+                    turn_id: Some(turn_id.clone()),
+                    tool_name: "ExecCommand".into(),
+                    created_at: chrono::Utc::now(),
+                    completed_at: Some(chrono::Utc::now()),
+                    duration_ms: 1,
+                    authority_class: AuthorityClass::OperatorInstruction,
+                    status: ToolExecutionStatus::Success,
+                    input: json!({"cmd": "verify"}),
+                    output: json!({"exit_code": 0}),
+                    summary: "oldest owner tool evidence".into(),
+                    invocation_surface: None,
+                };
+                storage.append_tool_execution(&tool).unwrap();
+                turn.tool_execution_ids.push(tool.id.clone());
+
+                let transcript = TranscriptEntry::new(
+                    "default",
+                    TranscriptEntryKind::AssistantRound,
+                    Some(1),
+                    None,
+                    json!({
+                        "turn_id": turn_id,
+                        "work_item_id": work_item.id,
+                        "blocks": [{
+                            "type": "text",
+                            "text": "oldest owner assistant evidence"
+                        }]
+                    }),
+                );
+                storage.append_transcript_entry(&transcript).unwrap();
+            }
+            storage.append_turn(&turn).unwrap();
+
+            let other_turn_id = format!("turn-other-{index:02}");
+            let mut other = TurnRecord::new("default", other_turn_id, index * 2 + 1);
+            other.owner = Some(crate::types::TurnOwner::WorkItem {
+                work_item_id: "work-other".into(),
+            });
+            other.current_work_item_id = Some("work-other".into());
+            storage.append_turn(&other).unwrap();
+        }
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: None,
+                actor_display_name: None,
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "continue current work item".into(),
+            },
+        );
+        let reprojection = RecentTurnsReprojection {
+            turn_records: storage.read_recent_turns(12).unwrap(),
+            messages: Vec::new(),
+            briefs: Vec::new(),
+            tools: Vec::new(),
+            transcript: Vec::new(),
+            current_message,
+            current_work_item: Some(work_item),
+            initial_budget: 64_000,
+        };
+
+        let WorkItemScopedReprojection::Rendered {
+            section,
+            evidence,
+            turns_loaded,
+        } = reproject_work_item_scoped_with_limit(&storage, &reprojection, 64_000, 64).unwrap()
+        else {
+            panic!("owner-scoped projection should render");
+        };
+
+        assert_eq!(turns_loaded, 20);
+        assert!(section.content.contains("owned request 01"));
+        assert!(section.content.contains("oldest owner assistant evidence"));
+        assert!(section.content.contains("oldest owner tool evidence"));
+        assert!(!section.content.contains("turn-other"));
+        assert!(evidence
+            .iter()
+            .any(|reference| reference.reference == "turn:turn-owned-01"));
+        assert!(evidence.iter().all(|reference| {
+            reference.owner
+                == ProjectionOwner::WorkItem {
+                    work_item_id: "work-current".into(),
+                }
+        }));
     }
 
     fn active_task(

--- a/src/projection_eval/mod.rs
+++ b/src/projection_eval/mod.rs
@@ -21,6 +21,15 @@ pub const PROJECTION_MANIFEST_SCHEMA_VERSION: u32 = 1;
 pub const PROJECTION_SCORECARD_SCHEMA_VERSION: u32 = 1;
 pub const HISTORY_SELECTOR_SCHEMA_VERSION: u32 = 1;
 
+const DIAGNOSTIC_INVARIANTS: [&str; 6] = [
+    "prompt_budget_respected",
+    "current_input_retained",
+    "direct_predecessor_retained",
+    "canonical_evidence_unique",
+    "evidence_owner_consistent",
+    "section_representation_exclusive",
+];
+
 /// Selects which canonical history candidates are eligible for a request
 /// projection. Selectors are pure request-scoped policy; they do not own
 /// runtime state, scheduling, settlement, or provider calls.
@@ -40,6 +49,14 @@ impl HistorySelector {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectionOutcome {
+    Projected,
+    Fallback,
+    IdenticalRenderNoop,
+}
+
 /// Request-scoped diagnostic metadata shared by all history selectors.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProjectionDiagnostics {
@@ -52,6 +69,20 @@ pub struct ProjectionDiagnostics {
     pub input_chars: usize,
     pub fallback_reason: Option<String>,
     pub policy_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_window_scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_window_limit: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_window_turns_loaded: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_window_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_window_budget_tokens: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projection_outcome: Option<ProjectionOutcome>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invariant_results: Option<Vec<ProjectionInvariantResult>>,
 }
 
 impl ProjectionDiagnostics {
@@ -73,11 +104,52 @@ impl ProjectionDiagnostics {
             input_chars,
             fallback_reason: None,
             policy_version: format!("history_selector_v{}", HISTORY_SELECTOR_SCHEMA_VERSION),
+            history_window_scope: None,
+            history_window_limit: None,
+            history_window_turns_loaded: None,
+            history_window_source: None,
+            history_window_budget_tokens: None,
+            projection_outcome: None,
+            invariant_results: None,
         }
     }
 
     pub fn with_fallback_reason(mut self, reason: impl Into<String>) -> Self {
         self.fallback_reason = Some(reason.into());
+        self.projection_outcome = Some(ProjectionOutcome::Fallback);
+        self
+    }
+
+    pub fn with_projection_outcome(mut self, outcome: ProjectionOutcome) -> Self {
+        self.projection_outcome = Some(outcome);
+        self
+    }
+
+    pub fn with_history_window(
+        mut self,
+        scope: impl Into<String>,
+        limit: usize,
+        turns_loaded: usize,
+        source: impl Into<String>,
+        budget_tokens: usize,
+    ) -> Self {
+        self.history_window_scope = Some(scope.into());
+        self.history_window_limit = Some(limit);
+        self.history_window_turns_loaded = Some(turns_loaded);
+        self.history_window_source = Some(source.into());
+        self.history_window_budget_tokens = Some(budget_tokens);
+        self
+    }
+
+    pub fn with_manifest_invariants(mut self, manifest: &ProjectionManifest) -> Self {
+        self.invariant_results = Some(
+            manifest
+                .invariant_results
+                .iter()
+                .filter(|result| DIAGNOSTIC_INVARIANTS.contains(&result.code.as_str()))
+                .cloned()
+                .collect(),
+        );
         self
     }
 }
@@ -557,9 +629,9 @@ fn diagnostics_for_prompt(
     ProjectionDiagnostics::new(
         selector,
         if selector == HistorySelector::RecentTurns {
-            "default_compatible_selector"
+            "agent_recent_selector"
         } else {
-            "request_scoped_comparison"
+            "work_item_scoped_selector"
         },
         current_work_item_id,
         input_message_count,
@@ -966,6 +1038,70 @@ mod tests {
             serde_json::to_string(&scoped).unwrap(),
             "\"work_item_scoped\""
         );
+    }
+
+    #[test]
+    fn projection_diagnostics_new_fields_are_backward_compatible() {
+        let diagnostics: ProjectionDiagnostics = serde_json::from_value(serde_json::json!({
+            "schema_version": 1,
+            "history_selector": "recent_turns",
+            "selection_reason": "legacy",
+            "current_work_item_id": null,
+            "input_message_count": 1,
+            "input_estimated_tokens": 2,
+            "input_chars": 3,
+            "fallback_reason": null,
+            "policy_version": "history_selector_v1"
+        }))
+        .unwrap();
+        assert_eq!(diagnostics.history_window_limit, None);
+        assert_eq!(diagnostics.projection_outcome, None);
+        assert_eq!(diagnostics.invariant_results, None);
+    }
+
+    #[test]
+    fn identical_render_noop_is_not_reported_as_fallback() {
+        let diagnostics = ProjectionDiagnostics::new(
+            HistorySelector::WorkItemScoped,
+            "identical_render",
+            None,
+            0,
+            0,
+            0,
+        )
+        .with_projection_outcome(ProjectionOutcome::IdenticalRenderNoop);
+        assert_eq!(
+            diagnostics.projection_outcome,
+            Some(ProjectionOutcome::IdenticalRenderNoop)
+        );
+        assert_eq!(diagnostics.fallback_reason, None);
+    }
+
+    #[test]
+    fn projection_diagnostics_persist_the_six_runtime_safety_invariants() {
+        let manifest = manifest(vec![evidence(
+            "message:current",
+            ProjectionEvidenceRole::CurrentInput,
+        )]);
+        let diagnostics = ProjectionDiagnostics::new(
+            HistorySelector::WorkItemScoped,
+            "scoped",
+            Some("work-1".into()),
+            1,
+            1,
+            1,
+        )
+        .with_manifest_invariants(&manifest);
+        let invariant_results = diagnostics.invariant_results.unwrap();
+        assert_eq!(invariant_results.len(), 6);
+        assert!(!invariant_results
+            .iter()
+            .any(|result| result.code == "activation_binding_consistent"));
+        assert!(DIAGNOSTIC_INVARIANTS.iter().all(|expected| {
+            invariant_results
+                .iter()
+                .any(|result| result.code == *expected)
+        }));
     }
 
     #[test]

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -18,8 +18,8 @@ use sha2::{Digest, Sha256};
 use crate::{
     context::{
         build_context_with_default_external_ingress, reproject_recent_turns,
-        reproject_work_item_scoped, BuiltContext, ContextConfig, ContextPlanEvidence,
-        RecentTurnsReprojection,
+        reproject_work_item_scoped_with_limit, BuiltContext, ContextConfig, ContextPlanEvidence,
+        RecentTurnsReprojection, WorkItemScopedReprojection,
     },
     projection_eval::{
         compare_prompt_history_selectors, manifest_from_effective_prompt,
@@ -96,6 +96,20 @@ pub struct EffectivePrompt {
     pub(crate) recent_turns_reprojection: Option<RecentTurnsReprojection>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum HistoryReprojectionOutcome {
+    Adopted {
+        prompt: EffectivePrompt,
+        turns_loaded: usize,
+    },
+    NoCurrentWorkItem,
+    NoOwnedTurnRecords,
+    IdenticalRenderNoop {
+        prompt: EffectivePrompt,
+        turns_loaded: usize,
+    },
+}
+
 impl EffectivePrompt {
     pub fn projection_manifest(&self) -> ProjectionManifest {
         manifest_from_effective_prompt(self)
@@ -120,17 +134,45 @@ impl EffectivePrompt {
         budget: usize,
         available_tools: &[ToolSpec],
         selector: HistorySelector,
-    ) -> Option<Self> {
-        let reprojection = self.recent_turns_reprojection.as_ref()?;
-        let replacement = match selector {
-            HistorySelector::RecentTurns => reproject_recent_turns(storage, reprojection, budget),
+        work_item_scoped_window: usize,
+    ) -> Result<HistoryReprojectionOutcome> {
+        if selector == HistorySelector::WorkItemScoped
+            && !matches!(self.projection_owner, ProjectionOwner::WorkItem { .. })
+        {
+            return Ok(HistoryReprojectionOutcome::NoCurrentWorkItem);
+        }
+        let Some(reprojection) = self.recent_turns_reprojection.as_ref() else {
+            return Ok(HistoryReprojectionOutcome::NoOwnedTurnRecords);
+        };
+        let (replacement, replacement_evidence, turns_loaded) = match selector {
+            HistorySelector::RecentTurns => {
+                let Some(replacement) = reproject_recent_turns(storage, reprojection, budget)
+                else {
+                    return Ok(HistoryReprojectionOutcome::NoOwnedTurnRecords);
+                };
+                (replacement, None, reprojection.turn_count())
+            }
             HistorySelector::WorkItemScoped => {
-                reproject_work_item_scoped(storage, reprojection, budget)
+                match reproject_work_item_scoped_with_limit(
+                    storage,
+                    reprojection,
+                    budget,
+                    work_item_scoped_window,
+                )? {
+                    WorkItemScopedReprojection::NoCurrentWorkItem => {
+                        return Ok(HistoryReprojectionOutcome::NoCurrentWorkItem);
+                    }
+                    WorkItemScopedReprojection::NoOwnedTurnRecords => {
+                        return Ok(HistoryReprojectionOutcome::NoOwnedTurnRecords);
+                    }
+                    WorkItemScopedReprojection::Rendered {
+                        section,
+                        evidence,
+                        turns_loaded,
+                    } => (section, Some(evidence), turns_loaded),
+                }
             }
         };
-        // An unavailable scoped projection must fall back at the request
-        // boundary; it must never become an empty history section.
-        let replacement = replacement?;
         let replacement_for_evidence = replacement.clone();
         let mut context_sections = self
             .context_sections
@@ -146,8 +188,20 @@ impl EffectivePrompt {
             .min(context_sections.len());
         context_sections.insert(insertion_index, replacement);
         let rendered_context_attachment = render_sections(&context_sections);
+        let mut prompt = self.clone();
+        if let Some(evidence) = replacement_evidence {
+            prompt
+                .projection_evidence
+                .insert("recent_turns".to_string(), evidence);
+        }
+        prompt
+            .context_plan_evidence
+            .record_reprojection("recent_turns", Some(&replacement_for_evidence));
         if rendered_context_attachment == self.rendered_context_attachment {
-            return None;
+            return Ok(HistoryReprojectionOutcome::IdenticalRenderNoop {
+                prompt,
+                turns_loaded,
+            });
         }
         let context_fingerprint = reprojected_context_fingerprint(
             &self.cache_identity,
@@ -156,20 +210,42 @@ impl EffectivePrompt {
             &context_sections,
             available_tools,
         );
-        let mut prompt = self.clone();
         prompt.context_sections = context_sections;
         prompt.rendered_context_attachment = rendered_context_attachment;
         prompt.cache_identity.context_fingerprint = context_fingerprint;
-        prompt
-            .context_plan_evidence
-            .record_reprojection("recent_turns", Some(&replacement_for_evidence));
-        Some(prompt)
+        Ok(HistoryReprojectionOutcome::Adopted {
+            prompt,
+            turns_loaded,
+        })
     }
 
     pub(crate) fn recent_turns_initial_budget(&self) -> Option<usize> {
         self.recent_turns_reprojection
             .as_ref()
             .map(RecentTurnsReprojection::initial_budget)
+    }
+
+    pub(crate) fn recent_turn_count(&self) -> usize {
+        self.recent_turns_reprojection
+            .as_ref()
+            .map_or(0, RecentTurnsReprojection::turn_count)
+    }
+
+    pub(crate) fn history_reprojection_budget(&self, maximum: usize) -> usize {
+        let recent_turns_allocated = self
+            .context_plan_evidence
+            .decisions
+            .iter()
+            .find(|decision| decision.candidate_id == "recent_turns")
+            .map_or(0, |decision| decision.allocated_estimated_tokens);
+        let other_allocated = self
+            .context_plan_evidence
+            .allocated_estimated_tokens
+            .saturating_sub(recent_turns_allocated);
+        self.context_plan_evidence
+            .total_budget_estimated_tokens
+            .saturating_sub(other_allocated)
+            .min(maximum)
     }
 
     pub(crate) fn reproject_recent_turns(
@@ -2520,6 +2596,57 @@ mod tests {
         ));
         assert!(dump.contains("[test_section][id: test-stable-id-123][Stable]"));
         assert!(dump.contains("[context_section][id: ctx-id-456][AgentScoped]"));
+    }
+
+    #[test]
+    fn history_reprojection_budget_uses_only_remaining_context_budget() {
+        let mut prompt = EffectivePrompt {
+            identity: sample_identity(),
+            agent_home: PathBuf::from("/tmp/agent-home"),
+            execution: sample_execution_snapshot(),
+            loaded_agents_md: LoadedAgentsMd::default(),
+            loaded_agent_memory: LoadedAgentMemory::default(),
+            cache_identity: sample_cache_identity(),
+            system_sections: Vec::new(),
+            context_sections: Vec::new(),
+            rendered_system_prompt: String::new(),
+            rendered_context_attachment: String::new(),
+            projection_owner: ProjectionOwner::AgentLifecycle {
+                agent_id: "default".into(),
+            },
+            projection_binding: None,
+            projection_turn_id: None,
+            projection_evidence: ProjectionEvidenceIndex::new(),
+            context_plan_evidence: ContextPlanEvidence {
+                total_budget_estimated_tokens: 100,
+                allocated_estimated_tokens: 90,
+                decisions: vec![
+                    crate::context::ContextPlanDecision {
+                        candidate_id: "current_input".into(),
+                        section_name: "current_input".into(),
+                        requested_estimated_tokens: 70,
+                        minimum_estimated_tokens: 70,
+                        allocated_estimated_tokens: 70,
+                        outcome: crate::context::ContextPlanOutcome::Full,
+                        reason: crate::context::ContextPlanReason::SelectedFull,
+                    },
+                    crate::context::ContextPlanDecision {
+                        candidate_id: "recent_turns".into(),
+                        section_name: "recent_turns".into(),
+                        requested_estimated_tokens: 20,
+                        minimum_estimated_tokens: 0,
+                        allocated_estimated_tokens: 20,
+                        outcome: crate::context::ContextPlanOutcome::Full,
+                        reason: crate::context::ContextPlanReason::SelectedFull,
+                    },
+                ],
+            },
+            recent_turns_reprojection: None,
+        };
+
+        assert_eq!(prompt.history_reprojection_budget(64), 30);
+        prompt.context_plan_evidence.total_budget_estimated_tokens = 20;
+        assert_eq!(prompt.history_reprojection_budget(64), 0);
     }
 
     #[test]

--- a/src/runtime/turn/context_management.rs
+++ b/src/runtime/turn/context_management.rs
@@ -1,12 +1,41 @@
 //! Context management eligibility diagnostics for tool results.
 
 use crate::config::ModelRouteRef;
-use crate::projection_eval::{HistorySelector, ProjectionDiagnostics};
+use crate::projection_eval::{HistorySelector, ProjectionDiagnostics, ProjectionOutcome};
 use crate::provider::{
     AgentProvider, ConversationMessage, ModelBlock, ProviderPromptCapability, ProviderTurnRequest,
     ToolResultBlock,
 };
 use serde_json::Value;
+
+const DEFAULT_WORK_ITEM_SCOPED_WINDOW_MESSAGES: usize = 64;
+const MAX_WORK_ITEM_SCOPED_WINDOW_MESSAGES: usize = 512;
+const WORK_ITEM_SCOPED_WINDOW_MESSAGES_ENV: &str = "HOLON_CONTEXT_WORK_ITEM_SCOPED_WINDOW_MESSAGES";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum HistoryWindowPolicySource {
+    Environment,
+    Default,
+}
+
+impl HistoryWindowPolicySource {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Environment => "env",
+            Self::Default => "default",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct HistoryWindowMessages {
+    pub(super) limit: usize,
+    pub(super) source: HistoryWindowPolicySource,
+}
+
+pub(super) fn configured_work_item_scoped_window_messages() -> HistoryWindowMessages {
+    configured_work_item_scoped_window_messages_with_lookup(|key| std::env::var(key).ok())
+}
 
 pub(super) fn configured_history_selector(
     agent_id: &str,
@@ -61,7 +90,25 @@ fn configured_history_selector_with_lookup(
     ];
     keys.iter()
         .find_map(|key| lookup(key).and_then(|value| parse_configured_history_selector(&value)))
-        .unwrap_or(HistorySelector::RecentTurns)
+        .unwrap_or(HistorySelector::WorkItemScoped)
+}
+
+fn configured_work_item_scoped_window_messages_with_lookup(
+    mut lookup: impl FnMut(&str) -> Option<String>,
+) -> HistoryWindowMessages {
+    let parsed = lookup(WORK_ITEM_SCOPED_WINDOW_MESSAGES_ENV)
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0);
+    match parsed {
+        Some(messages) => HistoryWindowMessages {
+            limit: messages.min(MAX_WORK_ITEM_SCOPED_WINDOW_MESSAGES),
+            source: HistoryWindowPolicySource::Environment,
+        },
+        None => HistoryWindowMessages {
+            limit: DEFAULT_WORK_ITEM_SCOPED_WINDOW_MESSAGES,
+            source: HistoryWindowPolicySource::Default,
+        },
+    }
 }
 
 fn selector_env_component(value: &str) -> String {
@@ -89,15 +136,33 @@ pub(super) fn projection_diagnostic(
     prompt: &crate::prompt::EffectivePrompt,
     selector: HistorySelector,
     fallback_reason: Option<&str>,
+    history_window_scope: &str,
+    history_window_limit: usize,
+    history_window_turns_loaded: usize,
+    history_window_source: &str,
+    history_window_budget_tokens: usize,
+    outcome: ProjectionOutcome,
 ) -> Value {
-    let mut diagnostic = prompt
-        .projection_manifest_for_selector(selector)
+    let manifest = prompt.projection_manifest_for_selector(selector);
+    let mut diagnostic = manifest
         .diagnostics
+        .clone()
         .unwrap_or_else(|| {
             ProjectionDiagnostics::new(selector, "request_scoped_projection", None, 0, 0, 0)
-        });
+        })
+        .with_history_window(
+            history_window_scope,
+            history_window_limit,
+            history_window_turns_loaded,
+            history_window_source,
+            history_window_budget_tokens,
+        )
+        .with_manifest_invariants(&manifest)
+        .with_projection_outcome(outcome);
     if let Some(reason) = fallback_reason {
-        diagnostic = diagnostic.with_fallback_reason(reason);
+        diagnostic = diagnostic
+            .with_fallback_reason(reason)
+            .with_projection_outcome(outcome);
     }
     serde_json::to_value(diagnostic).unwrap_or_else(|_| {
         serde_json::json!({
@@ -214,16 +279,44 @@ mod tests {
     use async_trait::async_trait;
 
     use super::{
-        configured_history_selector_with_lookup, parse_configured_history_selector, HistorySelector,
+        configured_history_selector_with_lookup,
+        configured_work_item_scoped_window_messages_with_lookup, parse_configured_history_selector,
+        HistorySelector, HistoryWindowPolicySource,
     };
 
     #[test]
-    fn history_selector_defaults_to_recent_turns() {
+    fn history_selector_defaults_to_work_item_scoped() {
         assert_eq!(parse_configured_history_selector("unknown"), None);
         assert_eq!(
             parse_configured_history_selector(" work_item_scoped "),
             Some(HistorySelector::WorkItemScoped)
         );
+        let model = ModelRouteRef::parse("openai@default/gpt-5").unwrap();
+        assert_eq!(
+            configured_history_selector_with_lookup("agent-1", &model, |_| None),
+            HistorySelector::WorkItemScoped
+        );
+    }
+
+    #[test]
+    fn work_item_scoped_window_policy_parses_caps_and_falls_back() {
+        let policy =
+            configured_work_item_scoped_window_messages_with_lookup(|_| Some("128".to_string()));
+        assert_eq!(policy.limit, 128);
+        assert_eq!(policy.source, HistoryWindowPolicySource::Environment);
+
+        let capped =
+            configured_work_item_scoped_window_messages_with_lookup(|_| Some("999".to_string()));
+        assert_eq!(capped.limit, 512);
+        assert_eq!(capped.source, HistoryWindowPolicySource::Environment);
+
+        for invalid in ["0", "invalid"] {
+            let fallback = configured_work_item_scoped_window_messages_with_lookup(|_| {
+                Some(invalid.to_string())
+            });
+            assert_eq!(fallback.limit, 64);
+            assert_eq!(fallback.source, HistoryWindowPolicySource::Default);
+        }
     }
 
     #[test]

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -42,7 +42,8 @@ use super::completion::{
     rejects_truncated_mutation_tool_call, result_work_item_id, truncated_mutation_recovery_hint,
 };
 use super::context_management::{
-    configured_history_selector, context_management_diagnostic, projection_diagnostic,
+    configured_history_selector, configured_work_item_scoped_window_messages,
+    context_management_diagnostic, projection_diagnostic,
     projection_fallback_reason as provider_projection_fallback_reason,
 };
 use super::projection::{
@@ -1149,27 +1150,73 @@ impl TurnExecution<'_> {
             .await?;
         let configured_selector =
             configured_history_selector(agent_id, &turn_model_state.effective_model);
+        let scoped_window = configured_work_item_scoped_window_messages();
+        let context_config = runtime.current_context_config().await;
+        let projection_budget =
+            effective_prompt.history_reprojection_budget(context_config.turn_projection_budget());
         let mut projection_selector = configured_selector;
         let mut projection_fallback_reason =
             provider_projection_fallback_reason(provider.as_ref(), configured_selector);
+        let mut projection_outcome = crate::projection_eval::ProjectionOutcome::Projected;
+        let mut history_window_scope =
+            if configured_selector == crate::projection_eval::HistorySelector::WorkItemScoped {
+                "work_item_owner"
+            } else {
+                "agent_recent"
+            };
+        let mut history_window_limit =
+            if configured_selector == crate::projection_eval::HistorySelector::WorkItemScoped {
+                scoped_window.limit
+            } else {
+                context_config.recent_messages
+            };
+        let mut history_window_source =
+            if configured_selector == crate::projection_eval::HistorySelector::WorkItemScoped {
+                scoped_window.source.as_str()
+            } else {
+                "context_config"
+            };
+        let mut history_window_turns_loaded = effective_prompt.recent_turn_count();
         if configured_selector == crate::projection_eval::HistorySelector::WorkItemScoped {
             if projection_fallback_reason.is_none() {
-                let context_config = runtime.current_context_config().await;
-                if effective_prompt
-                    .reproject_for_history_selector(
-                        &runtime.inner.storage,
-                        context_config.turn_projection_budget(),
-                        &available_tools,
-                        configured_selector,
-                    )
-                    .map(|projected| effective_prompt = projected)
-                    .is_none()
-                {
-                    projection_fallback_reason = Some("work_item_scoped_projection_unavailable");
+                match effective_prompt.reproject_for_history_selector(
+                    &runtime.inner.storage,
+                    projection_budget,
+                    &available_tools,
+                    configured_selector,
+                    scoped_window.limit,
+                )? {
+                    crate::prompt::HistoryReprojectionOutcome::Adopted {
+                        prompt,
+                        turns_loaded,
+                    } => {
+                        effective_prompt = prompt;
+                        history_window_turns_loaded = turns_loaded;
+                    }
+                    crate::prompt::HistoryReprojectionOutcome::IdenticalRenderNoop {
+                        prompt,
+                        turns_loaded,
+                    } => {
+                        effective_prompt = prompt;
+                        history_window_turns_loaded = turns_loaded;
+                        projection_outcome =
+                            crate::projection_eval::ProjectionOutcome::IdenticalRenderNoop;
+                    }
+                    crate::prompt::HistoryReprojectionOutcome::NoCurrentWorkItem => {
+                        projection_fallback_reason = Some("no_current_work_item");
+                    }
+                    crate::prompt::HistoryReprojectionOutcome::NoOwnedTurnRecords => {
+                        projection_fallback_reason = Some("no_owned_turn_records");
+                    }
                 }
             }
             if projection_fallback_reason.is_some() {
                 projection_selector = crate::projection_eval::HistorySelector::RecentTurns;
+                projection_outcome = crate::projection_eval::ProjectionOutcome::Fallback;
+                history_window_scope = "agent_recent";
+                history_window_limit = context_config.recent_messages;
+                history_window_source = "context_config";
+                history_window_turns_loaded = effective_prompt.recent_turn_count();
             }
         }
         let allowed_tool_names = available_tools
@@ -1289,6 +1336,12 @@ impl TurnExecution<'_> {
                     &effective_prompt,
                     projection_selector,
                     projection_fallback_reason,
+                    history_window_scope,
+                    history_window_limit,
+                    history_window_turns_loaded,
+                    history_window_source,
+                    projection_budget,
+                    projection_outcome,
                 );
                 let context_build_ms = context_build_started.elapsed().as_millis() as u64;
                 let (result, provider_started_at, provider_completed_at, provider_round_ms) =
@@ -1684,6 +1737,12 @@ impl TurnExecution<'_> {
                     &effective_prompt,
                     projection_selector,
                     projection_fallback_reason,
+                    history_window_scope,
+                    history_window_limit,
+                    history_window_turns_loaded,
+                    history_window_source,
+                    projection_budget,
+                    projection_outcome,
                 );
                 let context_build_ms = context_build_started.elapsed().as_millis() as u64;
                 let (result, provider_started_at, provider_completed_at, provider_round_ms) =

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
-use rusqlite::{params, OptionalExtension, ToSql, Transaction};
+use rusqlite::{params, params_from_iter, OptionalExtension, ToSql, Transaction};
 use sha2::{Digest, Sha256};
 
 use crate::runtime_db::agent_relations::{
@@ -2502,6 +2502,35 @@ impl TranscriptRepository<'_> {
             rows.map(|row| decode_transcript_entry_payload(&row?))
                 .collect()
         }
+    }
+
+    pub fn for_turn_ids(
+        &self,
+        agent_id: &str,
+        turn_ids: &[String],
+    ) -> Result<Vec<TranscriptEntry>> {
+        if turn_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = std::iter::repeat_n("?", turn_ids.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(&format!(
+            "SELECT payload_json
+             FROM transcript_entries
+             WHERE agent_id = ?
+               AND turn_id IN ({placeholders})
+             ORDER BY COALESCE(transcript_seq, 9223372036854775807) ASC,
+                      created_at ASC,
+                      evidence_id ASC"
+        ))?;
+        let rows = statement.query_map(
+            params_from_iter(std::iter::once(agent_id).chain(turn_ids.iter().map(String::as_str))),
+            |row| row.get::<_, String>(0),
+        )?;
+        rows.map(|row| decode_transcript_entry_payload(&row?))
+            .collect()
     }
 
     pub fn by_id(&self, agent_id: Option<&str>, entry_id: &str) -> Result<Option<TranscriptEntry>> {

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -7492,6 +7492,48 @@ CREATE TABLE working_memory_deltas (
     }
 
     #[test]
+    fn transcript_entries_for_turn_ids_are_scoped_and_stably_ordered() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        assert!(db
+            .transcript_entries()
+            .for_turn_ids("agent-a", &[])?
+            .is_empty());
+
+        let created_at = Utc::now();
+        for (agent_id, turn_id, entry_id, sequence, offset_millis) in [
+            ("agent-a", "turn-1", "entry-c", Some(2), 0),
+            ("agent-a", "turn-2", "entry-b", None, 1),
+            ("agent-a", "turn-1", "entry-a", None, 1),
+            ("agent-a", "turn-3", "entry-other-turn", Some(1), 0),
+            ("agent-b", "turn-1", "entry-other-agent", Some(0), 0),
+        ] {
+            let mut entry = TranscriptEntry::new(
+                agent_id,
+                TranscriptEntryKind::AssistantRound,
+                None,
+                None,
+                serde_json::json!({ "turn_id": turn_id }),
+            );
+            entry.id = entry_id.into();
+            entry.transcript_seq = sequence;
+            entry.created_at = created_at + chrono::Duration::milliseconds(offset_millis);
+            db.transcript_entries().upsert(&entry)?;
+        }
+
+        let turn_ids = vec!["turn-2".to_owned(), "turn-1".to_owned()];
+        let entries = db.transcript_entries().for_turn_ids("agent-a", &turn_ids)?;
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["entry-c", "entry-a", "entry-b"]
+        );
+        Ok(())
+    }
+
+    #[test]
     fn legacy_turn_owner_fallback_is_conservative() {
         let mut work_item_turn = TurnRecord::new("agent-owner", "turn-work", 1);
         work_item_turn.current_work_item_id = Some("work-1".into());

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         ContextEpisodeRecord, DeliverySummaryRecord, ExternalTriggerRecord, MessageEnvelope,
         OperatorDeliveryRecord, OperatorNotificationRecord, OperatorTransportBinding,
         QueueEntryRecord, TaskRecord, TaskStatus, TimerRecord, ToolExecutionRecord,
-        TranscriptEntry, TurnRecord, WaitConditionRecord, WorkItemContinuationFrame,
+        TranscriptEntry, TurnOwner, TurnRecord, WaitConditionRecord, WorkItemContinuationFrame,
         WorkItemDelegationRecord, WorkItemDelegationState, WorkItemRecord, WorkspaceEntry,
         WorkspaceOccupancyRecord,
     },
@@ -706,6 +706,16 @@ impl AppStorage {
         return runtime_db.turn_records().recent(limit);
     }
 
+    pub fn read_recent_turns_for_owner(
+        &self,
+        owner: &TurnOwner,
+        limit: usize,
+    ) -> Result<Vec<TurnRecord>> {
+        self.runtime_db
+            .turn_records()
+            .recent_for_owner(&self.storage_agent_id()?, owner, limit)
+    }
+
     pub fn read_turn_by_id(&self, turn_id: &str) -> Result<Option<TurnRecord>> {
         self.runtime_db
             .turn_records()
@@ -724,6 +734,12 @@ impl AppStorage {
         return runtime_db
             .transcript_entries()
             .all(self.current_agent_id()?.as_deref());
+    }
+
+    pub fn read_transcript_for_turns(&self, turn_ids: &[String]) -> Result<Vec<TranscriptEntry>> {
+        self.runtime_db
+            .transcript_entries()
+            .for_turn_ids(&self.storage_agent_id()?, turn_ids)
     }
 
     pub fn read_transcript_entry_by_id(&self, entry_id: &str) -> Result<Option<TranscriptEntry>> {


### PR DESCRIPTION
## 概要

- 默认启用 `work_item_scoped` history selector，并新增单一配置 `HOLON_CONTEXT_WORK_ITEM_SCOPED_WINDOW_MESSAGES`（默认 64，上限 512）
- 按当前 WorkItem owner 独立读取更深的 TurnRecord 窗口，再按所选 turn 精确补水 message、brief、tool execution 与 transcript
- 保持 `recent_turns` fallback 的读取成本与现有 token budget 边界不变
- 拆分 fallback/no-op 原因，并持久化六条 projection invariant 诊断
- 补齐配置、repository、context、projection/runtime diagnostics 回归测试与实现决策文档

## 验证

- `cargo test --all-targets`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
- 独立只读代码审查：未发现阻塞性问题

Closes #2837
