### PR TITLE
feat: allow peer invocation of independent agents

### DIFF
--- a/docs/rfcs/agent-identity-relations-and-message-delivery.md
+++ b/docs/rfcs/agent-identity-relations-and-message-delivery.md
@@ -315,6 +315,7 @@ agent. The first implementation is deny-by-default and evaluates these grants:
 
 - authenticated operator control;
 - supervising parent;
+- peer invocation of active persistent independent agents;
 - explicitly authorized peer agents;
 - external ingress bindings; and
 - future scoped runtime capabilities.
@@ -331,7 +332,8 @@ The initial send policy is:
 | authenticated operator control with `agent.message.send` scope | allow unless an applicable explicit deny exists |
 | active supervising parent using the supervision follow-up route | allow while that supervision remains active |
 | lineage parent without active supervision | deny unless an explicit scoped allow exists |
-| peer agent | deny unless an explicit scoped allow exists |
+| peer agent using the `agent_invocation` route to an active persistent independent target | allow unless an applicable explicit rule overrides it |
+| any other peer-agent message | deny unless an explicit scoped allow exists |
 | configured external ingress binding | allow only within that binding's target and content scope |
 | any other caller | deny |
 
@@ -378,9 +380,10 @@ The ordinary tree hides `Deleted` identities. Historical lineage, task
 evidence, deletion jobs, and tombstones remain queryable through their
 authorized historical surfaces.
 
-Operator visibility does not imply peer visibility. An agent must not gain the
-ability to enumerate or message every tree node merely because the operator can
-see it.
+Operator visibility does not imply peer visibility. The narrow peer invocation
+grant is derived from canonical `persistent + independent` lifecycle facts, not
+from tree visibility, and does not grant peer enumeration or other message
+routes.
 
 ## 4. Operator Interaction With Subagents
 
@@ -562,7 +565,7 @@ The service evaluates one request in this order:
 4. begin the atomic admission transaction and read and fence the target
    identity lifecycle;
 5. authorize message admission under relation and message policy from the same
-   transaction snapshot;
+   transaction snapshot, recording any derived grant in admission evidence;
 6. atomically create or reuse the delivery and queue record;
 7. commit the admission transaction; and
 8. trigger post-commit scheduler reconciliation.
@@ -1056,8 +1059,8 @@ not be combined with first introducing the replacement state.
 - retryable stopped/queue-unavailable rejection can succeed later with the same
   key, while a response-lost committed admission still replays one delivery;
 - authenticated operator control, active supervision, lineage-only parent,
-  explicitly authorized peer, external binding, and unknown caller follow the
-  initial authorization matrix;
+  persistent independent peer invocation, explicitly authorized peer, external
+  binding, and unknown caller follow the initial authorization matrix;
 - an applicable explicit deny overrides an allow and supervision close removes
   the derived parent grant; when detach is implemented, lifecycle detach does
   not recreate it;

