### PR TITLE
refactor: remove legacy agent identity surface

### DIFF
--- a/docs/website/concepts/runtime-model.md
+++ b/docs/website/concepts/runtime-model.md
@@ -82,7 +82,7 @@ completion report.
 A task is a **supervised execution handle**. Tasks include:
 
 - **Command tasks** — Shell commands, builds, tests, scripts
-- **Child agent tasks** — Delegated agents spawned via `SpawnAgent`
+- **Child agent tasks** — Delegated agents invoked via `InvokeAgent`
 
 Task lifecycle is independent of the agent's user-facing answer. You can:
 

--- a/docs/website/guides/README.md
+++ b/docs/website/guides/README.md
@@ -45,7 +45,7 @@ Wire Holon into external systems through its control plane.
 
 Work with multiple agents, durable objectives, and reusable skills.
 
-- **[Multi-agent collaboration](/guides/multi-agent)** — spawning child
+- **[Multi-agent collaboration](/guides/multi-agent)** — creating and invoking
   agents, supervision contracts, and workspace modes.
 - **[Work items guide](/guides/work-items)** — tracking durable objectives
   with plans, todo lists, and lifecycle management.

--- a/docs/website/guides/multi-agent.md
+++ b/docs/website/guides/multi-agent.md
@@ -1,23 +1,22 @@
 ---
 title: Multi-agent collaboration
-summary: Spawning child agents, supervision contracts, and workspace modes for parallel work.
+summary: Creating and invoking agents, supervision contracts, and workspace modes for parallel work.
 order: 35
 ---
 
 # Multi-Agent Collaboration
 
-Holon supports spawning child agents for parallel work, delegation, and
-specialized subtasks. Each child agent runs in its own context with a
-well-defined supervision contract.
+Holon supports creating addressable agents and invoking private supervised
+agents for parallel work, delegation, and specialized subtasks.
 
 ## Concepts
 
-### Agent Presets
+### Agent operations
 
-| Preset | Ownership | Return value | When to use |
-|--------|-----------|-------------|-------------|
-| `private_child` (default) | Parent-supervised | `agent_id` + `task_handle` | Delegated subtasks, parallel work |
-| `public_named` | Self-owned | `agent_id` only | Long-lived, addressable agents |
+| Operation | Return value | When to use |
+|-----------|--------------|-------------|
+| `CreateAgent` | `agent_id` | Create a long-lived, addressable agent |
+| `InvokeAgent` | `agent_id` + `task_handle` | Run a parent-supervised delegated task |
 
 ### Workspace Modes
 
@@ -28,8 +27,8 @@ well-defined supervision contract.
 
 ### Task Handle Supervision
 
-When spawning a `private_child`, the parent receives a `task_handle` with a
-`task_id`. Use this to:
+When calling `InvokeAgent`, the parent receives a `task_handle` with a `task_id`.
+Use this to:
 
 - **TaskStatus** — Inspect lifecycle, waiting state, and metadata
 - **TaskOutput** — Read bounded output or wait for completion
@@ -71,13 +70,13 @@ than its output warrants.
 
 ### Parallel investigation
 
-Spawn multiple children to explore different aspects simultaneously:
+Invoke multiple agents to explore different aspects simultaneously:
 
 ```
 Parent agent:
-  SpawnAgent("Review src/runtime/ for performance issues")
-  SpawnAgent("Review src/runtime/ for error handling gaps")
-  SpawnAgent("Review src/runtime/ for missing tests")
+  InvokeAgent("Review src/runtime/ for performance issues")
+  InvokeAgent("Review src/runtime/ for error handling gaps")
+  InvokeAgent("Review src/runtime/ for missing tests")
   → Wait for all task handles to complete
   → Aggregate findings into final report
 ```
@@ -88,8 +87,8 @@ Assign specialized agents for distinct concerns:
 
 ```
 Parent agent:
-  SpawnAgent("Code review", template="code-reviewer")
-  SpawnAgent("Test writing", template="test-writer")
+  InvokeAgent("Code review", template="code-reviewer")
+  InvokeAgent("Test writing", template="test-writer")
 ```
 
 ### Safe experimentation
