### PR TITLE
feat: show agent incarnation badge in web gui

### DIFF
--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -257,6 +257,14 @@ export function AgentOverviewPanel({
           </div>
         )}
         {!renaming && agent.name ? <small className="agent-id-line">{agent.id}</small> : null}
+        {!renaming && agent.incarnation != null && agent.incarnation > 1 ? (
+          <small
+            className="agent-incarnation-line"
+            title={t("agent.incarnationTitle", { value: agent.incarnation })}
+          >
+            {t("agent.incarnationBadge", { value: agent.incarnation })}
+          </small>
+        ) : null}
         {renameError ? (
           <small className="agent-rename-error" role="alert">
             {renameError}

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -913,6 +913,10 @@ const en = {
     deleteConfirmPrompt: "Type {{id}} to confirm deletion. This cannot be undone.",
     deleteConfirmLabel: "Type agent ID to confirm",
     cascadePrivateChildren: "Also delete private child agents",
+    // Incarnation
+    incarnationBadge: "Incarnation {{value}}",
+    incarnationTitle:
+      "This id was explicitly recreated after a completed deletion; incarnation {{value}} is a fresh identity and does not inherit the previous agent's state.",
     // Rename
     rename: "Rename",
     renameAria: "Rename agent",

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -914,6 +914,10 @@ const zh: Record<string, any> = {
     deleteConfirmPrompt: "输入 {{id}} 以确认删除。此操作不可撤销。",
     deleteConfirmLabel: "输入智能体 ID 以确认",
     cascadePrivateChildren: "同时删除私有子智能体",
+    // 转世（删除后重建）
+    incarnationBadge: "第 {{value}} 代身份",
+    incarnationTitle:
+      "该 ID 在删除清理完成后被显式重建；第 {{value}} 代是全新身份，不继承原智能体的任何状态。",
     // Rename
     rename: "重命名",
     renameAria: "重命名 agent",

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -24,6 +24,7 @@ function agentStateFixture(agentId: string): components["schemas"]["AgentStateSn
         profile_preset: "public_named",
         status: "active",
         is_default_agent: false,
+        incarnation: 1,
       },
       agent: {
         id: agentId,
@@ -1399,6 +1400,7 @@ describe("createRuntimeClient agent naming", () => {
               identity: {
                 agent_id: "alpha",
                 name: "Alpha One",
+                incarnation: 2,
                 is_default_agent: false,
                 visibility: "public",
                 ownership: "self_owned",
@@ -1430,10 +1432,11 @@ describe("createRuntimeClient agent naming", () => {
         visibility: "public",
         ownership: "self_owned",
         isDefaultAgent: false,
+        incarnation: 2,
       }),
     );
     expect(bootstrap.agents[1]).toEqual(
-      expect.objectContaining({ id: "main", isDefaultAgent: true }),
+      expect.objectContaining({ id: "main", isDefaultAgent: true, incarnation: undefined }),
     );
     expect(bootstrap.agents[1].name).toBeUndefined();
   });

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -200,6 +200,7 @@ interface AgentListEntryDto {
     visibility?: string;
     ownership?: string;
     profile_preset?: string;
+    incarnation?: number;
   };
   status?: string;
   scheduling_posture?: {
@@ -2211,6 +2212,7 @@ function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: B
   const visibility = entry.identity?.visibility;
   const ownership = entry.identity?.ownership;
   const isDefaultAgent = entry.identity?.is_default_agent ?? undefined;
+  const incarnation = entry.identity?.incarnation ?? undefined;
   const wsList = state?.workspace?.workspaces ?? [];
   const activeWs = wsList.find((w) => w.is_active);
   // Fallback to list entry's active_workspace_entry when state hasn't loaded yet.
@@ -2251,6 +2253,7 @@ function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: B
     visibility,
     ownership,
     isDefaultAgent,
+    incarnation,
     badge: badgeFor(id),
     badgeHue: hueFor(id),
     profile,

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -2251,6 +2251,14 @@ export interface components {
             identity: {
                 agent_id: string;
                 delegated_from_task_id?: string | null;
+                /**
+                 * Format: uint64
+                 * @description Monotonic incarnation counter; 1 for the original identity and +1
+                 *      for every explicit recreation of the same agent id after a fully
+                 *      completed deletion.
+                 * @default 1
+                 */
+                incarnation: number;
                 is_default_agent: boolean;
                 /** @enum {string} */
                 kind: "default" | "named" | "child";
@@ -2294,6 +2302,14 @@ export interface components {
             identity: {
                 agent_id: string;
                 delegated_from_task_id?: string | null;
+                /**
+                 * Format: uint64
+                 * @description Monotonic incarnation counter; 1 for the original identity and +1
+                 *      for every explicit recreation of the same agent id after a fully
+                 *      completed deletion.
+                 * @default 1
+                 */
+                incarnation: number;
                 is_default_agent: boolean;
                 /** @enum {string} */
                 kind: "default" | "named" | "child";
@@ -2527,6 +2543,14 @@ export interface components {
             identity: {
                 agent_id: string;
                 delegated_from_task_id?: string | null;
+                /**
+                 * Format: uint64
+                 * @description Monotonic incarnation counter; 1 for the original identity and +1
+                 *      for every explicit recreation of the same agent id after a fully
+                 *      completed deletion.
+                 * @default 1
+                 */
+                incarnation: number;
                 is_default_agent: boolean;
                 /** @enum {string} */
                 kind: "default" | "named" | "child";
@@ -2628,6 +2652,14 @@ export interface components {
                     identity: {
                         agent_id: string;
                         delegated_from_task_id?: string | null;
+                        /**
+                         * Format: uint64
+                         * @description Monotonic incarnation counter; 1 for the original identity and +1
+                         *      for every explicit recreation of the same agent id after a fully
+                         *      completed deletion.
+                         * @default 1
+                         */
+                        incarnation: number;
                         is_default_agent: boolean;
                         /** @enum {string} */
                         kind: "default" | "named" | "child";
@@ -2789,6 +2821,14 @@ export interface components {
                 identity: {
                     agent_id: string;
                     delegated_from_task_id?: string | null;
+                    /**
+                     * Format: uint64
+                     * @description Monotonic incarnation counter; 1 for the original identity and +1
+                     *      for every explicit recreation of the same agent id after a fully
+                     *      completed deletion.
+                     * @default 1
+                     */
+                    incarnation: number;
                     is_default_agent: boolean;
                     /** @enum {string} */
                     kind: "default" | "named" | "child";
@@ -3046,6 +3086,14 @@ export interface components {
                 identity: {
                     agent_id: string;
                     delegated_from_task_id?: string | null;
+                    /**
+                     * Format: uint64
+                     * @description Monotonic incarnation counter; 1 for the original identity and +1
+                     *      for every explicit recreation of the same agent id after a fully
+                     *      completed deletion.
+                     * @default 1
+                     */
+                    incarnation: number;
                     is_default_agent: boolean;
                     /** @enum {string} */
                     kind: "default" | "named" | "child";
@@ -3241,6 +3289,14 @@ export interface components {
                     identity: {
                         agent_id: string;
                         delegated_from_task_id?: string | null;
+                        /**
+                         * Format: uint64
+                         * @description Monotonic incarnation counter; 1 for the original identity and +1
+                         *      for every explicit recreation of the same agent id after a fully
+                         *      completed deletion.
+                         * @default 1
+                         */
+                        incarnation: number;
                         is_default_agent: boolean;
                         /** @enum {string} */
                         kind: "default" | "named" | "child";

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -331,6 +331,8 @@ export interface AgentSummary {
   ownership?: string;
   /** True for the runtime default agent, which cannot be renamed. */
   isDefaultAgent?: boolean;
+  /** Monotonic incarnation counter; 1 unless the id was recreated after a completed deletion. */
+  incarnation?: number;
   badge: string;
   badgeTone?: "muted";
   badgeHue?: number;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -5695,6 +5695,17 @@ code {
   color: var(--muted);
 }
 
+.agent-incarnation-line {
+  display: block;
+  font-size: 11px;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border-radius: 999px;
+  padding: 1px 8px;
+  width: fit-content;
+  margin-top: 4px;
+}
+
 .agent-rename-error {
   display: block;
   margin-top: 4px;


### PR DESCRIPTION
## 概要

#2794 的 GUI 收尾切片（后端 incarnation 数据模型与 API 已随 #2851 合并）。

- `AgentOverviewPanel` 在 agent 名称下方显示 incarnation 徽标，**仅当 `incarnation > 1` 时展示**（原始身份 `incarnation = 1` 不显示，避免噪音）。
- 徽标带 tooltip，说明该 id 是删除清理完成后显式重建的全新身份，不继承原 agent 状态。
- `client.ts` / `types.ts`：`AgentSummary` 增加 `incarnation?: number`，从 list DTO 的 `identity.incarnation` 投影。
- `make transport-types` 重新生成 `generated/openapi.ts`，与 #2851 合入的 OpenAPI 规范对齐（CI 会校验生成文件一致性）。
- i18n：en / zh-CN 补充 `incarnationBadge` / `incarnationTitle` 文案。

## 验证

- `npm run typecheck`（tsconfig.json + tsconfig.node.json）通过
- `npx vitest run src/runtime/client.test.ts src/i18n/resources.test.ts`：42 tests 全过（含 incarnation 投影断言）
- `npm run build` 通过