### PR TITLE
fix: isolate cross-agent delivery execution identities

### DIFF
--- a/docs/rfcs/agent-identity-relations-and-message-delivery.md
+++ b/docs/rfcs/agent-identity-relations-and-message-delivery.md
@@ -539,6 +539,16 @@ AgentMessageEnvelope
   admission_evidence
 ```
 
+Caller execution identifiers are provenance, not target execution bindings.
+`current_turn_id`, `current_task_id`, and `current_work_item_id` remain in the
+durable caller context and must not populate the target message's `turn_id`,
+`task_id`, or `work_item_id`. The target runtime allocates its own turn and
+derives any task or WorkItem execution binding from target-owned admission
+state. During upgrade, a queued delivery may clear the legacy bindings only
+when its trusted delivery ledger record proves that all present target fields
+were copied exactly from a different caller agent; ordinary message metadata
+is not sufficient evidence.
+
 `admission_evidence` identifies the policy grant or active relation used for
 admission and the lifecycle fence observed by the transaction. The immutable
 origin, authority class, correlation, causation, and admission evidence enter

--- a/src/runtime/agent_message_delivery.rs
+++ b/src/runtime/agent_message_delivery.rs
@@ -105,11 +105,6 @@ impl AgentMessageDeliveryService<'_> {
             request.content,
         )
         .with_admission(caller.delivery_surface, caller.admission_context);
-        message.turn_id.clone_from(&caller.current_turn_id);
-        message.task_id.clone_from(&caller.current_task_id);
-        message
-            .work_item_id
-            .clone_from(&caller.current_work_item_id);
         message.correlation_id.clone_from(&request.correlation_id);
         message.causation_id.clone_from(&request.causation_id);
         message.metadata = Some(serde_json::json!({
@@ -159,6 +154,39 @@ impl AgentMessageDeliveryService<'_> {
         };
         Ok(PreparedAgentMessageDelivery { message, record })
     }
+}
+
+pub(crate) fn isolate_legacy_cross_agent_execution_bindings(
+    message: &mut MessageEnvelope,
+    delivery: &AgentMessageDeliveryRecord,
+) -> bool {
+    let Some(caller_agent_id) = delivery.caller.caller_agent_id.as_deref() else {
+        return false;
+    };
+    if caller_agent_id == message.agent_id
+        || delivery.target_agent_id != message.agent_id
+        || delivery.message_id.as_deref() != Some(message.id.as_str())
+        || delivery.outcome != AgentMessageDeliveryOutcome::Accepted
+        || delivery.state != AgentMessageDeliveryState::Queued
+    {
+        return false;
+    }
+
+    let caller = &delivery.caller;
+    let has_source_binding = caller.current_turn_id.is_some()
+        || caller.current_task_id.is_some()
+        || caller.current_work_item_id.is_some();
+    let bindings_match = message.turn_id == caller.current_turn_id
+        && message.task_id == caller.current_task_id
+        && message.work_item_id == caller.current_work_item_id;
+    if !has_source_binding || !bindings_match {
+        return false;
+    }
+
+    message.turn_id = None;
+    message.task_id = None;
+    message.work_item_id = None;
+    true
 }
 
 #[cfg(test)]
@@ -217,4 +245,62 @@ fn digest<T: Serialize>(domain: &[u8], value: &T) -> Result<String> {
         .iter()
         .map(|byte| format!("{byte:02x}"))
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        AdmissionContext, AgentMessagePrincipalKind, AuthorityClass, MessageBody,
+        MessageDeliverySurface, MessageOrigin,
+    };
+
+    #[test]
+    fn dispatched_legacy_delivery_keeps_execution_bindings_for_replay() {
+        let caller = AgentMessageCallerContext {
+            caller_principal: "runtime:agent-invocation".into(),
+            caller_agent_id: Some("caller-agent".into()),
+            principal_kind: AgentMessagePrincipalKind::RuntimeCapability,
+            route: "agent_invocation".into(),
+            origin: MessageOrigin::Task {
+                task_id: "task-caller".into(),
+            },
+            authority_class: AuthorityClass::RuntimeInstruction,
+            delivery_surface: MessageDeliverySurface::RuntimeSystem,
+            admission_context: AdmissionContext::RuntimeOwned,
+            current_turn_id: Some("turn-caller".into()),
+            current_task_id: Some("task-caller".into()),
+            current_work_item_id: Some("work-caller".into()),
+        };
+        let mut prepared = AgentMessageDeliveryService::prepare(
+            AgentMessageSendRequest {
+                target_agent_id: "target-agent".into(),
+                content: MessageBody::Text {
+                    text: "legacy interrupted invocation".into(),
+                },
+                client_idempotency_key: "legacy-dispatched-bindings".into(),
+                correlation_id: None,
+                causation_id: None,
+                requested_priority: None,
+            },
+            caller.clone(),
+        )
+        .unwrap();
+        prepared.message.turn_id.clone_from(&caller.current_turn_id);
+        prepared.message.task_id.clone_from(&caller.current_task_id);
+        prepared
+            .message
+            .work_item_id
+            .clone_from(&caller.current_work_item_id);
+        prepared.record.outcome = AgentMessageDeliveryOutcome::Accepted;
+        prepared.record.state = AgentMessageDeliveryState::Dispatched;
+
+        assert!(!isolate_legacy_cross_agent_execution_bindings(
+            &mut prepared.message,
+            &prepared.record,
+        ));
+        assert_eq!(prepared.message.turn_id, caller.current_turn_id);
+        assert_eq!(prepared.message.task_id, caller.current_task_id);
+        assert_eq!(prepared.message.work_item_id, caller.current_work_item_id);
+    }
 }

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -437,12 +437,43 @@ impl<'a> SchedulerDecisionExecutor<'a> {
     }
 
     async fn prepare_message(&self, candidate: QueueCandidate) -> Result<PrepareMessageOutcome> {
+        let queue_entry = self
+            .runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&candidate.message.id)?;
+        let mut persisted_message = self
+            .runtime
+            .inner
+            .storage
+            .read_message_by_id(&candidate.message.id)?
+            .ok_or_else(|| anyhow!("claimed message is missing persisted ingress evidence"))?;
+        let isolated_legacy_execution_bindings = if queue_entry
+            .as_ref()
+            .is_some_and(|entry| entry.status == QueueEntryStatus::Queued)
+        {
+            self.runtime
+                .inner
+                .runtime_db
+                .agent_message_deliveries()
+                .latest_for_message(&persisted_message.id)?
+                .as_ref()
+                .is_some_and(|delivery| {
+                    super::agent_message_delivery::isolate_legacy_cross_agent_execution_bindings(
+                        &mut persisted_message,
+                        delivery,
+                    )
+                })
+        } else {
+            false
+        };
         let prior_closure = self
             .runtime
             .closure_decision_for_state(&candidate.prior_state, None)
             .await?;
         let mut dispatch_plan = self.runtime.build_message_dispatch_plan(
-            &candidate.message,
+            &persisted_message,
             prior_closure,
             &candidate.prior_state,
         )?;
@@ -456,25 +487,14 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             &projection,
             scheduler::SchedulerBoundary::RunLoop,
             scheduler::SchedulerInput::Message {
-                message: &candidate.message,
+                message: &persisted_message,
                 model_turn_allowed: dispatch_plan.model_turn_allowed,
                 continuation_resolution: dispatch_plan.continuation_resolution.as_ref(),
             },
         );
         let scheduler_decision_events =
-            scheduler::scheduler_decision_events(&candidate.message.agent_id, &legacy_decision)?;
-        let persisted_message = self
-            .runtime
-            .inner
-            .storage
-            .read_message_by_id(&candidate.message.id)?
-            .ok_or_else(|| anyhow!("claimed message is missing persisted ingress evidence"))?;
-        let replay_source_turn_id = self
-            .runtime
-            .inner
-            .runtime_db
-            .queue_entries()
-            .latest(&candidate.message.id)?
+            scheduler::scheduler_decision_events(&persisted_message.agent_id, &legacy_decision)?;
+        let replay_source_turn_id = queue_entry
             .filter(|entry| entry.status == QueueEntryStatus::Interrupted)
             .and_then(|_| persisted_message.turn_id.clone());
         let canonical_claim = match self.canonical_activation_plan(
@@ -592,7 +612,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             };
             let run_id = crate::ids::run_id();
             let abort_token = CancellationToken::new();
-            let claim_audit_events = vec![
+            let mut claim_audit_events = vec![
                 scheduler_decision_events[0].clone(),
                 scheduler_decision_events[1].clone(),
                 AuditEvent::legacy(
@@ -605,6 +625,16 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     }),
                 ),
             ];
+            if isolated_legacy_execution_bindings {
+                claim_audit_events.push(AuditEvent::legacy(
+                    "agent_message_execution_bindings_isolated",
+                    serde_json::json!({
+                        "message_id": persisted_message.id,
+                        "agent_id": persisted_message.agent_id,
+                        "reason": "legacy_cross_agent_caller_bindings",
+                    }),
+                ));
+            }
             let agent_id = candidate.message.agent_id.clone();
             let mut attempt = 0;
             loop {
@@ -2435,6 +2465,130 @@ mod tests {
             assert_eq!(cause.scenario_class(), scenario_class);
             assert_eq!(cause.reason(), reason);
         }
+    }
+
+    #[tokio::test]
+    async fn queued_legacy_cross_agent_delivery_isolated_before_target_turn() {
+        use crate::{
+            runtime::tests::support::{context_config, CountingProvider},
+            types::{
+                AgentMessageCallerContext, AgentMessagePrincipalKind, AgentMessageSendRequest,
+            },
+        };
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(CountingProvider {
+                calls: Mutex::new(0),
+                reply: "unused",
+            }),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        let caller = AgentMessageCallerContext {
+            caller_principal: "runtime:agent-invocation".into(),
+            caller_agent_id: Some("caller-agent".into()),
+            principal_kind: AgentMessagePrincipalKind::RuntimeCapability,
+            route: "agent_invocation".into(),
+            origin: MessageOrigin::Task {
+                task_id: "task-caller".into(),
+            },
+            authority_class: AuthorityClass::RuntimeInstruction,
+            delivery_surface: MessageDeliverySurface::RuntimeSystem,
+            admission_context: AdmissionContext::RuntimeOwned,
+            current_turn_id: Some("turn-caller".into()),
+            current_task_id: Some("task-caller".into()),
+            current_work_item_id: Some("work-caller".into()),
+        };
+        let mut prepared = AgentMessageDeliveryService::prepare(
+            AgentMessageSendRequest {
+                target_agent_id: "default".into(),
+                content: MessageBody::Text {
+                    text: "legacy queued invocation".into(),
+                },
+                client_idempotency_key: "legacy-cross-agent-bindings".into(),
+                correlation_id: None,
+                causation_id: None,
+                requested_priority: None,
+            },
+            caller.clone(),
+        )
+        .unwrap();
+        prepared.message.turn_id.clone_from(&caller.current_turn_id);
+        prepared.message.task_id.clone_from(&caller.current_task_id);
+        prepared
+            .message
+            .work_item_id
+            .clone_from(&caller.current_work_item_id);
+        runtime
+            .agent_message_delivery_service()
+            .deliver(&prepared)
+            .await
+            .unwrap();
+        let message_id = prepared.message.id.clone();
+        drop(runtime);
+
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(CountingProvider {
+                calls: Mutex::new(0),
+                reply: "unused",
+            }),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        let RunLoopPoll::Message(scheduled) = SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap()
+        else {
+            panic!("legacy queued delivery should remain executable");
+        };
+        assert_eq!(scheduled.message.turn_id, None);
+        assert_eq!(scheduled.message.task_id, None);
+        assert_eq!(scheduled.message.work_item_id, None);
+        let stored = runtime
+            .inner
+            .storage
+            .read_message_by_id(&message_id)
+            .unwrap()
+            .expect("claimed message remains durable");
+        assert_eq!(stored.turn_id.as_deref(), Some("turn-caller"));
+        assert_eq!(stored.task_id.as_deref(), Some("task-caller"));
+        assert_eq!(stored.work_item_id.as_deref(), Some("work-caller"));
+        let delivery = runtime
+            .inner
+            .runtime_db
+            .agent_message_deliveries()
+            .latest_for_message(&message_id)
+            .unwrap()
+            .expect("delivery provenance remains durable");
+        assert_eq!(delivery.caller, caller);
+
+        runtime
+            .begin_interactive_turn(Some(&scheduled.message), None, None)
+            .await
+            .unwrap();
+        assert_ne!(
+            runtime
+                .agent_state()
+                .await
+                .unwrap()
+                .current_turn_id
+                .as_deref(),
+            Some("turn-caller")
+        );
     }
 
     #[tokio::test]

--- a/src/runtime_db/agent_message_delivery.rs
+++ b/src/runtime_db/agent_message_delivery.rs
@@ -753,7 +753,9 @@ mod tests {
         let (dir, db) = runtime_db()?;
         seed_target(&db, AgentStatus::AwakeIdle)?;
         let prepared = prepare("stable-key", "hello")?;
-        assert_eq!(prepared.message.turn_id.as_deref(), Some("turn-delivery"));
+        assert_eq!(prepared.message.turn_id, None);
+        assert_eq!(prepared.message.task_id, None);
+        assert_eq!(prepared.message.work_item_id, None);
         let first = db.transitions().commit_delivery_admission(
             &admission_command(&prepared),
             None,
@@ -787,6 +789,18 @@ mod tests {
         assert_eq!(
             stored.caller.caller_agent_id.as_deref(),
             Some("caller-agent")
+        );
+        assert_eq!(
+            stored.caller.current_turn_id.as_deref(),
+            Some("turn-delivery")
+        );
+        assert_eq!(
+            stored.caller.current_task_id.as_deref(),
+            Some("task-delivery")
+        );
+        assert_eq!(
+            stored.caller.current_work_item_id.as_deref(),
+            Some("work-delivery")
         );
 
         let database_path = dir.path().join("state/runtime.sqlite");


### PR DESCRIPTION
## 变更摘要

- 跨 agent delivery 不再把 caller 的 `turn_id`、`task_id`、`work_item_id` 传播为目标执行绑定；目标 turn 由既有 enqueue 路径分配独立 ID。
- caller 执行身份仍保留在 durable delivery record，并投影为明确命名的来源 metadata，保持 correlation、causation、origin、authority 与 admission 证据完整。
- 为升级前遗留消息增加窄兼容：仅当 queue entry 与 delivery 均仍为 `Queued`，且 envelope 绑定可由可信 delivery record 证明是跨 agent caller 来源时，才在 claim 前原子清除错误绑定；`Interrupted`/已 dispatched 执行保持原身份用于恢复。
- 更新 agent identity/message delivery RFC，并补充新投递、legacy queued 隔离和 interrupted replay 负向回归测试。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test dispatched_legacy_delivery_keeps_execution_bindings_for_replay --lib`
- `cargo test queued_legacy_cross_agent_delivery_isolated_before_target_turn --lib`
- `cargo test --all-targets -- --test-threads=1`

Closes #2874
