### PR TITLE
fix: show agent display name in sidebar agent list

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -598,14 +598,14 @@ export function App() {
                 <button
                   className={`agent-row ${selectedAgentId === agent.id ? "is-selected" : ""} ${agent.lifecycle}`}
                   key={agent.id}
-                  title={`${agent.id} · ${agent.focusSummary} · ${status.title}`}
+                  title={`${agent.name ? `${agent.name} (${agent.id})` : agent.id} · ${agent.focusSummary} · ${status.title}`}
                   type="button"
                   onClick={() => navigateAgent(agent.id)}
                 >
                   <span className={`agent-badge ${agent.badgeTone ?? ""}`} style={agent.badgeHue != null && !agent.badgeTone ? ({ "--badge-hue": `${agent.badgeHue}` } as CSSProperties) : undefined}>{agent.badge}</span>
                   <span className="agent-row-main">
                     <span className="agent-row-title">
-                      <strong>{agent.id}</strong>
+                      <strong>{agent.name ?? agent.id}</strong>
                       {unreadView?.mode === "stale_sync_error" ? (
                         <span className="agent-row-unread is-stale" aria-label={t("app.unreadSyncError")} title={t("app.unreadSyncError")}>
                           !
@@ -623,6 +623,7 @@ export function App() {
                         <StatusDotIcon tone={status.tone} />
                       </span>
                     </span>
+                    {agent.name ? <small>{agent.id}</small> : null}
                     {workSummary ? (
                       <span className="agent-row-meta">
                         <span>{workSummary}</span>


### PR DESCRIPTION
## What changed

The left sidebar agent list rendered `agent.id` only and ignored `AgentSummary.name`, so renamed agents kept showing the technical id. The dashboard cards and the topbar already use the `name ?? id` pattern; the sidebar row was the only surface left behind.

- Sidebar `agent-row` now renders `agent.name ?? agent.id` in the title.
- When a display name exists, the technical id is shown as a secondary line via the existing `.agent-row small` style (same pattern as dashboard agent cards).
- Row tooltip now leads with `name (id)` when a name exists.

## Runtime concept

Web GUI presentation only; no runtime contract change. `AgentSummary.name` was already projected from `AgentListEntryDto.identity.name`.

## Verification

- `npm run typecheck` ✅
- `npx vitest run src/app` — 5/5 ✅