### PR TITLE
fix: 删除周期性 WorkItem 进度催更

### DIFF
--- a/docs/rfcs/operator-display-levels-and-event-presentation.md
+++ b/docs/rfcs/operator-display-levels-and-event-presentation.md
@@ -499,10 +499,12 @@ Events:
 - `work_item_enqueue_requested`
 - `work_item_turn_end_committed`
 - `work_item_turn_end_commit_skipped`
-- `work_item_stale_reminder_injected`
-- `work_item_stale_reminder_skipped`
 - `work_item_waiting_intents_cancelled`
 - `missing_current_work_item_before_wait`
+
+Historical logs may also contain `work_item_stale_reminder_injected` and
+`work_item_stale_reminder_skipped`. The runtime no longer emits these events,
+but presentation keeps decoding them for existing audit history.
 
 Policy:
 

--- a/docs/rfcs/work-item-current-focus.md
+++ b/docs/rfcs/work-item-current-focus.md
@@ -27,6 +27,10 @@ rollback; disagreement is a hard blocker, never a precedence rule.
 focus fact. It may retain the WorkItem that owns an already admitted turn even
 after durable focus changes.
 
+The runtime does not infer stalled progress from provider rounds without a
+WorkItem mutation and does not inject periodic WorkItem progress reminders.
+Waiting, handoff, and completion state remain explicit lifecycle transitions.
+
 ## Invariants
 
 For every non-null canonical focus:

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -50,17 +50,11 @@ use super::projection::{
     build_round_estimated_tokens, build_turn_local_projection_with_runtime_reminder,
     normalize_provider_attempt_timing, provider_attempt_model_state, TurnLocalProjectionOutcome,
 };