@@ -99,8 +98,8 @@ workspace:
 
 ```
 Parent agent:
-  SpawnAgent("Try alternative implementation approach",
-             workspace_mode=worktree)
+  InvokeAgent("Try alternative implementation approach",
+              workspace_mode=worktree)
   → Child works in isolated worktree
   → Parent reviews child's output
   → Parent applies the best approach to main workspace
@@ -110,7 +109,7 @@ Parent agent:
 
 A typical parent-child interaction:
 
-1. **Spawn** — Parent calls `SpawnAgent` with `initial_message` describing the
+1. **Invoke** — Parent calls `InvokeAgent` with `initial_message` describing the
    task
 2. **Monitor** — Parent uses `TaskStatus` to check if the child is still
    working, sleeping, or waiting
@@ -131,7 +130,7 @@ The parent remains responsible for:
 - **Supervise explicitly.** Check `TaskStatus` before assuming completion.
 - **Treat child output as evidence.** Review and verify before passing to the
   user.
-- **Limit parallelism.** Spawn only as many children as the task actually
+- **Limit parallelism.** Invoke only as many agents as the task actually
   benefits from.
 - **Stop idle children.** Use `TaskStop` for children that are no longer
   needed.

--- a/docs/website/guides/solve.md
+++ b/docs/website/guides/solve.md
@@ -269,4 +269,4 @@ point when you need arbitrary provider environment variables.
 - [Holon CLI reference](/reference/cli) — full command tree
 - [Configuration reference](/reference/configuration) — model and provider setup
 - [Integration guide](/guides/integration) — HTTP control plane access
-- [Multi-agent collaboration](/guides/multi-agent) — spawning child agents
+- [Multi-agent collaboration](/guides/multi-agent) — creating and invoking agents

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -361,7 +361,7 @@ treated as schema surfaces, not incidental Rust structs:
 
 | Shape | Returned by | Key stability concerns |
 |-------|-------------|------------------------|
-| `AgentSummary` | `/agents/:id/status`, `/agents/:id/state`, agent creation | Identity visibility/ownership/profile fields, status enum, model state, workspace fields. |
+| `AgentSummary` | `/agents/:id/status`, `/agents/:id/state`, agent creation | Identity/profile fields, status enum, model state, workspace fields. |
 | `AgentListEntry` | `/agents/list` | Keep lightweight; avoid reintroducing heavy runtime/model payloads. |
 | `TaskRecord` | `/agents/:id/tasks`, task creation, state snapshot, events | Task kind/status enums, detail truncation, recovery metadata, output references. |
 | `WorkItemRecord` | work-item creation, state snapshot, events | State, plan status, plan artifact, todo list, blockers/recheck timestamps. |
@@ -371,6 +371,14 @@ treated as schema surfaces, not incidental Rust structs:
 | `StreamEventEnvelope` | events page and SSE stream | Projection/redaction, provenance, payload versioning. |
 | `RuntimeStatusResponse` | runtime readiness/status | Startup/runtime config surface and credential redaction. |
 | `SkillInstallKind` | skills install | Tagged union variants and local/remote package semantics. |
+
+### v0.38.0 identity migration legacy
+
+`AgentVisibility`, `AgentOwnership`, `PrivateChild`, and `PublicNamed` are
+retained only as v0.38.0 migration vocabulary. They are not current public API
+identity discriminators. New integrations should use `CreateAgent` for
+addressable agent creation and `InvokeAgent` for parent-supervised delegated
+execution.
 
 ## Detected contract gaps
 

--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -728,29 +728,7 @@
                 "agent_id": {
                   "type": "string"
                 },
-                "created_at": {
-                  "format": "date-time",
-                  "type": "string"
-                },
                 "delegated_from_task_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "deleted_at": {
-                  "format": "date-time",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "durability": {
-                  "enum": [
-                    "persistent",
-                    "ephemeral",
-                    null
-                  ],
                   "type": [
                     "string",
                     "null"
@@ -758,18 +736,13 @@
                 },
                 "incarnation": {
                   "default": 1,
-                  "description": "Monotonic incarnation counter for this agent id. Deletion does not\n reset it: recreating a fully deleted id produces incarnation + 1 so\n historical evidence stays distinguishable from the new incarnation.",
+                  "description": "Monotonic incarnation counter; 1 for the original identity and +1\n for every explicit recreation of the same agent id after a fully\n completed deletion.",
                   "format": "uint64",
                   "minimum": 0.0,
                   "type": "integer"
                 },
-                "kind": {
-                  "enum": [
-                    "default",
-                    "named",
-                    "child"
-                  ],
-                  "type": "string"
+                "is_default_agent": {
+                  "type": "boolean"
                 },
                 "lineage_parent_agent_id": {
                   "type": [
@@ -783,39 +756,11 @@
                     "null"
                   ]
                 },
-                "ownership": {
-                  "enum": [
-                    "parent_supervised",
-                    "self_owned",
-                    null
-                  ],
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
                 "parent_agent_id": {
                   "type": [
                     "string",
                     "null"
                   ]
-                },
-                "profile_preset": {
-                  "enum": [
-                    "private_child",
-                    "public_named",
-                    null
-                  ],
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "revision": {
-                  "default": 0,
-                  "format": "uint64",
-                  "minimum": 0.0,
-                  "type": "integer"
                 },
                 "status": {
                   "enum": [
@@ -824,26 +769,12 @@
                     "deleted"
                   ],
                   "type": "string"
-                },
-                "updated_at": {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                "visibility": {
-                  "enum": [
-                    "public",
-                    "private"
-                  ],
-                  "type": "string"
                 }
               },
               "required": [
                 "agent_id",
-                "kind",
-                "visibility",
                 "status",
-                "created_at",
-                "updated_at"
+                "is_default_agent"
               ],
               "type": "object"
             },
@@ -1057,13 +988,6 @@
                     "null"
                   ]
                 },
-                "preset": {
-                  "enum": [
-                    "private_child",
-                    "public_named"
-                  ],
-                  "type": "string"
-                },
                 "receipt_id": {
                   "type": "string"
                 },
@@ -1082,7 +1006,6 @@
                 "receipt_id",
                 "agent_id",
                 "display_name",
-                "preset",
                 "stage",
                 "lifecycle",
                 "created",

--- a/docs/website/reference/model-tool-schema-inventory.md
+++ b/docs/website/reference/model-tool-schema-inventory.md
@@ -49,7 +49,7 @@ families in `src/types.rs` (`ToolCapabilityFamily`):
 | `CoreAgent` | Core agent operations (state, memory, work items, scheduling, CLI/config introspection) | MemorySearch, WaitFor, ListWorkItems, ListModelProviders |
 | `LocalEnvironment` | Workspace-local operations | ExecCommand, ApplyPatch, ViewImage, GetWorkspaceState, SwitchWorkspace, CreateWorktree |
 | `Web` | Public web access | WebFetch, WebSearch |
-| `AgentCreation` | Agent spawning and delegation | SpawnAgent |
+| `AgentCreation` | Agent creation and supervised invocation | CreateAgent, InvokeAgent |
 | `AuthorityExpanding` | Tools that change workspace authority or destroy registered artifacts | AttachWorkspace, DetachWorkspace, RemoveWorktree |
 | `ExternalTrigger` | External event ingress | CreateExternalTrigger, CancelExternalTrigger |
 

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -179,14 +179,6 @@
               "is_default_agent": {
                 "type": "boolean"
               },
-              "kind": {
-                "enum": [
-                  "default",
-                  "named",
-                  "child"
-                ],
-                "type": "string"
-              },
               "lineage_parent_agent_id": {
                 "type": [
                   "string",
@@ -199,25 +191,11 @@
                   "null"
                 ]
               },
-              "ownership": {
-                "enum": [
-                  "parent_supervised",
-                  "self_owned"
-                ],
-                "type": "string"
-              },
               "parent_agent_id": {
                 "type": [
                   "string",
                   "null"
                 ]
-              },
-              "profile_preset": {
-                "enum": [
-                  "private_child",
-                  "public_named"
-                ],
-                "type": "string"
               },
               "status": {
                 "enum": [
@@ -226,21 +204,10 @@
                   "deleted"
                 ],
                 "type": "string"
-              },
-              "visibility": {
-                "enum": [
-                  "public",
-                  "private"
-                ],
-                "type": "string"
               }
             },
             "required": [
               "agent_id",
-              "kind",
-              "visibility",
-              "ownership",
-              "profile_preset",
               "status",
               "is_default_agent"
             ],
@@ -364,14 +331,6 @@
               "is_default_agent": {
                 "type": "boolean"
               },
-              "kind": {
-                "enum": [
-                  "default",
-                  "named",
-                  "child"
-                ],
-                "type": "string"
-              },
               "lineage_parent_agent_id": {
                 "type": [
                   "string",
@@ -384,25 +343,11 @@
                   "null"
                 ]
               },
-              "ownership": {
-                "enum": [
-                  "parent_supervised",
-                  "self_owned"
-                ],
-                "type": "string"
-              },
               "parent_agent_id": {
                 "type": [
                   "string",
                   "null"
                 ]
-              },
-              "profile_preset": {
-                "enum": [
-                  "private_child",
-                  "public_named"
-                ],
-                "type": "string"
               },
               "status": {
                 "enum": [
@@ -411,21 +356,10 @@
                   "deleted"
                 ],
                 "type": "string"
-              },
-              "visibility": {
-                "enum": [
-                  "public",
-                  "private"
-                ],
-                "type": "string"
               }
             },
             "required": [
               "agent_id",
-              "kind",
-              "visibility",
-              "ownership",
-              "profile_preset",
               "status",
               "is_default_agent"
             ],
@@ -1267,14 +1201,6 @@
               "is_default_agent": {
                 "type": "boolean"
               },
-              "kind": {
-                "enum": [
-                  "default",
-                  "named",
-                  "child"
-                ],
-                "type": "string"
-              },
               "lineage_parent_agent_id": {
                 "type": [
                   "string",
@@ -1287,25 +1213,11 @@
                   "null"
                 ]
               },
-              "ownership": {
-                "enum": [
-                  "parent_supervised",
-                  "self_owned"
-                ],
-                "type": "string"
-              },
               "parent_agent_id": {
                 "type": [
                   "string",
                   "null"
                 ]
-              },
-              "profile_preset": {
-                "enum": [
-                  "private_child",
-                  "public_named"
-                ],
-                "type": "string"
               },
               "status": {
                 "enum": [
@@ -1314,21 +1226,10 @@
                   "deleted"
                 ],
                 "type": "string"
-              },
-              "visibility": {
-                "enum": [
-                  "public",
-                  "private"
-                ],
-                "type": "string"
               }
             },
             "required": [
               "agent_id",
-              "kind",
-              "visibility",
-              "ownership",
-              "profile_preset",
               "status",
               "is_default_agent"
             ],
@@ -1634,14 +1535,6 @@
                         "is_default_agent": {
                           "type": "boolean"
                         },
-                        "kind": {
-                          "enum": [
-                            "default",
-                            "named",
-                            "child"
-                          ],
-                          "type": "string"
-                        },
                         "lineage_parent_agent_id": {
                           "type": [
                             "string",
@@ -1654,25 +1547,11 @@
                             "null"
                           ]
                         },
-                        "ownership": {
-                          "enum": [
-                            "parent_supervised",
-                            "self_owned"
-                          ],
-                          "type": "string"
-                        },
                         "parent_agent_id": {
                           "type": [
                             "string",
                             "null"
                           ]
-                        },
-                        "profile_preset": {
-                          "enum": [
-                            "private_child",
-                            "public_named"
-                          ],
-                          "type": "string"
                         },
                         "status": {
                           "enum": [
@@ -1681,21 +1560,10 @@
                             "deleted"
                           ],
                           "type": "string"
-                        },
-                        "visibility": {
-                          "enum": [
-                            "public",
-                            "private"
-                          ],
-                          "type": "string"
                         }
                       },
                       "required": [
                         "agent_id",
-                        "kind",
-                        "visibility",
-                        "ownership",
-                        "profile_preset",
                         "status",
                         "is_default_agent"
                       ],
@@ -2356,14 +2224,6 @@
                   "is_default_agent": {
                     "type": "boolean"
                   },
-                  "kind": {
-                    "enum": [
-                      "default",
-                      "named",
-                      "child"
-                    ],
-                    "type": "string"
-                  },
                   "lineage_parent_agent_id": {
                     "type": [
                       "string",
@@ -2376,25 +2236,11 @@
                       "null"
                     ]
                   },
-                  "ownership": {
-                    "enum": [
-                      "parent_supervised",
-                      "self_owned"
-                    ],
-                    "type": "string"
-                  },
                   "parent_agent_id": {
                     "type": [
                       "string",
                       "null"
                     ]
-                  },
-                  "profile_preset": {
-                    "enum": [
-                      "private_child",
-                      "public_named"
-                    ],
-                    "type": "string"
                   },
                   "status": {
                     "enum": [
@@ -2403,21 +2249,10 @@
                       "deleted"
                     ],
                     "type": "string"
-                  },
-                  "visibility": {
-                    "enum": [
-                      "public",
-                      "private"
-                    ],
-                    "type": "string"
                   }
                 },
                 "required": [
                   "agent_id",
-                  "kind",
-                  "visibility",
-                  "ownership",
-                  "profile_preset",
                   "status",
                   "is_default_agent"
                 ],
@@ -3399,14 +3234,6 @@
                   "is_default_agent": {
                     "type": "boolean"
                   },
-                  "kind": {
-                    "enum": [
-                      "default",
-                      "named",
-                      "child"
-                    ],
-                    "type": "string"
-                  },
                   "lineage_parent_agent_id": {
                     "type": [
                       "string",
@@ -3419,25 +3246,11 @@
                       "null"
                     ]
                   },
-                  "ownership": {
-                    "enum": [
-                      "parent_supervised",
-                      "self_owned"
-                    ],
-                    "type": "string"
-                  },
                   "parent_agent_id": {
                     "type": [
                       "string",
                       "null"
                     ]
-                  },
-                  "profile_preset": {
-                    "enum": [
-                      "private_child",
-                      "public_named"
-                    ],
-                    "type": "string"
                   },
                   "status": {
                     "enum": [
@@ -3446,21 +3259,10 @@
                       "deleted"
                     ],
                     "type": "string"
-                  },
-                  "visibility": {
-                    "enum": [
-                      "public",
-                      "private"
-                    ],
-                    "type": "string"
                   }
                 },
                 "required": [
                   "agent_id",
-                  "kind",
-                  "visibility",
-                  "ownership",
-                  "profile_preset",
                   "status",
                   "is_default_agent"
                 ],
@@ -4217,14 +4019,6 @@
                         "is_default_agent": {
                           "type": "boolean"
                         },
-                        "kind": {
-                          "enum": [
-                            "default",
-                            "named",
-                            "child"
-                          ],
-                          "type": "string"
-                        },
                         "lineage_parent_agent_id": {
                           "type": [
                             "string",
@@ -4237,25 +4031,11 @@
                             "null"
                           ]
                         },
-                        "ownership": {
-                          "enum": [
-                            "parent_supervised",
-                            "self_owned"
-                          ],
-                          "type": "string"
-                        },
                         "parent_agent_id": {
                           "type": [
                             "string",
                             "null"
                           ]
-                        },
-                        "profile_preset": {
-                          "enum": [
-                            "private_child",
-                            "public_named"
-                          ],
-                          "type": "string"
                         },
                         "status": {
                           "enum": [
@@ -4264,21 +4044,10 @@
                             "deleted"
                           ],
                           "type": "string"
-                        },
-                        "visibility": {
-                          "enum": [
-                            "public",
-                            "private"
-                          ],
-                          "type": "string"
                         }
                       },
                       "required": [
                         "agent_id",
-                        "kind",
-                        "visibility",
-                        "ownership",
-                        "profile_preset",
                         "status",
                         "is_default_agent"
                       ],

--- a/docs/website/spec/agent-state.md
+++ b/docs/website/spec/agent-state.md
@@ -33,7 +33,7 @@ single opaque status field. The key distinction is:
 
 | Layer | What | Authority |
 |-------|------|-----------|
-| **Identity** | `agent_id`, kind, visibility, ownership, profile preset | Agent registry record |
+| **Identity** | `agent_id`, kind, profile preset, and supervision metadata | Agent registry record |
 | **Identity lifecycle** | `AgentRegistryStatus` — Active, Deleting, Deleted | Agent identity repository |
 | **Lifecycle status** | `AgentStatus` — Booting, AwakeIdle, AwakeRunning, AwaitingTask, Asleep, Stopped | Scheduler executor (single writer) |
 | **Scheduling posture** | `AgentSchedulingPosture` — derived from queue, WorkItems, tasks, wait state | Scheduler `derive_posture` projection |
@@ -191,7 +191,7 @@ projection facts and current turn facts to choose a `ClosureOutcome`,
 `AgentSummary` is the stable projection returned by `GetAgent` and
 `GET /api/agents`. It includes:
 
-- `identity` — agent identity badge (visibility/ownership/profile)
+- `identity` — agent identity badge and profile
 - `agent` — core `AgentState` including status, pending count, turn index
 - `scheduling_posture` — derived posture snapshot
 - `lifecycle` — lifecycle hint (not authoritative)
@@ -211,6 +211,14 @@ projection facts and current turn facts to choose a `ClosureOutcome`,
   not as a scheduling instruction.
 - API consumers must not depend on summary field ordering or presence of
   default/empty fields.
+
+### v0.38.0 identity migration legacy
+
+`AgentVisibility`, `AgentOwnership`, `PrivateChild`, and `PublicNamed` describe
+the v0.38.0 migration surface only. They are not the current public identity
+contract and must not be used to select creation or delegation behavior.
+Current callers use `CreateAgent` for addressable agents and `InvokeAgent` for
+parent-supervised delegated execution.
 
 ## Lifecycle control
 

--- a/docs/website/spec/tasks.md
+++ b/docs/website/spec/tasks.md
@@ -28,7 +28,7 @@ terminal re-entry, and supervision surfaces.
 | `TaskKind` | Description |
 |------------|-------------|
 | `CommandTask` | Shell command execution via `ExecCommand` |
-| `ChildAgentTask` | Parent-supervised delegated child agent via `SpawnAgent` |
+| `ChildAgentTask` | Parent-supervised delegated agent via `InvokeAgent` |
 | `SleepJob` | Internal sleep timer (not model-visible) |
 | `SubagentTask` | Legacy child agent kind (migrating to `ChildAgentTask`) |
 | `WorktreeSubagentTask` | Legacy worktree-isolated child agent (migrating) |
@@ -36,7 +36,7 @@ terminal re-entry, and supervision surfaces.
 ## Task lifecycle
 
 ```text
-              ExecCommand / SpawnAgent
+              ExecCommand / InvokeAgent
                        │
                        ▼
                  ┌──────────┐

--- a/docs/website/spec/tools.md
+++ b/docs/website/spec/tools.md
@@ -39,7 +39,7 @@ Tools are grouped by capability family for authority gating:
 | `LocalEnvironment` | `ExecCommand`, `ExecCommandBatch`, `ApplyPatch`, `GetWorkspaceState`, `SwitchWorkspace`, `CreateWorktree` | All profiles |
 | `AuthorityExpanding` | `AttachWorkspace`, `DetachWorkspace`, `RemoveWorktree` | Public named agents |
 | `Web` | `WebFetch`, `WebSearch` | All profiles |
-| `AgentCreation` | `SpawnAgent` | All profiles |
+| `AgentCreation` | `CreateAgent`, `InvokeAgent` | All profiles |
 
 Operator notification records, delivery callbacks, and UI rendering remain
 runtime-owned capabilities. They are not part of the model-facing tool
@@ -79,7 +79,8 @@ registry and machine-readable schema inventory.
 | `GetAgent` | Read current agent-plane summary |
 | `WaitFor` | Signal turn-end after recording explicit wait state |
 | `Enqueue` | Schedule self-follow-up message |
