### PR TITLE
test: make real-daemon web e2e self-contained with a stub provider

### DIFF
--- a/web-gui/app/e2e/real-daemon/daemon-fixture.ts
+++ b/web-gui/app/e2e/real-daemon/daemon-fixture.ts
@@ -1,7 +1,8 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { createWriteStream } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createWriteStream, type WriteStream } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import http from "node:http";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -49,6 +50,33 @@ async function reservePort(): Promise<number> {
       server.close((error) => error ? reject(error) : resolve(address.port));
     });
   });
+}
+
+/**
+ * The daemon fails fast at startup unless the configured model chain has a
+ * usable provider, and CI runners hold no provider credentials. Every daemon
+ * therefore gets a local stub provider that rejects requests quickly, so
+ * startup succeeds and turns settle as deterministic provider errors without
+ * external network calls. Specs that need real provider behavior override
+ * OPENAI_API_KEY / HOLON_OPENAI_BASE_URL through `options.env`.
+ */
+async function startStubProvider(): Promise<{ baseUrl: string; stop: () => Promise<void> }> {
+  const port = await reservePort();
+  const server = http.createServer((_request, response) => {
+    response.writeHead(500, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "e2e stub provider rejection" } }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    async stop() {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
 }
 
 function waitForExit(child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<void> {
@@ -107,6 +135,7 @@ async function createDaemon(
   const artifactDir = path.resolve("test-results", "real-daemon", `worker-${workerIndex}`);
   const stdoutPath = path.join(artifactDir, "daemon.stdout.log");
   const stderrPath = path.join(artifactDir, "daemon.stderr.log");
+  const stubProvider = await startStubProvider();
   const port = await reservePort();
   const baseUrl = `http://127.0.0.1:${port}`;
   const binary = path.resolve(
@@ -114,6 +143,7 @@ async function createDaemon(
   );
   let child: ChildProcessWithoutNullStreams | undefined;
   let agentCreated = false;
+  let stderrStream: WriteStream | undefined;
 
   await mkdir(home, { recursive: true });
   await mkdir(artifactDir, { recursive: true });
@@ -136,6 +166,8 @@ async function createDaemon(
         ...process.env,
         HOLON_HOME: home,
         HOLON_MODEL: "openai/gpt-5.4",
+        OPENAI_API_KEY: "e2e-provider-key",
+        HOLON_OPENAI_BASE_URL: stubProvider.baseUrl,
         HOLON_CONTROL_AUTH_MODE: "required",
         HOLON_CALLBACK_BASE_URL: baseUrl,
         ...(options.env ?? {}),
@@ -143,7 +175,8 @@ async function createDaemon(
       stdio: ["ignore", "pipe", "pipe"],
     });
     child.stdout.pipe(createWriteStream(stdoutPath, { flags: "a" }));
-    child.stderr.pipe(createWriteStream(stderrPath, { flags: "a" }));
+    stderrStream = createWriteStream(stderrPath, { flags: "a" });
+    child.stderr.pipe(stderrStream);
     await waitForReady(baseUrl, controlToken, child);
     if (!agentCreated) {
       const response = await fetch(
@@ -221,13 +254,26 @@ async function createDaemon(
     await start();
   } catch (error) {
     await stop();
+    if (stderrStream && !stderrStream.closed) {
+      await new Promise<void>((resolve) => stderrStream!.close(() => resolve()));
+    }
+    let stderrTail = "";
+    try {
+      stderrTail = (await readFile(stderrPath, "utf8")).slice(-2000).trim();
+    } catch {
+      // Diagnostics only; keep the original error when the log is unavailable.
+    }
+    await stubProvider.stop();
     await rm(root, { recursive: true, force: true });
-    throw error;
+    throw stderrTail
+      ? new Error(`${String(error)}\n--- daemon stderr (tail) ---\n${stderrTail}`)
+      : error;
   }
   return {
     controller,
     cleanup: async () => {
       await stop();
+      await stubProvider.stop();
       await rm(root, { recursive: true, force: true });
     },
   };

--- a/web-gui/app/e2e/real-daemon/production-smoke.spec.ts
+++ b/web-gui/app/e2e/real-daemon/production-smoke.spec.ts
@@ -24,7 +24,8 @@ test("production assets authenticate and use real snapshot, SSE, and route refre
   });
 
   const unauthorized = await page.request.get(`${daemon.baseUrl}/api/handshake`);
-  expect(unauthorized.status()).toBe(403);
+  // #2758 standardized missing credentials on 401 Unauthorized.
+  expect(unauthorized.status()).toBe(401);
 
   await installLocalToken(page, daemon.token);
   await page.goto(daemon.baseUrl);


### PR DESCRIPTION
## Root cause

The `Real daemon` job in the Web E2E workflow has failed on **every** main run since it was introduced in #2665 (40+ runs), while `Chromium P0` stayed green. The job only runs on `push`/`schedule`/`workflow_dispatch` — never on PRs — so nothing surfaced the breakage.

Two independent causes:

1. **Daemon startup failure (all specs, all retries).** The fixture spawns the daemon with `HOLON_MODEL=openai/gpt-5.4` but CI runners have no `OPENAI_API_KEY`. The daemon fails fast at startup (`no available providers for configured model chain: … missing OPENAI_API_KEY`, exit code 1), so every spec died in `waitForReady`. `abort-current-run.spec.ts` already supplied its own dummy key + local hanging provider; the other two specs had nothing.
2. **Stale auth assertion in `production-smoke.spec.ts`.** #2758 standardized missing credentials on `401 Unauthorized` (was `403`); the spec still asserted 403.

## Changes

- `daemon-fixture.ts`: every daemon now gets a local stub provider (fast deterministic 500s) plus default `OPENAI_API_KEY`/`HOLON_OPENAI_BASE_URL` env, so startup succeeds and turns settle as provider errors without external network calls. Spec-provided `env` still wins (the abort spec's hanging provider is unaffected). When readiness fails, the thrown error now includes the daemon stderr tail so the cause is visible directly in CI logs.
- `production-smoke.spec.ts`: expect 401 for the unauthenticated handshake, per #2758.

The daemon's startup fail-fast behavior itself is unchanged — missing credentials should still be a hard operator-visible error; the test fixture is what needed to be self-contained.

## Verification

- `test:e2e:real-daemon` in a CI-like environment (`env -u OPENAI_API_KEY …`): **3/3 passed**, and **9/9 with `--workers=1 --repeat-each=3`** (same as the main-repeat job).
- Mocked suite `test:e2e -- --project=chromium`: 10/10; `test:e2e:production-bundle` passed; typecheck passed (part of build).
- Note: the PR workflow does not run the real-daemon job; verified locally and can be confirmed on the branch via `workflow_dispatch`.