### PR TITLE
fix: bind existing invocations to delivery execution

### DIFF
--- a/docs/rfcs/agent-actor-invocation-model.md
+++ b/docs/rfcs/agent-actor-invocation-model.md
@@ -496,6 +496,13 @@ Simple public prompts can default to `auto_on_agent_result`.
 Parent-supervised child work should usually default to `caller_acceptance`,
 because the parent may need to review the child result and request fixes.
 
+For an existing-agent invocation, `auto_on_agent_result` is scoped to the
+specific admitted delivery. The runtime durably binds that delivery to its
+canonical execution activation and turn, then follows any typed wait, task
+rejoin, or WorkItem continuation until that execution lineage reaches a
+terminal result. A newer unrelated target turn cannot complete or fail the
+invocation, and delivery consumption is not itself successful task completion.
+
 ## Agent Lifecycle
 
 Agent lifecycle is separate from task lifecycle.

--- a/docs/rfcs/agent-identity-relations-and-message-delivery.md
+++ b/docs/rfcs/agent-identity-relations-and-message-delivery.md
@@ -638,6 +638,13 @@ rejected
 `consumed` means that the admitted message was incorporated into a target turn.
 It does not mean that requested work completed successfully.
 
+When a delivery backs a result-bearing actor invocation, queue claim also binds
+the delivery to the canonical execution activation and turn in the same
+transaction. The invocation observes that activation's execution outcome and
+continuations; it must not infer completion from the target agent's latest turn,
+global idle state, or a later unrelated runtime error. Delivery state remains
+the incorporation ledger: `consumed` alone is never an invocation result.
+
 Adapters may initially return only `queued` or `rejected`, while later
 observation surfaces expose subsequent state.
 

--- a/src/domain/agent.rs
+++ b/src/domain/agent.rs
@@ -289,6 +289,10 @@ pub struct AgentMessageDeliveryRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub correlation_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub causation_id: Option<String>,

--- a/src/host.rs
+++ b/src/host.rs
@@ -63,16 +63,16 @@ use crate::{
         AgentDeletionJob, AgentDeletionStatus, AgentDetail, AgentDurability, AgentIdentityRecord,
         AgentIdentityView, AgentKind, AgentLifecycleHint, AgentListEntry,
         AgentMessageCallerContext, AgentMessageDeliveryOutcome, AgentMessageDeliveryRejectionCode,
-        AgentMessagePrincipalKind, AgentMessageSendRequest, AgentModelResolution,
-        AgentModelResolutionStatus, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
-        AgentState, AgentStatus, AgentSummary, AgentSupervisionState, AgentTokenUsageSummary,
-        AgentTreeNode, AgentTreeProjection, AgentVisibility, AuthorityClass, ChildAgentSummary,
-        ClosureOutcome, CreateAgentRequest, ExternalTriggerRecord, ExternalTriggerStatus,
-        ExternalTriggerSummary, LoadedAgentsMdView, MessageBody, MessageDeliverySurface,
-        MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationRecord, Priority,
-        QueueEntryStatus, RuntimeFailureSummary, TaskKind, TaskRecord, TaskStatus, TimerRecord,
-        TokenUsage, TranscriptEntry, TranscriptEntryKind, WaitConditionSummary, WorkspaceEntry,
-        WorkspaceOccupancyRecord,
+        AgentMessageDeliveryState, AgentMessagePrincipalKind, AgentMessageSendRequest,
+        AgentModelResolution, AgentModelResolutionStatus, AgentOwnership, AgentProfilePreset,
+        AgentRegistryStatus, AgentState, AgentStatus, AgentSummary, AgentSupervisionState,
+        AgentTokenUsageSummary, AgentTreeNode, AgentTreeProjection, AgentVisibility,
+        AuthorityClass, ChildAgentSummary, ClosureOutcome, CreateAgentRequest,
+        ExternalTriggerRecord, ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMdView,
+        MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
+        OperatorNotificationRecord, Priority, QueueEntryStatus, RuntimeFailureSummary, TaskKind,
+        TaskRecord, TaskStatus, TimerRecord, TokenUsage, TranscriptEntry, TranscriptEntryKind,
+        WaitConditionSummary, WorkspaceEntry, WorkspaceOccupancyRecord,
     },
 };
 
