### PR TITLE
fix: sample existing agent turn before delivery

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -4227,15 +4227,21 @@ impl RuntimeHost {
             caller,
         )?;
         let identity = self.agent_identity_record(target_agent_id)?;
-        let (identity, runtime, receipt) = match identity {
+        let (identity, runtime, child_turn_baseline, receipt) = match identity {
             Some(identity) if identity.status == AgentRegistryStatus::Active => {
                 match self.get_or_create_agent(target_agent_id).await {
                     Ok(runtime) => {
+                        let child_turn_baseline = runtime.agent_state().await?.turn_index;
                         let receipt = runtime
                             .agent_message_delivery_service()
                             .deliver(&prepared)
                             .await?;
-                        (Some(identity), Some(runtime), receipt)
+                        (
+                            Some(identity),
+                            Some(runtime),
+                            Some(child_turn_baseline),
+                            receipt,
+                        )
                     }
                     Err(activation_error) => {
                         let latest_identity = self.agent_identity_record(target_agent_id)?;
@@ -4247,7 +4253,12 @@ impl RuntimeHost {
                                 .runtime_db()
                                 .agent_message_deliveries()
                                 .admit_without_queue(&prepared.record)?;
-                            (Some(latest_identity.unwrap_or(identity)), None, receipt)
+                            (
+                                Some(latest_identity.unwrap_or(identity)),
+                                None,
+                                None,
+                                receipt,
+                            )
                         } else {
                             return Err(activation_error);
                         }
@@ -4259,7 +4270,7 @@ impl RuntimeHost {
                     .runtime_db()
                     .agent_message_deliveries()
                     .admit_without_queue(&prepared.record)?;
-                (identity, None, receipt)
+                (identity, None, None, receipt)
             }
         };
         if receipt.outcome != AgentMessageDeliveryOutcome::Accepted {
@@ -4295,13 +4306,18 @@ impl RuntimeHost {
                 "use an agent id already available through the caller's authorized agent context",
             ))
         })?;
-        let runtime = runtime.ok_or_else(|| {
+        runtime.ok_or_else(|| {
             anyhow!(
                 "accepted delivery {} targets an inactive agent",
                 receipt.delivery_id
             )
         })?;
-        let child_turn_baseline = runtime.agent_state().await?.turn_index;
+        let child_turn_baseline = child_turn_baseline.ok_or_else(|| {
+            anyhow!(
+                "accepted delivery {} is missing its pre-delivery turn baseline",
+                receipt.delivery_id
+            )
+        })?;
 
         let mut task_detail = json!({
             "target_agent_id": target_agent_id,
@@ -6458,6 +6474,86 @@ mod tests {
             .expect("terminal invocation must not delete its target during restart convergence");
         assert_eq!(restarted_identity.status, AgentRegistryStatus::Active);
         assert!(restarted.agent_data_dir(&created.agent_id).exists());
+    }
+
+    #[tokio::test]
+    async fn existing_agent_samples_child_turn_before_delivery_admission() {
+        struct DeliveryCheckpointGuard;
+
+        impl Drop for DeliveryCheckpointGuard {
+            fn drop(&mut self) {
+                crate::runtime::release_delivery_checkpoint();
+            }
+        }
+
+        let (_home, host) = test_host();
+        let parent = host.default_runtime().await.unwrap();
+        let created = parent
+            .agent_invocation_service()
+            .invoke(InvokeAgentRequest {
+                target: InvokeAgentTarget::NewSubagent {
+                    template: None,
+                    workspace_mode: ChildAgentWorkspaceMode::Inherit,
+                    model_resolution: Some(inherited_model_resolution("openai", "gpt-5.4")),
+                },
+                message: "first invocation".into(),
+                authority_class: AuthorityClass::OperatorInstruction,
+            })
+            .await
+            .unwrap();
+        let first_terminal = wait_for_terminal_task(&parent, &created.task_handle.task_id).await;
+        assert_eq!(first_terminal.status, TaskStatus::Completed);
+
+        let child = host.get_or_create_agent(&created.agent_id).await.unwrap();
+        for _ in 0..100 {
+            if child.agent_state().await.unwrap().status == AgentStatus::Asleep {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let child_turn_baseline = child.agent_state().await.unwrap().turn_index;
+
+        crate::runtime::enable_delivery_checkpoint(created.agent_id.clone());
+        let _checkpoint_guard = DeliveryCheckpointGuard;
+        let parent_for_invoke = parent.clone();
+        let child_agent_id = created.agent_id.clone();
+        let invocation = tokio::spawn(async move {
+            parent_for_invoke
+                .agent_invocation_service()
+                .invoke(InvokeAgentRequest {
+                    target: InvokeAgentTarget::ExistingAgent {
+                        agent_id: child_agent_id,
+                    },
+                    message: "second invocation".into(),
+                    authority_class: AuthorityClass::OperatorInstruction,
+                })
+                .await
+        });
+
+        crate::runtime::wait_for_delivery_checkpoint().await;
+        for _ in 0..100 {
+            let state = child.agent_state().await.unwrap();
+            if state.turn_index > child_turn_baseline && state.status == AgentStatus::Asleep {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let child_state = child.agent_state().await.unwrap();
+        assert!(child_state.turn_index > child_turn_baseline);
+        assert_eq!(child_state.status, AgentStatus::Asleep);
+
+        crate::runtime::release_delivery_checkpoint();
+        let receipt = invocation.await.unwrap().unwrap();
+        let terminal = wait_for_terminal_task(&parent, &receipt.task_handle.task_id).await;
+        assert_eq!(terminal.status, TaskStatus::Completed);
+        assert_eq!(
+            terminal
+                .detail
+                .as_ref()
+                .and_then(|detail| detail.get("child_turn_baseline"))
+                .and_then(Value::as_u64),
+            Some(child_turn_baseline)
+        );
     }
 
     #[tokio::test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -35,7 +35,10 @@ mod worktree;
 
 pub(crate) use agent_message_delivery::AgentMessageDeliveryService;
 #[cfg(test)]
-pub(crate) use agent_message_delivery::PreparedAgentMessageDelivery;
+pub(crate) use agent_message_delivery::{
+    enable_delivery_checkpoint, release_delivery_checkpoint, wait_for_delivery_checkpoint,
+    PreparedAgentMessageDelivery,
+};
 pub use first_run_intro::maybe_enqueue_first_run_intro;
 pub(crate) use lifecycle::LightweightAgentStateProjection;
 pub(crate) use repair::is_wake_only_message;

--- a/src/runtime/agent_message_delivery.rs
+++ b/src/runtime/agent_message_delivery.rs
@@ -2,6 +2,13 @@ use anyhow::{bail, Result};
 use chrono::Utc;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
+#[cfg(test)]
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Mutex,
+};
+#[cfg(test)]
+use tokio::sync::Notify;
 
 use super::RuntimeHandle;
 use crate::types::{
@@ -11,6 +18,17 @@ use crate::types::{
 };
 
 const DELIVERY_IDEMPOTENCY_NAMESPACE: &str = "agent_message_delivery";
+
+#[cfg(test)]
+static DELIVERY_CHECKPOINT_ENABLED: AtomicBool = AtomicBool::new(false);
+#[cfg(test)]
+static DELIVERY_AT_CHECKPOINT: AtomicBool = AtomicBool::new(false);
+#[cfg(test)]
+static DELIVERY_CHECKPOINT_AGENT_ID: Mutex<Option<String>> = Mutex::new(None);
+#[cfg(test)]
+static DELIVERY_REACHED_CHECKPOINT: Notify = Notify::const_new();
+#[cfg(test)]
+static DELIVERY_ALLOW_CONTINUE: Notify = Notify::const_new();
 
 pub(crate) struct AgentMessageDeliveryService<'a> {
     runtime: &'a RuntimeHandle,
@@ -32,9 +50,13 @@ impl AgentMessageDeliveryService<'_> {
         &self,
         prepared: &PreparedAgentMessageDelivery,
     ) -> Result<AgentMessageDeliveryReceipt> {
-        self.runtime
+        let receipt = self
+            .runtime
             .enqueue_delivery(prepared.message.clone(), &prepared.record)
-            .await
+            .await?;
+        #[cfg(test)]
+        wait_at_delivery_checkpoint(&prepared.record.target_agent_id).await;
+        Ok(receipt)
     }
 
     pub(crate) fn prepare(
@@ -136,6 +158,42 @@ impl AgentMessageDeliveryService<'_> {
         };
         Ok(PreparedAgentMessageDelivery { message, record })
     }
+}
+
+#[cfg(test)]
+async fn wait_at_delivery_checkpoint(agent_id: &str) {
+    if !DELIVERY_CHECKPOINT_ENABLED.load(Ordering::SeqCst)
+        || DELIVERY_CHECKPOINT_AGENT_ID.lock().unwrap().as_deref() != Some(agent_id)
+    {
+        return;
+    }
+    DELIVERY_AT_CHECKPOINT.store(true, Ordering::SeqCst);
+    DELIVERY_REACHED_CHECKPOINT.notify_one();
+    DELIVERY_ALLOW_CONTINUE.notified().await;
+    DELIVERY_AT_CHECKPOINT.store(false, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(crate) fn enable_delivery_checkpoint(agent_id: impl Into<String>) {
+    *DELIVERY_CHECKPOINT_AGENT_ID.lock().unwrap() = Some(agent_id.into());
+    DELIVERY_AT_CHECKPOINT.store(false, Ordering::SeqCst);
+    DELIVERY_CHECKPOINT_ENABLED.store(true, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(crate) async fn wait_for_delivery_checkpoint() {
+    while !DELIVERY_AT_CHECKPOINT.load(Ordering::SeqCst) {
+        DELIVERY_REACHED_CHECKPOINT.notified().await;
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn release_delivery_checkpoint() {
+    if !DELIVERY_CHECKPOINT_ENABLED.swap(false, Ordering::SeqCst) {
+        return;
+    }
+    *DELIVERY_CHECKPOINT_AGENT_ID.lock().unwrap() = None;
+    DELIVERY_ALLOW_CONTINUE.notify_one();
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary
- sample an existing agent’s child turn baseline before admitting the invocation delivery
- preserve the pre-delivery baseline for the ActorInvocation monitor so a fast completed turn cannot be mistaken for prior history
- add a deterministic regression checkpoint covering an asleep child completing before `deliver` returns

## Verification
- `cargo test --lib host::tests::existing_agent_samples_child_turn_before_delivery_admission -- --nocapture`
- `cargo test --test runtime_subagents -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2840