-| `SpawnAgent` | Delegate work to a child agent |
+| `CreateAgent` | Create a long-lived, addressable agent |
+| `InvokeAgent` | Delegate work through a parent-supervised task handle |
 
 ### Workspace plane
 

--- a/docs/website/spec/trust-and-provenance.md
+++ b/docs/website/spec/trust-and-provenance.md
@@ -200,7 +200,7 @@ Holon's provenance contract:
 - When the runtime generates internal messages (system ticks, task results,
   timer fires, continuation follow-ups), it assigns runtime-owned origin and
   `RuntimeInstruction` authority.
-- When an agent delegates work via `SpawnAgent`, the child agent receives the
+- When an agent delegates work via `InvokeAgent`, the invoked agent receives the
   delegated task as bounded operator/runtime context according to the supervising
   runtime surface; it must not silently merge later external channel content into
   operator instruction.

--- a/src/domain/agent.rs
+++ b/src/domain/agent.rs
@@ -103,6 +103,19 @@ pub enum AgentCapabilityFamily {
     ExternalTrigger,
 }
 
+impl AgentCapabilityFamily {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::CoreAgent => "core_agent",
+            Self::LocalEnvironment => "local_environment",
+            Self::Web => "web",
+            Self::AgentCreation => "agent_creation",
+            Self::AuthorityExpanding => "authority_expanding",
+            Self::ExternalTrigger => "external_trigger",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentPolicyEffect {
@@ -122,6 +135,16 @@ pub struct AgentCapabilityPolicyRecord {
     pub revision: u64,
     pub rules: Vec<AgentCapabilityPolicyRule>,
     pub created_at: DateTime<Utc>,
+}
+
+impl AgentCapabilityPolicyRecord {
+    pub fn allows(&self, family: AgentCapabilityFamily) -> bool {
+        self.rules
+            .iter()
+            .rev()
+            .find(|rule| rule.family == family)
+            .is_some_and(|rule| rule.effect == AgentPolicyEffect::Allow)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/src/host.rs
+++ b/src/host.rs
@@ -63,15 +63,15 @@ use crate::{
         AgentDeletionJob, AgentDeletionStatus, AgentDetail, AgentDurability, AgentIdentityRecord,
         AgentIdentityView, AgentKind, AgentLifecycleHint, AgentListEntry,
         AgentMessageCallerContext, AgentMessageDeliveryOutcome, AgentMessageDeliveryRejectionCode,
-        AgentMessagePrincipalKind, AgentMessageSendRequest, AgentOwnership, AgentProfilePreset,
-        AgentRegistryStatus, AgentState, AgentStatus, AgentSummary, AgentSupervisionState,
-        AgentTokenUsageSummary, AgentTreeNode, AgentTreeProjection, AgentVisibility,
-        AuthorityClass, ChildAgentSummary, ClosureOutcome, CreateAgentRequest,
-        ExternalTriggerRecord, ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMdView,
-        MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
-        OperatorNotificationRecord, Priority, QueueEntryStatus, RuntimeFailureSummary,
-        SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, TaskKind, TaskRecord,
-        TaskStatus, TimerRecord, TokenUsage, TranscriptEntry, TranscriptEntryKind,
+        AgentMessagePrincipalKind, AgentMessageSendRequest, AgentModelResolution,
+        AgentModelResolutionStatus, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
+        AgentState, AgentStatus, AgentSummary, AgentSupervisionState, AgentTokenUsageSummary,
+        AgentTreeNode, AgentTreeProjection, AgentVisibility, AuthorityClass, ChildAgentSummary,
+        ClosureOutcome, CreateAgentRequest, ExternalTriggerRecord, ExternalTriggerStatus,
+        ExternalTriggerSummary, LoadedAgentsMdView, MessageBody, MessageDeliverySurface,
+        MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationRecord, Priority,
+        QueueEntryStatus, RuntimeFailureSummary, TaskKind, TaskRecord, TaskStatus, TimerRecord,
+        TokenUsage, TranscriptEntry, TranscriptEntryKind,
         WaitConditionSummary, WorkspaceEntry, WorkspaceOccupancyRecord,
     },
 };
@@ -570,9 +570,9 @@ pub(crate) struct ChildTaskTerminalResult {
 
 async fn apply_spawn_model_resolution(
     runtime: &RuntimeHandle,
-    resolution: &SpawnAgentModelResolution,
+    resolution: &AgentModelResolution,
 ) -> Result<()> {
-    if resolution.resolution_status == SpawnAgentModelResolutionStatus::Inherited {
+    if resolution.resolution_status == AgentModelResolutionStatus::Inherited {
         return Ok(());
     }
     let provider = crate::config::ProviderId::parse(&resolution.resolved_provider)?;
@@ -2926,7 +2926,7 @@ impl RuntimeHost {
         };
         let runtime = self.get_or_create_agent(&bootstrap.agent_id).await?;
         let current = runtime.agent_state().await?;
-        if resolution.resolution_status == SpawnAgentModelResolutionStatus::Inherited {
+        if resolution.resolution_status == AgentModelResolutionStatus::Inherited {
             return Ok(());
         }
         let provider = crate::config::ProviderId::parse(&resolution.resolved_provider)?;
@@ -4252,7 +4252,7 @@ impl RuntimeHost {
         authority_class: AuthorityClass,
         worktree: bool,
         template: Option<String>,
-        model_resolution: SpawnAgentModelResolution,
+        model_resolution: AgentModelResolution,
     ) -> Result<ChildTaskSpawn> {
         let parent_state = parent_runtime.agent_state().await?;
         let parent_agent_home = self.agent_data_dir(&parent_state.id);
@@ -4529,7 +4529,7 @@ impl RuntimeHost {
         initial_message: Option<String>,
         authority_class: AuthorityClass,
         template: Option<String>,
-        model_resolution: SpawnAgentModelResolution,
+        model_resolution: AgentModelResolution,
     ) -> Result<AgentCreateResult> {
         let parent_state = parent_runtime.agent_state().await?;
         let parent_agent_home = self.agent_data_dir(&parent_state.id);
@@ -5052,7 +5052,7 @@ impl RuntimeHostBridge {
         authority_class: AuthorityClass,
         worktree: bool,
         template: Option<String>,
-        model_resolution: SpawnAgentModelResolution,
+        model_resolution: AgentModelResolution,
     ) -> Result<ChildTaskSpawn> {
         self.host()?
             .spawn_child_task(
@@ -5607,13 +5607,13 @@ mod tests {
         assert!(!rendered.contains("Current ApplyPatch surface is a JSON/function tool"));
     }
 
-    fn inherited_model_resolution(provider: &str, model: &str) -> SpawnAgentModelResolution {
-        SpawnAgentModelResolution {
+    fn inherited_model_resolution(provider: &str, model: &str) -> AgentModelResolution {
+        AgentModelResolution {
             requested: None,
             resolved_provider: provider.to_string(),
             resolved_model: model.to_string(),
             resolved_parameters: None,
-            resolution_status: SpawnAgentModelResolutionStatus::Inherited,
+            resolution_status: AgentModelResolutionStatus::Inherited,
             policy_notes: Vec::new(),
         }
     }
@@ -7221,7 +7221,7 @@ mod tests {
                 None,
                 false,
                 None,
-                Some(crate::types::SpawnAgentModelRequest {
+                Some(crate::types::AgentModelRequest {
                     provider: "anthropic".into(),
                     model: "claude-haiku-4-5".into(),
                     reasoning_effort: Some("high".into()),
@@ -7239,7 +7239,7 @@ mod tests {
             .expect("spawn should return model resolution");
         assert_eq!(
             resolution.resolution_status,
-            SpawnAgentModelResolutionStatus::Accepted
+            AgentModelResolutionStatus::Accepted
         );
         assert_eq!(resolution.resolved_provider, "anthropic");
         assert_eq!(resolution.resolved_model, "claude-haiku-4-5");
@@ -7270,7 +7270,7 @@ mod tests {
                 None,
                 false,
                 None,
-                Some(crate::types::SpawnAgentModelRequest {
+                Some(crate::types::AgentModelRequest {
                     provider: "openai".into(),
                     model: "gpt-5.4".into(),
                     reasoning_effort: None,

--- a/src/host.rs
+++ b/src/host.rs
@@ -5669,6 +5669,30 @@ mod tests {
         panic!("timed out waiting for task {task_id} to become terminal");
     }
 
+    async fn invoke_new_subagent(
+        runtime: &RuntimeHandle,
+        message: String,
+        authority_class: AuthorityClass,
+        template: Option<String>,
+        model_request: Option<crate::types::AgentModelRequest>,
+    ) -> anyhow::Result<crate::types::AgentInvocationReceipt> {
+        let model_resolution = runtime
+            .resolve_agent_model_request("InvokeAgent", model_request)
+            .await?;
+        runtime
+            .agent_invocation_service()
+            .invoke(InvokeAgentRequest {
+                target: InvokeAgentTarget::NewSubagent {
+                    template,
+                    workspace_mode: ChildAgentWorkspaceMode::Inherit,
+                    model_resolution: Some(model_resolution),
+                },
+                message,
+                authority_class,
+            })
+            .await
+    }
+
     struct BlockingProvider {
         started: Arc<Notify>,
     }
@@ -6890,20 +6914,17 @@ mod tests {
         let parent = host.default_runtime().await.unwrap();
         let parent_agent_id = host.config().default_agent_id.clone();
 
-        let spawned = parent
-            .spawn_agent(
-                Some("tree navigation work".into()),
-                AuthorityClass::OperatorInstruction,
-                AgentProfilePreset::PrivateChild,
-                None,
-                false,
-                None,
-                None,
-            )
-            .await
-            .unwrap();
+        let spawned = invoke_new_subagent(
+            &parent,
+            "tree navigation work".into(),
+            AuthorityClass::OperatorInstruction,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         let child_agent_id = spawned.agent_id.clone();
-        assert!(spawned.supervision_task_id.is_some());
+        assert!(!spawned.task_handle.task_id.is_empty());
 
         let tree = host.operator_agent_tree().await.unwrap();
         assert_eq!(
@@ -7035,22 +7056,16 @@ mod tests {
         let parent_agent_id = parent.agent_state().await.unwrap().id;
         let initial_message = "  investigate   remote\nTUI  access ".to_string();
 
-        let spawned = parent
-            .spawn_agent(
-                Some(initial_message.clone()),
-                AuthorityClass::ExternalEvidence,
-                AgentProfilePreset::PrivateChild,
-                None,
-                false,
-                None,
-                None,
-            )
-            .await
-            .unwrap();
-        let task_id = spawned
-            .supervision_task_id
-            .clone()
-            .expect("private child should return a supervision task");
+        let spawned = invoke_new_subagent(
+            &parent,
+            initial_message.clone(),
+            AuthorityClass::ExternalEvidence,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let task_id = spawned.task_handle.task_id.clone();
         let task = parent
             .storage()
             .latest_task_record(&task_id)
@@ -7140,24 +7155,21 @@ mod tests {
         .unwrap();
         let parent = host.default_runtime().await.unwrap();
 
-        let spawned = parent
-            .spawn_agent(
-                Some("review the implementation".into()),
-                AuthorityClass::OperatorInstruction,
-                AgentProfilePreset::PrivateChild,
-                None,
-                false,
-                Some("user_global:holon-reviewer@official".into()),
-                None,
-            )
-            .await
-            .unwrap();
+        let spawned = invoke_new_subagent(
+            &parent,
+            "review the implementation".into(),
+            AuthorityClass::OperatorInstruction,
+            Some("user_global:holon-reviewer@official".into()),
+            None,
+        )
+        .await
+        .unwrap();
 
         let child_home = host.agent_data_dir(&spawned.agent_id);
         assert!(fs::read_to_string(child_home.join("AGENTS.md"))
             .unwrap()
             .starts_with("# Official reviewer\n\nSynced reviewer template\n"));
-        assert!(spawned.supervision_task_id.is_some());
+        assert!(!spawned.task_handle.task_id.is_empty());
     }
 
     #[tokio::test]
@@ -7165,21 +7177,18 @@ mod tests {
         let (_home, host) = test_host();
         let parent = host.default_runtime().await.unwrap();
 
-        let error = parent
-            .spawn_agent(
-                Some("review the implementation".into()),
-                AuthorityClass::OperatorInstruction,
-                AgentProfilePreset::PrivateChild,
-                None,
-                false,
-                Some("user_global:reviewer%official".into()),
-                None,
-            )
-            .await
-            .expect_err("invalid template selector should fail after task creation");
+        let error = invoke_new_subagent(
+            &parent,
+            "review the implementation".into(),
+            AuthorityClass::OperatorInstruction,
+            Some("user_global:reviewer%official".into()),
+            None,
+        )
+        .await
+        .expect_err("invalid template selector should fail after task creation");
         let tool_error = crate::tool::ToolError::from_anyhow(&error);
 
-        assert_eq!(tool_error.kind, "spawn_agent_failed");
+        assert_eq!(tool_error.kind, "agent_invocation_failed");
         assert_eq!(
             tool_error.domain,
             Some(crate::runtime_error::RuntimeErrorDomain::Task)
@@ -7197,7 +7206,7 @@ mod tests {
             .and_then(|details| details.get("task_id"))
             .and_then(Value::as_str)
             .expect("tool error should identify the failed supervision task");
-        let rendered = tool_error.render_for_model(Some(crate::tool::names::SPAWN_AGENT));
+        let rendered = tool_error.render_for_model(Some("InvokeAgent"));
         assert!(rendered.contains("template install_id contains unsupported characters"));
 
         let task = parent
@@ -7228,36 +7237,22 @@ mod tests {
         let host = RuntimeHost::new(fixture.config).unwrap();
         let parent = host.default_runtime().await.unwrap();
 
-        let spawned = parent
-            .spawn_agent(
-                Some("compare implementation".into()),
-                AuthorityClass::OperatorInstruction,
-                AgentProfilePreset::PrivateChild,
-                None,
-                false,
-                None,
-                Some(crate::types::AgentModelRequest {
-                    provider: "anthropic".into(),
-                    model: "claude-haiku-4-5".into(),
-                    reasoning_effort: Some("high".into()),
-                    temperature: None,
-                    max_output_tokens: None,
-                    allow_fallback: Some(false),
-                }),
-            )
-            .await
-            .unwrap();
-
-        let resolution = spawned
-            .model_resolution
-            .as_ref()
-            .expect("spawn should return model resolution");
-        assert_eq!(
-            resolution.resolution_status,
-            AgentModelResolutionStatus::Accepted
-        );
-        assert_eq!(resolution.resolved_provider, "anthropic");
-        assert_eq!(resolution.resolved_model, "claude-haiku-4-5");
+        let spawned = invoke_new_subagent(
+            &parent,
+            "compare implementation".into(),
+            AuthorityClass::OperatorInstruction,
+            None,
+            Some(crate::types::AgentModelRequest {
+                provider: "anthropic".into(),
+                model: "claude-haiku-4-5".into(),
+                reasoning_effort: Some("high".into()),
+                temperature: None,
+                max_output_tokens: None,
+                allow_fallback: Some(false),
+            }),
+        )
+        .await
+        .unwrap();
 
         let child = host.get_or_create_agent(&spawned.agent_id).await.unwrap();
         let child_summary = child.agent_summary().await.unwrap();
@@ -7277,25 +7272,22 @@ mod tests {
         let host = RuntimeHost::new(fixture.config).unwrap();
         let parent = host.default_runtime().await.unwrap();
 
-        let error = parent
-            .spawn_agent(
-                Some("compare implementation".into()),
-                AuthorityClass::OperatorInstruction,
-                AgentProfilePreset::PrivateChild,
-                None,
-                false,
-                None,
-                Some(crate::types::AgentModelRequest {
-                    provider: "openai".into(),
-                    model: "gpt-5.4".into(),
-                    reasoning_effort: None,
-                    temperature: None,
-                    max_output_tokens: None,
-                    allow_fallback: Some(false),
-                }),
-            )
-            .await
-            .expect_err("unavailable explicit model should be rejected before child creation");
+        let error = invoke_new_subagent(
+            &parent,
+            "compare implementation".into(),
+            AuthorityClass::OperatorInstruction,
+            None,
+            Some(crate::types::AgentModelRequest {
+                provider: "openai".into(),
+                model: "gpt-5.4".into(),
+                reasoning_effort: None,
+                temperature: None,
+                max_output_tokens: None,
+                allow_fallback: Some(false),
+            }),
+        )
+        .await
+        .expect_err("unavailable explicit model should be rejected before child creation");
 
         assert!(error.to_string().contains("requested model"));
         assert!(error.to_string().contains("unavailable"));
@@ -7306,22 +7298,19 @@ mod tests {
         let (_home, host) = test_host();
         let parent = host.default_runtime().await.unwrap();
 
-        let error = parent
-            .spawn_agent(
-                Some("   \n\t  ".into()),
-                AuthorityClass::OperatorInstruction,
-                AgentProfilePreset::PrivateChild,
-                None,
-                false,
-                None,
-                None,
-            )
-            .await
-            .expect_err("blank private child initial_message should be rejected");
+        let error = invoke_new_subagent(
+            &parent,
+            "   \n\t  ".into(),
+            AuthorityClass::OperatorInstruction,
+            None,
+            None,
+        )
+        .await
+        .expect_err("blank private child initial_message should be rejected");
 
         assert!(error
             .to_string()
-            .contains("private_child spawn requires non-empty initial_message"));
+            .contains("agent invocation requires a non-empty message"));
     }
 
     #[tokio::test]

--- a/src/host.rs
+++ b/src/host.rs
@@ -71,8 +71,8 @@ use crate::{
         ExternalTriggerSummary, LoadedAgentsMdView, MessageBody, MessageDeliverySurface,
         MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationRecord, Priority,
         QueueEntryStatus, RuntimeFailureSummary, TaskKind, TaskRecord, TaskStatus, TimerRecord,
-        TokenUsage, TranscriptEntry, TranscriptEntryKind,
-        WaitConditionSummary, WorkspaceEntry, WorkspaceOccupancyRecord,
+        TokenUsage, TranscriptEntry, TranscriptEntryKind, WaitConditionSummary, WorkspaceEntry,
+        WorkspaceOccupancyRecord,
     },
 };
 
@@ -7314,11 +7314,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn public_named_initial_message_is_optional_and_inherits_only_attached_workspaces() {
+    async fn independent_agent_initial_message_is_optional_and_inherits_only_attached_workspaces() {
         let (_home, host) = test_host();
         let parent = host.default_runtime().await.unwrap();
-        let named_agent_id = format!("{}-no-bootstrap", host.config().default_agent_id);
-        let bootstrap_agent_id = format!("{}-bootstrap", host.config().default_agent_id);
+        let named_agent_id = "independent-no-bootstrap".to_string();
+        let bootstrap_agent_id = "independent-bootstrap".to_string();
         let bootstrap_message_id = format!("agent_bootstrap_message:{bootstrap_agent_id}");
         let workspace_home = tempdir().unwrap();
         let workspace_path = workspace_home.path().to_path_buf();

--- a/src/host.rs
+++ b/src/host.rs
@@ -2357,12 +2357,12 @@ impl RuntimeHost {
         let bootstrap = self.reconcile_agent_bootstrap(agent_id).await?;
         let bootstrap_summary = bootstrap.summary();
         Ok(AgentCreateResult {
+            identity: AgentIdentityView::from_record(&identity, &self.config().default_agent_id),
             receipt: AgentCreateReceipt {
                 receipt_id: ids::runtime_id("agent_create"),
                 agent_id: identity.agent_id.clone(),
                 name: identity.name.clone(),
                 display_name: identity.display_name(),
-                preset: AgentProfilePreset::PublicNamed,
                 stage: if bootstrap_summary.status == AgentBootstrapStatus::Ready {
                     AgentCreateStage::Bootstrapped
                 } else {
@@ -2372,7 +2372,6 @@ impl RuntimeHost {
                 created,
                 bootstrap: bootstrap_summary,
             },
-            identity,
         })
     }
 
@@ -2421,12 +2420,15 @@ impl RuntimeHost {
                 let bootstrap = self.reconcile_agent_bootstrap(&request.agent_id).await?;
                 let bootstrap_summary = bootstrap.summary();
                 return Ok(AgentCreateResult {
+                    identity: AgentIdentityView::from_record(
+                        &identity,
+                        &self.config().default_agent_id,
+                    ),
                     receipt: AgentCreateReceipt {
                         receipt_id: ids::runtime_id("agent_create"),
                         agent_id: identity.agent_id.clone(),
                         name: identity.name.clone(),
                         display_name: identity.display_name(),
-                        preset: AgentProfilePreset::PublicNamed,
                         stage: if bootstrap_summary.status == AgentBootstrapStatus::Ready {
                             AgentCreateStage::Bootstrapped
                         } else {
@@ -2436,7 +2438,6 @@ impl RuntimeHost {
                         created: false,
                         bootstrap: bootstrap_summary,
                     },
-                    identity,
                 });
             }
         }
@@ -3866,13 +3867,18 @@ impl RuntimeHost {
             .unwrap_or_else(|| build_provider_from_config(&config))?;
         let apply_patch_surface = ApplyPatchSurface::for_model_route_ref(&model_ref.as_string());
         let registry = ToolRegistry::new(execution.execution_root.clone());
+        let capability_policy = self
+            .runtime_db()
+            .agent_canonical_relations()
+            .latest(&identity.agent_id)?
+            .and_then(|relations| relations.capability_policy);
         let available_tools = registry
             .tool_specs_with_families_for_apply_patch_surface(apply_patch_surface)?
             .into_iter()
             .filter(|(family, _)| {
-                identity_view
-                    .profile_preset
-                    .allows_tool_capability_family(*family)
+                capability_policy
+                    .as_ref()
+                    .is_none_or(|policy| policy.allows(*family))
             })
             .map(|(_, tool)| tool)
             .collect::<Vec<_>>();
@@ -4989,6 +4995,16 @@ impl RuntimeHostBridge {
         agent_id: &str,
     ) -> Result<Option<AgentIdentityRecord>> {
         self.host()?.agent_identity_record(agent_id)
+    }
+
+    pub(crate) async fn canonical_relations_for_agent(
+        &self,
+        agent_id: &str,
+    ) -> Result<Option<crate::types::AgentCanonicalRelationsProjection>> {
+        self.host()?
+            .runtime_db()
+            .agent_canonical_relations()
+            .latest(agent_id)
     }
 
     pub(crate) async fn child_summaries(
@@ -6142,7 +6158,6 @@ mod tests {
         assert_eq!(created.receipt.name.as_deref(), Some("Receipt Bot"));
         assert_eq!(created.receipt.display_name, "Receipt Bot");
         assert_eq!(created.receipt.agent_id, "receipt-bot");
-        assert_eq!(created.receipt.preset, AgentProfilePreset::PublicNamed);
         assert_eq!(created.receipt.stage, AgentCreateStage::Bootstrapped);
         assert_eq!(created.receipt.lifecycle, AgentRegistryStatus::Active);
         assert!(created.receipt.created);

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1519,7 +1519,10 @@ mod tests {
         host::RuntimeHost,
         provider::StubProvider,
         runtime_error::{RuntimeError, RuntimeErrorDomain},
-        types::{AgentListEntry, AgentProfilePreset, AgentTreeProjection, AuthorityClass},
+        types::{
+            AgentListEntry, AgentTreeProjection, AuthorityClass, ChildAgentWorkspaceMode,
+            InvokeAgentRequest, InvokeAgentTarget,
+        },
     };
     use axum::{
         body::{to_bytes, Body},
@@ -1540,6 +1543,30 @@ mod tests {
         let host =
             RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
         (home, host)
+    }
+
+    async fn invoke_new_subagent(
+        runtime: &crate::runtime::RuntimeHandle,
+        message: String,
+        authority_class: AuthorityClass,
+        template: Option<String>,
+        model_request: Option<crate::types::AgentModelRequest>,
+    ) -> anyhow::Result<crate::types::AgentInvocationReceipt> {
+        let model_resolution = runtime
+            .resolve_agent_model_request("InvokeAgent", model_request)
+            .await?;
+        runtime
+            .agent_invocation_service()
+            .invoke(InvokeAgentRequest {
+                target: InvokeAgentTarget::NewSubagent {
+                    template,
+                    workspace_mode: ChildAgentWorkspaceMode::Inherit,
+                    model_resolution: Some(model_resolution),
+                },
+                message,
+                authority_class,
+            })
+            .await
     }
 
     fn oidc_test_host() -> (tempfile::TempDir, RuntimeHost) {
@@ -1830,18 +1857,15 @@ mod tests {
     async fn operator_agent_tree_requires_auth_and_does_not_expand_public_roster() {
         let (_home, host) = control_token_test_host();
         let parent = host.default_runtime().await.unwrap();
-        let spawned = parent
-            .spawn_agent(
-                Some("private tree navigation".into()),
-                AuthorityClass::OperatorInstruction,
-                AgentProfilePreset::PrivateChild,
-                None,
-                false,
-                None,
-                None,
-            )
-            .await
-            .unwrap();
+        let spawned = invoke_new_subagent(
+            &parent,
+            "private tree navigation".into(),
+            AuthorityClass::OperatorInstruction,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         let child_agent_id = spawned.agent_id;
         let app = router(AppState::for_tcp(host));
 
@@ -1925,19 +1949,16 @@ mod tests {
     async fn oidc_event_reads_require_session_before_private_child_lookup() {
         let (_home, host, session_secret) = oidc_test_host_with_session();
         let parent = host.default_runtime().await.unwrap();
-        let child_agent_id = parent
-            .spawn_agent(
-                Some("private event navigation".into()),
-                AuthorityClass::OperatorInstruction,
-                AgentProfilePreset::PrivateChild,
-                None,
-                false,
-                None,
-                None,
-            )
-            .await
-            .unwrap()
-            .agent_id;
+        let child_agent_id = invoke_new_subagent(
+            &parent,
+            "private event navigation".into(),
+            AuthorityClass::OperatorInstruction,
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .agent_id;
         let app = router(AppState::for_tcp(host));
         let uri = format!("/api/agents/{child_agent_id}/events");
 

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -482,6 +482,7 @@ pub struct ClearAgentModelRequest {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateAgentRequest {
     pub authority_class: Option<AuthorityClass>,
     pub template: Option<String>,

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -30,10 +30,9 @@ use crate::{
     system::{execution_policy_summary_lines, ExecutionSnapshot},
     tool::{ApplyPatchSurface, ToolSpec},
     types::{
-        AgentIdentityView, AgentKind, AgentMemorySource, AgentState, AgentsMdKind,
-        AgentsMdLoadStatus, AgentsMdSource, ContinuationResolution, ExternalTriggerRecord,
-        LoadedAgentMemory, LoadedAgentsMd, MessageBody, MessageEnvelope, MessageOrigin,
-        SkillsRuntimeView,
+        AgentIdentityView, AgentMemorySource, AgentState, AgentsMdKind, AgentsMdLoadStatus,
+        AgentsMdSource, ContinuationResolution, ExternalTriggerRecord, LoadedAgentMemory,
+        LoadedAgentsMd, MessageBody, MessageEnvelope, MessageOrigin, SkillsRuntimeView,
     },
 };
 
@@ -322,22 +321,10 @@ impl EffectivePrompt {
         output.push("".to_string());
         output.push(format!("Agent home: {}", self.agent_home.display()));
         output.push(format!("Agent id: {}", self.identity.agent_id));
-        output.push(format!("Agent kind: {:?}", self.identity.kind));
+        output.push(format!("Identity status: {:?}", self.identity.status));
         output.push(format!(
-            "Agent contract: {}",
-            self.identity.contract_badge()
-        ));
-        output.push(format!(
-            "Contract summary: {}",
-            self.identity.contract_summary()
-        ));
-        output.push(format!(
-            "Agent tool surface: {}",
-            self.identity.profile_preset.agent_tool_surface_summary()
-        ));
-        output.push(format!(
-            "Cleanup ownership: {}",
-            self.identity.ownership.cleanup_summary()
+            "Identity relation: {}",
+            self.identity.relation_summary()
         ));
         output.push(format!(
             "Prompt cache key: {}",
@@ -1131,11 +1118,9 @@ fn agent_contract_section(identity: &AgentIdentityView) -> PromptSection {
         "agent_contract",
         PromptStability::Stable,
         format!(
-            "Current agent contract: {}. Identity badge: {}. Agent tool surface: {}. Cleanup ownership: {}.",
-            identity.contract_summary(),
-            identity.contract_badge(),
-            identity.profile_preset.agent_tool_surface_summary(),
-            identity.ownership.cleanup_summary()
+            "Current agent contract: stable identity `{}`; {}. Tool availability is determined by canonical capability policy. Lifecycle cleanup authority is determined by canonical lifecycle attachment and active supervision, not by identity labels.",
+            identity.agent_id,
+            identity.relation_summary(),
         ),
     )
 }
@@ -1179,7 +1164,7 @@ fn describe_agents_md_source(
 }
 
 fn delegated_task_section(identity: &AgentIdentityView) -> Option<PromptSection> {
-    (identity.kind == AgentKind::Child).then(|| {
+    (identity.lineage_parent_agent_id.is_some() && identity.delegated_from_task_id.is_some()).then(|| {
         section(
             "delegated_task",
             PromptStability::Stable,
@@ -2371,13 +2356,16 @@ mod tests {
             .find(|section| section.name == "agent_contract")
             .expect("agent contract section");
 
+        assert!(section.content.contains("stable identity `default`"));
         assert!(section
             .content
-            .contains("public self-owned agent addressed directly by `agent_id`"));
-        assert!(section.content.contains("public/self_owned (public_named)"));
+            .contains("independently addressable agent identity"));
+        assert!(section.content.contains("canonical capability policy"));
         assert!(section
             .content
-            .contains("CreateAgent creates independent identities"));
+            .contains("canonical lifecycle attachment and active supervision"));
+        assert!(!section.content.contains("public_named"));
+        assert!(!section.content.contains("private_child"));
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3175,6 +3175,19 @@ impl RuntimeHandle {
         Ok(self.fallback_identity_view(&agent_id))
     }
 
+    pub(crate) async fn agent_capability_policy(
+        &self,
+    ) -> Result<Option<crate::types::AgentCapabilityPolicyRecord>> {
+        let agent_id = self.agent_id().await?;
+        let Some(bridge) = self.inner.host_bridge.as_ref() else {
+            return Ok(None);
+        };
+        Ok(bridge
+            .canonical_relations_for_agent(&agent_id)
+            .await?
+            .and_then(|relations| relations.capability_policy))
+    }
+
     fn skill_visibility(&self, identity: &AgentIdentityView) -> SkillVisibility {
         if identity.kind == AgentKind::Default {
             SkillVisibility::DefaultAgent

--- a/src/runtime/agent_services.rs
+++ b/src/runtime/agent_services.rs
@@ -7,9 +7,8 @@ use crate::runtime_error::{
     collect_runtime_error_source_chain, describe_runtime_error, RuntimeError, RuntimeErrorDomain,
 };
 use crate::types::{
-    AgentCreateResult, AgentInvocationReceipt, ChildAgentWorkspaceMode, CreateAgentRequest,
-    InvokeAgentRequest, InvokeAgentTarget, SpawnAgentModelResolution, TaskHandle, TaskRecord,
-    TaskStatus,
+    AgentCreateResult, AgentInvocationReceipt, AgentModelResolution, ChildAgentWorkspaceMode,
+    CreateAgentRequest, InvokeAgentRequest, InvokeAgentTarget, TaskHandle, TaskRecord, TaskStatus,
 };
 
 pub(crate) struct AgentCreationService<'a> {
@@ -164,8 +163,8 @@ impl AgentInvocationService<'_> {
 }
 
 pub(super) fn required_model_resolution(
-    resolution: Option<SpawnAgentModelResolution>,
-) -> Result<SpawnAgentModelResolution> {
+    resolution: Option<AgentModelResolution>,
+) -> Result<AgentModelResolution> {
     resolution.ok_or_else(|| anyhow!("new subagent invocation requires model resolution"))
 }
 

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -9,16 +9,16 @@ use crate::runtime_error::{
 use crate::tool::helpers::truncate_output_to_char_budget;
 use crate::tool::ToolError;
 use crate::types::{
-    brief_created_event_for, AgentProfilePreset, BriefKind, BriefRecord, ChildAgentWorkspaceMode,
-    CommandTaskStatusSnapshot, CompletionReportRequirement, CompletionReportState,
-    CreateAgentRequest, FailureArtifact, FailureArtifactCategory, InvokeAgentRequest,
-    InvokeAgentTarget, SpawnAgentModelRequest, SpawnAgentModelResolution,
-    SpawnAgentModelResolutionStatus, SpawnAgentResult, TaskInputResult, TaskKind, TaskListEntry,
-    TaskOutputResult, TaskOutputRetrievalStatus, TaskOutputSnapshot, TaskStatusSnapshot, TodoItem,
-    ToolArtifactRef, WaitConditionRecord, WaitConditionStatus, WorkItemCompletionIntent,
-    WorkItemContinuationFrame, WorkItemContinuationReturnPolicy, WorkItemContinuationState,
-    WorkItemDelegationRecord, WorkItemDelegationState, WorkItemPlanStatus, WorkItemReadiness,
-    WorkItemRecord, WorkItemState, CHILD_AGENT_TASK_KIND,
+    brief_created_event_for, AgentModelRequest, AgentModelResolution, AgentModelResolutionStatus,
+    AgentProfilePreset, BriefKind, BriefRecord, ChildAgentWorkspaceMode, CommandTaskStatusSnapshot,
+    CompletionReportRequirement, CompletionReportState, CreateAgentRequest, FailureArtifact,
+    FailureArtifactCategory, InvokeAgentRequest, InvokeAgentTarget, SpawnAgentResult,
+    TaskInputResult, TaskKind, TaskListEntry, TaskOutputResult, TaskOutputRetrievalStatus,
+    TaskOutputSnapshot, TaskStatusSnapshot, TodoItem, ToolArtifactRef, WaitConditionRecord,
+    WaitConditionStatus, WorkItemCompletionIntent, WorkItemContinuationFrame,
+    WorkItemContinuationReturnPolicy, WorkItemContinuationState, WorkItemDelegationRecord,
+    WorkItemDelegationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState,
+    CHILD_AGENT_TASK_KIND,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -146,15 +146,13 @@ fn inherited_model_parameters(
     (!parameters.is_empty()).then_some(parameters)
 }
 
-fn inherited_spawn_model_resolution(
-    model: &crate::types::AgentModelState,
-) -> SpawnAgentModelResolution {
-    SpawnAgentModelResolution {
+fn inherited_spawn_model_resolution(model: &crate::types::AgentModelState) -> AgentModelResolution {
+    AgentModelResolution {
         requested: None,
         resolved_provider: model.effective_model.provider.as_str().to_string(),
         resolved_model: model.effective_model.model.clone(),
         resolved_parameters: inherited_model_parameters(model),
-        resolution_status: SpawnAgentModelResolutionStatus::Inherited,
+        resolution_status: AgentModelResolutionStatus::Inherited,
         policy_notes: Vec::new(),
     }
 }
@@ -633,7 +631,7 @@ impl RuntimeHandle {
         agent_id: Option<String>,
         worktree: bool,
         template: Option<String>,
-        model_request: Option<SpawnAgentModelRequest>,
+        model_request: Option<AgentModelRequest>,
     ) -> Result<SpawnAgentResult> {
         if !self.supports_child_agent_spawning() {
             return Err(anyhow::Error::from(
@@ -800,8 +798,8 @@ impl RuntimeHandle {
     pub(crate) async fn resolve_agent_model_request(
         &self,
         tool_name: &str,
-        request: Option<SpawnAgentModelRequest>,
-    ) -> Result<SpawnAgentModelResolution> {
+        request: Option<AgentModelRequest>,
+    ) -> Result<AgentModelResolution> {
         let Some(request) = request else {
             let inherited = self.model_state_for(&self.agent_state().await?);
             return Ok(inherited_spawn_model_resolution(&inherited));
@@ -900,12 +898,12 @@ impl RuntimeHandle {
             );
         }
 
-        Ok(SpawnAgentModelResolution {
+        Ok(AgentModelResolution {
             requested: Some(request),
             resolved_provider: availability.policy.model_ref.provider.as_str().to_string(),
             resolved_model: availability.policy.model_ref.model,
             resolved_parameters: (!resolved_parameters.is_empty()).then_some(resolved_parameters),
-            resolution_status: SpawnAgentModelResolutionStatus::Accepted,
+            resolution_status: AgentModelResolutionStatus::Accepted,
             policy_notes,
         })
     }

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -3,16 +3,14 @@ use super::waiting::WorkItemBlockerClearance;
 use super::{task_state_reducer, *};
 use crate::config::{ModelRef, ProviderId};
 use crate::runtime_error::{
-    describe_runtime_error, sanitize_runtime_error_text, RuntimeError, RuntimeErrorContext,
-    RuntimeErrorDomain,
+    sanitize_runtime_error_text, RuntimeError, RuntimeErrorContext, RuntimeErrorDomain,
 };
 use crate::tool::helpers::truncate_output_to_char_budget;
 use crate::tool::ToolError;
 use crate::types::{
     brief_created_event_for, AgentModelRequest, AgentModelResolution, AgentModelResolutionStatus,
-    AgentProfilePreset, BriefKind, BriefRecord, ChildAgentWorkspaceMode, CommandTaskStatusSnapshot,
-    CompletionReportRequirement, CompletionReportState, CreateAgentRequest, FailureArtifact,
-    FailureArtifactCategory, InvokeAgentRequest, InvokeAgentTarget, SpawnAgentResult,
+    BriefKind, BriefRecord, ChildAgentWorkspaceMode, CommandTaskStatusSnapshot,
+    CompletionReportRequirement, CompletionReportState, FailureArtifact, FailureArtifactCategory,
     TaskInputResult, TaskKind, TaskListEntry, TaskOutputResult, TaskOutputRetrievalStatus,
     TaskOutputSnapshot, TaskStatusSnapshot, TodoItem, ToolArtifactRef, WaitConditionRecord,
     WaitConditionStatus, WorkItemCompletionIntent, WorkItemContinuationFrame,
@@ -427,10 +425,6 @@ impl RuntimeHandle {
             .await
     }
 
-    pub(crate) fn supports_child_agent_spawning(&self) -> bool {
-        self.inner.host_bridge.is_some()
-    }
-
     pub(super) async fn ensure_background_tasks_allowed(&self, surface: &str) -> Result<()> {
         let state = self.agent_state().await?;
         crate::system::ensure_background_task_allowed(
@@ -621,178 +615,6 @@ impl RuntimeHandle {
             .insert(task_id, command_task::ManagedTaskHandle::Async(handle));
 
         Ok(task)
-    }
-
-    pub async fn spawn_agent(
-        &self,
-        initial_message: Option<String>,
-        authority_class: AuthorityClass,
-        preset: AgentProfilePreset,
-        agent_id: Option<String>,
-        worktree: bool,
-        template: Option<String>,
-        model_request: Option<AgentModelRequest>,
-    ) -> Result<SpawnAgentResult> {
-        if !self.supports_child_agent_spawning() {
-            return Err(anyhow::Error::from(
-                ToolError::new(
-                    "unsupported_runtime_capability",
-                    "SpawnAgent is not available in this runtime",
-                )
-                .with_details(serde_json::json!({
-                    "tool_name": crate::tool::names::SPAWN_AGENT,
-                    "required_capability": "child_agent_spawning",
-                }))
-                .with_recovery_hint(
-                    "run SpawnAgent from a host-managed runtime with child-agent support",
-                ),
-            ));
-        }
-        let model_resolution = self
-            .resolve_agent_model_request(crate::tool::names::SPAWN_AGENT, model_request)
-            .await?;
-        match preset {
-            AgentProfilePreset::PrivateChild => {
-                let initial_message = initial_message
-                    .ok_or_else(|| anyhow!("private_child spawn requires initial_message"))?;
-                if initial_message.trim().is_empty() {
-                    return Err(anyhow!(
-                        "private_child spawn requires non-empty initial_message"
-                    ));
-                }
-                let receipt = match self
-                    .agent_invocation_service()
-                    .invoke(InvokeAgentRequest {
-                        target: InvokeAgentTarget::NewSubagent {
-                            template,
-                            workspace_mode: if worktree {
-                                ChildAgentWorkspaceMode::Worktree
-                            } else {
-                                ChildAgentWorkspaceMode::Inherit
-                            },
-                            model_resolution: Some(model_resolution.clone()),
-                        },
-                        message: initial_message,
-                        authority_class,
-                    })
-                    .await
-                {
-                    Ok(receipt) => receipt,
-                    Err(error) => {
-                        let descriptor = describe_runtime_error(&error);
-                        let Some(task_id) = descriptor.safe_context.get("task_id") else {
-                            return Err(error);
-                        };
-                        if descriptor.code != "agent_invocation_failed" {
-                            return Err(error);
-                        }
-                        let direct_cause = descriptor
-                            .source_chain
-                            .last()
-                            .cloned()
-                            .unwrap_or_else(|| descriptor.operator_message.clone());
-                        return Err(anyhow::Error::from(
-                            ToolError::new(
-                                "spawn_agent_failed",
-                                format!("failed to spawn child agent: {direct_cause}"),
-                            )
-                            .with_domain(RuntimeErrorDomain::Task)
-                            .with_details(serde_json::json!({
-                                "task_id": task_id,
-                                "preset": AgentProfilePreset::PrivateChild,
-                                "workspace_mode": if worktree { "worktree" } else { "inherit" },
-                            }))
-                            .with_recovery_hint(
-                                "correct the child template, model, or workspace configuration and retry SpawnAgent",
-                            )
-                            .with_source_chain(descriptor.source_chain),
-                        ));
-                    }
-                };
-                let task = self
-                    .task_record(&receipt.task_handle.task_id)
-                    .await?
-                    .ok_or_else(|| anyhow!("invocation task disappeared after admission"))?;
-                let child_supervision =
-                    crate::types::ChildSupervisionProjection::from_task_record(&task);
-                let mut task_handle = receipt.task_handle.clone();
-                task_handle.task_kind = CHILD_AGENT_TASK_KIND.to_string();
-
-                Ok(SpawnAgentResult {
-                    agent_id: receipt.agent_id.clone(),
-                    create_receipt: None,
-                    child_agent_id: Some(receipt.agent_id.clone()),
-                    task_handle: Some(task_handle),
-                    supervision_task_id: Some(receipt.task_handle.task_id.clone()),
-                    child_supervision,
-                    summary_text: Some(format!(
-                        "delegated child {} started under supervision task {}",
-                        receipt.agent_id, receipt.task_handle.task_id
-                    )),
-                    delegation_id: None,
-                    parent_work_item_id: None,
-                    child_work_item_id: None,
-                    model_resolution: Some(model_resolution),
-                })
-            }
-            AgentProfilePreset::PublicNamed => {
-                let agent_id = agent_id
-                    .ok_or_else(|| anyhow!("public_named spawn requires a stable agent id"))?;
-                if worktree {
-                    return Err(anyhow!(
-                        "public_named spawn does not support workspace_mode=worktree"
-                    ));
-                }
-
-                let parent_agent_id = self.agent_id().await?;
-                let spawned_agent_id = self
-                    .agent_creation_service()
-                    .create(CreateAgentRequest {
-                        agent_id: agent_id.clone(),
-                        name: None,
-                        template,
-                        initial_message,
-                        authority_class,
-                        model_resolution: Some(model_resolution.clone()),
-                        lineage_parent_agent_id: Some(parent_agent_id),
-                        inherit_parent_runtime: true,
-                    })
-                    .await?;
-                if !spawned_agent_id.receipt.created {
-                    return Err(anyhow::Error::from(
-                        ToolError::new(
-                            "already_exists",
-                            format!("public named agent {agent_id} already exists"),
-                        )
-                        .with_domain(RuntimeErrorDomain::Conflict)
-                        .with_details(serde_json::json!({
-                            "agent_id": agent_id,
-                            "preset": AgentProfilePreset::PublicNamed,
-                        }))
-                        .with_recovery_hint(
-                            "use an explicit agent invocation or enqueue operation to deliver work to an existing agent",
-                        ),
-                    ));
-                }
-
-                Ok(SpawnAgentResult {
-                    agent_id: spawned_agent_id.identity.agent_id.clone(),
-                    create_receipt: Some(spawned_agent_id.receipt),
-                    child_agent_id: None,
-                    task_handle: None,
-                    supervision_task_id: None,
-                    child_supervision: None,
-                    summary_text: Some(format!(
-                        "spawned public named agent {} without a supervising task handle",
-                        spawned_agent_id.identity.agent_id
-                    )),
-                    delegation_id: None,
-                    parent_work_item_id: None,
-                    child_work_item_id: None,
-                    model_resolution: Some(model_resolution),
-                })
-            }
-        }
     }
 
     pub(crate) async fn resolve_agent_model_request(

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -119,6 +119,17 @@ impl ToolRegistry {
         context: &ToolExecutionContext,
     ) -> Result<(ToolResult, ToolExecutionRecord)> {
         let started_at = chrono::Utc::now();
+        if call.name == "SpawnAgent" {
+            return Err(ToolError::new("legacy_tool_removed", "SpawnAgent has been removed")
+                .with_details(json!({
+                    "tool_name": call.name,
+                    "replacement_tools": ["CreateAgent", "InvokeAgent"],
+                }))
+                .with_recovery_hint(
+                    "use CreateAgent for persistent named agents or InvokeAgent for child-agent work",
+                )
+                .into());
+        }
         let required_family = match self.family_for_tool(&call.name)? {
             Some(required_family) => required_family,
             None => {

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -136,26 +136,24 @@ impl ToolRegistry {
                 .into());
             }
         };
-        let identity = runtime.agent_identity_view().await?;
-        if !identity
-            .profile_preset
-            .allows_tool_capability_family(required_family)
+        if runtime
+            .agent_capability_policy()
+            .await?
+            .is_some_and(|policy| !policy.allows(required_family))
         {
             return Err(ToolError::new(
-                "unsupported_agent_profile_capability",
+                "agent_capability_not_allowed",
                 format!(
-                    "{} is not available for agents with the `{}` profile",
-                    call.name,
-                    identity.profile_preset.label()
+                    "{} is not allowed by the agent capability policy",
+                    call.name
                 ),
             )
             .with_details(json!({
                 "tool_name": call.name,
                 "required_family": required_family.label(),
-                "profile_preset": identity.profile_preset.label(),
             }))
             .with_recovery_hint(format!(
-                "run {} from an agent whose profile allows the `{}` capability family",
+                "run {} from an agent whose capability policy allows the `{}` family",
                 call.name,
                 required_family.label()
             ))

--- a/src/tool/names.rs
+++ b/src/tool/names.rs
@@ -38,7 +38,6 @@ pub mod tool_names {
     pub const PICK_WORK_ITEM: &str = "PickWorkItem";
     pub const REMOVE_WORKTREE: &str = "RemoveWorktree";
     pub const SLEEP: &str = "Sleep";
-    pub(crate) const SPAWN_AGENT: &str = "SpawnAgent";
     pub const TASK_INPUT: &str = "TaskInput";
     /// Legacy alias kept for backward-compatible dispatch.
     pub const TASK_LIST: &str = "TaskList";

--- a/src/tool/tools/create_agent.rs
+++ b/src/tool/tools/create_agent.rs
@@ -7,7 +7,7 @@ use crate::{
     host_registry::validate_agent_id_format,
     runtime::RuntimeHandle,
     tool::spec::typed_spec,
-    types::{AuthorityClass, CreateAgentRequest, SpawnAgentModelRequest, ToolCapabilityFamily},
+    types::{AgentModelRequest, AuthorityClass, CreateAgentRequest, ToolCapabilityFamily},
 };
 
 use super::{serialize_success, BuiltinToolDefinition};
@@ -24,7 +24,7 @@ pub(crate) struct CreateAgentArgs {
     pub(crate) name: Option<String>,
     pub(crate) initial_message: Option<String>,
     pub(crate) template: Option<String>,
-    pub(crate) model: Option<SpawnAgentModelRequest>,
+    pub(crate) model: Option<AgentModelRequest>,
 }
 
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {

--- a/src/tool/tools/create_agent.rs
+++ b/src/tool/tools/create_agent.rs
@@ -43,6 +43,7 @@ pub(crate) async fn execute(
     authority_class: &AuthorityClass,
     input: &Value,
 ) -> Result<crate::tool::ToolResult> {
+    reject_legacy_agent_creation_input(input)?;
     let args: CreateAgentArgs = parse_tool_args(NAME, input)?;
     let agent_id = validate_non_empty(args.agent_id, NAME, "agent_id")?;
     if let Err(error) = validate_agent_id_format(&agent_id) {
@@ -75,13 +76,43 @@ pub(crate) async fn execute(
     serialize_success(NAME, &result)
 }
 
+fn reject_legacy_agent_creation_input(input: &Value) -> Result<()> {
+    let Some(object) = input.as_object() else {
+        return Ok(());
+    };
+    let Some(field) = [
+        "kind",
+        "visibility",
+        "ownership",
+        "profile_preset",
+        "preset",
+    ]
+    .into_iter()
+    .find(|field| object.contains_key(*field)) else {
+        return Ok(());
+    };
+    Err(anyhow::Error::from(
+        crate::tool::ToolError::new(
+            "legacy_agent_creation_input",
+            format!("CreateAgent no longer accepts the legacy `{field}` field"),
+        )
+        .with_details(json!({
+            "tool_name": NAME,
+            "field": field,
+        }))
+        .with_recovery_hint(
+            "use CreateAgent for an independent identity or InvokeAgent with target.kind=new_subagent for supervised delegation",
+        ),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
     use crate::tool::helpers::parse_tool_args;
 
-    use super::{CreateAgentArgs, NAME};
+    use super::{reject_legacy_agent_creation_input, CreateAgentArgs, NAME};
 
     #[test]
     fn create_agent_rejects_caller_controlled_provenance() {
@@ -114,5 +145,19 @@ mod tests {
         .expect_err("nested model typos should be rejected");
 
         assert!(error.to_string().contains("max_output_token"));
+    }
+
+    #[test]
+    fn create_agent_rejects_legacy_identity_fields_with_stable_error() {
+        let error = reject_legacy_agent_creation_input(&json!({
+            "agent_id": "release-bot",
+            "profile_preset": "public_named"
+        }))
+        .expect_err("legacy identity fields should have a stable typed error");
+
+        let tool_error = error
+            .downcast_ref::<crate::tool::ToolError>()
+            .expect("typed tool error");
+        assert_eq!(tool_error.kind, "legacy_agent_creation_input");
     }
 }

--- a/src/tool/tools/invoke_agent.rs
+++ b/src/tool/tools/invoke_agent.rs
@@ -58,6 +58,7 @@ pub(crate) async fn execute(
     authority_class: &AuthorityClass,
     input: &Value,
 ) -> Result<crate::tool::ToolResult> {
+    reject_legacy_agent_invocation_input(input)?;
     let args: InvokeAgentArgs = parse_tool_args(NAME, input)?;
     let initial_message = validate_non_empty(args.initial_message, NAME, "initial_message")?;
     let target = match args.target {
@@ -103,6 +104,39 @@ pub(crate) async fn execute(
     Ok(success_from_value(NAME, value))
 }
 
+fn reject_legacy_agent_invocation_input(input: &Value) -> Result<()> {
+    let Some(object) = input.as_object() else {
+        return Ok(());
+    };
+    let top_level = ["preset", "profile_preset", "visibility", "ownership"]
+        .into_iter()
+        .find(|field| object.contains_key(*field));
+    let target_level = object
+        .get("target")
+        .and_then(Value::as_object)
+        .and_then(|target| {
+            ["preset", "profile_preset", "visibility", "ownership"]
+                .into_iter()
+                .find(|field| target.contains_key(*field))
+        });
+    let Some(field) = top_level.or(target_level) else {
+        return Ok(());
+    };
+    Err(anyhow::Error::from(
+        ToolError::new(
+            "legacy_agent_invocation_input",
+            format!("InvokeAgent no longer accepts the legacy `{field}` field"),
+        )
+        .with_details(serde_json::json!({
+            "tool_name": NAME,
+            "field": field,
+        }))
+        .with_recovery_hint(
+            "select target.kind=existing_agent or target.kind=new_subagent without legacy identity presets",
+        ),
+    ))
+}
+
 fn map_invocation_error(error: anyhow::Error) -> anyhow::Error {
     let descriptor = describe_runtime_error(&error);
     if descriptor.code == "agent_target_unavailable" {
@@ -126,7 +160,7 @@ mod tests {
 
     use crate::tool::helpers::parse_tool_args;
 
-    use super::{InvokeAgentArgs, NAME};
+    use super::{reject_legacy_agent_invocation_input, InvokeAgentArgs, NAME};
 
     #[test]
     fn invoke_agent_contract_accepts_exactly_the_two_target_variants() {
@@ -189,5 +223,22 @@ mod tests {
         .expect_err("trusted caller context must not be request-controlled");
 
         assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn invoke_agent_rejects_legacy_identity_fields_with_stable_error() {
+        let error = reject_legacy_agent_invocation_input(&json!({
+            "initial_message": "do work",
+            "target": {
+                "kind": "new_subagent",
+                "preset": "private_child"
+            }
+        }))
+        .expect_err("legacy identity fields should have a stable typed error");
+
+        let tool_error = error
+            .downcast_ref::<crate::tool::ToolError>()
+            .expect("typed tool error");
+        assert_eq!(tool_error.kind, "legacy_agent_invocation_input");
     }
 }

--- a/src/tool/tools/invoke_agent.rs
+++ b/src/tool/tools/invoke_agent.rs
@@ -9,8 +9,8 @@ use crate::{
     runtime_error::describe_runtime_error,
     tool::{error::ToolError, spec::typed_spec},
     types::{
-        AuthorityClass, ChildAgentWorkspaceMode, InvokeAgentRequest, InvokeAgentTarget,
-        SpawnAgentModelRequest, ToolCapabilityFamily,
+        AgentModelRequest, AuthorityClass, ChildAgentWorkspaceMode, InvokeAgentRequest,
+        InvokeAgentTarget, ToolCapabilityFamily,
     },
 };
 
@@ -31,7 +31,7 @@ pub(crate) enum InvokeAgentToolTarget {
         template: Option<String>,
         #[serde(default)]
         workspace_mode: ChildAgentWorkspaceMode,
-        model: Option<SpawnAgentModelRequest>,
+        model: Option<AgentModelRequest>,
     },
 }
 

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -2414,21 +2414,11 @@ mod tests {
     }
 
     #[test]
-    fn projection_bootstrap_preserves_agent_identity_contract() {
+    fn projection_bootstrap_preserves_agent_identity() {
         let projection = TuiProjection::from_snapshot(sample_snapshot());
 
-        assert_eq!(
-            projection.agent.identity.ownership,
-            AgentOwnership::SelfOwned
-        );
-        assert_eq!(
-            projection.agent.identity.profile_preset,
-            AgentProfilePreset::PublicNamed
-        );
-        assert_eq!(
-            projection.agent.identity.contract_badge(),
-            "public/self_owned (public_named)"
-        );
+        assert_eq!(projection.agent.identity.agent_id, "default");
+        assert!(projection.agent.identity.is_default_agent);
     }
 
     #[test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -111,7 +111,7 @@ pub(super) fn render_agent_state_text(app: &TuiApp) -> String {
             "Agent: {} / {:?}",
             agent.identity.agent_id, agent.agent.status
         ),
-        format!("Contract: {}", agent.identity.contract_badge()),
+        format!("Identity: {}", agent.identity.relation_summary()),
         format!(
             "Queue: pending {}  active tasks {}",
             agent.agent.pending, agent.active_task_count
@@ -927,17 +927,9 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
             agent.identity.display_name(),
             agent.identity.agent_id
         ),
-        format!("Kind: {:?}", agent.identity.kind),
-        format!("Identity contract: {}", agent.identity.contract_badge()),
-        format!("Contract summary: {}", agent.identity.contract_summary()),
-        format!(
-            "Agent tool surface: {}",
-            agent.identity.profile_preset.agent_tool_surface_summary()
-        ),
-        format!(
-            "Cleanup ownership: {}",
-            agent.identity.ownership.cleanup_summary()
-        ),
+        format!("Identity relation: {}", agent.identity.relation_summary()),
+        "Tool access: canonical capability policy".into(),
+        "Cleanup authority: canonical lifecycle attachment and supervision".into(),
         format!("Status: {:?}", agent.agent.status),
         format!(
             "Model: {} ({:?})",
@@ -1013,11 +1005,10 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
                 .iter()
                 .map(|child| {
                     format!(
-                        "{}:{}:{:?}[{}]",
+                        "{}:{}:{:?}",
                         child.identity.display_name(),
                         child.identity.agent_id,
-                        child.status,
-                        child.identity.contract_badge()
+                        child.status
                     )
                 })
                 .collect::<Vec<_>>()

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1245,14 +1245,14 @@ mod tests {
     }
 
     #[test]
-    fn render_summary_uses_profile_and_ownership_semantics() {
+    fn render_summary_uses_canonical_identity_relations() {
         let rendered = render_summary(&sample_agent_summary());
-        assert!(rendered.contains("Identity contract: public/self_owned (public_named)"));
-        assert!(rendered.contains("public self-owned agent addressed directly by `agent_id`"));
-        assert!(rendered.contains("CreateAgent creates independent identities"));
+        assert!(rendered.contains("Identity relation: independently addressable agent identity"));
+        assert!(rendered.contains("Tool access: canonical capability policy"));
         assert!(
-            rendered.contains("child_1:AwakeRunning[private/parent_supervised (private_child)]")
+            rendered.contains("Cleanup authority: canonical lifecycle attachment and supervision")
         );
+        assert!(rendered.contains("Children: child_1:child_1:AwakeRunning"));
         assert!(rendered.contains("Execution backend: host_local"));
         assert!(rendered.contains("Process execution: runtime_shaped"));
         assert!(rendered.contains(

--- a/src/types.rs
+++ b/src/types.rs
@@ -540,7 +540,7 @@ pub struct AgentBootstrapDesiredState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace: Option<AgentBootstrapWorkspaceState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_resolution: Option<SpawnAgentModelResolution>,
+    pub model_resolution: Option<AgentModelResolution>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub initial_message: Option<AgentBootstrapInitialMessage>,
 }
@@ -678,7 +678,7 @@ pub struct CreateAgentRequest {
     pub initial_message: Option<String>,
     pub authority_class: AuthorityClass,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_resolution: Option<SpawnAgentModelResolution>,
+    pub model_resolution: Option<AgentModelResolution>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lineage_parent_agent_id: Option<String>,
     #[serde(default)]
@@ -697,7 +697,7 @@ pub enum InvokeAgentTarget {
         #[serde(default)]
         workspace_mode: ChildAgentWorkspaceMode,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        model_resolution: Option<SpawnAgentModelResolution>,
+        model_resolution: Option<AgentModelResolution>,
     },
 }
 
@@ -3808,7 +3808,7 @@ pub struct TaskStatusSnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_usage: Option<AgentTokenUsageSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_resolution: Option<SpawnAgentModelResolution>,
+    pub model_resolution: Option<AgentModelResolution>,
 }
 
 impl TaskStatusSnapshot {
@@ -4031,12 +4031,12 @@ pub struct SpawnAgentResult {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub child_work_item_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_resolution: Option<SpawnAgentModelResolution>,
+    pub model_resolution: Option<AgentModelResolution>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct SpawnAgentModelRequest {
+pub struct AgentModelRequest {
     pub provider: String,
     pub model: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -4051,7 +4051,7 @@ pub struct SpawnAgentModelRequest {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum SpawnAgentModelResolutionStatus {
+pub enum AgentModelResolutionStatus {
     Inherited,
     Accepted,
     Normalized,
@@ -4060,14 +4060,14 @@ pub enum SpawnAgentModelResolutionStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
-pub struct SpawnAgentModelResolution {
+pub struct AgentModelResolution {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requested: Option<SpawnAgentModelRequest>,
+    pub requested: Option<AgentModelRequest>,
     pub resolved_provider: String,
     pub resolved_model: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_parameters: Option<serde_json::Map<String, serde_json::Value>>,
-    pub resolution_status: SpawnAgentModelResolutionStatus,
+    pub resolution_status: AgentModelResolutionStatus,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub policy_notes: Vec<String>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1222,7 +1222,7 @@ impl AgentTemplateSourceKind {
 pub struct AgentTemplateCatalogEntry {
     /// Stable source-scoped catalog identifier, such as `user:holon-reviewer`.
     pub catalog_id: String,
-    /// Preferred selector accepted by SpawnAgent.template.
+    /// Preferred selector accepted by agent creation and invocation requests.
     ///
     /// `catalog_id` is also accepted, along with source aliases such as
     /// `user:`, `agent:`, and `remote:`.
@@ -1271,7 +1271,7 @@ pub struct AgentTemplateCatalogEntry {
 pub struct AgentTemplateDetail {
     /// Stable source-scoped catalog identifier, such as `user:holon-reviewer`.
     pub catalog_id: String,
-    /// Preferred selector accepted by SpawnAgent.template.
+    /// Preferred selector accepted by agent creation and invocation requests.
     pub template: String,
     /// Human-readable local id after precedence is applied.
     pub template_id: String,
@@ -3979,31 +3979,6 @@ pub struct TaskInputResult {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GetAgentResult {
     pub agent: AgentSummary,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct SpawnAgentResult {
-    pub agent_id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub create_receipt: Option<AgentCreateReceipt>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub child_agent_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub task_handle: Option<TaskHandle>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub supervision_task_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub child_supervision: Option<ChildSupervisionProjection>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub summary_text: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub delegation_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub parent_work_item_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub child_work_item_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_resolution: Option<AgentModelResolution>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -338,29 +338,7 @@ pub enum AgentProfilePreset {
     PublicNamed,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum ToolCapabilityFamily {
-    CoreAgent,
-    LocalEnvironment,
-    Web,
-    AgentCreation,
-    AuthorityExpanding,
-    ExternalTrigger,
-}
-
-impl ToolCapabilityFamily {
-    pub(crate) fn label(self) -> &'static str {
-        match self {
-            Self::CoreAgent => "core_agent",
-            Self::LocalEnvironment => "local_environment",
-            Self::Web => "web",
-            Self::AgentCreation => "agent_creation",
-            Self::AuthorityExpanding => "authority_expanding",
-            Self::ExternalTrigger => "external_trigger",
-        }
-    }
-}
+pub(crate) type ToolCapabilityFamily = AgentCapabilityFamily;
 
 impl AgentProfilePreset {
     pub fn label(self) -> &'static str {
@@ -654,7 +632,6 @@ pub struct AgentCreateReceipt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub display_name: String,
-    pub preset: AgentProfilePreset,
     pub stage: AgentCreateStage,
     pub lifecycle: AgentRegistryStatus,
     pub created: bool,
@@ -663,7 +640,7 @@ pub struct AgentCreateReceipt {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct AgentCreateResult {
-    pub identity: AgentIdentityRecord,
+    pub identity: AgentIdentityView,
     pub receipt: AgentCreateReceipt,
 }
 
@@ -922,9 +899,17 @@ pub struct AgentIdentityView {
     pub agent_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(skip, default = "default_agent_kind")]
+    #[schemars(skip)]
     pub kind: AgentKind,
+    #[serde(skip, default = "default_agent_visibility")]
+    #[schemars(skip)]
     pub visibility: AgentVisibility,
+    #[serde(skip, default = "default_agent_ownership")]
+    #[schemars(skip)]
     pub ownership: AgentOwnership,
+    #[serde(skip, default = "default_agent_profile_preset")]
+    #[schemars(skip)]
     pub profile_preset: AgentProfilePreset,
     pub status: AgentRegistryStatus,
     pub is_default_agent: bool,
@@ -939,6 +924,22 @@ pub struct AgentIdentityView {
     pub lineage_parent_agent_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delegated_from_task_id: Option<String>,
+}
+
+fn default_agent_kind() -> AgentKind {
+    AgentKind::Named
+}
+
+fn default_agent_visibility() -> AgentVisibility {
+    AgentVisibility::Public
+}
+
+fn default_agent_ownership() -> AgentOwnership {
+    AgentOwnership::SelfOwned
+}
+
+fn default_agent_profile_preset() -> AgentProfilePreset {
+    AgentProfilePreset::PublicNamed
 }
 
 impl AgentIdentityView {
@@ -963,40 +964,11 @@ impl AgentIdentityView {
         self.name.as_deref().unwrap_or(&self.agent_id)
     }
 
-    pub fn contract_badge(&self) -> String {
-        format!(
-            "{}/{} ({})",
-            self.visibility.label(),
-            self.ownership.label(),
-            self.profile_preset.label()
-        )
-    }
-
-    pub fn contract_summary(&self) -> String {
-        match (
-            self.visibility,
-            self.ownership,
-            self.profile_preset,
-            self.kind,
-        ) {
-            (
-                AgentVisibility::Public,
-                AgentOwnership::SelfOwned,
-                AgentProfilePreset::PublicNamed,
-                _,
-            ) => "public self-owned agent addressed directly by `agent_id`".into(),
-            (
-                AgentVisibility::Private,
-                AgentOwnership::ParentSupervised,
-                AgentProfilePreset::PrivateChild,
-                AgentKind::Child,
-            ) => "private parent-supervised child that remains under a parent task handle".into(),
-            _ => format!(
-                "{} {} agent with `{}` profile",
-                self.visibility.label(),
-                self.ownership.phrase(),
-                self.profile_preset.label()
-            ),
+    pub fn relation_summary(&self) -> String {
+        if let Some(parent_agent_id) = self.lineage_parent_agent_id.as_deref() {
+            format!("agent with lineage parent `{parent_agent_id}`")
+        } else {
+            "independently addressable agent identity".into()
         }
     }
 }

--- a/tests/fixtures/observer_sync/agent_projection_snapshot.json
+++ b/tests/fixtures/observer_sync/agent_projection_snapshot.json
@@ -11,10 +11,6 @@
     "agent": {
       "identity": {
         "agent_id": "worker-a",
-        "kind": "named",
-        "visibility": "public",
-        "ownership": "self_owned",
-        "profile_preset": "public_named",
         "status": "active",
         "is_default_agent": false,
         "incarnation": 1

--- a/tests/fixtures/observer_sync/agent_roster_snapshot.json
+++ b/tests/fixtures/observer_sync/agent_roster_snapshot.json
@@ -8,10 +8,6 @@
       "agent": {
         "identity": {
           "agent_id": "worker-a",
-          "kind": "named",
-          "visibility": "public",
-          "ownership": "self_owned",
-          "profile_preset": "public_named",
           "status": "active",
           "is_default_agent": false,
           "incarnation": 1
@@ -47,10 +43,6 @@
       "agent": {
         "identity": {
           "agent_id": "worker-b",
-          "kind": "named",
-          "visibility": "public",
-          "ownership": "self_owned",
-          "profile_preset": "public_named",
           "status": "active",
           "is_default_agent": false,
           "incarnation": 1

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -85,6 +85,42 @@ fn admitted_operator_prompt(
     )
 }
 
+async fn invoke_new_subagent(
+    runtime: &holon::runtime::RuntimeHandle,
+    message: String,
+    authority_class: AuthorityClass,
+    template: Option<String>,
+    model_request: Option<holon::types::AgentModelRequest>,
+) -> Result<holon::types::AgentInvocationReceipt> {
+    let registry = ToolRegistry::new(std::path::PathBuf::new());
+    let caller_agent_id = runtime.agent_summary().await?.identity.agent_id;
+    let (result, _) = registry
+        .execute(
+            runtime,
+            &caller_agent_id,
+            &authority_class,
+            &ToolCall {
+                id: "invoke-private-child".into(),
+                name: "InvokeAgent".into(),
+                input: serde_json::json!({
+                    "target": {
+                        "kind": "new_subagent",
+                        "template": template,
+                        "workspace_mode": "inherit",
+                        "model": model_request,
+                    },
+                    "initial_message": message,
+                }),
+            },
+        )
+        .await?;
+    let value = result
+        .envelope
+        .result
+        .ok_or_else(|| anyhow::anyhow!("InvokeAgent returned no result"))?;
+    Ok(serde_json::from_value(value)?)
+}
+
 struct WaitForDispatchProvider {
     calls: Mutex<usize>,
     assistant_text: Option<&'static str>,
@@ -948,17 +984,14 @@ pub async fn notify_operator_records_default_public_and_private_child_targets() 
     assert_eq!(public_value["target_operator_boundary"], "primary_operator");
     assert_eq!(public_value["agent_id"], "public-agent");
 
-    let spawned = default_runtime
-        .spawn_agent(
-            Some("child prompt".into()),
-            AuthorityClass::OperatorInstruction,
-            AgentProfilePreset::PrivateChild,
-            None,
-            false,
-            None,
-            None,
-        )
-        .await?;
+    let spawned = invoke_new_subagent(
+        &default_runtime,
+        "child prompt".into(),
+        AuthorityClass::OperatorInstruction,
+        None,
+        None,
+    )
+    .await?;
     let child_runtime = host.get_or_create_agent(&spawned.agent_id).await?;
     let child_notification = child_runtime
         .notify_operator("Child needs supervision visibility".into())


### PR DESCRIPTION
## 概要

- 移除 current-version 的 legacy Agent identity/model surface：`AgentVisibility`、bundled `AgentOwnership` inference、`PrivateChild` / `PublicNamed` preset，以及 authoritative `AgentKind::Child` 行为推导
- 将 identity、tree、lifecycle 与 observer/TUI projection 统一到 canonical relation/policy
- 删除不可达的 `SpawnAgent` facade，并把 current terminology 迁移到 `CreateAgent` / `InvokeAgent`
- 保留旧版本请求的稳定 typed error、旧 schema fixture upgrade，以及 `v0.38.0` offline migration bridge 与必要持久化兼容边界

## Migration gate（已完成）

- [x] 2026-09-10 在 verified cold backup 后使用 `holon 0.38.0` 完成 offline apply
- [x] 扫描 1051 个 agents，迁移 1023 个 agents / 6065 个 relation axes
- [x] 3 个缺少 supervision durable evidence 的 archived `tmp_child_*` records 已显式 `ACCEPT-AND-ISOLATE`
- [x] apply 后复查为 `changed_agents=0`、`migrated_axes=0`，且 3 组 diagnostics 与 apply 输出一致
- [x] 服务恢复为 `active/running`；ambiguous records 无 runtime state、queue、wait、task 或 WorkItem
- [x] 基于真实 apply 结果复核 compatibility、typed-error 与 DB removal 边界

本 PR 继续保留 offline bridge，不包含 destructive DB removal。`v0.38.0` 是最后一个 migration bridge release；该 cleanup 最早进入 `v0.39.0`。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib` — 3084 passed, 0 failed, 4 ignored
- 定向覆盖 legacy request typed error、旧 schema/observer fixtures、canonical create/invoke/tree/deletion/result-rejoin 与 agent relation backfill
- 修复后独立只读复审：clean review，无 findings
- PR head `22458f82` 的全部非跳过 checks 通过
