### PR TITLE
fix: fail agent deletion closed when agent home is a symlink or escapes the agents root

### DIFF
--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -595,6 +595,11 @@ impl RuntimeHost {
         if !data_dir.exists() {
             return Ok(());
         }
+        // Refuse to delete anything that is not a runtime-managed directory:
+        // symlinked homes or paths resolving outside the agents root fail the
+        // job instead of removing unintended files.
+        let agents_root = self.config().data_dir.join("agents");
+        ensure_deletable_agent_home(&data_dir, &agents_root)?;
         // Rename to a trash name first to avoid partial-state visibility.
         let trash_dir = data_dir.with_extension("deleting_trash");
         if trash_dir.exists() {
@@ -695,5 +700,96 @@ impl RuntimeHost {
         // Fallback: remove directory directly.
         std::fs::remove_dir_all(path)
             .with_context(|| format!("removing worktree directory {}", path.display()))
+    }
+}
+
+/// Validate that an agent home path is safe to delete: it must be a real
+/// directory (not a symlink) that resolves inside the runtime agents root.
+/// Deletion fails closed so a tampered home cannot remove files outside the
+/// runtime data directory.
+fn ensure_deletable_agent_home(data_dir: &Path, agents_root: &Path) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(data_dir)
+        .with_context(|| format!("inspecting agent home {}", data_dir.display()))?;
+    if metadata.file_type().is_symlink() {
+        anyhow::bail!(
+            "agent home {} is a symlink; refusing deletion",
+            data_dir.display()
+        );
+    }
+    if !metadata.is_dir() {
+        anyhow::bail!(
+            "agent home {} is not a directory; refusing deletion",
+            data_dir.display()
+        );
+    }
+    let canonical_home = std::fs::canonicalize(data_dir)
+        .with_context(|| format!("canonicalizing agent home {}", data_dir.display()))?;
+    let canonical_root = std::fs::canonicalize(agents_root)
+        .with_context(|| format!("canonicalizing agents root {}", agents_root.display()))?;
+    if !canonical_home.starts_with(&canonical_root) {
+        anyhow::bail!(
+            "agent home {} resolves outside agents root {}; refusing deletion",
+            canonical_home.display(),
+            canonical_root.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deletable_home_accepts_plain_directory_inside_root() {
+        let root = tempfile::tempdir().unwrap();
+        let agents = root.path().join("agents");
+        std::fs::create_dir_all(agents.join("alpha")).unwrap();
+        ensure_deletable_agent_home(&agents.join("alpha"), &agents).unwrap();
+    }
+
+    #[test]
+    fn deletable_home_rejects_missing_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let agents = root.path().join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        let err = ensure_deletable_agent_home(&agents.join("missing"), &agents).unwrap_err();
+        assert!(err.to_string().contains("inspecting agent home"));
+    }
+
+    #[test]
+    fn deletable_home_rejects_plain_file() {
+        let root = tempfile::tempdir().unwrap();
+        let agents = root.path().join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("alpha"), "not a dir").unwrap();
+        let err = ensure_deletable_agent_home(&agents.join("alpha"), &agents).unwrap_err();
+        assert!(err.to_string().contains("is not a directory"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deletable_home_rejects_symlink_pointing_inside_root() {
+        let root = tempfile::tempdir().unwrap();
+        let agents = root.path().join("agents");
+        let real = root.path().join("real-alpha");
+        std::fs::create_dir_all(&real).unwrap();
+        std::fs::create_dir_all(&agents).unwrap();
+        std::os::unix::fs::symlink(&real, agents.join("alpha")).unwrap();
+        let err = ensure_deletable_agent_home(&agents.join("alpha"), &agents).unwrap_err();
+        assert!(err.to_string().contains("is a symlink"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deletable_home_rejects_symlink_pointing_outside_root() {
+        let root = tempfile::tempdir().unwrap();
+        let agents = root.path().join("agents");
+        let outside = root.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::create_dir_all(&agents).unwrap();
+        std::os::unix::fs::symlink(&outside, agents.join("alpha")).unwrap();
+        let err = ensure_deletable_agent_home(&agents.join("alpha"), &agents).unwrap_err();
+        assert!(err.to_string().contains("is a symlink"));
     }
 }

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -71,4 +71,5 @@ http_async_tests!(
     control_prompt_is_open_over_unix_socket_auto,
     control_runtime_status_is_open_over_unix_socket_when_auth_required,
     control_runtime_readiness_is_open_over_unix_socket_when_auth_required,
+    control_agent_delete_fails_closed_when_home_is_symlink,
 );

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -32,6 +32,7 @@ use tokio::net::TcpListener;
 use tokio::net::UnixListener;
 use tokio::time::{sleep, Duration, Instant};
 
+use super::runtime_helpers::wait_until_async_for;
 use super::{
     attach_default_workspace, connect_addr, git, init_git_repo, spawn_server,
     spawn_server_for_host, spawn_server_with_config, spawn_server_with_runtime_config,
@@ -188,6 +189,67 @@ pub async fn control_agent_delete_rejects_default_and_reports_unknown() -> Resul
         .send()
         .await?;
     assert_eq!(unknown.status(), reqwest::StatusCode::NOT_FOUND);
+
+    server.abort();
+    Ok(())
+}
+
+#[cfg(unix)]
+pub async fn control_agent_delete_fails_closed_when_home_is_symlink() -> Result<()> {
+    let host = RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ok")))?;
+    attach_default_workspace(&host).await?;
+    host.create_named_agent("delete-symlink", None).await?;
+    host.get_or_create_agent("delete-symlink").await?;
+
+    // Tamper with the agent home: replace it with a symlink to a directory
+    // outside the agents root. Deletion must fail the job, not the victim.
+    let agents_root = host.config().data_dir.join("agents");
+    let home = agents_root.join("delete-symlink");
+    let victim = tempdir()?;
+    std::fs::write(victim.path().join("sentinel.txt"), "keep me")?;
+    std::fs::remove_dir_all(&home)?;
+    std::os::unix::fs::symlink(victim.path(), &home)?;
+
+    let (base, server) = spawn_server_for_host(host.clone()).await?;
+    let client = Client::new();
+    let response: serde_json::Value = client
+        .delete(format!("{base}/api/control/agents/delete-symlink"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let deletion_id = response["job"]["deletion_id"]
+        .as_str()
+        .expect("deletion id")
+        .to_string();
+
+    wait_until_async_for(Duration::from_secs(10), || {
+        let client = client.clone();
+        let url = format!("{base}/api/control/agents/delete-symlink/delete-status");
+        async move {
+            let status: serde_json::Value = client.get(url).send().await?.json().await?;
+            Ok(status["job"]["status"] == serde_json::json!("retryable_failed"))
+        }
+    })
+    .await?;
+
+    let status: serde_json::Value = client
+        .get(format!(
+            "{base}/api/control/agents/delete-symlink/delete-status"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(status["identity"]["status"], "deleting");
+    assert_eq!(status["job"]["deletion_id"], deletion_id);
+    assert!(status["job"]["last_error"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("is a symlink"));
+    assert!(victim.path().join("sentinel.txt").exists());
+    assert!(home.symlink_metadata().is_ok());
 
     server.abort();
     Ok(())


### PR DESCRIPTION
## What changed

Deletion Home phase hardening (part of #2418): before trashing/removing an agent home, the deletion job validates the home path via `ensure_deletable_agent_home`:

- `symlink_metadata` must report a real directory — symlink, plain file, and missing path are all refused
- the canonicalized home must stay inside the canonicalized `data_dir/agents` root

Any violation fails the deletion job (`retryable_failed`) while the identity remains `deleting`; the runtime never follows the symlink or removes files outside the agents root.

## Why

The Home phase previously operated on whatever `data_dir/agents/<agent_id>` resolved to, so a tampered home could turn agent deletion into deletion of an arbitrary directory. Deletion is the only path that removes whole trees, so it must fail closed on anything that is not a runtime-managed directory.

## Tests

- Unit: `deletion::tests::deletable_home_*` — accepts a plain directory inside the root; rejects missing directory, plain file, symlink pointing inside the root, symlink pointing outside the root.
- Integration (unix): `control_agent_delete_fails_closed_when_home_is_symlink` — home replaced by a symlink to a sentinel dir; `DELETE /api/control/agents/{id}` starts a job, status reaches `retryable_failed` with an `is a symlink` error, the sentinel file and the symlink itself survive, and the identity stays `deleting`.

Verification: `cargo fmt --all -- --check`, `RUSTFLAGS="-D warnings" cargo check --all-targets`, `cargo test --lib deletion::`, and the new integration test all pass.

Part of #2418 (acceptance sweep); follow-up slices cover #2794 reincarnation.