-use super::reminders::{
-    build_turn_budget_warning, build_work_item_stale_reminder,
-    maybe_reset_work_item_stale_reminder_cooldown, round_invalidates_checkpoint_anchor,
-    round_updated_work_item, runtime_reminder_fits_baseline, work_item_plan_status_label,
-    work_item_stale_reminder_cooldown_rounds, work_item_stale_reminder_rounds,
-};
+use super::reminders::{build_turn_budget_warning, round_invalidates_checkpoint_anchor};
 use super::{
     append_follow_up_user_texts, render_operator_interjection_text, AgentLoopOutcome,
     LoopControlOptions, ProviderRecoveryDirective, TurnModelSelection, TurnRoundRecord,
     MAX_OUTPUT_RECOVERY_ATTEMPTS, ROUND_TEXT_PREVIEW_LIMIT,
-    WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS,
 };
 use super::{truncate_preview, CHECKPOINT_RESUME_PROMPT};
 use crate::runtime::{
@@ -1126,8 +1120,6 @@ impl TurnExecution<'_> {
         let mut last_assistant_citations = Vec::<Citation>::new();
         let mut last_assistant_round_id: Option<String> = None;
         let mut max_output_recovery_count = 0usize;
-        let mut rounds_since_work_item_update = 0usize;
-        let mut rounds_since_work_item_reminder = work_item_stale_reminder_cooldown_rounds();
         let mut checkpoint_state = {
             let guard = runtime.inner.agent.lock().await;
             checkpoint_state_from_last_terminal(guard.state.last_turn_terminal.as_ref())
@@ -1421,78 +1413,6 @@ impl TurnExecution<'_> {
                 let checkpoint_request_id =
                     Some(format!("turn-{turn_index}-round-{round}-checkpoint"));
                 let mut prompt_frame = build_provider_prompt_frame(&effective_prompt);
-                let reminder_rounds = work_item_stale_reminder_rounds();
-                let reminder_cooldown_rounds = work_item_stale_reminder_cooldown_rounds();
-                let stale_work_item_reminder = if rounds_since_work_item_update >= reminder_rounds
-                    && rounds_since_work_item_reminder >= reminder_cooldown_rounds
-                {
-                    let current_work_item_id = {
-                        let guard = runtime.inner.agent.lock().await;
-                        guard.state.current_work_item_id.clone()
-                    };
-                    current_work_item_id
-                        .as_deref()
-                        .and_then(|id| runtime.inner.storage.latest_work_item(id).ok().flatten())
-                        .map(|work_item| {
-                            let reminder = build_work_item_stale_reminder(
-                                &work_item,
-                                rounds_since_work_item_update,
-                            );
-                            (work_item, reminder)
-                        })
-                } else {
-                    None
-                };
-                let stale_work_item_reminder = if let Some((work_item, reminder)) =
-                    stale_work_item_reminder
-                {
-                    // Continuation reminders are part of the complete provider request, so this
-                    // check uses the model prompt budget rather than the recent-turns sub-budget.
-                    let request_prompt_budget = context_config.prompt_budget_estimated_tokens;
-                    if runtime_reminder_fits_baseline(
-                        &prompt_frame,
-                        &available_tools,
-                        request_prompt_budget,
-                        &reminder,
-                    ) {
-                        Some((work_item, reminder))
-                    } else {
-                        let event = AuditEvent::legacy(
-                            "work_item_stale_reminder_skipped",
-                            serde_json::json!({
-                                "agent_id": agent_id,
-                                "round": round,
-                                "work_item_id": work_item.id,
-                                "plan_status": work_item_plan_status_label(work_item.plan_status),
-                                "rounds_since_work_item_update": rounds_since_work_item_update,
-                                "cooldown_rounds": reminder_cooldown_rounds,
-                                "reason": "baseline_budget",
-                            }),
-                        );
-                        runtime.inner.storage.append_event(&event)?;
-                        None
-                    }
-                } else {
-                    None
-                };
-                if let Some((work_item, reminder)) = stale_work_item_reminder.as_ref() {
-                    runtime.inner.storage.append_event(&AuditEvent::legacy(
-                        "work_item_stale_reminder_injected",
-                        serde_json::json!({
-                            "agent_id": agent_id,
-                            "round": round,
-                            "work_item_id": work_item.id,
-                            "plan_status": work_item_plan_status_label(work_item.plan_status),
-                            "rounds_since_work_item_update": rounds_since_work_item_update,
-                            "cooldown_rounds": reminder_cooldown_rounds,
-                            "text_preview": truncate_preview(reminder, ROUND_TEXT_PREVIEW_LIMIT),
-                        }),
-                    ))?;
-                }
-                maybe_reset_work_item_stale_reminder_cooldown(
-                    &mut rounds_since_work_item_reminder,
-                    stale_work_item_reminder.is_some(),
-                );
                 let budget_warning = if let Some(budget) = turn_budget.as_ref() {
                     let turns_elapsed = turn_index.saturating_sub(budget.run_start_turn_index);
 
@@ -1515,17 +1435,7 @@ impl TurnExecution<'_> {
                 } else {
                     None
                 };
-                let runtime_reminder: Option<String> = match (
-                    stale_work_item_reminder
-                        .as_ref()
-                        .map(|(_, reminder)| reminder.as_str()),
-                    budget_warning.as_deref(),
-                ) {
-                    (Some(work_item), Some(budget)) => Some(format!("{work_item}\n\n{budget}")),
-                    (Some(reminder), None) => Some(reminder.to_string()),
-                    (None, Some(budget)) => Some(budget.to_string()),
-                    (None, None) => None,
-                };
+                let runtime_reminder = budget_warning;
                 let mut recent_turns_budget = effective_prompt.recent_turns_initial_budget();
                 let mut recent_turns_retry_attempts = 0usize;
                 let projection = loop {
@@ -3245,13 +3155,6 @@ impl TurnExecution<'_> {
             if round_invalidates_checkpoint_anchor(&round_record) {
                 checkpoint_state.anchor_generation =
                     checkpoint_state.anchor_generation.saturating_add(1);
-            }
-            if round_updated_work_item(&round_record) {
-                rounds_since_work_item_update = 0;
-                rounds_since_work_item_reminder = WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS;
-            } else {
-                rounds_since_work_item_update = rounds_since_work_item_update.saturating_add(1);
-                rounds_since_work_item_reminder = rounds_since_work_item_reminder.saturating_add(1);
             }
             completed_rounds.push(round_record);
 

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -104,12 +104,6 @@ const MIN_EXACT_TAIL_ROUNDS: usize = 2;
 pub(super) const CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS: usize = 256;
 const DEGRADED_ROUND_PROVENANCE_MARKER: &str = "[runtime: last turn content trimmed to fit prompt budget — truncated sections are marked inline]";
 const DEGRADED_ROUND_MINIMUM_CONTENT_CHARS: usize = 200;
-const WORK_ITEM_STALE_REMINDER_ROUNDS: usize = 10;
-const WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS: usize = 10;
-const WORK_ITEM_STALE_REMINDER_MAX_TOKENS: usize = 512;
-const WORK_ITEM_STALE_REMINDER_PLAN_LINE_LIMIT: usize = 8;
-const WORK_ITEM_STALE_REMINDER_PLAN_CHAR_LIMIT: usize = 1_200;
-const WORK_ITEM_STALE_REMINDER_TODO_LIMIT: usize = 8;
 const TURN_RECORD_SCAN_LIMIT: usize = 4096;
 const OPERATOR_INTERJECTION_HEADER: &str =
     "[Operator message received while this turn was in progress]";

--- a/src/runtime/turn/reminders.rs
+++ b/src/runtime/turn/reminders.rs
@@ -1,26 +1,12 @@
-//! Work-item stale reminders and runtime reminder injection.
+//! Runtime reminder and checkpoint helpers.
 
 use crate::tool::names as tn;
-use std::env;
 
-use crate::provider::{ConversationMessage, ProviderPromptFrame};
-use crate::tool::{
-    spec::{ToolResultEnvelope, ToolResultStatus},
-    ToolSpec,
-};
-use crate::types::{TodoItemState, WorkItemPlanStatus, WorkItemRecord};
+use crate::provider::ConversationMessage;
+use crate::tool::spec::{ToolResultEnvelope, ToolResultStatus};
 
-use super::projection::{
-    estimate_prompt_blocks_tokens, estimate_prompt_frame_tokens, estimate_text_tokens,
-    estimate_tool_specs_tokens,
-};
 use super::truncate_preview;
-use super::{
-    TurnRoundRecord, CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS, DELTA_CHECKPOINT_PREVIEW_LIMIT,
-    WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS, WORK_ITEM_STALE_REMINDER_MAX_TOKENS,
-    WORK_ITEM_STALE_REMINDER_PLAN_CHAR_LIMIT, WORK_ITEM_STALE_REMINDER_PLAN_LINE_LIMIT,
-    WORK_ITEM_STALE_REMINDER_ROUNDS, WORK_ITEM_STALE_REMINDER_TODO_LIMIT,
-};
+use super::{TurnRoundRecord, DELTA_CHECKPOINT_PREVIEW_LIMIT};
 
 pub(super) fn tool_result_invalidates_checkpoint_anchor(envelope: &ToolResultEnvelope) -> bool {
     envelope.status == ToolResultStatus::Success
@@ -41,130 +27,6 @@ pub(super) fn round_invalidates_checkpoint_anchor(round: &TurnRoundRecord) -> bo
         .any(tool_result_invalidates_checkpoint_anchor)
 }
 
-pub(super) fn round_updated_work_item(round: &TurnRoundRecord) -> bool {
-    round.tool_result_envelopes.iter().any(|envelope| {
-        envelope.status == ToolResultStatus::Success
-            && matches!(
-                envelope.tool_name.as_str(),
-                tn::CREATE_WORK_ITEM
-                    | tn::PICK_WORK_ITEM
-                    | tn::UPDATE_WORK_ITEM
-                    | tn::COMPLETE_WORK_ITEM
-            )
-    })
-}
-
-pub(super) fn work_item_stale_reminder_rounds() -> usize {
-    env_usize_or_default(
-        "HOLON_WORK_ITEM_STALE_REMINDER_ROUNDS",
-        WORK_ITEM_STALE_REMINDER_ROUNDS,
-    )
-}
-
-pub(super) fn work_item_stale_reminder_cooldown_rounds() -> usize {
-    env_usize_or_default(
-        "HOLON_WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS",
-        WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS,
-    )
-}
-
-pub(super) fn work_item_stale_reminder_max_tokens() -> usize {
-    env_usize_or_default(
-        "HOLON_WORK_ITEM_STALE_REMINDER_MAX_TOKENS",
-        WORK_ITEM_STALE_REMINDER_MAX_TOKENS,
-    )
-}
-
-pub(super) fn env_usize_or_default(name: &str, default: usize) -> usize {
-    env::var(name)
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(default)
-}
-
-pub(super) fn build_work_item_stale_reminder(
-    work_item: &WorkItemRecord,
-    rounds_since_update: usize,
-) -> String {
-    let mut lines = vec![
-        "[Runtime-generated work item progress reminder]".to_string(),
-        format!(
-            "The current work item has gone {rounds_since_update} provider rounds without a successful CreateWorkItem, PickWorkItem, UpdateWorkItem, or CompleteWorkItem call."
-        ),
-        "Before continuing broad exploration, realign with the current work item. If material progress, scope changes, blockers, or completed checklist items have emerged, call UpdateWorkItem. If the current in-progress step is still not ready to update, state the specific missing fact and run only the next bounded command/query.".to_string(),
-        String::new(),
-        "Current work item snapshot:".to_string(),
-        format!("- Id: {}", work_item.id),
-        format!("- Objective: {}", work_item.objective),
-        format!(
-            "- Plan status: {}",
-            work_item_plan_status_label(work_item.plan_status)
-        ),
-    ];
-    if let Some(plan) = work_item
-        .plan_artifact
-        .as_ref()
-        .map(|artifact| artifact.preview.as_str())
-        .filter(|preview| !preview.trim().is_empty())
-    {
-        lines.push("- Plan:".to_string());
-        let mut plan_chars = 0usize;
-        for line in plan.lines().take(WORK_ITEM_STALE_REMINDER_PLAN_LINE_LIMIT) {
-            let remaining = WORK_ITEM_STALE_REMINDER_PLAN_CHAR_LIMIT.saturating_sub(plan_chars);
-            if remaining == 0 {
-                break;
-            }
-            let rendered = truncate_preview(line, remaining);
-            plan_chars = plan_chars.saturating_add(rendered.len());
-            lines.push(format!("  {rendered}"));
-        }
-        let omitted_lines = plan
-            .lines()
-            .skip(WORK_ITEM_STALE_REMINDER_PLAN_LINE_LIMIT)
-            .count();
-        if omitted_lines > 0 || plan_chars >= WORK_ITEM_STALE_REMINDER_PLAN_CHAR_LIMIT {
-            lines.push("  ... plan truncated".to_string());
-        }
-    }
-    if !work_item.todo_list.is_empty() {
-        lines.push("- Todo list:".to_string());
-        lines.extend(
-            work_item
-                .todo_list
-                .iter()
-                .filter(|todo| todo.state != TodoItemState::Completed)
-                .take(WORK_ITEM_STALE_REMINDER_TODO_LIMIT)
-                .map(|todo| format!("  - [{}] {}", todo_item_state_label(todo.state), todo.text)),
-        );
-        let omitted = work_item
-            .todo_list
-            .iter()
-            .filter(|todo| todo.state != TodoItemState::Completed)
-            .skip(WORK_ITEM_STALE_REMINDER_TODO_LIMIT)
-            .count();
-        if omitted > 0 {
-            lines.push(format!(
-                "  - ... {omitted} more active todo item(s) omitted"
-            ));
-        }
-    }
-    if let Some(blocked_by) = work_item.blocked_by.as_deref() {
-        lines.push(format!("- Blocked by: {blocked_by}"));
-    }
-    let reminder = lines.join("\n");
-    truncate_reminder_to_token_budget(&reminder, work_item_stale_reminder_max_tokens())
-}
-
-pub(super) fn maybe_reset_work_item_stale_reminder_cooldown(
-    rounds_since_work_item_reminder: &mut usize,
-    reminder_injected: bool,
-) {
-    if reminder_injected {
-        *rounds_since_work_item_reminder = 0;
-    }
-}
-
 /// Build a turn budget warning injected when the agent is on the last
 /// allowed turn of a run. This is a cooperative hint, not enforcement;
 /// the scheduling layer enforces max_turns independently.
@@ -178,48 +40,6 @@ pub(super) fn build_turn_budget_warning(max_turns: u64, turns_elapsed: u64) -> S
     ]
     .join("
 ")
-}
-
-pub(super) fn truncate_reminder_to_token_budget(reminder: &str, max_tokens: usize) -> String {
-    if estimate_text_tokens(reminder) <= max_tokens {
-        return reminder.to_string();
-    }
-    let max_chars = max_tokens.saturating_mul(4).max(256);
-    format!(
-        "{}\n... reminder truncated to fit token budget",
-        truncate_preview(reminder, max_chars)
-    )
-}
-
-pub(super) fn runtime_reminder_fits_baseline(
-    prompt_frame: &ProviderPromptFrame,
-    available_tools: &[ToolSpec],
-    request_prompt_budget: usize,
-    reminder: &str,
-) -> bool {
-    let effective_budget_estimated_tokens = request_prompt_budget
-        .saturating_sub(estimate_tool_specs_tokens(available_tools))
-        .saturating_sub(CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS);
-    let baseline_with_reminder = estimate_prompt_frame_tokens(prompt_frame)
-        .saturating_add(estimate_prompt_blocks_tokens(&prompt_frame.context_blocks))
-        .saturating_add(estimate_text_tokens(reminder));
-    baseline_with_reminder <= effective_budget_estimated_tokens
-}
-
-pub(super) fn work_item_plan_status_label(status: WorkItemPlanStatus) -> &'static str {
-    match status {
-        WorkItemPlanStatus::Draft => "draft",
-        WorkItemPlanStatus::Ready => "ready",
-        WorkItemPlanStatus::NeedsInput => "needs_input",
-    }
-}
-
-pub(super) fn todo_item_state_label(state: TodoItemState) -> &'static str {
-    match state {
-        TodoItemState::Pending => "pending",
-        TodoItemState::InProgress => "in_progress",
-        TodoItemState::Completed => "completed",
-    }
 }
 
 pub(super) fn build_delta_checkpoint_prompt(

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -7,8 +7,7 @@ use crate::tool::{
     ToolError, ToolSpec,
 };
 use crate::types::{
-    AuthorityClass, MessageBody, MessageKind, MessageOrigin, Priority, TodoItemState,
-    TurnTerminalCheckpointRecord, WorkItemPlanStatus, WorkItemRecord,
+    AuthorityClass, MessageBody, MessageKind, MessageOrigin, Priority, TurnTerminalCheckpointRecord,
 };
 use chrono::Utc;
 
@@ -20,25 +19,6 @@ use super::projection::*;
 use super::reminders::*;
 use super::tool_summary::*;
 use super::*;
-
-fn fixture_plan_artifact(
-    work_item: &WorkItemRecord,
-    preview: impl Into<String>,
-) -> crate::types::WorkItemPlanArtifact {
-    let preview = preview.into();
-    crate::types::WorkItemPlanArtifact {
-        owner_agent_id: work_item.agent_id.clone(),
-        workspace_id: crate::types::agent_home_workspace_id(&work_item.agent_id),
-        workspace_alias: Some(crate::types::AGENT_HOME_WORKSPACE_ID.into()),
-        relative_path: crate::work_item_plan::plan_relative_path(&work_item.id),
-        path: std::path::PathBuf::from(format!("/tmp/{}/plan.md", work_item.id)),
-        hash: "sha256:test".into(),
-        bytes: preview.len() as u64,
-        updated_at: chrono::Utc::now(),
-        preview,
-        preview_complete: true,
-    }
-}
 
 #[tokio::test]
 async fn persist_turn_record_uses_turn_id_not_numeric_sequence_collisions() {
@@ -647,44 +627,9 @@ fn fixture_round_with_tool_result(
 }
 
 #[test]
-fn build_work_item_stale_reminder_includes_current_work_item_snapshot() {
-    let mut work_item = WorkItemRecord::new(
-        "default",
-        "Ship work item reminder tests",
-        crate::types::WorkItemState::Open,
-    );
-    work_item.id = "work_reminder".into();
-    work_item.plan_status = WorkItemPlanStatus::Ready;
-    work_item.plan_artifact = Some(fixture_plan_artifact(
-        &work_item,
-        "Patch runtime reminder.\nRun focused tests.",
-    ));
-    work_item.todo_list = vec![
-        crate::types::TodoItem {
-            text: "Patch runtime reminder".into(),
-            state: TodoItemState::InProgress,
-        },
-        crate::types::TodoItem {
-            text: "Run focused tests".into(),
-            state: TodoItemState::Pending,
-        },
-    ];
-
-    let reminder = build_work_item_stale_reminder(&work_item, 10);
-
-    assert!(reminder.contains("[Runtime-generated work item progress reminder]"));
-    assert!(reminder.contains("- Id: work_reminder"));
-    assert!(reminder.contains("- Objective: Ship work item reminder tests"));
-    assert!(reminder.contains("- Plan status: ready"));
-    assert!(reminder.contains("Patch runtime reminder."));
-    assert!(reminder.contains("  - [in_progress] Patch runtime reminder"));
-    assert!(reminder.contains("  - [pending] Run focused tests"));
-}
-
-#[test]
 fn build_turn_local_projection_includes_runtime_reminder() {
     let prompt_frame = fixture_prompt_frame();
-    let reminder = "[Runtime-generated work item progress reminder]\nCall UpdateWorkItem if material progress emerged.";
+    let reminder = build_turn_budget_warning(5, 4);
 
     let projection = build_turn_local_projection_with_runtime_reminder(
         &prompt_frame,
@@ -696,7 +641,7 @@ fn build_turn_local_projection_includes_runtime_reminder() {
         4_000,
         120,
         2_500,
-        Some(reminder),
+        Some(&reminder),
     );
 
     let TurnLocalProjectionOutcome::Projection(projection) = projection else {
@@ -704,86 +649,9 @@ fn build_turn_local_projection_includes_runtime_reminder() {
     };
     assert!(projection.conversation.iter().any(|message| matches!(
         message,
-        ConversationMessage::UserText(text) if text == reminder
-    )));
-    assert!(projection.compaction.is_none());
-}
-
-#[test]
-fn stale_reminder_cooldown_resets_only_when_reminder_is_injected() {
-    let mut rounds_since_work_item_reminder = 12usize;
-    maybe_reset_work_item_stale_reminder_cooldown(&mut rounds_since_work_item_reminder, false);
-    assert_eq!(
-        rounds_since_work_item_reminder, 12,
-        "skipped reminder must not consume cooldown"
-    );
-
-    maybe_reset_work_item_stale_reminder_cooldown(&mut rounds_since_work_item_reminder, true);
-    assert_eq!(
-        rounds_since_work_item_reminder, 0,
-        "only injected reminder should reset cooldown"
-    );
-}
-
-#[test]
-fn large_work_item_stale_reminder_does_not_force_baseline_over_budget() {
-    let mut work_item = WorkItemRecord::new(
-        "default",
-        "Keep reminder bounded with large plan and todo list",
-        crate::types::WorkItemState::Open,
-    );
-    work_item.id = "work_large_reminder".into();
-    work_item.plan_status = WorkItemPlanStatus::Ready;
-    work_item.plan_artifact = Some(fixture_plan_artifact(
-        &work_item,
-        (0..80)
-            .map(|idx| format!("step {idx}: {}", "inspect and verify ".repeat(40)))
-            .collect::<Vec<_>>()
-            .join("\n"),
-    ));
-    work_item.todo_list = (0..80)
-        .map(|idx| crate::types::TodoItem {
-            text: format!("todo {idx}: {}", "finish bounded work ".repeat(30)),
-            state: if idx % 3 == 0 {
-                TodoItemState::Completed
-            } else if idx % 3 == 1 {
-                TodoItemState::InProgress
-            } else {
-                TodoItemState::Pending
-            },
-        })
-        .collect();
-    let reminder = build_work_item_stale_reminder(&work_item, 10);
-    let prompt_frame = fixture_prompt_frame();
-
-    assert!(reminder.contains("... plan truncated"));
-    assert!(!reminder.contains("[completed]"));
-    assert!(runtime_reminder_fits_baseline(
-        &prompt_frame,
-        &[],
-        4_000,
-        &reminder
-    ));
-    let projection = build_turn_local_projection_with_runtime_reminder(
-        &prompt_frame,
-        &[],
-        &[],
-        &TurnLocalCheckpointState::default(),
-        Some("req-large".into()),
-        4_000,
-        4_000,
-        120,
-        2_500,
-        Some(&reminder),
-    );
-
-    let TurnLocalProjectionOutcome::Projection(projection) = projection else {
-        panic!("expected bounded reminder to fit baseline");
-    };
-    assert!(projection.conversation.iter().any(|message| matches!(
-        message,
         ConversationMessage::UserText(text) if text == &reminder
     )));
+    assert!(projection.compaction.is_none());
 }
 
 fn checkpoint_state_with_latest(
@@ -2995,67 +2863,6 @@ fn round_does_not_invalidate_when_no_state_mutations() {
 fn round_does_not_invalidate_when_empty_envelopes() {
     let round = fixture_round(1, "text");
     assert!(!round_invalidates_checkpoint_anchor(&round));
-}
-
-// -----------------------------------------------------------------------
-// round_updated_work_item tests
-// -----------------------------------------------------------------------
-
-#[test]
-fn round_updated_work_item_true_for_successful_work_item_tools() {
-    for tool_name in [
-        "CreateWorkItem",
-        "PickWorkItem",
-        "UpdateWorkItem",
-        "CompleteWorkItem",
-    ] {
-        let mut round = fixture_round(1, "text");
-        round.tool_result_envelopes = vec![ToolResultEnvelope {
-            tool_name: tool_name.to_string(),
-            status: ToolResultStatus::Success,
-            summary_text: None,
-            result: Some(serde_json::json!({})),
-            error: None,
-        }];
-        assert!(
-            round_updated_work_item(&round),
-            "{tool_name} success should count as work item update"
-        );
-    }
-}
-
-#[test]
-fn round_updated_work_item_false_for_apply_patch() {
-    let mut round = fixture_round(1, "text");
-    round.tool_result_envelopes = vec![ToolResultEnvelope {
-        tool_name: "ApplyPatch".to_string(),
-        status: ToolResultStatus::Success,
-        summary_text: None,
-        result: Some(serde_json::json!({})),
-        error: None,
-    }];
-    assert!(!round_updated_work_item(&round));
-}
-
-#[test]
-fn round_updated_work_item_false_for_failed_work_item_tool() {
-    let mut round = fixture_round(1, "text");
-    round.tool_result_envelopes = vec![ToolResultEnvelope {
-        tool_name: "CreateWorkItem".to_string(),
-        status: ToolResultStatus::Error,
-        summary_text: None,
-        result: None,
-        error: Some(ToolError {
-            kind: "invalid".to_string(),
-            message: "bad".to_string(),
-            domain: None,
-            details: None,
-            recovery_hint: None,
-            retryable: false,
-            source_chain: Vec::new(),
-        }),
-    }];
-    assert!(!round_updated_work_item(&round));
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## 变更摘要

- 删除按 provider 轮数触发的周期性 WorkItem stale/progress reminder 注入路径
- 删除三个仅服务于该机制的环境变量及相关计数、事件和测试
- 保留 turn budget warning、WorkItem 生命周期持久化及交付契约
- 将展示层已有 reminder 事件明确为历史数据兼容，不再由运行时持续产生

## 验证

- `cargo test --lib runtime::turn::tests`（94 项通过）
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`

Closes #2877
