### PR TITLE
feat: improve Chinese PDF generation guidance

### DIFF
--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -13,8 +13,9 @@ PDF as a simple editable text format.
 
 Common neutral backends include `pypdf` for page and metadata operations,
 `pdfplumber` for text and table inspection, ReportLab or `pdf-lib` for
-generation, Poppler for rendering, and qpdf for structural checks. OCR is a
-separate, explicitly selected path such as local Tesseract.
+generation, HTML/CSS plus a local browser for typography-heavy documents,
+Poppler for rendering, and qpdf for structural checks. OCR is a separate,
+explicitly selected path such as local Tesseract.
 
 ## When To Use
 
@@ -46,7 +47,11 @@ operation and report the limitation.
 - Use **pypdf** for page assembly, rotation, cropping, metadata, common forms,
   and supported encryption operations.
 - Use **pdfplumber** for positioned text and rule-based table extraction.
-- Use **ReportLab** or **pdf-lib** for deliberate PDF generation and drawing.
+- Prefer **HTML/CSS plus a local browser or WeasyPrint** for reports, proposals,
+  manuals, and other prose-heavy documents where typography and page design
+  matter.
+- Use **ReportLab** or **pdf-lib** for precise drawing, overlays, labels, forms,
+  and documents whose layout is naturally coordinate-driven.
 - Use **Poppler** tools for local text extraction or rendering when installed.
 - Use **qpdf** for structural validation and supported transformations.
 - Use **Tesseract** only for explicitly requested local OCR and retain the
@@ -64,17 +69,39 @@ document change rather than in-place prose editing.
    attachments, links, page boxes, fonts, and page count.
 3. Decide whether the task is extraction, page transformation, annotation,
    redaction, generation, or reconstruction.
-4. Select the narrowest local backend that supports the operation.
-5. Produce a new output without activating links or embedded content.
-6. Reopen the result and check page count, dimensions, metadata, bookmarks,
+4. For generation, establish the document type, audience, visual tone, page
+   size, language coverage, font files, hierarchy, color tokens, and recurring
+   components before writing rendering code. Read
+   [`references/generation.md`](references/generation.md) for the required
+   typography and layout workflow. The reusable
+   [`assets/chinese-report.css`](assets/chinese-report.css) is a neutral starting
+   point for polished Chinese or mixed Chinese/Latin reports, not a substitute
+   for matching the operator's requested brand or style.
+5. Select the narrowest local backend that supports the operation.
+6. Produce a new output without activating links or embedded content.
+7. Reopen the result and check page count, dimensions, metadata, bookmarks,
    forms, attachments, encryption state, and expected text.
-7. Render every changed page when possible and compare it with the intended
-   visual result.
-8. For extraction or OCR, sample the output against rendered pages and record
+8. Render every changed or generated page to images. Inspect the actual pages,
+   not only the source HTML or drawing commands, and revise visible defects
+   before delivery.
+9. For extraction or OCR, sample the output against rendered pages and record
    ambiguous tables, reading order, missing glyphs, and low-confidence text.
 
 ## Quality Rules
 
+- Never rely on Helvetica, Times, or another Latin-only base font for Chinese,
+  Japanese, or Korean text. Discover an appropriate local font, verify glyph
+  coverage, and ensure fonts are embedded or otherwise reliably available in
+  the produced PDF.
+- Use a deliberate type scale, spacing rhythm, margins, line length, and color
+  palette. A technically valid PDF with backend-default styling is not a
+  finished generated document.
+- For prose-heavy documents, prefer semantic flow layout over manually placing
+  every line. Prevent headings, tables, figures, and callouts from splitting in
+  visually confusing ways.
+- Check rendered pages for missing-glyph boxes, substituted fonts, clipping,
+  overlap, isolated headings, sparse spill pages, inconsistent spacing, weak
+  contrast, and unreadably dense tables.
 - Preserve intended page order, orientation, crop boxes, and dimensions.
 - Distinguish visual redaction from secure content removal; verify that redacted
   text and related objects are not extractable.
@@ -88,5 +115,6 @@ document change rather than in-place prose editing.
 
 Report the output path, page range and operation, tools used, whether OCR or any
 network service was used, structural and visual checks, signature or form
-impact, and extraction or OCR limitations. State explicitly when active content
-was present but not executed.
+impact, font family and embedding status for generated documents, and extraction
+or OCR limitations. State explicitly when active content was present but not
+executed.