--- a/src/domain/agent.rs
+++ b/src/domain/agent.rs
@@ -257,6 +257,12 @@ pub struct AgentMessageCallerContext {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentMessageDerivedGrant {
+    PersistentIndependentPeerInvocation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct AgentMessageAdmissionEvidence {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity_revision: Option<u64>,
@@ -272,6 +278,8 @@ pub struct AgentMessageAdmissionEvidence {
     pub route: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub matched_rule_index: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub derived_grant: Option<AgentMessageDerivedGrant>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]

--- a/src/host.rs
+++ b/src/host.rs
@@ -5317,10 +5317,9 @@ mod tests {
         storage::AppStorage,
         system::WorkspaceProjectionKind,
         types::{
-            AgentDeletionPhase, AgentDeletionStatus, AgentKind, AgentMessagePolicyRecord,
-            AgentMessagePolicyRule, AgentMessagePrincipalKind, AgentOwnership, AgentPolicyEffect,
-            AgentProfilePreset, AgentRegistryStatus, AgentStatus, AgentVisibility, AuthorityClass,
-            BriefKind, BriefRecord, ChildAgentWorkspaceMode, ControlAction, DeliverySummaryRecord,
+            AgentDeletionPhase, AgentDeletionStatus, AgentKind, AgentOwnership, AgentProfilePreset,
+            AgentRegistryStatus, AgentStatus, AgentVisibility, AuthorityClass, BriefKind,
+            BriefRecord, ChildAgentWorkspaceMode, ControlAction, DeliverySummaryRecord,
             InvokeAgentRequest, InvokeAgentTarget, MessageBody, MessageEnvelope, MessageKind,
             MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus, TaskRecord,
             TaskRecoverySpec, TaskStatus, TurnTerminalKind, WaitConditionKind, WaitConditionRecord,
@@ -6647,26 +6646,6 @@ mod tests {
             })
             .await
             .unwrap();
-        let identity = host
-            .agent_identity_record("canonical-existing")
-            .unwrap()
-            .unwrap();
-        host.runtime_db()
-            .agent_canonical_relations()
-            .upsert_message_policy(&AgentMessagePolicyRecord {
-                agent_id: identity.agent_id.clone(),
-                revision: 1,
-                default_effect: AgentPolicyEffect::Deny,
-                rules: vec![AgentMessagePolicyRule {
-                    principal_kind: AgentMessagePrincipalKind::PeerAgent,
-                    principal_id: Some(parent_agent_id),
-                    route: Some("agent_invocation".into()),
-                    effect: AgentPolicyEffect::Allow,
-                }],
-                created_at: identity.created_at,
-            })
-            .unwrap();
-
         let target = host.get_public_agent("canonical-existing").await.unwrap();
         let before_summary = target.agent_summary().await.unwrap();
         let before_relations = host

--- a/src/runtime/agent_message_delivery.rs
+++ b/src/runtime/agent_message_delivery.rs
@@ -147,6 +147,7 @@ impl AgentMessageDeliveryService<'_> {
                 principal_id: Some(principal_id),
                 route: caller.route,
                 matched_rule_index: None,
+                derived_grant: None,
             },
             rejection_code: None,
             retryable: false,

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -545,8 +545,24 @@ async fn filtered_tool_specs_keep_agent_creation_family_for_public_named_agent()
 #[tokio::test]
 async fn invoke_agent_hides_unknown_and_unauthorized_targets() {
     let (_home, host, runtime) = host_backed_test_runtime().await;
-    host.create_named_agent("unauthorized-target", None)
+    let unauthorized_target = host
+        .create_named_agent("unauthorized-target", None)
         .await
+        .unwrap();
+    host.runtime_db()
+        .agent_canonical_relations()
+        .upsert_message_policy(&crate::types::AgentMessagePolicyRecord {
+            agent_id: unauthorized_target.agent_id,
+            revision: 1,
+            default_effect: crate::types::AgentPolicyEffect::Deny,
+            rules: vec![crate::types::AgentMessagePolicyRule {
+                principal_kind: crate::types::AgentMessagePrincipalKind::PeerAgent,
+                principal_id: None,
+                route: Some("agent_invocation".into()),
+                effect: crate::types::AgentPolicyEffect::Deny,
+            }],
+            created_at: unauthorized_target.created_at,
+        })
         .unwrap();
 
     let mut descriptors = Vec::new();

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -549,11 +549,19 @@ async fn invoke_agent_hides_unknown_and_unauthorized_targets() {
         .create_named_agent("unauthorized-target", None)
         .await
         .unwrap();
+    let message_policy_revision = host
+        .runtime_db()
+        .agent_canonical_relations()
+        .latest(&unauthorized_target.agent_id)
+        .unwrap()
+        .and_then(|relations| relations.message_policy)
+        .map_or(0, |policy| policy.revision)
+        .saturating_add(1);
     host.runtime_db()
         .agent_canonical_relations()
         .upsert_message_policy(&crate::types::AgentMessagePolicyRecord {
             agent_id: unauthorized_target.agent_id,
-            revision: 1,
+            revision: message_policy_revision,
             default_effect: crate::types::AgentPolicyEffect::Deny,
             rules: vec![crate::types::AgentMessagePolicyRule {
                 principal_kind: crate::types::AgentMessagePrincipalKind::PeerAgent,

--- a/src/runtime_db/agent_message_delivery.rs
+++ b/src/runtime_db/agent_message_delivery.rs
@@ -8,10 +8,11 @@ use crate::{
     runtime_db::agent_relations::canonical_relations_from_connection,
     runtime_db::AgentMessageDeliveryRepository,
     types::{
-        AgentIdentityLifecycle, AgentIdentityRecord, AgentMessageAdmissionEvidence,
-        AgentMessageDeliveryError, AgentMessageDeliveryOutcome, AgentMessageDeliveryReceipt,
-        AgentMessageDeliveryRecord, AgentMessageDeliveryRejectionCode, AgentMessageDeliveryState,
-        AgentPolicyEffect, AgentRegistryStatus, AgentState, AgentStatus,
+        AgentCanonicalDurability, AgentIdentityLifecycle, AgentIdentityRecord,
+        AgentLifecycleAttachment, AgentMessageAdmissionEvidence, AgentMessageDeliveryError,
+        AgentMessageDeliveryOutcome, AgentMessageDeliveryReceipt, AgentMessageDeliveryRecord,
+        AgentMessageDeliveryRejectionCode, AgentMessageDeliveryState, AgentMessageDerivedGrant,
+        AgentMessagePrincipalKind, AgentPolicyEffect, AgentRegistryStatus, AgentState, AgentStatus,
     },
 };
 
@@ -217,8 +218,29 @@ pub(crate) fn prepare_delivery_admission_tx(
                     .is_none_or(|expected| expected == candidate.caller.route)
         })
     });
+    let derived_grant = matched_rule.is_none()
+        && identity
+            .as_ref()
+            .is_some_and(|identity| identity.status == AgentRegistryStatus::Active)
+        && candidate.caller.principal_kind == AgentMessagePrincipalKind::PeerAgent
+        && candidate.caller.route == "agent_invocation"
+        && relations.as_ref().is_some_and(|relations| {
+            relations
+                .durability
+                .as_ref()
+                .is_some_and(|record| record.durability == AgentCanonicalDurability::Persistent)
+                && relations
+                    .lifecycle_attachment
+                    .as_ref()
+                    .is_some_and(|record| {
+                        record.attachment == AgentLifecycleAttachment::Independent
+                    })
+        });
     let allowed = matched_rule.map_or_else(
-        || policy.is_some_and(|policy| policy.default_effect == AgentPolicyEffect::Allow),
+        || {
+            derived_grant
+                || policy.is_some_and(|policy| policy.default_effect == AgentPolicyEffect::Allow)
+        },
         |(_, rule)| rule.effect == AgentPolicyEffect::Allow,
     );
     let evidence = AgentMessageAdmissionEvidence {
@@ -237,6 +259,8 @@ pub(crate) fn prepare_delivery_admission_tx(
         principal_id: Some(principal_id.to_string()),
         route: candidate.caller.route.clone(),
         matched_rule_index: matched_rule.map(|(index, _)| index),
+        derived_grant: derived_grant
+            .then_some(AgentMessageDerivedGrant::PersistentIndependentPeerInvocation),
     };
     let rejection = match identity.as_ref().map(|identity| identity.status) {
         None => Some((
@@ -542,11 +566,14 @@ mod tests {
             RuntimeDb,
         },
         types::{
-            AdmissionContext, AgentKind, AgentMessageCallerContext, AgentMessageDeliveryError,
-            AgentMessageDeliveryOutcome, AgentMessageDeliveryRejectionCode,
-            AgentMessagePrincipalKind, AgentMessageSendRequest, AgentOwnership, AgentProfilePreset,
-            AgentState, AgentStatus, AgentVisibility, AuthorityClass, MessageBody,
-            MessageDeliverySurface, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus,
+            AdmissionContext, AgentCanonicalDurability, AgentDurabilityRecord, AgentKind,
+            AgentLifecycleAttachment, AgentLifecycleAttachmentRecord, AgentMessageCallerContext,
+            AgentMessageDeliveryError, AgentMessageDeliveryOutcome,
+            AgentMessageDeliveryRejectionCode, AgentMessageDerivedGrant, AgentMessagePolicyRecord,
+            AgentMessagePolicyRule, AgentMessagePrincipalKind, AgentMessageSendRequest,
+            AgentOwnership, AgentPolicyEffect, AgentProfilePreset, AgentState, AgentStatus,
+            AgentVisibility, AuthorityClass, MessageBody, MessageDeliverySurface, MessageOrigin,
+            Priority, QueueEntryRecord, QueueEntryStatus,
         },
     };
     use tempfile::TempDir;
@@ -593,6 +620,24 @@ mod tests {
         }
     }
 
+    fn peer_caller() -> AgentMessageCallerContext {
+        AgentMessageCallerContext {
+            caller_principal: "agent:caller-agent".into(),
+            caller_agent_id: Some("caller-agent".into()),
+            principal_kind: AgentMessagePrincipalKind::PeerAgent,
+            route: "agent_invocation".into(),
+            origin: MessageOrigin::Task {
+                task_id: "task-peer-delivery".into(),
+            },
+            authority_class: AuthorityClass::ExternalEvidence,
+            delivery_surface: MessageDeliverySurface::RuntimeSystem,
+            admission_context: AdmissionContext::RuntimeOwned,
+            current_turn_id: Some("turn-peer-delivery".into()),
+            current_task_id: Some("task-peer-delivery".into()),
+            current_work_item_id: Some("work-peer-delivery".into()),
+        }
+    }
+
     fn request(key: &str, text: &str) -> AgentMessageSendRequest {
         AgentMessageSendRequest {
             target_agent_id: "target-agent".into(),
@@ -606,6 +651,13 @@ mod tests {
 
     fn prepare(key: &str, text: &str) -> Result<crate::runtime::PreparedAgentMessageDelivery> {
         AgentMessageDeliveryService::prepare(request(key, text), caller())
+    }
+
+    fn prepare_from_peer(
+        key: &str,
+        text: &str,
+    ) -> Result<crate::runtime::PreparedAgentMessageDelivery> {
+        AgentMessageDeliveryService::prepare(request(key, text), peer_caller())
     }
 
     fn admission_command(
@@ -750,6 +802,126 @@ mod tests {
             receipt.correlation_id.as_deref(),
             Some("correlation-delivery")
         );
+        Ok(())
+    }
+
+    #[test]
+    fn persistent_independent_peer_invocation_uses_auditable_derived_grant() -> Result<()> {
+        let (dir, db) = runtime_db()?;
+        seed_target(&db, AgentStatus::AwakeIdle)?;
+        let prepared = prepare_from_peer("peer-default", "delegate work")?;
+        let accepted = db.transitions().commit_delivery_admission(
+            &admission_command(&prepared),
+            None,
+            &prepared.record,
+        )?;
+        let delivery_id = accepted
+            .delivery_receipt
+            .context("missing accepted peer receipt")?
+            .delivery_id;
+        let stored = db
+            .agent_message_deliveries()
+            .latest(&delivery_id)?
+            .context("missing peer delivery")?;
+        assert_eq!(stored.outcome, AgentMessageDeliveryOutcome::Accepted);
+        assert_eq!(stored.admission_evidence.matched_rule_index, None);
+        assert_eq!(
+            stored.admission_evidence.derived_grant,
+            Some(AgentMessageDerivedGrant::PersistentIndependentPeerInvocation)
+        );
+
+        let database_path = dir.path().join("state/runtime.sqlite");
+        let lock_path = dir.path().join("state/runtime.lock");
+        drop(db);
+        let reopened = RuntimeDb::open_and_migrate(database_path, lock_path)?;
+        assert_eq!(
+            reopened
+                .agent_message_deliveries()
+                .latest(&delivery_id)?
+                .context("peer delivery did not survive restart")?
+                .admission_evidence
+                .derived_grant,
+            Some(AgentMessageDerivedGrant::PersistentIndependentPeerInvocation)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_peer_deny_overrides_the_derived_grant() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        seed_target(&db, AgentStatus::AwakeIdle)?;
+        let identity = db
+            .agent_identities()
+            .latest("target-agent")?
+            .context("missing target identity")?;
+        db.agent_canonical_relations()
+            .upsert_message_policy(&AgentMessagePolicyRecord {
+                agent_id: identity.agent_id,
+                revision: 1,
+                default_effect: AgentPolicyEffect::Deny,
+                rules: vec![AgentMessagePolicyRule {
+                    principal_kind: AgentMessagePrincipalKind::PeerAgent,
+                    principal_id: Some("caller-agent".into()),
+                    route: Some("agent_invocation".into()),
+                    effect: AgentPolicyEffect::Deny,
+                }],
+                created_at: identity.created_at,
+            })?;
+
+        let prepared = prepare_from_peer("peer-deny", "delegate work")?;
+        let rejected = db
+            .agent_message_deliveries()
+            .admit_without_queue(&prepared.record)?;
+        assert_eq!(
+            rejected.rejection_code,
+            Some(AgentMessageDeliveryRejectionCode::MessageNotAuthorized)
+        );
+        let stored = db
+            .agent_message_deliveries()
+            .latest(&rejected.delivery_id)?
+            .context("missing rejected peer delivery")?;
+        assert_eq!(stored.admission_evidence.matched_rule_index, Some(0));
+        assert_eq!(stored.admission_evidence.derived_grant, None);
+        Ok(())
+    }
+
+    #[test]
+    fn ephemeral_independent_target_has_no_peer_invocation_default() -> Result<()> {
+        let (_dir, db) = runtime_db()?;
+        seed_target(&db, AgentStatus::AwakeIdle)?;
+        let identity = db
+            .agent_identities()
+            .latest("target-agent")?
+            .context("missing target identity")?;
+        db.agent_canonical_relations()
+            .upsert_durability(&AgentDurabilityRecord {
+                agent_id: identity.agent_id.clone(),
+                durability: AgentCanonicalDurability::Ephemeral,
+                revision: 1,
+                created_at: identity.created_at,
+            })?;
+        db.agent_canonical_relations().upsert_lifecycle_attachment(
+            &AgentLifecycleAttachmentRecord {
+                agent_id: identity.agent_id,
+                attachment: AgentLifecycleAttachment::Independent,
+                revision: 1,
+                created_at: identity.created_at,
+            },
+        )?;
+
+        let prepared = prepare_from_peer("peer-ephemeral", "delegate work")?;
+        let rejected = db
+            .agent_message_deliveries()
+            .admit_without_queue(&prepared.record)?;
+        assert_eq!(
+            rejected.rejection_code,
+            Some(AgentMessageDeliveryRejectionCode::MessageNotAuthorized)
+        );
+        let stored = db
+            .agent_message_deliveries()
+            .latest(&rejected.delivery_id)?
+            .context("missing ephemeral rejection")?;
+        assert_eq!(stored.admission_evidence.derived_grant, None);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- allow `PeerAgent` delivery on the `agent_invocation` route by derived default only when the target is active, persistent, and independently attached
- keep every matching persisted message-policy rule authoritative, so an explicit allow or deny overrides the derived default
- persist the derived-admission reason in delivery audit evidence, update the host behavior coverage, and document the contract in the agent identity/delivery RFC

The derived default does not apply to supervised children, ephemeral runtimes, inactive targets, external ingress, operator-control routes, or other message routes.

## Verification

- `cargo fmt --all -- --check`
- `cargo test runtime_db::agent_message_delivery` (9 passed)
- `cargo test canonical_existing_invocation_preserves_target_configuration_and_relations` (1 passed)
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #2857
