### PR TITLE
ci: run real-daemon web e2e on schedule and dispatch only

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -71,8 +71,8 @@ jobs:
           retention-days: 7
 
   real-daemon:
-    name: Real daemon (${{ github.event_name == 'schedule' && 'nightly repeat' || 'main repeat' }})
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: Real daemon (${{ github.event_name == 'schedule' && 'nightly repeat' || 'on demand' }})
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     defaults:


### PR DESCRIPTION
## Why

The `Real daemon` job in Web E2E rebuilds the Rust daemon, installs toolchains, and runs the 3-spec suite with `--repeat-each=3 --workers=1` (up to a 45-minute timeout). Running that heavyweight suite on **every** push to main costs a lot for little signal, now that the suite is stable again (#2882):

- Fast regression gating on PRs and main pushes is already covered by the mocked **Chromium P0** job (~2 min).
- Deep real-daemon regression is covered by the **nightly** schedule run (`--repeat-each=20`).
- On-demand verification (e.g. for PRs touching daemon/e2e code, as done for #2882) is available via `workflow_dispatch` on any branch.

## Changes

- `real-daemon` job: drop the `push` trigger; run only on `schedule` and `workflow_dispatch`.
- Rename the dispatch-run label from the now-misleading `main repeat` to `on demand` (`nightly repeat` is unchanged).
- The workflow-level `on.push` trigger stays so Chromium P0 keeps running on main pushes.