--- a/skills/pdf/assets/chinese-report.css
+++ b/skills/pdf/assets/chinese-report.css
@@ -1,0 +1,305 @@
+@page {
+  size: A4;
+  margin: 18mm 18mm 20mm;
+}
+
+:root {
+  --font-sans: "Noto Sans CJK SC", "Source Han Sans SC", "PingFang SC",
+    "Microsoft YaHei", sans-serif;
+  --font-serif: "Noto Serif CJK SC", "Source Han Serif CN", "Songti SC",
+    serif;
+  --ink: #182230;
+  --muted: #667085;
+  --accent: #175cd3;
+  --accent-dark: #1849a9;
+  --accent-soft: #eff6ff;
+  --surface: #f8fafc;
+  --border: #d0d5dd;
+  --rule: #e4e7ec;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 10.5pt;
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.68;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+p,
+li {
+  orphans: 3;
+  widows: 3;
+}
+
+p {
+  margin: 0 0 0.82em;
+}
+
+a {
+  color: var(--accent-dark);
+  text-decoration-thickness: 0.06em;
+  text-underline-offset: 0.14em;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  break-after: avoid;
+  color: var(--ink);
+  font-weight: 700;
+  letter-spacing: -0.018em;
+  line-height: 1.28;
+  text-wrap: balance;
+}
+
+h1 {
+  margin: 0 0 0.7em;
+  font-size: 26pt;
+}
+
+h2 {
+  margin: 1.65em 0 0.65em;
+  padding-bottom: 0.32em;
+  border-bottom: 1px solid var(--rule);
+  font-size: 17pt;
+}
+
+h3 {
+  margin: 1.35em 0 0.52em;
+  font-size: 13pt;
+}
+
+h4 {
+  margin: 1.1em 0 0.4em;
+  font-size: 10.5pt;
+}
+
+ul,
+ol {
+  margin: 0.2em 0 1em;
+  padding-left: 1.5em;
+}
+
+li {
+  margin: 0.22em 0;
+  padding-left: 0.12em;
+}
+
+blockquote {
+  margin: 1.2em 0;
+  padding: 0.78em 1em;
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+  color: #344054;
+}
+
+code,
+pre {
+  font-family: "Noto Sans Mono CJK SC", "SFMono-Regular", Consolas, monospace;
+}
+
+code {
+  padding: 0.08em 0.3em;
+  border-radius: 3px;
+  background: #f2f4f7;
+  font-size: 0.9em;
+}
+
+pre {
+  overflow-wrap: anywhere;
+  margin: 1em 0;
+  padding: 0.9em 1em;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #101828;
+  color: #f2f4f7;
+  font-size: 8.5pt;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+table {
+  width: 100%;
+  margin: 1.15em 0 1.4em;
+  border-collapse: collapse;
+  break-inside: avoid;
+  font-size: 9.2pt;
+  line-height: 1.5;
+}
+
+thead {
+  display: table-header-group;
+}
+
+tr {
+  break-inside: avoid;
+}
+
+th,
+td {
+  padding: 0.58em 0.68em;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: var(--surface);
+  color: #344054;
+  font-weight: 700;
+}
+
+img,
+svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+figure {
+  margin: 1.2em 0 1.4em;
+  break-inside: avoid;
+}
+
+figcaption,
+.caption {
+  margin-top: 0.55em;
+  color: var(--muted);
+  font-size: 8.5pt;
+  line-height: 1.45;
+}
+
+.cover {
+  display: flex;
+  min-height: 236mm;
+  flex-direction: column;
+  justify-content: center;
+  break-after: page;
+}
+
+.cover::before {
+  width: 18mm;
+  height: 3px;
+  margin-bottom: 11mm;
+  background: var(--accent);
+  content: "";
+}
+
+.cover h1 {
+  max-width: 16.5em;
+  margin-bottom: 0.45em;
+  font-size: 30pt;
+}
+
+.cover .subtitle {
+  max-width: 34em;
+  margin: 0;
+  color: #475467;
+  font-size: 13pt;
+  line-height: 1.55;
+}
+
+.cover .meta {
+  margin-top: 12mm;
+  color: var(--muted);
+  font-size: 9pt;
+}
+
+.kicker {
+  margin-bottom: 0.75em;
+  color: var(--accent-dark);
+  font-size: 8.5pt;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lead {
+  max-width: 38em;
+  margin-bottom: 1.25em;
+  color: #344054;
+  font-size: 11.5pt;
+  line-height: 1.72;
+  text-wrap: pretty;
+}
+
+.summary {
+  margin: 1.25em 0 1.5em;
+  padding: 1em 1.1em;
+  border: 1px solid #b2ccff;
+  border-radius: 7px;
+  background: var(--accent-soft);
+  break-inside: avoid;
+}
+
+.summary > :last-child,
+.callout > :last-child {
+  margin-bottom: 0;
+}
+
+.callout {
+  margin: 1.15em 0 1.4em;
+  padding: 0.9em 1em;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface);
+  break-inside: avoid;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin: 1.2em 0 1.5em;
+}
+
+.metric {
+  padding: 0.85em 0.9em;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  break-inside: avoid;
+}
+
+.metric .value {
+  display: block;
+  color: var(--accent-dark);
+  font-size: 18pt;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.metric .label {
+  display: block;
+  margin-top: 0.3em;
+  color: var(--muted);
+  font-size: 8.5pt;
+}
+
+.page-break {
+  break-before: page;
+}
+
+.keep-together {
+  break-inside: avoid;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.small {
+  font-size: 8.5pt;
+}

--- a/skills/pdf/references/generation.md
+++ b/skills/pdf/references/generation.md
@@ -1,0 +1,186 @@
+# PDF Generation
+
+Use this workflow whenever the task creates or reconstructs a PDF. The goal is
+not merely a valid file: the document must remain readable, visually coherent,
+and portable on a machine that does not share the authoring environment.
+
+## 1. Choose the Rendering Model
+
+Choose the backend from the document's structure:
+
+- **HTML/CSS to PDF**: default for reports, proposals, guides, newsletters,
+  resumes, and mixed text/table/image documents. Browser layout handles flowing
+  prose, wrapping, spacing, and page breaks better than manual coordinates.
+- **ReportLab or pdf-lib**: use for labels, certificates, forms, overlays,
+  diagrams, fixed-position one-pagers, or drawing-heavy output.
+- **Source application export**: when an editable DOCX, PPTX, or spreadsheet is
+  the real source of truth, generate that source first and export a PDF locally.
+
+Do not choose a coordinate-driven library merely because it can emit PDF. It
+often produces brittle wrapping, inconsistent vertical rhythm, and unattractive
+default typography for long documents.
+
+## 2. Establish a Small Design System
+
+Before implementing pages, write down:
+
+- document class and audience
+- page size and orientation
+- body and display font families
+- body size and leading
+- heading scale
+- page margins and content width
+- primary text, muted text, border, surface, and accent colors
+- recurring components such as cover, summary, callout, table, figure, and
+  footer
+
+For a neutral A4 Chinese business report, use these starting ranges:
+
+| Element | Starting value |
+| --- | --- |
+| Page margins | 16–22 mm |
+| Body | 10–11 pt |
+| Body line height | 1.55–1.75 |
+| H1 | 24–30 pt |
+| H2 | 16–19 pt |
+| H3 | 12–14 pt |
+| Caption / metadata | 8–9 pt |
+| Paragraph measure | roughly 32–45 full-width Chinese characters |
+
+Use one main font family and at most one contrasting display family. Use one
+accent hue plus neutral colors unless the operator provides brand tokens.
+Prefer whitespace, alignment, hierarchy, and rules over decorative gradients,
+heavy shadows, or many unrelated colors.
+
+The bundled `../assets/chinese-report.css` provides a restrained default for
+Chinese and mixed Chinese/Latin reports. Copy it into the task's working
+directory and customize its tokens and components for the requested identity.
+
+## 3. Select and Verify Chinese Fonts
+
+### Discovery
+
+Never assume that a font name exists. Inspect the local system:
+
+```bash
+fc-match "Noto Sans CJK SC"
+fc-match "Noto Serif CJK SC"
+fc-list :lang=zh family file | head -40
+```
+
+Reasonable open-font preferences include Noto Sans/Serif CJK SC and Source Han
+Sans/Serif CN. Platform fonts such as PingFang SC or Microsoft YaHei may be
+appropriate when locally installed and redistribution is not required.
+
+Use the Simplified Chinese (`SC`) face for mainland Simplified Chinese unless
+the task requires Traditional Chinese, Japanese, or Korean glyph conventions.
+Do not silently use a Japanese CJK face for Chinese merely because it contains
+the characters.
+
+### Embedding
+
+- HTML/browser generation may subset and embed the selected local font. Verify
+  the result rather than assuming it did.
+- For portable output, use an operator-approved font file with a license that
+  permits embedding. A CSS `@font-face` rule is more deterministic than a long
+  system fallback chain.
+- ReportLab `TTFont` requires a supported TrueType-outline font. Many CJK
+  OTF/TTC packages, including some Noto CJK installations, use PostScript/CFF
+  outlines and fail even when `subfontIndex` is correct. Test registration
+  before building the document. For a supported TTC collection, inspect and
+  select the correct `subfontIndex` instead of copying an index from another
+  machine. If the selected font is unsupported, choose a suitable
+  TrueType-outline font or switch to the HTML/CSS path; do not silently fall
+  back to Helvetica.
+- Avoid non-embedded viewer-dependent CJK fonts for deliverables that must render
+  consistently elsewhere.
+
+Inspect the finished document:
+
+```bash
+pdffonts output.pdf
+pdftotext output.pdf - | sed -n '1,80p'
+```
+
+For every font used for visible content, check that `emb` is `yes` where the
+backend supports embedding. Extracted text should preserve representative
+Chinese punctuation, numerals, Latin abbreviations, and uncommon characters.
+Some browser/PDF combinations expose embedded CJK glyphs as anonymous Type 3
+fonts. In that case, `emb=yes` alone is insufficient: verify rendered glyph
+quality and text extraction, and change the backend if named/searchable font
+behavior is a delivery requirement.
+
+## 4. Compose Pages Deliberately
+
+- Give the first page a clear entry point: title, concise subtitle, ownership or
+  date metadata, and enough whitespace.
+- Balance display-heading line breaks. Never leave one or two Chinese
+  characters isolated on a title line; use semantic manual breaks when the
+  renderer's balancing is insufficient.
+- Keep headings with the following paragraph. Avoid a heading alone at the
+  bottom of a page.
+- Use paragraph spacing or first-line indentation consistently, not both by
+  accident.
+- Keep body text comfortably dense. Do not shrink text to rescue an overloaded
+  page; edit content, restructure sections, or add a page.
+- Use tables for comparison, not general page layout. Repeat headers when the
+  backend supports it and avoid overly narrow columns.
+- Keep figures with their captions and preserve image aspect ratios. Use
+  sufficient source resolution for the final physical size.
+- Use page breaks intentionally before major sections, but avoid sparse pages
+  caused by unnecessary forced breaks.
+- Make links visibly distinct without printing raw, distracting URLs unless the
+  document needs them.
+
+## 5. Render and Review
+
+For local Chrome:
+
+```bash
+google-chrome \
+  --headless --disable-gpu --no-pdf-header-footer \
+  --allow-file-access-from-files \
+  --print-to-pdf=output.pdf input.html
+```
+
+Some container environments also require `--no-sandbox`; add it only when the
+local execution environment requires it.
+
+Render every page to images:
+
+```bash
+mkdir -p rendered
+pdftoppm -png -r 144 output.pdf rendered/page
+```
+
+Inspect all rendered pages at readable scale. A contact sheet is useful for
+rhythm and consistency, but inspect individual pages for text defects.
+
+Revise when any of these appear:
+
+- missing-glyph boxes or visibly wrong regional glyph forms
+- unexpected font substitution or unembedded primary fonts
+- clipped, overlapping, or off-page content
+- one- or two-character title lines and very short paragraph spill lines
+- headings stranded at page bottoms
+- isolated final lines or sparse spill pages
+- inconsistent margins, heading spacing, or component styles
+- weak hierarchy, low contrast, excessive decoration, or monotonous walls of
+  text
+- tables whose cells wrap into unreadable fragments
+- low-resolution or stretched images
+
+Run structural and text checks again after the final visual revision.
+
+## 6. Delivery Evidence
+
+Report:
+
+- rendering backend and relevant conversion command
+- page size and page count
+- primary font family and embedding result
+- whether all pages were rendered and visually inspected
+- any substitutions, unsupported typography, or portability limitations
+
+Do not claim the document is visually verified when only the source or extracted
+text was inspected.


### PR DESCRIPTION
## Summary

- add explicit Chinese font discovery, fallback, embedding, and validation guidance to the PDF skill
- prefer HTML/CSS-to-PDF for styled long-form Chinese documents and document ReportLab font limitations
- add a reusable A4 Chinese business report stylesheet with cover, metrics, cards, tables, callouts, and pagination controls
- require page rendering and visual inspection for missing glyphs, awkward line breaks, clipping, overlap, and layout imbalance

## Verification

- `python /home/jolestar/.holon/agents/holon-template-dev/skills/skill-creator/scripts/quick_validate.py skills/pdf`
- `git diff --check`
- generated and inspected a four-page Chinese PDF sample
- verified embedded fonts and searchable Chinese text
- visually reviewed all four rendered pages with no missing glyphs, clipping, overlap, or unnatural line breaks
