### PR TITLE
feat(web): stop the current turn from the chat composer

### DIFF
--- a/docs/implementation-decisions/126-current-run-abort-modes.md
+++ b/docs/implementation-decisions/126-current-run-abort-modes.md
@@ -1,0 +1,33 @@
+# Current-run abort modes: turn-scoped vs lifecycle stop
+
+## Decision
+
+`POST /api/control/agents/{agent_id}/current-run/abort` supports two modes:
+`stop_after_abort` (default, existing behavior) cancels the current run and
+applies the stop projection, leaving the agent `Stopped` until an explicit
+lifecycle start. `idle_after_abort` cancels the same run token but applies the
+idle projection instead, so the agent stays awake (or falls naturally asleep)
+and immediately accepts the next operator prompt.
+
+## Why
+
+- The Web GUI chat composer exposes a turn-scoped "stop this turn" action that
+  must not degrade into a lifecycle stop: after stopping a misbehaving turn,
+  the operator expects to type and send the next prompt without discovering a
+  hidden "start the agent again" step. Before this split, the only abort mode
+  left every agent `Stopped` and the next control prompt failed with
+  `409 agent is stopped; start first`.
+- Lifecycle stop keeps its stronger side effects (interrupting active tasks,
+  releasing workspace occupancy, revoking external triggers) exclusive to
+  `ControlAction::Stop`; `idle_after_abort` performs no lifecycle cleanup, it
+  only interrupts the in-flight turn and settles its queue entry as
+  `Interrupted`.
+- Keeping `stop_after_abort` as the default preserves existing CLI and API
+  callers that treat abort as "stop everything now".
+
+## Preserved boundary / tradeoff
+
+`idle_after_abort` only makes sense while a run is active; stale run ids and
+absent runs still surface the same 409 conflict responses. Queued follow-up
+messages may still be processed after a turn-scoped abort because the agent
+remains schedulable.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -118,3 +118,4 @@ Current decision notes:
 - [119 models.dev Supplemental Catalog](./119-models-dev-supplemental-catalog.md)
 - [124 Ollama Tool-Only Round Placeholder User Text](./124-ollama-tool-only-round-placeholder-user-text.md)
 - [125 Agent Id Reincarnation Same Row](./125-agent-id-reincarnation-same-row.md)
+- [126 Current-Run Abort Modes](./126-current-run-abort-modes.md)

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -648,10 +648,11 @@ pub async fn abort_current_run(
     authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let mode = match request.mode.as_deref().unwrap_or("stop_after_abort") {
         "stop_after_abort" => CurrentRunAbortMode::StopAfterAbort,
+        "idle_after_abort" => CurrentRunAbortMode::IdleAfterAbort,
         "pause_after_abort" => CurrentRunAbortMode::StopAfterAbort,
         other => {
             return Err(bad_request(format!(
-                "unsupported abort mode {other}; expected stop_after_abort or deprecated alias pause_after_abort"
+                "unsupported abort mode {other}; expected stop_after_abort, idle_after_abort, or deprecated alias pause_after_abort"
             )))
         }
     };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2559,12 +2559,14 @@ struct CurrentRunAbortHandle {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CurrentRunAbortMode {
     StopAfterAbort,
+    IdleAfterAbort,
 }
 
 impl CurrentRunAbortMode {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::StopAfterAbort => "stop_after_abort",
+            Self::IdleAfterAbort => "idle_after_abort",
         }
     }
 }
@@ -3036,7 +3038,16 @@ impl RuntimeHandle {
             *reason = "operator_aborted".into();
         }
         handle.token.cancel();
