### PR TITLE
release: prepare v0.39.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,18 +328,18 @@ jobs:
         run: |
           set -euo pipefail
           cat > release-notes.md <<EOF
-          This release introduces the canonical Agent identity and invocation model, including named Agent creation, Agent tree and detail APIs, native CreateAgent and InvokeAgent tools, reliable Agent messaging, and a restart-safe migration bridge that backfills legacy Agent metadata without rebuilding Agent state.
+          This release completes the current Agent identity model with canonical detail, rename, recreation, and incarnation-aware surfaces, removes the legacy identity compatibility model after its migration window, and strengthens long-lived Agent lifecycle, delivery, history, workspace, and Web GUI behavior.
 
           Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64. The macOS app DMG is a universal binary supporting both x86_64 and arm64. The Linux amd64 binary supports Ubuntu 22.04 or newer (glibc 2.35 or newer).
 
           ## Changes
 
-          - Add canonical Agent names, detail and tree APIs, duplicate-name protection, and typed name errors ([#2796](https://github.com/holon-run/holon/pull/2796), [#2801](https://github.com/holon-run/holon/pull/2801), [#2802](https://github.com/holon-run/holon/pull/2802), [#2813](https://github.com/holon-run/holon/pull/2813)).
-          - Centralize Agent creation and invocation, add reconciliation, and expose native CreateAgent and InvokeAgent tools ([#2799](https://github.com/holon-run/holon/pull/2799), [#2804](https://github.com/holon-run/holon/pull/2804), [#2815](https://github.com/holon-run/holon/pull/2815), [#2824](https://github.com/holon-run/holon/pull/2824)).
-          - Persist canonical Agent relations and policies, switch new writes to the canonical model, and add restart-safe dry-run/apply/retry backfill for legacy Agent metadata ([#2812](https://github.com/holon-run/holon/pull/2812), [#2825](https://github.com/holon-run/holon/pull/2825)).
-          - Add reliable Agent message delivery with durable ledger-backed retry and recovery behavior ([#2822](https://github.com/holon-run/holon/pull/2822)).
-          - Improve provider and transport reliability, including request-send disconnect retries, partial Ollama discovery tolerance, browser-compatible WebFetch headers and TLS fingerprinting, and raw workspace file streaming ([#2816](https://github.com/holon-run/holon/pull/2816), [#2818](https://github.com/holon-run/holon/pull/2818), [#2821](https://github.com/holon-run/holon/pull/2821), [#2823](https://github.com/holon-run/holon/pull/2823), [#2826](https://github.com/holon-run/holon/pull/2826)).
-          - Add Holon operations, server operations, and office assistant templates, plus multilingual documentation and web file-browser improvements ([#2805](https://github.com/holon-run/holon/pull/2805), [#2807](https://github.com/holon-run/holon/pull/2807), [#2808](https://github.com/holon-run/holon/pull/2808), [#2814](https://github.com/holon-run/holon/pull/2814), [#2817](https://github.com/holon-run/holon/pull/2817), [#2820](https://github.com/holon-run/holon/pull/2820)).
+          - Add canonical Agent detail and rename surfaces across HTTP, CLI, native tools, and the Web GUI ([#2842](https://github.com/holon-run/holon/pull/2842), [#2843](https://github.com/holon-run/holon/pull/2843), [#2844](https://github.com/holon-run/holon/pull/2844), [#2846](https://github.com/holon-run/holon/pull/2846)).
+          - Make fully deleted Agent IDs safely recreatable as new incarnations and expose incarnation state in the Web GUI ([#2851](https://github.com/holon-run/holon/pull/2851), [#2855](https://github.com/holon-run/holon/pull/2855)).
+          - Remove the legacy Agent identity model after the v0.38.0 migration bridge, while retaining stable upgrade and typed-error boundaries ([#2856](https://github.com/holon-run/holon/pull/2856)).
+          - Strengthen Agent and WorkItem lifecycle behavior with pre-delivery turn sampling, deeper WorkItem-scoped history, and detached WorkItem completion support ([#2845](https://github.com/holon-run/holon/pull/2845), [#2848](https://github.com/holon-run/holon/pull/2848), [#2854](https://github.com/holon-run/holon/pull/2854)).
+          - Harden Agent workspace handling by rejecting symlinked homes during deletion and initializing an explicit agent-local temporary directory ([#2839](https://github.com/holon-run/holon/pull/2839), [#2849](https://github.com/holon-run/holon/pull/2849)).
+          - Return canonical workspace URIs from ViewImage for Web GUI consumption and add crates.io publishing to the release pipeline ([#2836](https://github.com/holon-run/holon/pull/2836), [#2853](https://github.com/holon-run/holon/pull/2853)).
 
           ## Install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "holon"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 default-run = "holon"
 authors = ["Holon Contributors"]

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Status and compatibility
 
 Holon is under active development. The current recommended release is
-[`v0.38.0`](https://github.com/holon-run/holon/releases/tag/v0.38.0).
+[`v0.39.0`](https://github.com/holon-run/holon/releases/tag/v0.39.0).
 
 The current project focus remains the Rust runtime: agent lifecycle, queues,
 WaitFor/wake, tasks, WorkItems, trust boundaries, local workspaces, and

--- a/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
+++ b/apps/macos/HolonMenu/Tests/HolonMenuTests/HolonMenuClientTests.swift
@@ -36,7 +36,7 @@ final class HolonMenuClientTests: XCTestCase {
           "socket_path": "/tmp/holon.sock",
           "http_addr": "127.0.0.1:7878",
           "web_url": "http://127.0.0.1:7878",
-          "product_version": "0.38.0 (abcdef0)",
+          "product_version": "0.39.0 (abcdef0)",
           "control_protocol_version": 1,
           "lifecycle_owner": "standalone",
           "executable_path": "/Applications/Holon.app/Contents/Resources/bin/holon",

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -108,7 +108,7 @@ waitable, delegable, and deliverable.
 ## Status and compatibility
 
 The current recommended release is
-[`v0.38.0`](https://github.com/holon-run/holon/releases/tag/v0.38.0).
+[`v0.39.0`](https://github.com/holon-run/holon/releases/tag/v0.39.0).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project maintains

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -11676,7 +11676,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.38.0"
+    "version": "0.39.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/docs/website/zh-CN/README.md
+++ b/docs/website/zh-CN/README.md
@@ -90,7 +90,7 @@ Holon 把 Agent 的工作拆解为几个显式的运行时对象：
 ## 状态与兼容性
 
 当前推荐版本是
-[`v0.38.0`](https://github.com/holon-run/holon/releases/tag/v0.38.0)。
+[`v0.39.0`](https://github.com/holon-run/holon/releases/tag/v0.39.0)。
 
 `v0.15.0` 是 Holon Rust 运行时进入公开兼容性维护的基线版本。从该版本起，项目对 CLI、
 daemon/API 语义和本地持久化存储维持兼容性预期。

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository-local release and development scripts."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Ensure unittest resolves this repository's test modules."""

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -18,10 +18,6 @@ function agentStateFixture(agentId: string): components["schemas"]["AgentStateSn
     agent: {
       identity: {
         agent_id: agentId,
-        kind: "named",
-        visibility: "public",
-        ownership: "self_owned",
-        profile_preset: "public_named",
         status: "active",
         is_default_agent: false,
         incarnation: 1,
@@ -416,7 +412,7 @@ describe("createRuntimeClient", () => {
     await expect(client.getAgentState("agent-one")).resolves.toEqual(
       expect.objectContaining({
         id: "agent-one",
-        profile: "public · self_owned · public_named",
+        profile: "public",
       }),
     );
     expect(seen).toEqual(["http://example.test:7878/api/agents/agent-one/state"]);

--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -2260,19 +2260,11 @@ export interface components {
                  */
                 incarnation: number;
                 is_default_agent: boolean;
-                /** @enum {string} */
-                kind: "default" | "named" | "child";
                 lineage_parent_agent_id?: string | null;
                 name?: string | null;
-                /** @enum {string} */
-                ownership: "parent_supervised" | "self_owned";
                 parent_agent_id?: string | null;
                 /** @enum {string} */
-                profile_preset: "private_child" | "public_named";
-                /** @enum {string} */
                 status: "active" | "deleting" | "deleted";
-                /** @enum {string} */
-                visibility: "public" | "private";
             };
             job: {
                 agent_id: string;
@@ -2311,19 +2303,11 @@ export interface components {
                  */
                 incarnation: number;
                 is_default_agent: boolean;
-                /** @enum {string} */
-                kind: "default" | "named" | "child";
                 lineage_parent_agent_id?: string | null;
                 name?: string | null;
-                /** @enum {string} */
-                ownership: "parent_supervised" | "self_owned";
                 parent_agent_id?: string | null;
                 /** @enum {string} */
-                profile_preset: "private_child" | "public_named";
-                /** @enum {string} */
                 status: "active" | "deleting" | "deleted";
-                /** @enum {string} */
-                visibility: "public" | "private";
             };
             job?: {
                 agent_id: string;
@@ -2552,19 +2536,11 @@ export interface components {
                  */
                 incarnation: number;
                 is_default_agent: boolean;
-                /** @enum {string} */
-                kind: "default" | "named" | "child";
                 lineage_parent_agent_id?: string | null;
                 name?: string | null;
-                /** @enum {string} */
-                ownership: "parent_supervised" | "self_owned";
                 parent_agent_id?: string | null;
                 /** @enum {string} */
-                profile_preset: "private_child" | "public_named";
-                /** @enum {string} */
                 status: "active" | "deleting" | "deleted";
-                /** @enum {string} */
-                visibility: "public" | "private";
             };
             lineage_children?: {
                 child_agent_id: string;
@@ -2661,19 +2637,11 @@ export interface components {
                          */
                         incarnation: number;
                         is_default_agent: boolean;
-                        /** @enum {string} */
-                        kind: "default" | "named" | "child";
                         lineage_parent_agent_id?: string | null;
                         name?: string | null;
-                        /** @enum {string} */
-                        ownership: "parent_supervised" | "self_owned";
                         parent_agent_id?: string | null;
                         /** @enum {string} */
-                        profile_preset: "private_child" | "public_named";
-                        /** @enum {string} */
                         status: "active" | "deleting" | "deleted";
-                        /** @enum {string} */
-                        visibility: "public" | "private";
                     };
                     observability: {
                         /** @enum {string|null} */
@@ -2830,19 +2798,11 @@ export interface components {
                      */
                     incarnation: number;
                     is_default_agent: boolean;
-                    /** @enum {string} */
-                    kind: "default" | "named" | "child";
                     lineage_parent_agent_id?: string | null;
                     name?: string | null;
-                    /** @enum {string} */
-                    ownership: "parent_supervised" | "self_owned";
                     parent_agent_id?: string | null;
                     /** @enum {string} */
-                    profile_preset: "private_child" | "public_named";
-                    /** @enum {string} */
                     status: "active" | "deleting" | "deleted";
-                    /** @enum {string} */
-                    visibility: "public" | "private";
                 };
                 /**
                  * @default {
@@ -3095,19 +3055,11 @@ export interface components {
                      */
                     incarnation: number;
                     is_default_agent: boolean;
-                    /** @enum {string} */
-                    kind: "default" | "named" | "child";
                     lineage_parent_agent_id?: string | null;
                     name?: string | null;
-                    /** @enum {string} */
-                    ownership: "parent_supervised" | "self_owned";
                     parent_agent_id?: string | null;
                     /** @enum {string} */
-                    profile_preset: "private_child" | "public_named";
-                    /** @enum {string} */
                     status: "active" | "deleting" | "deleted";
-                    /** @enum {string} */
-                    visibility: "public" | "private";
                 };
                 /**
                  * @default {
@@ -3298,19 +3250,11 @@ export interface components {
                          */
                         incarnation: number;
                         is_default_agent: boolean;
-                        /** @enum {string} */
-                        kind: "default" | "named" | "child";
                         lineage_parent_agent_id?: string | null;
                         name?: string | null;
-                        /** @enum {string} */
-                        ownership: "parent_supervised" | "self_owned";
                         parent_agent_id?: string | null;
                         /** @enum {string} */
-                        profile_preset: "private_child" | "public_named";
-                        /** @enum {string} */
                         status: "active" | "deleting" | "deleted";
-                        /** @enum {string} */
-                        visibility: "public" | "private";
                     };
                     /**
                      * @default {

--- a/web-gui/openapi-tools/package-lock.json
+++ b/web-gui/openapi-tools/package-lock.json
@@ -62,9 +62,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.17",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.17.tgz",
-      "integrity": "sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==",
+      "version": "1.34.20",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.20.tgz",
+      "integrity": "sha512-ypeBZ/6BKXR9+7/TtbKhbl4UgD7raHhPS12oknlKno2A8+lnFkxIwiE/Aklu6L2cd/ioH+fCWuMxi9/p3EyAPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -73,7 +73,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.2",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -118,9 +118,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -211,9 +211,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- bump the crate and recommended release references to `0.39.0`
- prepare release notes for the completed canonical Agent identity model, incarnation-aware recreation, legacy identity cleanup, lifecycle/workspace hardening, ViewImage workspace URIs, and crates.io publishing
- refresh the OpenAPI document, generated TypeScript client, and client fixtures against the current Rust transport contract
- update the OpenAPI tooling lockfile to patched compatible transitive versions with a clean Node 24 install and zero known audit vulnerabilities
- make repository-local Python release/E2E modules resolve deterministically by marking `scripts` and `tests` as packages

## Release boundary

This PR prepares the `v0.39.0` release only. It does **not** create a tag, publish crates or artifacts, trigger the release workflow, or merge itself.

## Release qualification evidence

- Rust format, warning-free all-target checks, tests, snapshots, and resource audits passed
- clean Node `24.19.0` Web CI, deterministic OpenAPI generation checks, and `npm audit` passed with zero vulnerabilities
- locked Rust build and `cargo publish --dry-run --locked --allow-dirty` passed, including isolated crate packaging/compilation
- concurrent runtime tests and repeated stress runs passed
- Docker manifest validation, image smoke, and all 11 deterministic scheduler-required release cases passed
- real-data two-stage upgrade from `v0.38.0` to candidate schema `61` passed, including retained data/history/workspace behavior and database integrity checks
- Python release/E2E test discovery passed with 106 tests after the package-resolution fix

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check --all-targets`
- `cargo test --all-targets`
- `make snapshots-check`
- `make test-resource-lint`
- `make web-ci` with Node `24.19.0` and clean `node_modules`
- `cargo publish --dry-run --locked --allow-dirty`
- `make test-concurrent`
- `make test-concurrent-repeat`
- `make docker-e2e-validate`
- `make docker-smoke`
- `python3 scripts/docker-e2e.py --image holon:dev --skip-build --profile scheduler-required --scheduler-matrix --timeout 120`
- isolated real-data `v0.38.0 -> v0.39.0` two-stage upgrade with `EXPECTED_SCHEMA=61`