@@ -418,6 +418,7 @@ pub(crate) struct RuntimeHostBridge {
 pub(crate) struct ChildTaskSpawn {
     pub child_agent_id: String,
     pub child_turn_baseline: u64,
+    pub delivery_id: Option<String>,
     pub task_detail: Value,
 }
 
@@ -566,6 +567,21 @@ pub(crate) struct ChildTaskTerminalResult {
     pub status: TaskStatus,
     pub text: String,
     pub task_detail: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+struct InvocationTerminalEvidence {
+    status: TaskStatus,
+    text: String,
+    activation_id: Option<String>,
+    turn_id: Option<String>,
+    completion_ref: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+enum InvocationSettlementCursor {
+    Attempt(String),
+    WorkItem(String),
 }
 
 async fn apply_spawn_model_resolution(
@@ -4349,6 +4365,7 @@ impl RuntimeHost {
         Ok(ChildTaskSpawn {
             child_agent_id: child_identity.agent_id,
             child_turn_baseline,
+            delivery_id: None,
             task_detail,
         })
     }
@@ -4523,6 +4540,7 @@ impl RuntimeHost {
         Ok(ChildTaskSpawn {
             child_agent_id: target_agent_id.to_string(),
             child_turn_baseline,
+            delivery_id: Some(receipt.delivery_id),
             task_detail,
         })
     }
@@ -4715,6 +4733,681 @@ impl RuntimeHost {
                 task_detail,
             });
         }
+    }
+
+    async fn await_invocation_delivery_terminal_result(
+        &self,
+        child_agent_id: &str,
+        delivery_id: &str,
+        invocation_task_id: &str,
+        worktree: bool,
+    ) -> Result<ChildTaskTerminalResult> {
+        let storage = self.agent_storage(child_agent_id)?;
+        let identity = self
+            .active_agent_identity(child_agent_id)
+            .map_err(anyhow::Error::from)?;
+        if let Some(evidence) = self.invocation_delivery_terminal_evidence(
+            &storage,
+            child_agent_id,
+            delivery_id,
+            invocation_task_id,
+        )? {
+            return self
+                .invocation_terminal_result(&storage, &identity, delivery_id, evidence, worktree)
+                .await;
+        }
+
+        let _runtime = self.get_or_create_agent(child_agent_id).await?;
+        loop {
+            if let Some(evidence) = self.invocation_delivery_terminal_evidence(
+                &storage,
+                child_agent_id,
+                delivery_id,
+                invocation_task_id,
+            )? {
+                return self
+                    .invocation_terminal_result(
+                        &storage,
+                        &identity,
+                        delivery_id,
+                        evidence,
+                        worktree,
+                    )
+                    .await;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    fn invocation_delivery_terminal_evidence(
+        &self,
+        storage: &AppStorage,
+        child_agent_id: &str,
+        delivery_id: &str,
+        invocation_task_id: &str,
+    ) -> Result<Option<InvocationTerminalEvidence>> {
+        use crate::domain::execution_protocol::{
+            ConversationOutcome, ExecutionAttemptState, ExecutionBinding, ExecutionOutcome,
+            ExecutionSourceIdentity, WorkItemExecutionState, WorkItemOutcome,
+        };
+
+        let Some(delivery) = self
+            .runtime_db()
+            .agent_message_deliveries()
+            .latest(delivery_id)?
+        else {
+            return Ok(Some(InvocationTerminalEvidence {
+                status: TaskStatus::Failed,
+                text: format!(
+                    "agent invocation failed: delivery {delivery_id} is missing from the durable ledger"
+                ),
+                activation_id: None,
+                turn_id: None,
+                completion_ref: None,
+            }));
+        };
+        anyhow::ensure!(
+            delivery.target_agent_id == child_agent_id,
+            "delivery {delivery_id} targets {}, not {child_agent_id}",
+            delivery.target_agent_id
+        );
+        anyhow::ensure!(
+            delivery.caller.current_task_id.as_deref() == Some(invocation_task_id)
+                && delivery.correlation_id.as_deref() == Some(invocation_task_id),
+            "delivery {delivery_id} does not belong to invocation task {invocation_task_id}"
+        );
+        match delivery.state {
+            AgentMessageDeliveryState::Failed | AgentMessageDeliveryState::Rejected => {
+                return Ok(Some(InvocationTerminalEvidence {
+                    status: TaskStatus::Failed,
+                    text: format!(
+                        "agent invocation delivery {delivery_id} failed: {}",
+                        delivery
+                            .diagnostic
+                            .as_deref()
+                            .unwrap_or("target execution was rejected before completion")
+                    ),
+                    activation_id: delivery.activation_id,
+                    turn_id: delivery.turn_id,
+                    completion_ref: None,
+                }));
+            }
+            AgentMessageDeliveryState::CancelledByDeletion => {
+                return Ok(Some(InvocationTerminalEvidence {
+                    status: TaskStatus::Cancelled,
+                    text: format!(
+                        "agent invocation delivery {delivery_id} was cancelled because the target agent was deleted"
+                    ),
+                    activation_id: delivery.activation_id,
+                    turn_id: delivery.turn_id,
+                    completion_ref: None,
+                }));
+            }
+            AgentMessageDeliveryState::Queued | AgentMessageDeliveryState::Dispatched
+                if delivery.activation_id.is_none() =>
+            {
+                return Ok(None);
+            }
+            AgentMessageDeliveryState::Queued
+            | AgentMessageDeliveryState::Dispatched
+            | AgentMessageDeliveryState::Consumed => {}
+        }
+        let Some(root_activation_id) = delivery.activation_id.clone() else {
+            return Ok(Some(InvocationTerminalEvidence {
+                status: TaskStatus::Failed,
+                text: format!(
+                    "agent invocation delivery {delivery_id} was consumed without a canonical execution binding"
+                ),
+                activation_id: None,
+                turn_id: delivery.turn_id,
+                completion_ref: None,
+            }));
+        };
+        let Some(execution) = self
+            .runtime_db()
+            .transitions()
+            .load_execution_protocol_state_if_initialized(child_agent_id)?
+        else {
+            return Ok(None);
+        };
+        let mut cursor = InvocationSettlementCursor::Attempt(root_activation_id.clone());
+        let mut visited = HashSet::new();
+        for _ in 0..128 {
+            let cursor_key = match &cursor {
+                InvocationSettlementCursor::Attempt(attempt_id) => {
+                    format!("attempt:{attempt_id}")
+                }
+                InvocationSettlementCursor::WorkItem(work_item_id) => {
+                    format!("work_item:{work_item_id}")
+                }
+            };
+            if !visited.insert(cursor_key) {
+                return Ok(Some(InvocationTerminalEvidence {
+                    status: TaskStatus::Failed,
+                    text: format!(
+                        "agent invocation delivery {delivery_id} has a cyclic execution continuation"
+                    ),
+                    activation_id: Some(root_activation_id),
+                    turn_id: delivery.turn_id,
+                    completion_ref: None,
+                }));
+            }
+            match cursor.clone() {
+                InvocationSettlementCursor::Attempt(attempt_id) => {
+                    let Some(attempt) = execution.attempts.get(&attempt_id).cloned() else {
+                        return Ok(Some(InvocationTerminalEvidence {
+                            status: TaskStatus::Failed,
+                            text: format!(
+                                "agent invocation delivery {delivery_id} references missing activation {attempt_id}"
+                            ),
+                            activation_id: Some(attempt_id),
+                            turn_id: delivery.turn_id,
+                            completion_ref: None,
+                        }));
+                    };
+                    match attempt.state {
+                        ExecutionAttemptState::Open => return Ok(None),
+                        ExecutionAttemptState::Interrupted => {
+                            if let Some(recovery) = execution
+                                .attempts
+                                .values()
+                                .filter(|candidate| {
+                                    candidate.recovery_of_attempt_id.as_deref()
+                                        == Some(attempt.attempt_id.as_str())
+                                })
+                                .max_by_key(|candidate| candidate.source.generation)
+                            {
+                                cursor = InvocationSettlementCursor::Attempt(
+                                    recovery.attempt_id.clone(),
+                                );
+                                continue;
+                            }
+                            if matches!(
+                                delivery.state,
+                                AgentMessageDeliveryState::Queued
+                                    | AgentMessageDeliveryState::Dispatched
+                            ) {
+                                return Ok(None);
+                            }
+                            return Ok(Some(InvocationTerminalEvidence {
+                                status: TaskStatus::Failed,
+                                text: format!(
+                                    "agent invocation activation {} was interrupted before recovery",
+                                    attempt.attempt_id
+                                ),
+                                activation_id: Some(attempt.attempt_id),
+                                turn_id: attempt.turn_id,
+                                completion_ref: None,
+                            }));
+                        }
+                        ExecutionAttemptState::ProtocolViolation => {
+                            return Ok(Some(InvocationTerminalEvidence {
+                                status: TaskStatus::Failed,
+                                text: format!(
+                                    "agent invocation activation {} ended in a protocol violation",
+                                    attempt.attempt_id
+                                ),
+                                activation_id: Some(attempt.attempt_id),
+                                turn_id: attempt.turn_id,
+                                completion_ref: None,
+                            }));
+                        }
+                        ExecutionAttemptState::Settled => {}
+                    }
+                    let Some(outcome_id) = attempt.terminal_outcome_id.as_deref() else {
+                        return Ok(None);
+                    };
+                    let Some(outcome) = execution.outcomes.get(outcome_id) else {
+                        return Ok(None);
+                    };
+                    match &outcome.outcome {
+                        ExecutionOutcome::Conversation(ConversationOutcome::Replied)
+                        | ExecutionOutcome::Command(_) => {
+                            let Some(turn_id) = attempt.turn_id.as_deref() else {
+                                return Ok(Some(InvocationTerminalEvidence {
+                                    status: TaskStatus::Failed,
+                                    text: format!(
+                                        "agent invocation activation {} settled without a turn identity",
+                                        attempt.attempt_id
+                                    ),
+                                    activation_id: Some(attempt.attempt_id),
+                                    turn_id: None,
+                                    completion_ref: None,
+                                }));
+                            };
+                            let tasks = self
+                                .runtime_db()
+                                .tasks()
+                                .latest_for_agent(child_agent_id, usize::MAX)?
+                                .into_iter()
+                                .filter(|task| {
+                                    task.detail
+                                        .as_ref()
+                                        .and_then(|detail| detail.get("parent_turn_id"))
+                                        .and_then(Value::as_str)
+                                        == Some(turn_id)
+                                })
+                                .collect::<Vec<_>>();
+                            if tasks.iter().any(|task| {
+                                matches!(
+                                    task.status,
+                                    TaskStatus::Queued
+                                        | TaskStatus::Running
+                                        | TaskStatus::Cancelling
+                                )
+                            }) {
+                                return Ok(None);
+                            }
+                            if !tasks.is_empty() {
+                                let task_ids = tasks
+                                    .iter()
+                                    .map(|task| task.id.as_str())
+                                    .collect::<HashSet<_>>();
+                                let continuations = execution
+                                    .attempts
+                                    .values()
+                                    .filter(|candidate| {
+                                        matches!(
+                                            &candidate.source.identity,
+                                            ExecutionSourceIdentity::TaskResult {
+                                                task_id,
+                                                ..
+                                            } if task_ids.contains(task_id.as_str())
+                                        )
+                                    })
+                                    .collect::<Vec<_>>();
+                                if tasks.iter().any(|task| {
+                                    !continuations.iter().any(|candidate| {
+                                        matches!(
+                                            &candidate.source.identity,
+                                            ExecutionSourceIdentity::TaskResult {
+                                                task_id,
+                                                ..
+                                            } if task_id == &task.id
+                                        )
+                                    })
+                                }) {
+                                    return Ok(None);
+                                }
+                                if let Some(continuation) = continuations
+                                    .into_iter()
+                                    .max_by_key(|candidate| candidate.source.generation)
+                                {
+                                    cursor = InvocationSettlementCursor::Attempt(
+                                        continuation.attempt_id.clone(),
+                                    );
+                                    continue;
+                                }
+                            }
+                            return self.invocation_terminal_evidence_for_turn(
+                                child_agent_id,
+                                delivery_id,
+                                &attempt,
+                            );
+                        }
+                        ExecutionOutcome::Conversation(ConversationOutcome::Wait { wait }) => {
+                            let Some(next) = execution
+                                .attempts
+                                .values()
+                                .filter(|candidate| {
+                                    matches!(
+                                        &candidate.source.identity,
+                                        ExecutionSourceIdentity::TriggeredWait {
+                                            wait_id,
+                                            ..
+                                        } if wait_id == &wait.wait_id
+                                    )
+                                })
+                                .max_by_key(|candidate| candidate.source.generation)
+                            else {
+                                return Ok(None);
+                            };
+                            cursor = InvocationSettlementCursor::Attempt(next.attempt_id.clone());
+                        }
+                        ExecutionOutcome::Conversation(
+                            ConversationOutcome::HandoffToWorkItemWait { work_item_id, .. },
+                        ) => {
+                            cursor = InvocationSettlementCursor::WorkItem(work_item_id.clone());
+                        }
+                        ExecutionOutcome::Conversation(ConversationOutcome::Paused { reason }) => {
+                            return Ok(Some(InvocationTerminalEvidence {
+                                status: TaskStatus::Failed,
+                                text: format!(
+                                    "agent invocation paused without a wake path: {reason}"
+                                ),
+                                activation_id: Some(attempt.attempt_id),
+                                turn_id: attempt.turn_id,
+                                completion_ref: None,
+                            }));
+                        }
+                        ExecutionOutcome::Conversation(ConversationOutcome::Interrupted {
+                            reason,
+                        }) => {
+                            return Ok(Some(InvocationTerminalEvidence {
+                                status: TaskStatus::Interrupted,
+                                text: format!("agent invocation was interrupted: {reason}"),
+                                activation_id: Some(attempt.attempt_id),
+                                turn_id: attempt.turn_id,
+                                completion_ref: None,
+                            }));
+                        }
+                        ExecutionOutcome::Conversation(ConversationOutcome::Failed { policy }) => {
+                            return Ok(Some(InvocationTerminalEvidence {
+                                status: TaskStatus::Failed,
+                                text: format!("agent invocation failed under policy {policy}"),
+                                activation_id: Some(attempt.attempt_id),
+                                turn_id: attempt.turn_id,
+                                completion_ref: None,
+                            }));
+                        }
+                        ExecutionOutcome::WorkItem(WorkItemOutcome::Complete { completion }) => {
+                            return Ok(Some(self.invocation_terminal_evidence_for_completion(
+                                storage, &attempt, completion,
+                            )?));
+                        }
+                        ExecutionOutcome::WorkItem(
+                            WorkItemOutcome::Continue
+                            | WorkItemOutcome::Wait { .. }
+                            | WorkItemOutcome::Yield { .. },
+                        ) => {
+                            let ExecutionBinding::WorkItem { work_item_id } = &attempt.binding
+                            else {
+                                return Ok(Some(InvocationTerminalEvidence {
+                                    status: TaskStatus::Failed,
+                                    text: "agent invocation WorkItem outcome lost its execution binding"
+                                        .into(),
+                                    activation_id: Some(attempt.attempt_id),
+                                    turn_id: attempt.turn_id,
+                                    completion_ref: None,
+                                }));
+                            };
+                            cursor = InvocationSettlementCursor::WorkItem(work_item_id.clone());
+                        }
+                        ExecutionOutcome::WorkItem(WorkItemOutcome::Pause { reason }) => {
+                            return Ok(Some(InvocationTerminalEvidence {
+                                status: TaskStatus::Failed,
+                                text: format!("agent invocation WorkItem paused: {reason}"),
+                                activation_id: Some(attempt.attempt_id),
+                                turn_id: attempt.turn_id,
+                                completion_ref: None,
+                            }));
+                        }
+                        ExecutionOutcome::WorkItem(WorkItemOutcome::Failed { policy }) => {
+                            return Ok(Some(InvocationTerminalEvidence {
+                                status: TaskStatus::Failed,
+                                text: format!(
+                                    "agent invocation WorkItem failed under policy {policy}"
+                                ),
+                                activation_id: Some(attempt.attempt_id),
+                                turn_id: attempt.turn_id,
+                                completion_ref: None,
+                            }));
+                        }
+                        ExecutionOutcome::WorkItem(WorkItemOutcome::Interrupted { reason }) => {
+                            return Ok(Some(InvocationTerminalEvidence {
+                                status: TaskStatus::Interrupted,
+                                text: format!(
+                                    "agent invocation WorkItem was interrupted: {reason}"
+                                ),
+                                activation_id: Some(attempt.attempt_id),
+                                turn_id: attempt.turn_id,
+                                completion_ref: None,
+                            }));
+                        }
+                        ExecutionOutcome::WorkItem(WorkItemOutcome::NeedsRepair { repair_id }) => {
+                            return Ok(Some(InvocationTerminalEvidence {
+                                status: TaskStatus::Failed,
+                                text: format!(
+                                    "agent invocation WorkItem requires repair: {repair_id}"
+                                ),
+                                activation_id: Some(attempt.attempt_id),
+                                turn_id: attempt.turn_id,
+                                completion_ref: None,
+                            }));
+                        }
+                    }
+                }
+                InvocationSettlementCursor::WorkItem(work_item_id) => {
+                    let Some(work_item) = execution.work_items.get(&work_item_id) else {
+                        return Ok(Some(InvocationTerminalEvidence {
+                            status: TaskStatus::Failed,
+                            text: format!(
+                                "agent invocation references missing WorkItem execution {work_item_id}"
+                            ),
+                            activation_id: Some(root_activation_id),
+                            turn_id: delivery.turn_id,
+                            completion_ref: None,
+                        }));
+                    };
+                    match &work_item.state {
+                        WorkItemExecutionState::InFlight { attempt_id, .. } => {
+                            cursor = InvocationSettlementCursor::Attempt(attempt_id.clone());
+                        }
+                        WorkItemExecutionState::Waiting { wait, .. } => {
+                            let Some(next) = execution
+                                .attempts
+                                .values()
+                                .filter(|candidate| {
+                                    matches!(
+                                        &candidate.source.identity,
+                                        ExecutionSourceIdentity::TriggeredWait {
+                                            wait_id,
+                                            ..
+                                        } if wait_id == &wait.wait_id
+                                    ) && matches!(
+                                        &candidate.binding,
+                                        ExecutionBinding::WorkItem {
+                                            work_item_id: candidate_work_item_id
+                                        } if candidate_work_item_id == &work_item_id
+                                    )
+                                })
+                                .max_by_key(|candidate| candidate.source.generation)
+                            else {
+                                return Ok(None);
+                            };
+                            cursor = InvocationSettlementCursor::Attempt(next.attempt_id.clone());
+                        }
+                        WorkItemExecutionState::Terminal { completion, .. } => {
+                            let attempt = execution
+                                .attempts
+                                .values()
+                                .filter(|candidate| {
+                                    matches!(
+                                        &candidate.binding,
+                                        ExecutionBinding::WorkItem {
+                                            work_item_id: candidate_work_item_id
+                                        } if candidate_work_item_id == &work_item_id
+                                    )
+                                })
+                                .max_by_key(|candidate| candidate.source.generation);
+                            return Ok(Some(if let Some(attempt) = attempt {
+                                self.invocation_terminal_evidence_for_completion(
+                                    storage, attempt, completion,
+                                )?
+                            } else {
+                                InvocationTerminalEvidence {
+                                    status: TaskStatus::Completed,
+                                    text: storage
+                                        .read_brief_by_id(completion)?
+                                        .map(|brief| brief.text)
+                                        .unwrap_or_default(),
+                                    activation_id: Some(root_activation_id),
+                                    turn_id: delivery.turn_id,
+                                    completion_ref: Some(completion.clone()),
+                                }
+                            }));
+                        }
+                        WorkItemExecutionState::NeedsRepair { repair_id, .. } => {
+                            return Ok(Some(InvocationTerminalEvidence {
+                                status: TaskStatus::Failed,
+                                text: format!(
+                                    "agent invocation WorkItem requires repair: {repair_id}"
+                                ),
+                                activation_id: Some(root_activation_id),
+                                turn_id: delivery.turn_id,
+                                completion_ref: None,
+                            }));
+                        }
+                        WorkItemExecutionState::Runnable { .. }
+                        | WorkItemExecutionState::Paused { .. } => return Ok(None),
+                    }
+                }
+            }
+        }
+        Ok(Some(InvocationTerminalEvidence {
+            status: TaskStatus::Failed,
+            text: format!(
+                "agent invocation delivery {delivery_id} exceeded the bounded continuation chain"
+            ),
+            activation_id: Some(root_activation_id),
+            turn_id: delivery.turn_id,
+            completion_ref: None,
+        }))
+    }
+
+    fn invocation_terminal_evidence_for_turn(
+        &self,
+        child_agent_id: &str,
+        delivery_id: &str,
+        attempt: &crate::domain::execution_protocol::ExecutionAttempt,
+    ) -> Result<Option<InvocationTerminalEvidence>> {
+        let Some(turn_id) = attempt.turn_id.as_deref() else {
+            return Ok(None);
+        };
+        let Some(turn) = self
+            .runtime_db()
+            .turn_records()
+            .by_id(Some(child_agent_id), turn_id)?
+        else {
+            return Ok(None);
+        };
+        let Some(terminal) = turn.terminal else {
+            return Ok(None);
+        };
+        let status = if terminal.kind.is_failure() {
+            TaskStatus::Failed
+        } else {
+            TaskStatus::Completed
+        };
+        let text = self
+            .assistant_text_for_turn(child_agent_id, turn_id)?
+            .or(terminal.reason)
+            .unwrap_or_else(|| {
+                format!(
+                    "agent invocation delivery {delivery_id} completed without additional output"
+                )
+            });
+        Ok(Some(InvocationTerminalEvidence {
+            status,
+            text,
+            activation_id: Some(attempt.attempt_id.clone()),
+            turn_id: Some(turn_id.to_string()),
+            completion_ref: None,
+        }))
+    }
+
+    fn invocation_terminal_evidence_for_completion(
+        &self,
+        storage: &AppStorage,
+        attempt: &crate::domain::execution_protocol::ExecutionAttempt,
+        completion: &str,
+    ) -> Result<InvocationTerminalEvidence> {
+        Ok(InvocationTerminalEvidence {
+            status: TaskStatus::Completed,
+            text: storage
+                .read_brief_by_id(completion)?
+                .map(|brief| brief.text)
+                .unwrap_or_default(),
+            activation_id: Some(attempt.attempt_id.clone()),
+            turn_id: attempt.turn_id.clone(),
+            completion_ref: Some(completion.to_string()),
+        })
+    }
+
+    fn assistant_text_for_turn(&self, agent_id: &str, turn_id: &str) -> Result<Option<String>> {
+        let text = self
+            .runtime_db()
+            .transcript_entries()
+            .for_turn_ids(agent_id, &[turn_id.to_string()])?
+            .into_iter()
+            .filter(|entry| {
+                entry.kind == TranscriptEntryKind::AssistantRound
+                    && entry.data.get("round_purpose").and_then(Value::as_str)
+                        != Some("runtime_checkpoint")
+            })
+            .flat_map(|entry| {
+                entry
+                    .data
+                    .get("blocks")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default()
+            })
+            .filter_map(|block| {
+                (block.get("type").and_then(Value::as_str) == Some("text"))
+                    .then(|| block.get("text").and_then(Value::as_str))
+                    .flatten()
+                    .map(str::trim)
+                    .filter(|text| !text.is_empty())
+                    .map(ToString::to_string)
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        Ok((!text.is_empty()).then_some(text))
+    }
+
+    async fn invocation_terminal_result(
+        &self,
+        storage: &AppStorage,
+        identity: &AgentIdentityRecord,
+        delivery_id: &str,
+        evidence: InvocationTerminalEvidence,
+        worktree: bool,
+    ) -> Result<ChildTaskTerminalResult> {
+        let state = storage
+            .read_agent()?
+            .unwrap_or_else(|| stopped_unloaded_agent(&identity.agent_id));
+        let mut metadata = json!({
+            "target_agent_id": identity.agent_id,
+            "target_agent_kind": identity.kind,
+            "target_agent_visibility": identity.visibility,
+            "target_agent_ownership": identity.ownership(),
+            "target_agent_profile_preset": identity.profile_preset(),
+            "delivery_id": delivery_id,
+            "activation_id": evidence.activation_id,
+            "turn_id": evidence.turn_id,
+            "completion_ref": evidence.completion_ref,
+            "token_usage": json!({
+                "total": crate::types::TokenUsage::new(state.total_input_tokens, state.total_output_tokens),
+                "last_turn": state.last_turn_token_usage.clone(),
+                "total_model_rounds": state.total_model_rounds,
+            }),
+        });
+        if identity.kind == AgentKind::Child {
+            metadata["child_agent_id"] = json!(identity.agent_id);
+            metadata["child_kind"] = json!(identity.kind);
+            metadata["child_visibility"] = json!(identity.visibility);
+            metadata["child_ownership"] = json!(identity.ownership());
+            metadata["child_profile_preset"] = json!(identity.profile_preset());
+        }
+        if worktree {
+            if let Some(worktree) = state.worktree_session.as_ref() {
+                let changed_files =
+                    Self::detect_changed_files_for_worktree(&worktree.worktree_path)
+                        .await
+                        .unwrap_or_default();
+                metadata["worktree"] = json!({
+                    "worktree_path": worktree.worktree_path,
+                    "worktree_branch": worktree.worktree_branch,
+                    "changed_files": changed_files,
+                });
+            }
+        }
+        Ok(ChildTaskTerminalResult {
+            status: evidence.status,
+            text: evidence.text,
+            task_detail: Some(metadata),
+        })
     }
 
     async fn completed_child_terminal_from_storage(
@@ -5133,13 +5826,26 @@ impl RuntimeHostBridge {
         Ok(())
     }
 
-    pub(crate) async fn await_child_terminal_result(
+    pub(crate) async fn await_agent_invocation_terminal_result(
         &self,
         child_agent_id: &str,
         child_turn_baseline: u64,
+        delivery_id: Option<&str>,
+        invocation_task_id: &str,
         worktree: bool,
         cleanup_agent_on_terminal: bool,
     ) -> Result<ChildTaskTerminalResult> {
+        if let Some(delivery_id) = delivery_id {
+            return self
+                .host()?
+                .await_invocation_delivery_terminal_result(
+                    child_agent_id,
+                    delivery_id,
+                    invocation_task_id,
+                    worktree,
+                )
+                .await;
+        }
         self.host()?
             .await_child_terminal_result(
                 child_agent_id,
@@ -6828,6 +7534,43 @@ mod tests {
         let child_state = child.agent_state().await.unwrap();
         assert!(child_state.turn_index > child_turn_baseline);
         assert_eq!(child_state.status, AgentStatus::Asleep);
+        let invocation_turn_index = child_state.turn_index;
+
+        child
+            .enqueue(
+                MessageEnvelope::new(
+                    created.agent_id.clone(),
+                    MessageKind::InternalFollowup,
+                    MessageOrigin::System {
+                        subsystem: "unrelated-test-message".into(),
+                    },
+                    AuthorityClass::RuntimeInstruction,
+                    Priority::Normal,
+                    MessageBody::Text {
+                        text: "unrelated turn after invocation".into(),
+                    },
+                )
+                .with_admission(
+                    MessageDeliverySurface::RuntimeSystem,
+                    AdmissionContext::RuntimeOwned,
+                ),
+            )
+            .await
+            .unwrap();
+        for _ in 0..100 {
+            let state = child.agent_state().await.unwrap();
+            if state.turn_index > invocation_turn_index && state.status == AgentStatus::Asleep {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let unrelated_turn_id = child
+            .agent_state()
+            .await
+            .unwrap()
+            .last_turn_terminal
+            .expect("unrelated turn should complete")
+            .turn_id;
 
         crate::runtime::release_delivery_checkpoint();
         let receipt = invocation.await.unwrap().unwrap();
@@ -6841,6 +7584,228 @@ mod tests {
                 .and_then(Value::as_u64),
             Some(child_turn_baseline)
         );
+        let detail = terminal.detail.as_ref().unwrap();
+        let delivery_id = detail["delivery_id"].as_str().unwrap();
+        let delivery = host
+            .runtime_db()
+            .agent_message_deliveries()
+            .latest(delivery_id)
+            .unwrap()
+            .expect("invocation delivery should remain persisted");
+        assert!(delivery.activation_id.is_some());
+        assert_eq!(detail["activation_id"], delivery.activation_id.unwrap());
+        assert_eq!(detail["turn_id"], delivery.turn_id.unwrap());
+        assert_ne!(detail["turn_id"], unrelated_turn_id);
+    }
+
+    #[tokio::test]
+    async fn concurrent_existing_agent_invocations_keep_distinct_execution_results() {
+        let (_home, host) = test_host();
+        let parent = host.default_runtime().await.unwrap();
+        let created = parent
+            .agent_invocation_service()
+            .invoke(InvokeAgentRequest {
+                target: InvokeAgentTarget::NewSubagent {
+                    template: None,
+                    workspace_mode: ChildAgentWorkspaceMode::Inherit,
+                    model_resolution: Some(inherited_model_resolution("openai", "gpt-5.4")),
+                },
+                message: "bootstrap invocation target".into(),
+                authority_class: AuthorityClass::OperatorInstruction,
+            })
+            .await
+            .unwrap();
+        let bootstrap = wait_for_terminal_task(&parent, &created.task_handle.task_id).await;
+        assert_eq!(bootstrap.status, TaskStatus::Completed);
+
+        let first_service = parent.agent_invocation_service();
+        let second_service = parent.agent_invocation_service();
+        let first = first_service.invoke(InvokeAgentRequest {
+            target: InvokeAgentTarget::ExistingAgent {
+                agent_id: created.agent_id.clone(),
+            },
+            message: "first concurrent invocation".into(),
+            authority_class: AuthorityClass::OperatorInstruction,
+        });
+        let second = second_service.invoke(InvokeAgentRequest {
+            target: InvokeAgentTarget::ExistingAgent {
+                agent_id: created.agent_id.clone(),
+            },
+            message: "second concurrent invocation".into(),
+            authority_class: AuthorityClass::OperatorInstruction,
+        });
+        let (first, second) = tokio::join!(first, second);
+        let first = first.unwrap();
+        let second = second.unwrap();
+        let first_task = wait_for_terminal_task(&parent, &first.task_handle.task_id).await;
+        let second_task = wait_for_terminal_task(&parent, &second.task_handle.task_id).await;
+        assert_eq!(first_task.status, TaskStatus::Completed);
+        assert_eq!(second_task.status, TaskStatus::Completed);
+
+        let first_detail = first_task.detail.as_ref().unwrap();
+        let second_detail = second_task.detail.as_ref().unwrap();
+        let first_delivery = host
+            .runtime_db()
+            .agent_message_deliveries()
+            .latest(first_detail["delivery_id"].as_str().unwrap())
+            .unwrap()
+            .unwrap();
+        let second_delivery = host
+            .runtime_db()
+            .agent_message_deliveries()
+            .latest(second_detail["delivery_id"].as_str().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_ne!(first_delivery.delivery_id, second_delivery.delivery_id);
+        assert_ne!(first_delivery.activation_id, second_delivery.activation_id);
+        assert_ne!(first_delivery.turn_id, second_delivery.turn_id);
+        assert_eq!(
+            first_detail["activation_id"],
+            first_delivery.activation_id.unwrap()
+        );
+        assert_eq!(first_detail["turn_id"], first_delivery.turn_id.unwrap());
+        assert_eq!(
+            second_detail["activation_id"],
+            second_delivery.activation_id.unwrap()
+        );
+        assert_eq!(second_detail["turn_id"], second_delivery.turn_id.unwrap());
+    }
+
+    #[tokio::test]
+    async fn failed_existing_agent_delivery_terminates_without_a_target_turn() {
+        let (_home, host) = test_host();
+        let parent = host.default_runtime().await.unwrap();
+        let created = parent
+            .agent_invocation_service()
+            .invoke(InvokeAgentRequest {
+                target: InvokeAgentTarget::NewSubagent {
+                    template: None,
+                    workspace_mode: ChildAgentWorkspaceMode::Inherit,
+                    model_resolution: Some(inherited_model_resolution("openai", "gpt-5.4")),
+                },
+                message: "bootstrap invocation target".into(),
+                authority_class: AuthorityClass::OperatorInstruction,
+            })
+            .await
+            .unwrap();
+        let bootstrap = wait_for_terminal_task(&parent, &created.task_handle.task_id).await;
+        assert_eq!(bootstrap.status, TaskStatus::Completed);
+        let child = host.get_or_create_agent(&created.agent_id).await.unwrap();
+        let child_turn_baseline = child.agent_state().await.unwrap().turn_index;
+        let parent_agent_id = host.config().default_agent_id.clone();
+
+        let task_id = "task-failed-existing-delivery";
+        let prepared = crate::runtime::AgentMessageDeliveryService::prepare(
+            AgentMessageSendRequest {
+                target_agent_id: created.agent_id.clone(),
+                content: MessageBody::Text {
+                    text: "must fail before execution".into(),
+                },
+                client_idempotency_key: task_id.into(),
+                correlation_id: Some(task_id.into()),
+                causation_id: None,
+                requested_priority: Some(Priority::Normal),
+            },
+            AgentMessageCallerContext {
+                caller_principal: format!("agent:{parent_agent_id}"),
+                caller_agent_id: Some(parent_agent_id),
+                principal_kind: AgentMessagePrincipalKind::SupervisingParent,
+                route: "supervision_follow_up".into(),
+                origin: MessageOrigin::Task {
+                    task_id: task_id.into(),
+                },
+                authority_class: AuthorityClass::OperatorInstruction,
+                delivery_surface: MessageDeliverySurface::RuntimeSystem,
+                admission_context: AdmissionContext::RuntimeOwned,
+                current_turn_id: None,
+                current_task_id: Some(task_id.into()),
+                current_work_item_id: None,
+            },
+        )
+        .unwrap();
+        let now = Utc::now();
+        let admitted = host
+            .runtime_db()
+            .transitions()
+            .commit_delivery_admission(
+                &crate::runtime_db::transitions::QueueTransitionCommand {
+                    agent_id: created.agent_id.clone(),
+                    operation: crate::runtime_db::transitions::QueueOperation::Admit,
+                    mutation: crate::runtime_db::transitions::QueueMutation::Upsert(
+                        crate::types::QueueEntryRecord {
+                            message_id: prepared.message.id.clone(),
+                            agent_id: created.agent_id.clone(),
+                            priority: Priority::Normal,
+                            status: QueueEntryStatus::Queued,
+                            created_at: now,
+                            updated_at: now,
+                        },
+                    ),
+                    scheduler_claim_work_item: None,
+                    agent_state: None,
+                    message_evidence: vec![prepared.message.clone()],
+                    transcript_entries: Vec::new(),
+                    turn_record: None,
+                    audit_events: Vec::new(),
+                    notify_scheduler: false,
+                    fault: None,
+                    brief_evidence: Vec::new(),
+                },
+                None,
+                &prepared.record,
+            )
+            .unwrap()
+            .delivery_receipt
+            .unwrap();
+        let queued = host
+            .runtime_db()
+            .queue_entries()
+            .latest(&prepared.message.id)
+            .unwrap()
+            .unwrap();
+        let mut dropped = queued.clone();
+        dropped.status = QueueEntryStatus::Dropped;
+        dropped.updated_at = Utc::now();
+        host.runtime_db()
+            .transitions()
+            .commit_queue(&crate::runtime_db::transitions::QueueTransitionCommand {
+                agent_id: created.agent_id.clone(),
+                operation: crate::runtime_db::transitions::QueueOperation::RepairDrop,
+                mutation: crate::runtime_db::transitions::QueueMutation::CompareAndSet {
+                    expected: queued,
+                    record: dropped,
+                },
+                scheduler_claim_work_item: None,
+                agent_state: None,
+                message_evidence: Vec::new(),
+                transcript_entries: Vec::new(),
+                turn_record: None,
+                audit_events: Vec::new(),
+                notify_scheduler: false,
+                fault: None,
+                brief_evidence: Vec::new(),
+            })
+            .unwrap();
+
+        let result = host
+            .await_invocation_delivery_terminal_result(
+                &created.agent_id,
+                &admitted.delivery_id,
+                task_id,
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.status, TaskStatus::Failed);
+        assert!(result.text.contains("queue processing terminated"));
+        assert_eq!(
+            child.agent_state().await.unwrap().turn_index,
+            child_turn_baseline
+        );
+        let detail = result.task_detail.unwrap();
+        assert_eq!(detail["delivery_id"], admitted.delivery_id);
+        assert!(detail["activation_id"].is_null());
+        assert!(detail["turn_id"].is_null());
     }
 
     #[tokio::test]

--- a/src/runtime/agent_message_delivery.rs
+++ b/src/runtime/agent_message_delivery.rs
@@ -124,6 +124,8 @@ impl AgentMessageDeliveryService<'_> {
             delivery_id,
             target_agent_id: request.target_agent_id,
             message_id: Some(message.id.clone()),
+            activation_id: None,
+            turn_id: None,
             correlation_id: request.correlation_id,
             causation_id: request.causation_id,
             idempotency_scope,

--- a/src/runtime/agent_services.rs
+++ b/src/runtime/agent_services.rs
@@ -150,6 +150,7 @@ impl AgentInvocationService<'_> {
                     workspace_mode.is_worktree(),
                     admitted.child_agent_id.clone(),
                     admitted.child_turn_baseline,
+                    admitted.delivery_id,
                     admitted.task_detail,
                 )
                 .await?;

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -377,6 +377,7 @@ impl RuntimeHandle {
         worktree: bool,
         child_agent_id: String,
         child_turn_baseline: u64,
+        delivery_id: Option<String>,
         task_detail: serde_json::Value,
     ) -> Result<TaskRecord> {
         let queued_task = TaskRecord {
@@ -403,6 +404,7 @@ impl RuntimeHandle {
                     false,
                     child_agent_id,
                     child_turn_baseline,
+                    delivery_id,
                     task_detail,
                 )
                 .await;
@@ -1074,6 +1076,7 @@ impl RuntimeHandle {
                     true,
                     child_agent_id,
                     child_turn_baseline,
+                    None,
                     task_detail,
                 )
                 .await;
@@ -1101,6 +1104,7 @@ impl RuntimeHandle {
         cleanup_agent_on_terminal: bool,
         child_agent_id: String,
         child_turn_baseline: u64,
+        delivery_id: Option<String>,
         task_detail: serde_json::Value,
     ) -> Result<()> {
         let Some(bridge) = self.inner.host_bridge.clone() else {
@@ -1159,9 +1163,11 @@ impl RuntimeHandle {
 
         let task_detail_for_result = task_detail.clone();
         let result = bridge
-            .await_child_terminal_result(
+            .await_agent_invocation_terminal_result(
                 &child_agent_id,
                 child_turn_baseline,
+                delivery_id.as_deref(),
+                &task_record.id,
                 worktree,
                 cleanup_agent_on_terminal,
             )
@@ -1401,19 +1407,27 @@ impl RuntimeHandle {
                     .detail
                     .as_ref()
                     .and_then(|detail| detail.get("child_turn_baseline"))
-                    .and_then(serde_json::Value::as_u64)
-                    .unwrap_or(bridge.child_turn_index(&target_agent_id).await?);
-                let task_detail = task.detail.clone().unwrap_or_else(|| serde_json::json!({}));
-                self.start_agent_invocation_monitor(
-                    task.clone(),
-                    authority_class,
-                    worktree,
-                    target_agent_id.clone(),
-                    child_turn_baseline,
-                    task_detail,
-                )
-                .await
-                .map(|_| ())
+                    .and_then(serde_json::Value::as_u64);
+                if let Some(child_turn_baseline) = child_turn_baseline {
+                    let delivery_id = detail_string(&task.detail, "delivery_id");
+                    let task_detail = task.detail.clone().unwrap_or_else(|| serde_json::json!({}));
+                    self.start_agent_invocation_monitor(
+                        task.clone(),
+                        authority_class,
+                        worktree,
+                        target_agent_id.clone(),
+                        child_turn_baseline,
+                        delivery_id,
+                        task_detail,
+                    )
+                    .await
+                    .map(|_| ())
+                } else {
+                    Err(anyhow!(
+                        "legacy existing-agent invocation {} is missing its durable turn baseline",
+                        task.id
+                    ))
+                }
             } else {
                 self.spawn_child_agent_task(task.clone(), prompt, authority_class, worktree, true)
                     .await

--- a/src/runtime_db/agent_message_delivery.rs
+++ b/src/runtime_db/agent_message_delivery.rs
@@ -500,6 +500,51 @@ pub(crate) fn advance_delivery_state_for_message_tx(
     compare_and_set_delivery_state_tx(tx, &record.delivery_id, expected_state, &record)
 }
 
+pub(crate) fn bind_delivery_execution_for_message_tx(
+    tx: &Transaction<'_>,
+    message_id: &str,
+    attempt: &crate::domain::execution_protocol::ExecutionAttempt,
+) -> Result<bool> {
+    let Some(mut record) = delivery_by_message_id_tx(tx, message_id)? else {
+        return Ok(false);
+    };
+    if !matches!(
+        record.state,
+        AgentMessageDeliveryState::Queued | AgentMessageDeliveryState::Dispatched
+    ) {
+        return Ok(false);
+    }
+    anyhow::ensure!(
+        attempt.source_message_id.as_deref() == Some(message_id),
+        "delivery execution attempt does not reference its message"
+    );
+    if let Some(existing) = record.activation_id.as_deref() {
+        anyhow::ensure!(
+            existing == attempt.attempt_id
+                || attempt.recovery_of_attempt_id.as_deref() == Some(existing),
+            "delivery execution attempt conflicts with its canonical activation"
+        );
+    }
+    if let (Some(existing), Some(turn_id)) = (record.turn_id.as_deref(), attempt.turn_id.as_deref())
+    {
+        anyhow::ensure!(
+            existing == turn_id || attempt.recovery_of_attempt_id.is_some(),
+            "delivery execution turn conflicts with its canonical activation"
+        );
+    }
+
+    let changed = record.activation_id.as_deref() != Some(attempt.attempt_id.as_str())
+        || record.turn_id != attempt.turn_id;
+    if !changed {
+        return Ok(false);
+    }
+    record.activation_id = Some(attempt.attempt_id.clone());
+    record.turn_id.clone_from(&attempt.turn_id);
+    record.updated_at = Utc::now();
+    replace_delivery_tx(tx, &record)?;
+    Ok(true)
+}
+
 pub(crate) fn cancel_active_deliveries_for_target_tx(
     tx: &Transaction<'_>,
     target_agent_id: &str,

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -15,8 +15,8 @@ use std::collections::BTreeMap;
 use crate::{
     runtime_db::{
         agent_message_delivery::{
-            advance_delivery_state_for_message_tx, delivery_by_message_id_tx,
-            persist_completed_admission_tx, persist_queued_admission_tx,
+            advance_delivery_state_for_message_tx, bind_delivery_execution_for_message_tx,
+            delivery_by_message_id_tx, persist_completed_admission_tx, persist_queued_admission_tx,
             prepare_delivery_admission_tx, AgentMessageDeliveryAdmissionDecision,
         },
         evidence::{
@@ -1184,7 +1184,7 @@ impl RuntimeTransitionRepository<'_> {
     fn commit_queue_transaction_with_delivery(
         &self,
         command: &QueueTransitionCommand,
-        execution_protocol: &ExecutionProtocolTransition,
+        execution_protocol_transition: &ExecutionProtocolTransition,
         wait_transition: Option<&QueueWaitTransition>,
         task_expectation: Option<&TaskExpectation>,
         completion: Option<&CompletionTransition>,
@@ -1243,7 +1243,7 @@ impl RuntimeTransitionRepository<'_> {
                 if completion.requires_execution_continuation {
                     validate_completion_execution_commands(
                         completion,
-                        &execution_protocol.commands,
+                        &execution_protocol_transition.commands,
                     )?;
                 }
                 for work_item in &completion.work_items {
@@ -1335,8 +1335,8 @@ impl RuntimeTransitionRepository<'_> {
             let execution_protocol = execution_protocol_repository::validate_execution_commands_tx(
                 tx,
                 &command.agent_id,
-                execution_protocol.bootstrap.as_ref(),
-                &execution_protocol.commands,
+                execution_protocol_transition.bootstrap.as_ref(),
+                &execution_protocol_transition.commands,
                 execution_work_items,
                 execution_wait_conditions,
                 execution_continuations,
@@ -1362,7 +1362,11 @@ impl RuntimeTransitionRepository<'_> {
                 return Ok(TransitionCommit::default());
             }
             if synchronize_delivery {
-                advance_delivery_for_queue_transition_tx(tx, command)?;
+                advance_delivery_for_queue_transition_tx(
+                    tx,
+                    command,
+                    execution_protocol_transition,
+                )?;
             }
             let agent_state_applied =
                 apply_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
@@ -2360,8 +2364,43 @@ fn queue_mutation_record(mutation: &QueueMutation) -> &QueueEntryRecord {
 fn advance_delivery_for_queue_transition_tx(
     tx: &Transaction<'_>,
     command: &QueueTransitionCommand,
+    execution_protocol: &ExecutionProtocolTransition,
 ) -> Result<bool> {
     let record = queue_mutation_record(&command.mutation);
+    let mut changed = false;
+    if command.operation == QueueOperation::Claim && record.status == QueueEntryStatus::Dequeued {
+        let admitted_attempt = execution_protocol.commands.iter().find_map(|command| {
+            let crate::domain::execution_protocol::ExecutionProtocolCommand::Admit(command) =
+                command
+            else {
+                return None;
+            };
+            (command.attempt.source_message_id.as_deref() == Some(record.message_id.as_str()))
+                .then_some(&command.attempt)
+        });
+        let bound_activation_id = delivery_by_message_id_tx(tx, &record.message_id)?
+            .and_then(|delivery| delivery.activation_id);
+        let stored_state = (admitted_attempt.is_none() && bound_activation_id.is_some())
+            .then(|| execution_protocol_repository::load_state_tx(tx, &record.agent_id))
+            .transpose()?;
+        let attempt = admitted_attempt.or_else(|| {
+            stored_state.as_ref().and_then(|state| {
+                bound_activation_id
+                    .as_deref()
+                    .and_then(|attempt_id| state.attempts.get(attempt_id))
+                    .or_else(|| {
+                        state.attempts.values().find(|attempt| {
+                            attempt.source_message_id.as_deref() == Some(record.message_id.as_str())
+                            && attempt.state
+                                == crate::domain::execution_protocol::ExecutionAttemptState::Open
+                        })
+                    })
+            })
+        });
+        if let Some(attempt) = attempt {
+            changed |= bind_delivery_execution_for_message_tx(tx, &record.message_id, attempt)?;
+        }
+    }
     let next = match (command.operation, &record.status) {
         (QueueOperation::Claim, QueueEntryStatus::Dequeued) => {
             Some(AgentMessageDeliveryState::Dispatched)
@@ -2376,17 +2415,19 @@ fn advance_delivery_for_queue_transition_tx(
         ) => Some(AgentMessageDeliveryState::Failed),
         _ => None,
     };
-    next.map(|next| {
-        advance_delivery_state_for_message_tx(
-            tx,
-            &record.message_id,
-            next,
-            (next == AgentMessageDeliveryState::Failed)
-                .then_some("message queue processing terminated before consumption"),
-        )
-    })
-    .transpose()
-    .map(Option::unwrap_or_default)
+    let advanced = next
+        .map(|next| {
+            advance_delivery_state_for_message_tx(
+                tx,
+                &record.message_id,
+                next,
+                (next == AgentMessageDeliveryState::Failed)
+                    .then_some("message queue processing terminated before consumption"),
+            )
+        })
+        .transpose()
+        .map(Option::unwrap_or_default)?;
+    Ok(changed || advanced)
 }
 
 fn validate_delivery_queue_admission(


### PR DESCRIPTION
## 概要

- 在 agent message delivery 账本中持久化 canonical `activation_id` 与 `turn_id`，并在 queue claim 的同一事务完成绑定
- 将 existing-agent invocation monitor 从全局 `turn_index`/最近 runtime error 改为精确观察自身 delivery、execution outcome 及 wait/task-rejoin/WorkItem continuation
- delivery `failed`/`cancelled_by_deletion` 确定性终结父 task；恢复时复用持久化 `delivery_id`，遗留记录不再以当前 turn 重置 baseline
- 更新 actor invocation 与 message delivery RFC，明确 `consumed` 不等于 invocation 成功

## 回归覆盖

- monitor 延迟启动且目标随后发生无关 turn 时，仍返回原 invocation 的 activation/turn
- 两个并行 existing-agent invocation 保持独立 delivery、activation 与 turn
- delivery 在目标 turn 前失败时，task 确定性失败且目标不会产生新 turn
- 既有 delivery ledger 生命周期与兼容性测试

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`

Closes #2875