-        scheduler::apply_stop_projection(&mut guard.state);
+        match request.mode {
+            CurrentRunAbortMode::StopAfterAbort => {
+                scheduler::apply_stop_projection(&mut guard.state);
+            }
+            // Turn-scoped interrupt: the agent stays awake so the operator can
+            // immediately submit the next prompt without a lifecycle start.
+            CurrentRunAbortMode::IdleAfterAbort => {
+                scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
+            }
+        }
         guard.persist_state(&self.inner.storage)?;
         drop(guard);
 

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -495,12 +495,27 @@ impl RuntimeHandle {
                     reason: Some("builtin web search is not requested by current config".into()),
                 }
             } else {
-                probe_builtin_web_search_capability(
+                let probe = probe_builtin_web_search_capability(
                     provider.as_ref(),
                     capability,
                     web_config.search.max_results,
-                )
-                .await
+                );
+                // The probe issues a live provider request during context
+                // build, before the abort-aware provider rounds start. Race
+                // it against the current-run abort token so a turn-scoped
+                // stop cannot hang on this phase until the provider timeout.
+                match self.current_run_abort_token().await {
+                    Some(snapshot) => tokio::select! {
+                        result = probe => result,
+                        _ = snapshot.token.cancelled() => {
+                            return Err(CurrentRunAborted {
+                                run_id: snapshot.run_id.clone(),
+                                reason: snapshot.reason(),
+                            }.into());
+                        }
+                    },
+                    None => probe.await,
+                }
             }
         } else {
             BuiltinWebSearchProbeCacheEntry {

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -13392,6 +13392,146 @@ async fn abort_current_run_aborts_provider_turn_and_stops_agent() {
 }
 
 #[tokio::test]
+async fn abort_current_run_idle_after_abort_keeps_agent_awake_and_accepts_next_prompt() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let started = Arc::new(tokio::sync::Notify::new());
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(BlockingProvider {
+            started: started.clone(),
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    append_default_host_identity(&runtime);
+    runtime
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator {
+                    actor_id: None,
+                    actor_display_name: None,
+                },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "block".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
+        .await
+        .unwrap();
+
+    let mut runner = tokio::spawn(runtime.clone().run());
+    tokio::select! {
+        _ = started.notified() => {}
+        result = &mut runner => panic!("runtime exited before provider start: {result:?}"),
+    }
+    let run_id = runtime
+        .agent_state()
+        .await
+        .unwrap()
+        .current_run_id
+        .expect("run id should be active");
+
+    let outcome = runtime
+        .abort_current_run(CurrentRunAbortRequest {
+            run_id: Some(run_id.clone()),
+            mode: CurrentRunAbortMode::IdleAfterAbort,
+        })
+        .await
+        .unwrap();
+    assert_eq!(outcome.run_id, run_id);
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            let state = runtime.agent_state().await.unwrap();
+            if state
+                .last_turn_terminal
+                .as_ref()
+                .is_some_and(|terminal| terminal.reason.as_deref() == Some("operator_aborted"))
+            {
+                break state;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("aborted terminal should be persisted");
+
+    let state = runtime.agent_state().await.unwrap();
+    // The idle projection lands as awake-idle and may then settle into a
+    // natural sleep once the scheduler finds no pending work. Both differ
+    // from the lifecycle Stop path, which leaves the agent Stopped and
+    // requiring an explicit start before the next prompt.
+    assert_ne!(state.status, AgentStatus::Stopped);
+    assert_eq!(state.current_run_id, None);
+    assert_eq!(
+        state
+            .last_turn_terminal
+            .as_ref()
+            .and_then(|terminal| terminal.reason.as_deref()),
+        Some("operator_aborted")
+    );
+    let queue_entries = runtime.storage().latest_queue_entries().unwrap();
+    assert!(queue_entries
+        .iter()
+        .any(|entry| entry.status == QueueEntryStatus::Interrupted));
+
+    // The turn-scoped abort must not require a lifecycle start: the next
+    // operator prompt is admitted and starts a fresh provider turn.
+    runtime
+        .enqueue(
+            MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator {
+                    actor_id: None,
+                    actor_display_name: None,
+                },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "block again".into(),
+                },
+            )
+            .with_admission(
+                MessageDeliverySurface::CliPrompt,
+                AdmissionContext::LocalProcess,
+            ),
+        )
+        .await
+        .unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            let state = runtime.agent_state().await.unwrap();
+            if state.current_run_id.is_some() {
+                break state;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("next prompt should start a new run");
+
+    runtime
+        .control(crate::types::ControlAction::Stop)
+        .await
+        .unwrap();
+    runner.await.unwrap().unwrap();
+}
+
+#[tokio::test]
 async fn operator_interjection_prompt_is_interjected_before_next_provider_round() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/web-gui/app/e2e/composer-stop-turn.spec.ts
+++ b/web-gui/app/e2e/composer-stop-turn.spec.ts
@@ -1,0 +1,183 @@
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type BrowserContext,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+
+interface FixtureAbortRequest {
+  agentId: string;
+  body: { run_id?: string; mode?: string };
+}
+
+interface FixtureState {
+  abortRequests: FixtureAbortRequest[];
+}
+
+function sessionFor(testInfo: TestInfo): string {
+  const testCase = testInfo.testId.replace(/[^a-zA-Z0-9_-]/g, "-");
+  return `${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${testInfo.retry}-${testCase}`;
+}
+
+function controlPath(session: string, path: string): string {
+  return `${path}?session=${encodeURIComponent(session)}`;
+}
+
+async function attachSession(context: BrowserContext, session: string): Promise<void> {
+  await context.addCookies([{
+    name: "holon_e2e_session",
+    value: session,
+    domain: "127.0.0.1",
+    path: "/",
+  }]);
+}
+
+async function configure(
+  request: APIRequestContext,
+  session: string,
+  body: Record<string, unknown>,
+): Promise<void> {
+  const response = await request.post(controlPath(session, "/__e2e__/configure"), { data: body });
+  expect(response.ok()).toBe(true);
+}
+
+async function fixtureState(
+  request: APIRequestContext,
+  session: string,
+): Promise<FixtureState> {
+  const response = await request.get(controlPath(session, "/__e2e__/state"));
+  expect(response.ok()).toBe(true);
+  return await response.json() as FixtureState;
+}
+
+function envelope(
+  agentId: string,
+  eventSeq: number,
+  type: string,
+  payload: Record<string, unknown>,
+) {
+  return {
+    id: `${agentId}-event-${eventSeq}`,
+    event_seq: eventSeq,
+    event_log_epoch: "e2e-epoch",
+    contract_version: 2,
+    ts: `2026-08-25T00:00:${String(eventSeq).padStart(2, "0")}Z`,
+    agent_id: agentId,
+    type,
+    payload_schema: `holon.runtime_event.${type}`,
+    payload_schema_version: 1,
+    payload,
+  };
+}
+
+async function appendEvent(
+  request: APIRequestContext,
+  session: string,
+  event: ReturnType<typeof envelope>,
+): Promise<void> {
+  const response = await request.post(controlPath(session, "/__e2e__/append-event"), {
+    data: { envelope: event, broadcast: true },
+  });
+  expect(response.ok()).toBe(true);
+}
+
+async function openAgent(page: Page, agentId: string): Promise<void> {
+  const button = page.getByRole("button", { name: `Open ${agentId}`, exact: true });
+  await expect(button).toBeVisible();
+  await button.click();
+  await expect(page.locator("form.composer")).toBeVisible();
+}
+
+test("composer swaps the send button for a turn-scoped stop while a run is active", async ({
+  page,
+  request,
+  context,
+}, testInfo) => {
+  const session = sessionFor(testInfo);
+  await attachSession(context, session);
+  const agentId = "bootstrap-agent";
+
+  await page.goto("/");
+  await openAgent(page, agentId);
+
+  const composer = page.locator("form.composer");
+  const textarea = composer.locator("textarea");
+  const sendButton = composer.getByRole("button", { name: "Send", exact: true });
+  const stopButton = composer.getByRole("button", { name: "Stop this turn", exact: true });
+
+  // No run: the composer keeps the ordinary send button.
+  await expect(sendButton).toBeVisible();
+  await expect(stopButton).toHaveCount(0);
+
+  // A turn starts: the empty composer switches to the stop button.
+  await appendEvent(request, session, envelope(agentId, 1, "message_processing_started", {
+    run_id: "run-e2e-1",
+  }));
+  await expect(stopButton).toBeVisible();
+  await expect(sendButton).toHaveCount(0);
+
+  // Typing restores the send button immediately.
+  await textarea.fill("follow-up");
+  await expect(sendButton).toBeVisible();
+  await expect(stopButton).toHaveCount(0);
+
+  // Clearing the draft while the turn still runs restores the stop button.
+  await textarea.fill("");
+  await expect(stopButton).toBeVisible();
+
+  // Clicking stop aborts with the run id the UI currently knows.
+  await stopButton.click();
+  await expect.poll(async () => (await fixtureState(request, session)).abortRequests).toEqual([
+    {
+      agentId,
+      body: {
+        run_id: "run-e2e-1",
+        mode: "idle_after_abort",
+        authority_class: "operator_instruction",
+      },
+    },
+  ]);
+
+  // The turn ends: the composer returns to the send button even though the
+  // draft stays empty.
+  await appendEvent(request, session, envelope(agentId, 2, "turn_terminal", {}));
+  await expect(sendButton).toBeVisible();
+  await expect(stopButton).toHaveCount(0);
+});
+
+test("stop-turn conflicts converge without surfacing an error", async ({
+  page,
+  request,
+  context,
+}, testInfo) => {
+  const session = sessionFor(testInfo);
+  await attachSession(context, session);
+  const agentId = "bootstrap-agent";
+
+  await configure(request, session, {
+    abortResponse: {
+      status: 409,
+      body: { error: "stale run_id run-e2e-2; current run is run-e2e-3", code: "stale_run_id" },
+    },
+  });
+
+  await page.goto("/");
+  await openAgent(page, agentId);
+
+  await appendEvent(request, session, envelope(agentId, 1, "message_processing_started", {
+    run_id: "run-e2e-2",
+  }));
+  const stopButton = page.locator("form.composer").getByRole("button", { name: "Stop this turn", exact: true });
+  await expect(stopButton).toBeVisible();
+
+  await stopButton.click();
+  await expect.poll(async () => (await fixtureState(request, session)).abortRequests.length)
+    .toBe(1);
+
+  // The conflict is treated as convergence: no composer error appears and the
+  // button does not stay stuck in a loading state.
+  await expect(page.locator("form.composer .composer-status")).toHaveCount(0);
+  await expect(stopButton).toBeEnabled();
+});

--- a/web-gui/app/e2e/fixture-server.mjs
+++ b/web-gui/app/e2e/fixture-server.mjs
@@ -36,6 +36,8 @@ function sessionFor(req, url) {
   if (!session) {
     session = {
       requests: [],
+      abortRequests: [],
+      abortResponse: null,
       globalStreams: new Set(),
       agentStreams: new Set(),
       visibleAgentIds: ["bootstrap-agent"],
@@ -48,6 +50,7 @@ function sessionFor(req, url) {
       eventLogEpoch: "e2e-epoch",
       visibilityScopeId: "e2e-scope",
       oldestRetainedSeqByAgentId: new Map(),
+      currentRunIdByAgentId: new Map(),
       snapshotThroughSeqByAgentId: new Map(),
       projectionLatestBriefByAgentId: new Map(),
     };
@@ -89,7 +92,8 @@ function eventHead(session, agentId) {
   );
 }
 
-function listEntry(agentId) {
+function listEntry(agentId, session) {
+  const currentRunId = session ? (session.currentRunIdByAgentId.get(agentId) ?? null) : null;
   return {
     identity: {
       agent_id: agentId,
@@ -97,29 +101,31 @@ function listEntry(agentId) {
       ownership: "self_owned",
       profile_preset: "public_named",
     },
-    status: "awake_idle",
+    status: currentRunId ? "awake_running" : "awake_idle",
+    current_run_id: currentRunId,
     pending: 0,
   };
 }
 
-function agentState(agentId) {
+function agentState(agentId, session) {
+  const running = Boolean(session?.currentRunIdByAgentId.get(agentId));
   return {
     agent: {
       identity: {
-        ...listEntry(agentId).identity,
+        ...listEntry(agentId, session).identity,
         kind: "named",
         status: "active",
         is_default_agent: false,
       },
       agent: {
         id: agentId,
-        status: "awake_idle",
-        current_run_id: null,
+        status: running ? "awake_running" : "awake_idle",
+        current_run_id: running ? (session.currentRunIdByAgentId.get(agentId) ?? null) : null,
         pending: 0,
         attached_workspaces: [],
         turn_index: 0,
       },
-      scheduling_posture: { posture: "idle", reason: "idle" },
+      scheduling_posture: { posture: running ? "active-turn" : "idle", reason: running ? "model_turn" : "idle" },
       active_task_count: 0,
       lifecycle: { accepts_external_messages: true },
       model: {
@@ -130,7 +136,7 @@ function agentState(agentId) {
       },
       closure: { outcome: "completed", runtime_posture: "awake" },
     },
-    session: { current_run_id: null, pending_count: 0, last_turn: null },
+    session: { current_run_id: running ? (session.currentRunIdByAgentId.get(agentId) ?? null) : null, pending_count: 0, last_turn: null },
     tasks: [],
     timers: [],
     work_items: [],
@@ -146,7 +152,7 @@ function rosterSnapshot(session) {
     event_log_epoch: session.eventLogEpoch,
     visibility_scope_id: session.visibilityScopeId,
     agents: session.visibleAgentIds.map((agentId) => ({
-          agent: listEntry(agentId),
+          agent: listEntry(agentId, session),
           event_window: {
             event_head_seq: eventHead(session, agentId),
             oldest_retained_seq: session.oldestRetainedSeqByAgentId.get(agentId) ?? 0,
@@ -196,7 +202,7 @@ function projectionSnapshot(session, agentId) {
     event_head_seq: eventHead(session, agentId),
     oldest_retained_seq: session.oldestRetainedSeqByAgentId.get(agentId) ?? 0,
     projection: {
-      agent: listEntry(agentId),
+      agent: listEntry(agentId, session),
       conversation: { latest_message_id: null, latest_transcript_entry_id: null },
       current_work_item: null,
       hydration_references: [],
@@ -224,6 +230,7 @@ async function handleControl(req, res, url) {
     const session = sessionFor(req, url);
     json(res, {
       requests: session.requests,
+      abortRequests: session.abortRequests,
       visibleAgentIds: session.visibleAgentIds,
       globalStreamCount: session.globalStreams.size,
       agentStreamCount: session.agentStreams.size,
@@ -268,6 +275,9 @@ async function handleControl(req, res, url) {
     if (Array.isArray(body.blockedBriefIds)) {
       session.blockedBriefIds = new Set(body.blockedBriefIds);
     }
+    if (body.abortResponse && typeof body.abortResponse === "object") {
+      session.abortResponse = body.abortResponse;
+    }
     if (typeof body.runtimeId === "string") session.runtimeId = body.runtimeId;
     if (typeof body.eventLogEpoch === "string") session.eventLogEpoch = body.eventLogEpoch;
     if (typeof body.visibilityScopeId === "string") {
@@ -303,6 +313,17 @@ async function handleControl(req, res, url) {
     if (!events.some((event) => event.event_seq === envelope.event_seq)) {
       events.push(envelope);
       session.eventsByAgentId.set(envelope.agent_id, events);
+    }
+    if (envelope.type === "message_processing_started" && typeof envelope.payload?.run_id === "string") {
+      session.currentRunIdByAgentId.set(envelope.agent_id, envelope.payload.run_id);
+    }
+    if (
+      envelope.type === "turn_terminal"
+      || envelope.type === "turn_terminal_aborted"
+      || envelope.type === "message_processing_aborted"
+      || envelope.type === "runtime_error"
+    ) {
+      session.currentRunIdByAgentId.delete(envelope.agent_id);
     }
     if (body.broadcast !== false) writeEvent(session.globalStreams, envelope);
     json(res, { appended: true });
@@ -357,7 +378,7 @@ async function handleApi(req, res, url) {
     return true;
   }
   if (url.pathname === "/api/agents/list") {
-    json(res, session.visibleAgentIds.map(listEntry));
+    json(res, session.visibleAgentIds.map((agentId) => listEntry(agentId, session)));
     return true;
   }
   if (url.pathname === "/api/agents/snapshot") {
@@ -366,12 +387,33 @@ async function handleApi(req, res, url) {
   }
   const stateMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/state$/);
   if (stateMatch) {
-    json(res, agentState(decodeURIComponent(stateMatch[1])));
+    json(res, agentState(decodeURIComponent(stateMatch[1]), session));
     return true;
   }
   if (url.pathname === "/api/events/stream") {
     session.streamGeneration += 1;
     openEventStream(req, res, session.globalStreams);
+    return true;
+  }
+  const abortMatch = url.pathname.match(
+    /^\/api\/control\/agents\/([^/]+)\/current-run\/abort$/,
+  );
+  if (abortMatch && req.method === "POST") {
+    const body = await requestBody(req);
+    session.abortRequests.push({
+      agentId: decodeURIComponent(abortMatch[1]),
+      body,
+    });
+    const response = session.abortResponse ?? {
+      status: 200,
+      body: { ok: true, aborted: true },
+    };
+    if (!session.abortResponse && session.currentRunIdByAgentId.get(abortMatch[1]) === body.run_id) {
+      // Turn-scoped abort: the run ends and the agent stays schedulable, so
+      // the next roster/state projection no longer reports a current run.
+      session.currentRunIdByAgentId.delete(abortMatch[1]);
+    }
+    json(res, response.body ?? {}, response.status ?? 200);
     return true;
   }
   const projectionMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/projection-snapshot$/);

--- a/web-gui/app/e2e/real-daemon/abort-current-run.spec.ts
+++ b/web-gui/app/e2e/real-daemon/abort-current-run.spec.ts
@@ -1,0 +1,164 @@
+import http from "node:http";
+import type { Server } from "node:http";
+import net from "node:net";
+
+import { expect, test } from "./daemon-fixture";
+
+interface HangingProvider {
+  server: Server;
+  baseUrl: string;
+  requests: Array<{ url: string }>;
+  stop(): Promise<void>;
+}
+
+async function reservePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to allocate a provider port"));
+        return;
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+async function startHangingProvider(): Promise<HangingProvider> {
+  const port = await reservePort();
+  const requests: Array<{ url: string }> = [];
+  const server = http.createServer((req, res) => {
+    requests.push({ url: `${req.method ?? ""} ${req.url ?? ""}` });
+    // Intentionally never respond: provider turns (and the builtin web search
+    // probe issued during turn context build) stay in flight until the
+    // runtime aborts the run and cancels the request.
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    requests,
+    async stop() {
+      // The daemon keeps hung provider sockets pooled; close() alone would
+      // wait for them forever, so drop the connections explicitly.
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+interface AgentRuntimeState {
+  agent: {
+    agent: {
+      status: string;
+      current_run_id: string | null;
+      pending: number;
+    };
+  };
+}
+
+interface AgentEventPage {
+  events?: Array<{ event_seq?: number; type?: string; payload?: { run_id?: string; reason?: string } }>;
+}
+
+interface DaemonApi {
+  api(pathname: string, init?: RequestInit): Promise<Response>;
+}
+
+async function agentState(daemon: DaemonApi, agentId: string): Promise<AgentRuntimeState> {
+  return await daemon.api(`/agents/${agentId}/state`).then((response) => response.json() as Promise<AgentRuntimeState>);
+}
+
+test("turn-scoped abort settles the current run and keeps the agent schedulable against a real daemon", async ({
+  daemonFactory,
+}) => {
+  const provider = await startHangingProvider();
+  const daemon = await daemonFactory({
+    webDist: "dist-e2e",
+    env: {
+      HOLON_OPENAI_BASE_URL: provider.baseUrl,
+      OPENAI_API_KEY: "e2e-provider-key",
+    },
+  });
+  const agentId = daemon.agentId;
+
+  try {
+    // A prompt starts a real run whose provider turn (or context-build probe)
+    // hangs against the frozen provider.
+    const prompt = await daemon.api(`/control/agents/${agentId}/prompt`, {
+      method: "POST",
+      body: JSON.stringify({ text: "first turn that must be stopped" }),
+    });
+    expect(prompt.status).toBe(200);
+
+    await expect.poll(async () => {
+      const state = await agentState(daemon, agentId);
+      return state.agent.agent.current_run_id;
+    }, { timeout: 20_000 }).not.toBeNull();
+    const runId = (await agentState(daemon, agentId)).agent.agent.current_run_id as string;
+    await expect.poll(() => provider.requests.length, { timeout: 20_000 }).toBeGreaterThanOrEqual(1);
+
+    // The turn-scoped abort carries the run id and settles quickly.
+    const abort = await daemon.api(`/control/agents/${agentId}/current-run/abort`, {
+      method: "POST",
+      body: JSON.stringify({
+        run_id: runId,
+        mode: "idle_after_abort",
+        authority_class: "operator_instruction",
+      }),
+    });
+    expect(abort.status).toBe(200);
+    await expect.poll(async () => {
+      const page = await daemon.api(`/agents/${agentId}/events?limit=100&order=desc`)
+        .then((response) => response.json() as Promise<AgentEventPage>);
+      return (page.events ?? []).filter((event) =>
+        event.type === "message_processing_aborted"
+        || event.type === "turn_terminal_aborted"
+        || event.type === "turn_terminal").length;
+    }, { timeout: 20_000 }).toBeGreaterThanOrEqual(2);
+    await expect.poll(async () => (await agentState(daemon, agentId)).agent.agent.current_run_id, { timeout: 20_000 }).toBeNull();
+    expect((await agentState(daemon, agentId)).agent.agent.status).not.toBe("stopped");
+
+    // The abort is turn-scoped, not a lifecycle stop: the very next prompt is
+    // admitted without a start and begins a fresh provider turn.
+    const providerRequestsAfterAbort = provider.requests.length;
+    const secondPrompt = await daemon.api(`/control/agents/${agentId}/prompt`, {
+      method: "POST",
+      body: JSON.stringify({ text: "second turn after the turn-scoped abort" }),
+    });
+    expect(secondPrompt.status).toBe(200);
+    await expect.poll(async () => (await agentState(daemon, agentId)).agent.agent.current_run_id, { timeout: 20_000 }).not.toBeNull();
+    await expect.poll(() => provider.requests.length, { timeout: 20_000 }).toBeGreaterThan(providerRequestsAfterAbort);
+
+    // A stale run id conflicts instead of silently aborting the new run.
+    const staleAbort = await daemon.api(`/control/agents/${agentId}/current-run/abort`, {
+      method: "POST",
+      body: JSON.stringify({
+        run_id: runId,
+        mode: "idle_after_abort",
+        authority_class: "operator_instruction",
+      }),
+    });
+    expect(staleAbort.status).toBe(409);
+
+    // Clean up the second run so the daemon can settle before teardown.
+    const secondRunId = (await agentState(daemon, agentId)).agent.agent.current_run_id;
+    if (secondRunId) {
+      const cleanup = await daemon.api(`/control/agents/${agentId}/current-run/abort`, {
+        method: "POST",
+        body: JSON.stringify({ run_id: secondRunId, mode: "idle_after_abort" }),
+      });
+      expect(cleanup.status).toBe(200);
+    }
+  } finally {
+    await provider.stop();
+  }
+});

--- a/web-gui/app/e2e/real-daemon/daemon-fixture.ts
+++ b/web-gui/app/e2e/real-daemon/daemon-fixture.ts
@@ -25,6 +25,8 @@ interface DaemonController {
 
 interface DaemonOptions {
   webDist: string;
+  /** Extra environment variables for the daemon process (e.g. provider overrides). */
+  env?: Record<string, string>;
 }
 
 type Fixtures = {
@@ -136,6 +138,7 @@ async function createDaemon(
         HOLON_MODEL: "openai/gpt-5.4",
         HOLON_CONTROL_AUTH_MODE: "required",
         HOLON_CALLBACK_BASE_URL: baseUrl,
+        ...(options.env ?? {}),
       },
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -228,6 +228,7 @@ export function App() {
   const startCodexDeviceLogin = useRuntimeStore((state) => state.startCodexDeviceLogin);
   const clearCodexDeviceLogin = useRuntimeStore((state) => state.clearCodexDeviceLogin);
   const sendOperatorPrompt = useRuntimeStore((state) => state.sendOperatorPrompt);
+  const abortCurrentRun = useRuntimeStore((state) => state.abortCurrentRun);
   const setAgentModel = useRuntimeStore((state) => state.setAgentModel);
   const clearAgentModel = useRuntimeStore((state) => state.clearAgentModel);
   const controlAgent = useRuntimeStore((state) => state.controlAgent);
@@ -719,6 +720,8 @@ export function App() {
             syncStatus={agentSyncStatus}
             displayLevel={effectiveDisplayLevel}
             sendingPrompt={selectedAgentSession?.sendingPrompt ?? false}
+            abortingRun={selectedAgentSession?.abortingRun ?? false}
+            abortError={selectedAgentSession?.abortError}
             promptError={selectedAgentSession?.promptError}
             modelCatalog={modelCatalog}
             modelCatalogLoading={modelCatalogLoading}
@@ -740,6 +743,7 @@ export function App() {
             onLoadOlderEvents={() => loadOlderAgentEvents(activeAgent.id, effectiveDisplayLevel)}
             onRetrySync={() => retryAgentSync(activeAgent.id)}
             onSendPrompt={(text, attachments) => sendOperatorPrompt(activeAgent.id, text, effectiveDisplayLevel, attachments)}
+            onAbortCurrentRun={(runId) => abortCurrentRun(activeAgent.id, runId)}
             onConversationRead={markSelectedAgentConversationRead}
             onOpenInspector={() => {
               showAgentOverview(activeAgent.id);

--- a/web-gui/app/src/features/agent/AgentPage.test.ts
+++ b/web-gui/app/src/features/agent/AgentPage.test.ts
@@ -7,6 +7,7 @@ import "../../i18n";
 import {
   attachmentKindForFile,
   captureScrollAnchor,
+  composerPrimaryAction,
   historyLoadDecision,
   isScrollKey,
   looksLikeProgrammaticBottomScroll,
@@ -72,6 +73,29 @@ describe("sync recovery status", () => {
     expect(markup).toContain("Conversation sync recovery failed (attempt 3)");
     expect(markup).toContain("baseline unavailable");
     expect(markup).toContain("Retry sync now");
+  });
+});
+
+describe("composer primary action", () => {
+  it("switches the send button to stop-run while a turn is running and the input is empty", () => {
+    expect(composerPrimaryAction({ currentRunId: "run-1", hasDraft: false, sendingPrompt: false })).toBe("stop-run");
+  });
+
+  it("reverts to send as soon as the operator types a draft", () => {
+    expect(composerPrimaryAction({ currentRunId: "run-1", hasDraft: true, sendingPrompt: false })).toBe("send");
+  });
+
+  it("returns to stop-run once the draft is cleared while the turn still runs", () => {
+    expect(composerPrimaryAction({ currentRunId: "run-1", hasDraft: false, sendingPrompt: false })).toBe("stop-run");
+  });
+
+  it("keeps the send action when no run is active", () => {
+    expect(composerPrimaryAction({ currentRunId: null, hasDraft: false, sendingPrompt: false })).toBe("send");
+    expect(composerPrimaryAction({ currentRunId: undefined, hasDraft: true, sendingPrompt: false })).toBe("send");
+  });
+
+  it("keeps the send action while a prompt submission is in flight", () => {
+    expect(composerPrimaryAction({ currentRunId: "run-1", hasDraft: false, sendingPrompt: true })).toBe("send");
   });
 });
 

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -2,6 +2,7 @@ import {
   ArrowUp,
   LoaderCircle,
   Paperclip,
+  Square,
   Unplug,
 } from "lucide-react";
 import {
@@ -39,6 +40,8 @@ interface AgentPageProps {
   syncStatus?: "idle" | "refreshing" | "streaming" | "recovering" | "stale" | "error";
   displayLevel: DisplayLevel;
   sendingPrompt: boolean;
+  abortingRun?: boolean;
+  abortError?: string;
   hasOlderEvents: boolean;
   loadingOlderEvents: boolean;
   promptError?: string;
@@ -59,6 +62,7 @@ interface AgentPageProps {
   onRetrySync: () => void;
   onAcknowledgeTruncation?: () => void;
   onSendPrompt: (text: string, attachments?: OperatorPromptAttachment[]) => Promise<void>;
+  onAbortCurrentRun: (runId: string) => Promise<void>;
   onConversationRead: () => void;
   onOpenInspector: () => void;
   onInspectActivity: (activity: AgentTimelineActivity) => void;
@@ -84,6 +88,22 @@ export function historyLoadDecision(hasHiddenTimelineItems: boolean, hasOlderEve
   if (hasHiddenTimelineItems) return "expand-local";
   if (hasOlderEvents) return "load-network";
   return "none";
+}
+
+export type ComposerPrimaryAction = "send" | "stop-run";
+
+/**
+ * The composer reuses the send button slot: while the agent is executing a
+ * turn and the operator has not typed anything, the button interrupts the
+ * current turn; as soon as a draft exists it becomes the send button again.
+ */
+export function composerPrimaryAction(state: {
+  currentRunId?: string | null;
+  hasDraft: boolean;
+  sendingPrompt: boolean;
+}): ComposerPrimaryAction {
+  if (state.sendingPrompt || state.hasDraft) return "send";
+  return state.currentRunId ? "stop-run" : "send";
 }
 
 export function storedComposerDraftKey(agentId: string): string {
@@ -312,6 +332,8 @@ export function AgentPage({
   syncStatus = "idle",
   displayLevel,
   sendingPrompt,
+  abortingRun = false,
+  abortError,
   hasOlderEvents,
   loadingOlderEvents,
   promptError,
@@ -331,6 +353,7 @@ export function AgentPage({
   onRetrySync,
   onAcknowledgeTruncation,
   onSendPrompt,
+  onAbortCurrentRun,
   onConversationRead,
   onOpenInspector,
   onInspectActivity,
@@ -403,7 +426,14 @@ export function AgentPage({
   const timelineTurns = useMemo(() => groupTimelineTurns(timeline), [timeline]);
   const targetTimelineItemId = useMemo(() => timeline.find((item) => itemHasEventSeq(item, targetEventSeq))?.id, [targetEventSeq, timeline]);
   const trimmedPrompt = prompt.trim();
-  const canSendPrompt = (trimmedPrompt.length > 0 || attachments.length > 0) && !sendingPrompt;
+  const composerHasDraft = trimmedPrompt.length > 0 || attachments.length > 0;
+  const composerAction = composerPrimaryAction({
+    currentRunId: activeAgent.currentRunId,
+    hasDraft: composerHasDraft,
+    sendingPrompt,
+  });
+  const canStopCurrentRun = composerAction === "stop-run" && Boolean(activeAgent.currentRunId) && !abortingRun;
+  const canSendPrompt = composerHasDraft && !sendingPrompt;
   const newestTimelineItem = timeline[timeline.length - 1];
   const timelineVersion = `${timeline.length}:${newestTimelineItem?.id ?? ""}:${timeline[0]?.id ?? ""}:${detail?.events?.length ?? 0}:${hasOlderEvents}`;
   const timelineLayoutVersion = useMemo(() => `${resumeRevision}:${timelineLayoutRevision(timelineTurns)}`, [resumeRevision, timelineTurns]);
@@ -613,6 +643,16 @@ export function AgentPage({
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     await sendDraftPrompt();
+  }
+
+  async function stopCurrentRun() {
+    const runId = activeAgent.currentRunId;
+    if (!runId || abortingRun) return;
+    try {
+      await onAbortCurrentRun(runId);
+    } catch {
+      // Keep the composer usable; runtime-store exposes the user-facing error.
+    }
   }
 
   async function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
@@ -946,6 +986,11 @@ export function AgentPage({
                 {promptError}
               </div>
             ) : null}
+            {abortError ? (
+              <div className="composer-status" role="alert">
+                {abortError}
+              </div>
+            ) : null}
             <div className="composer-toolbar">
               <div className="composer-right">
                 <Button
@@ -1106,9 +1151,24 @@ export function AgentPage({
                     )
                   ) : null}
                 </div>
-                <Button className="send-button" type="submit" size="icon" variant="accent" aria-label={t("common.send")} disabled={!canSendPrompt}>
-                  {sendingPrompt ? <LoaderCircle size={16} className="animate-spin" /> : <ArrowUp size={16} />}
-                </Button>
+                {composerAction === "stop-run" ? (
+                  <Button
+                    className="send-button send-button--stop"
+                    type="button"
+                    size="icon"
+                    variant="accent"
+                    aria-label={t("agent.stopCurrentTurn")}
+                    title={t("agent.stopCurrentTurnHint")}
+                    disabled={!canStopCurrentRun}
+                    onClick={() => void stopCurrentRun()}
+                  >
+                    {abortingRun ? <LoaderCircle size={16} className="animate-spin" /> : <Square size={14} />}
+                  </Button>
+                ) : (
+                  <Button className="send-button" type="submit" size="icon" variant="accent" aria-label={t("agentPage.send")} disabled={!canSendPrompt}>
+                    {sendingPrompt ? <LoaderCircle size={16} className="animate-spin" /> : <ArrowUp size={16} />}
+                  </Button>
+                )}
               </div>
             </div>
           </form>

--- a/web-gui/app/src/i18n/resources/en.ts
+++ b/web-gui/app/src/i18n/resources/en.ts
@@ -944,6 +944,8 @@ const en = {
     retrySync: "Retry sync now",
     // Composer
     sendInputAria: "Send operator input to {{id}}",
+    stopCurrentTurn: "Stop this turn",
+    stopCurrentTurnHint: "Interrupt the current turn only; the agent stays available for your next message",
     sendInputPlaceholder: "Send operator input to {{id}}…",
     dropImageHint: "Drop files to attach",
     // Thinking

--- a/web-gui/app/src/i18n/resources/zh-CN.ts
+++ b/web-gui/app/src/i18n/resources/zh-CN.ts
@@ -945,6 +945,8 @@ const zh: Record<string, any> = {
     retrySync: "立即重试同步",
     // 输入框
     sendInputAria: "向 {{id}} 发送操作者消息",
+    stopCurrentTurn: "停止本轮",
+    stopCurrentTurnHint: "仅中断当前这一轮执行；智能体保持可用，可直接发送下一条消息",
     sendInputPlaceholder: "向 {{id}} 发送操作者消息…",
     dropImageHint: "拖放文件以添加附件",
     // 思考级别

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -850,6 +850,42 @@ describe("createRuntimeClient", () => {
     );
   });
 
+  it("aborts the current run with the run id and turn-scoped mode", async () => {
+    const seen: Array<{ url: string; method: string; body: unknown; authorization?: string }> = [];
+    const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      seen.push({
+        url: `${url.origin}${url.pathname}`,
+        method: String(init?.method ?? "GET"),
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+        authorization: init?.headers ? String((init.headers as Record<string, string>).Authorization) : undefined,
+      });
+      return Response.json({ ok: true, aborted: true });
+    };
+
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      token: "secret-token",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await client.abortCurrentRun("agent one", "run-42");
+
+    expect(seen).toEqual([
+      {
+        url: "http://example.test:7878/api/control/agents/agent%20one/current-run/abort",
+        method: "POST",
+        body: {
+          run_id: "run-42",
+          mode: "idle_after_abort",
+          authority_class: "operator_instruction",
+        },
+        authorization: "Bearer secret-token",
+      },
+    ]);
+  });
+
   it("fetches full tool execution detail for inspector hydration", async () => {
     const seen: string[] = [];
     const fetchImpl = async (input: RequestInfo | URL) => {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -1284,6 +1284,24 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       }
       return { messageId: response.message_id };
     },
+    async abortCurrentRun(agentId: string, runId: string): Promise<void> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      await postJson<unknown>(
+        fetchImpl,
+        baseUrl,
+        `/control/agents/${encodeURIComponent(agentId)}/current-run/abort`,
+        {
+          // Turn-scoped interrupt: the agent stays schedulable so the next
+          // operator prompt does not require a lifecycle start.
+          run_id: runId,
+          mode: "idle_after_abort",
+          authority_class: "operator_instruction",
+        },
+        requestHeaders,
+      );
+    },
     async setAgentModel(agentId: string, model: string, reasoningEffort?: string): Promise<AgentModelStateDto | undefined> {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
@@ -2641,7 +2659,7 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
-class RuntimeHttpError extends Error {
+export class RuntimeHttpError extends Error {
   readonly status: number;
   readonly code?: string;
   /**

--- a/web-gui/app/src/runtime/conversation-store.ts
+++ b/web-gui/app/src/runtime/conversation-store.ts
@@ -42,6 +42,7 @@ export function emptyAgentSession(): AgentSessionState {
     contentStatus: "unknown",
     syncStatus: "idle",
     sendingPrompt: false,
+    abortingRun: false,
     detail: null,
     workItemDetailsById: {},
     taskDetailsById: {},
@@ -73,6 +74,7 @@ export function mergeCachedSessionIntoCurrent(
     targetEventLoading: current.targetEventLoading,
     liveStatus: current.liveStatus,
     sendingPrompt: current.sendingPrompt,
+    abortingRun: current.abortingRun,
   };
 }
 

--- a/web-gui/app/src/runtime/global-sync-coordinator.test.ts
+++ b/web-gui/app/src/runtime/global-sync-coordinator.test.ts
@@ -50,6 +50,7 @@ function sessionState(overrides: Partial<AgentSessionState> = {}): AgentSessionS
     contentStatus: "unknown",
     syncStatus: "idle",
     sendingPrompt: false,
+    abortingRun: false,
     detail: null,
     workItemDetailsById: {},
     taskDetailsById: {},

--- a/web-gui/app/src/runtime/runtime-store-helpers.ts
+++ b/web-gui/app/src/runtime/runtime-store-helpers.ts
@@ -56,6 +56,10 @@ export interface AgentSessionState extends SessionProjectionState {
   detailValidatedAt?: number;
   eventsValidatedAt?: number;
   sendingPrompt: boolean;
+  /** A turn-scoped current-run abort request is in flight for this agent. */
+  abortingRun: boolean;
+  /** Last non-conflict abort failure surfaced to the composer. */
+  abortError?: string;
   detail: AgentDetail | null;
   targetEventSeq?: number;
   lastStreamActivityAt?: string;

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -84,6 +84,7 @@ function sessionState(overrides: Partial<AgentSessionState> = {}): AgentSessionS
     contentStatus: "unknown",
     syncStatus: "idle",
     sendingPrompt: false,
+    abortingRun: false,
     detail: null,
     workItemDetailsById: {},
     taskDetailsById: {},
@@ -119,6 +120,140 @@ describe("sendOperatorPrompt", () => {
     } finally {
       useRuntimeStore.setState(previous, true);
     }
+  });
+});
+
+describe("abortCurrentRun", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function abortFetchMock(handlers: {
+    abort?: (init?: RequestInit) => Response;
+  } = {}) {
+    vi.stubGlobal("window", {
+      localStorage: new MemoryStorage(),
+      sessionStorage: new MemoryStorage(),
+      setTimeout,
+      clearTimeout,
+      location: { hostname: "localhost", protocol: "http:" },
+    });
+    return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/control/agents/agent-a/current-run/abort")) {
+        return handlers.abort
+          ? handlers.abort(init)
+          : jsonResponse({ ok: true, aborted: true });
+      }
+      if (url.endsWith("/handshake")) {
+        return jsonResponse({ capabilities: OBSERVER_SYNC_CAPABILITIES });
+      }
+      if (url.endsWith("/agents/list")) return jsonResponse([]);
+      if (url.endsWith("/agents/snapshot")) {
+        return jsonResponse({
+          contract_version: 1,
+          runtime_id: "runtime-1",
+          event_log_epoch: "epoch-1",
+          visibility_scope_id: "scope-1",
+          agents: [],
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+  }
+
+  it("posts a turn-scoped abort with the current run id", async () => {
+    const bodies: unknown[] = [];
+    const fetchMock = abortFetchMock({
+      abort: (init) => {
+        bodies.push(init?.body ? JSON.parse(String(init.body)) : undefined);
+        return jsonResponse({ ok: true, aborted: true });
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+
+    useRuntimeStore.setState({
+      sessionsByAgentId: { "agent-a": sessionState() },
+    });
+
+    await useRuntimeStore.getState().abortCurrentRun("agent-a", "run-1");
+
+    expect(bodies).toEqual([
+      { run_id: "run-1", mode: "idle_after_abort", authority_class: "operator_instruction" },
+    ]);
+    expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toMatchObject({
+      abortingRun: false,
+      abortError: undefined,
+    });
+  });
+
+  it("treats stale run conflicts as benign convergence instead of an error", async () => {
+    const fetchMock = abortFetchMock({
+      abort: () =>
+        new Response(
+          JSON.stringify({
+            error: "stale run_id run-old; current run is run-new",
+            code: "stale_run_id",
+          }),
+          { status: 409, headers: { "content-type": "application/json" } },
+        ),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+
+    useRuntimeStore.setState({
+      sessionsByAgentId: { "agent-a": sessionState() },
+    });
+
+    await useRuntimeStore.getState().abortCurrentRun("agent-a", "run-old");
+
+    expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toMatchObject({
+      abortingRun: false,
+      abortError: undefined,
+    });
+  });
+
+  it("surfaces abort failures as abortError and rethrows", async () => {
+    const fetchMock = abortFetchMock({
+      abort: () =>
+        new Response(JSON.stringify({ error: "gateway exploded" }), {
+          status: 502,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+
+    useRuntimeStore.setState({
+      sessionsByAgentId: { "agent-a": sessionState() },
+    });
+
+    await expect(
+      useRuntimeStore.getState().abortCurrentRun("agent-a", "run-1"),
+    ).rejects.toThrow("current-run/abort failed with 502");
+
+    expect(useRuntimeStore.getState().sessionsByAgentId["agent-a"]).toMatchObject({
+      abortingRun: false,
+    });
+    expect(
+      useRuntimeStore.getState().sessionsByAgentId["agent-a"]?.abortError,
+    ).toContain("gateway exploded");
+  });
+
+  it("ignores abort requests without an agent or run id", async () => {
+    const fetchMock = abortFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    await useRuntimeStore.getState().setRuntimeConnection({ mode: "local" });
+
+    await useRuntimeStore.getState().abortCurrentRun(undefined, "run-1");
+    await useRuntimeStore.getState().abortCurrentRun("agent-a", null);
+    await useRuntimeStore.getState().abortCurrentRun("agent-a", undefined);
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("current-run/abort"),
+      expect.anything(),
+    );
   });
 });
 
@@ -1169,6 +1304,7 @@ describe("brief projection and hydration", () => {
       contentStatus: "unknown",
       syncStatus: "idle",
       sendingPrompt: false,
+    abortingRun: false,
       detail: null,
       eventsBySeq: {
         23: {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -5,6 +5,7 @@ import {
   createRuntimeClient,
   isProjectionBusyError,
   projectRosterAgents,
+  RuntimeHttpError,
   type AgentEventStreamSubscription,
   type OperatorPromptAttachment,
   type AgentRosterSnapshotDto,
@@ -469,6 +470,7 @@ export interface RuntimeStoreState {
   loadAgentToolExecutionDetail: (agentId: string | undefined, toolExecutionId: string | undefined, fallbackActivity?: AgentTimelineActivity) => Promise<void>;
   loadOlderAgentEvents: (agentId: string | undefined, displayLevel: DisplayLevel) => Promise<void>;
   sendOperatorPrompt: (agentId: string | undefined, text: string, displayLevel: DisplayLevel, attachments?: OperatorPromptAttachment[]) => Promise<void>;
+  abortCurrentRun: (agentId: string | undefined, runId: string | null | undefined) => Promise<void>;
   setAgentModel: (agentId: string | undefined, model: string, displayLevel: DisplayLevel, reasoningEffort?: string) => Promise<void>;
   clearAgentModel: (agentId: string | undefined, displayLevel: DisplayLevel) => Promise<void>;
   controlAgent: (agentId: string | undefined, action: AgentControlAction) => Promise<void>;
@@ -685,6 +687,7 @@ export function resetSessionsForResume(
         ),
         targetEventLoading: false,
         sendingPrompt: false,
+        abortingRun: false,
         liveStatus: "stale" as const,
         reconnectAttempt: 0,
         briefHydrationById: Object.fromEntries(
@@ -3546,6 +3549,63 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => {
         },
       }));
       throw error;
+    }
+  },
+
+  abortCurrentRun: async (agentId, runId) => {
+    if (!agentId || !runId) return;
+    if (get().sessionsByAgentId[agentId]?.abortingRun) return;
+
+    const request = captureClientRequest();
+    set((state) => ({
+      sessionsByAgentId: {
+        ...state.sessionsByAgentId,
+        [agentId]: {
+          ...emptyAgentSession(),
+          ...state.sessionsByAgentId[agentId],
+          abortingRun: true,
+          abortError: undefined,
+        },
+      },
+    }));
+
+    try {
+      await request.client.abortCurrentRun(agentId, runId);
+      if (!isCurrentClientRequest(request)) return;
+      set((state) => ({
+        sessionsByAgentId: {
+          ...state.sessionsByAgentId,
+          [agentId]: {
+            ...emptyAgentSession(),
+            ...state.sessionsByAgentId[agentId],
+            abortingRun: false,
+            abortError: undefined,
+          },
+        },
+      }));
+      scheduleBootstrapRefresh(get, 250);
+    } catch (error) {
+      if (!isCurrentClientRequest(request)) return;
+      // The run already ended or the run_id expired: the event stream
+      // converges the composer state, so a conflict is not surfaced as an
+      // operator-facing failure.
+      const conflict =
+        error instanceof RuntimeHttpError &&
+        error.status === 409 &&
+        (error.code === "stale_run_id" || error.code === "no_current_run");
+      const message = error instanceof Error ? error.message : String(error);
+      set((state) => ({
+        sessionsByAgentId: {
+          ...state.sessionsByAgentId,
+          [agentId]: {
+            ...emptyAgentSession(),
+            ...state.sessionsByAgentId[agentId],
+            abortingRun: false,
+            abortError: conflict ? undefined : message,
+          },
+        },
+      }));
+      if (!conflict) throw error;
     }
   },
 

--- a/web-gui/app/src/runtime/session-cache.test.ts
+++ b/web-gui/app/src/runtime/session-cache.test.ts
@@ -27,6 +27,7 @@ function makeSession(overrides: Partial<AgentSessionState> = {}): AgentSessionSt
     contentStatus: "unknown",
     syncStatus: "idle",
     sendingPrompt: false,
+    abortingRun: false,
     detail: null,
     workItemDetailsById: {},
     taskDetailsById: {},

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -5314,6 +5314,10 @@ code {
   opacity: 0.45;
 }
 
+.send-button--stop {
+  background: var(--danger) !important;
+}
+
 .side-panel {
   display: flex;
   position: relative;


### PR DESCRIPTION
Closes #2863.

## What changed

### Runtime concept: turn-scoped abort mode

The issue requires that "停止本轮" only interrupts the current turn and is not equivalent to stopping the agent. The only existing abort mode (`stop_after_abort`) applies the stop projection: after aborting, the agent is `Stopped` and the next operator prompt fails with `409 agent is stopped; start first` (verified experimentally against a live daemon). That contradicts the issue's interaction boundary, so this PR adds:

- **`idle_after_abort` mode** for `POST /api/control/agents/{agent_id}/current-run/abort`: cancels the current run token but applies the idle projection, so the agent stays schedulable and the next prompt is accepted without a lifecycle start. `stop_after_abort` keeps its semantics and stays the default (CLI unchanged).
- **Abort-aware builtin web search probe**: the live provider probe issued during turn context build previously ignored the abort token, so an abort could hang on that phase until the 300s provider idle timeout. It now races the token like provider rounds do.

Decision record: `docs/implementation-decisions/126-current-run-abort-modes.md`.

### Web GUI

- The composer reuses the send button slot: while a turn is running and the input is empty, the button becomes **Stop this turn** (danger styling, `Square` icon, distinct title tooltip); typing any draft restores the send button instantly; clearing the draft restores the stop button while the turn still runs.
- `client.abortCurrentRun` posts `{ run_id, mode: "idle_after_abort", authority_class: "operator_instruction" }`.
- `runtime-store.abortCurrentRun` tracks `abortingRun`/`abortError` per agent session; `409` `stale_run_id`/`no_current_run` conflicts are treated as benign convergence (no operator-facing error), other failures surface in the composer status row.
- Fixed a latent a11y bug: the send button aria-label used a missing key (`common.send`) and rendered the raw key; it now uses `agentPage.send`.
- en / zh-CN copy for the new button and hint.

## Acceptance criteria (#2863)

- [x] 运行中且输入框为空时，发送按钮显示为"停止本轮"
- [x] 点击"停止本轮"会携带当前 run_id 调用 abort 接口
- [x] 用户输入任意内容后，按钮立即切回发送状态并按现有逻辑发送消息
- [x] 清空输入后，若 Turn 仍在运行，按钮重新显示为"停止本轮"
- [x] 停止本轮与停止 Agent 的语义和 UI 文案可明确区分（idle_after_abort + 文案/提示）
- [x] 覆盖按钮状态切换及 abort 请求的前端测试

## E2E verification

- **Chromium (mocked runtime)** — `composer-stop-turn.spec.ts`: full button state machine, abort payload with run id, 409 conflict convergence.
- **Real daemon** — `abort-current-run.spec.ts` drives a real `holon serve` against a hanging OpenAI-compatible provider: prompt → run active → abort with run id settles within seconds (`message_processing_aborted` + `turn_terminal`), the agent is **not** stopped, the next prompt immediately starts a fresh provider turn, and a stale run id still returns 409. 3/3 stable locally.
- The mocked fixture server now models the abort route and per-agent current-run state so roster/state projections behave like the real runtime.

## Tests

- `cargo fmt --all -- --check`, `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib abort_current_run` (idle mode keeps the agent awake and accepts the next prompt; stop mode still stops)
- `npm test` (531 passed), `npm run typecheck`, full Chromium e2e suite (10 passed), real-daemon abort spec ×3

Note: while iterating on the browser-driven real-daemon flow I observed pre-existing flakiness in the Web GUI global event stream under the local real-daemon fixture (the stream sometimes does not start, or stops delivering events while still reporting `streaming`); the existing `production-smoke` spec also fails locally with 401-vs-403 before any of these changes. Both look unrelated to this feature and are worth a separate investigation.
