### PR TITLE
feat: add read-side performance attribution

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,11 +6,21 @@ on:
     paths:
       - ".github/workflows/benchmark.yml"
       - "benchmark/**"
+      - "benches/**"
+      - "scripts/check-performance-gate.py"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
   pull_request:
     branches: [main]
     paths:
       - ".github/workflows/benchmark.yml"
       - "benchmark/**"
+      - "benches/**"
+      - "scripts/check-performance-gate.py"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
 
 permissions:
   contents: read
@@ -38,3 +48,43 @@ jobs:
       - name: Test benchmark harness
         working-directory: benchmark
         run: npm test
+
+  rust-performance:
+    name: Rust Performance Gate
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run stable performance subset
+        run: |
+          set -euo pipefail
+          mkdir -p target/performance
+          HOLON_BENCH_SAMPLES=5 \
+            HOLON_BENCH_FILTER="runtime_db.open_and_migrate.fresh,projection.agent_summary_storage.50_briefs_100_events" \
+            cargo bench --locked --bench runtime_db > target/performance/runtime_db.json
+          HOLON_BENCH_SAMPLES=5 \
+            HOLON_BENCH_FILTER="scheduler.work_queue_read_model.200,scheduler.due_rechecks.50,scheduler.active_waits.50" \
+            cargo bench --locked --bench scheduler > target/performance/scheduler.json
+          HOLON_BENCH_SAMPLES=5 \
+            HOLON_BENCH_FILTER="http.runtime_performance.100,http.work_items.200x10" \
+            cargo bench --locked --bench http_control > target/performance/http_control.json
+          HOLON_BENCH_SAMPLES=3 \
+            cargo bench --locked --bench memory_lifecycle > target/performance/memory_lifecycle.json
+
+      - name: Enforce catastrophic regression limits
+        run: |
+          python3 scripts/check-performance-gate.py target/performance \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload performance artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-performance
+          path: target/performance
+          if-no-files-found: error

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,23 @@ path = "src/lib.rs"
 [[bin]]
 name = "holon"
 path = "src/main.rs"
+
+[[bench]]
+name = "runtime_db"
+harness = false
+
+[[bench]]
+name = "scheduler"
+harness = false
+
+[[bench]]
+name = "http_control"
+harness = false
+
+[[bench]]
+name = "memory_lifecycle"
+harness = false
+
+[[bench]]
+name = "performance_attribution"
+harness = false

--- a/benches/http_control.rs
+++ b/benches/http_control.rs
@@ -1,0 +1,524 @@
+use std::{
+    hint::black_box,
+    process::Command,
+    sync::Arc,
+    thread,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result};
+use axum::{
+    body::{to_bytes, Body},
+    http::{Request, StatusCode},
+    Router,
+};
+use chrono::Utc;
+use holon::{
+    config::AppConfig,
+    host::RuntimeHost,
+    http::{router, AppState},
+    provider::StubProvider,
+};
+use serde::Serialize;
+use serde_json::Value;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+const DEFAULT_SAMPLES: usize = 10;
+const WARMUP_SAMPLES: usize = 1;
+const EXTRA_AGENTS: usize = 100;
+const WORK_ITEMS: usize = 200;
+const PERFORMANCE_REQUESTS_PER_SAMPLE: usize = 100;
+const WORK_ITEM_REQUESTS_PER_SAMPLE: usize = 10;
+
+#[derive(Serialize)]
+struct BenchmarkArtifact {
+    schema_version: &'static str,
+    benchmark_suite: &'static str,
+    workload_version: &'static str,
+    started_at: String,
+    environment: Environment,
+    config: BenchmarkConfig,
+    results: Vec<BenchmarkResult>,
+}
+
+#[derive(Serialize)]
+struct Environment {
+    git_revision: Option<String>,
+    git_dirty: Option<bool>,
+    os: &'static str,
+    arch: &'static str,
+    cpu_model: Option<String>,
+    logical_cpus: Option<usize>,
+    rustc_version: Option<String>,
+    build_profile: &'static str,
+    network_mode: &'static str,
+}
+
+#[derive(Serialize)]
+struct BenchmarkConfig {
+    warmup_repetitions: usize,
+    measured_repetitions: usize,
+    extra_agents: usize,
+    work_items: usize,
+    performance_requests_per_sample: usize,
+    work_item_requests_per_sample: usize,
+    transport: &'static str,
+}
+
+#[derive(Serialize)]
+struct BenchmarkResult {
+    benchmark_id: &'static str,
+    operations_per_sample: usize,
+    samples: Vec<Sample>,
+    summary: Summary,
+}
+
+#[derive(Clone, Serialize)]
+struct Sample {
+    iteration: usize,
+    wall_time_ns: u128,
+    user_cpu_ns: u128,
+    system_cpu_ns: u128,
+    peak_rss_kb: u64,
+    exit_status: &'static str,
+}
+
+#[derive(Serialize)]
+struct Summary {
+    median_wall_time_ns: u128,
+    min_wall_time_ns: u128,
+    max_wall_time_ns: u128,
+    median_absolute_deviation_ns: u128,
+    median_operations_per_second: f64,
+}
+
+struct HttpFixture {
+    _home: TempDir,
+    app: Router,
+    host: RuntimeHost,
+    default_agent_id: String,
+}
+
+fn main() -> Result<()> {
+    let samples = std::env::var("HOLON_BENCH_SAMPLES")
+        .ok()
+        .map(|value| value.parse::<usize>())
+        .transpose()
+        .context("HOLON_BENCH_SAMPLES must be a positive integer")?
+        .unwrap_or(DEFAULT_SAMPLES);
+    anyhow::ensure!(samples > 0, "HOLON_BENCH_SAMPLES must be positive");
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("building HTTP benchmark runtime")?;
+    let fixture = runtime.block_on(build_fixture())?;
+    let filter = benchmark_filter();
+    let results = run_benchmarks(&runtime, &fixture, samples, &filter)?;
+    anyhow::ensure!(
+        !results.is_empty(),
+        "HOLON_BENCH_FILTER selected no workloads"
+    );
+    let artifact = BenchmarkArtifact {
+        schema_version: "holon.performance.v0",
+        benchmark_suite: "http_control",
+        workload_version: "v1",
+        started_at: Utc::now().to_rfc3339(),
+        environment: environment(),
+        config: BenchmarkConfig {
+            warmup_repetitions: WARMUP_SAMPLES,
+            measured_repetitions: samples,
+            extra_agents: EXTRA_AGENTS,
+            work_items: WORK_ITEMS,
+            performance_requests_per_sample: PERFORMANCE_REQUESTS_PER_SAMPLE,
+            work_item_requests_per_sample: WORK_ITEM_REQUESTS_PER_SAMPLE,
+            transport: "tower.oneshot.in_process",
+        },
+        results,
+    };
+
+    println!("{}", serde_json::to_string_pretty(&artifact)?);
+    Ok(())
+}
+
+fn benchmark_filter() -> Vec<String> {
+    std::env::var("HOLON_BENCH_FILTER")
+        .ok()
+        .into_iter()
+        .flat_map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn benchmark_selected(filter: &[String], benchmark_id: &str) -> bool {
+    filter.is_empty() || filter.iter().any(|selected| selected == benchmark_id)
+}
+
+async fn build_fixture() -> Result<HttpFixture> {
+    let home = tempfile::tempdir().context("creating HTTP benchmark home")?;
+    std::fs::write(
+        home.path().join("config.json"),
+        r#"{"model":{"default":"openai/gpt-5.4"}}"#,
+    )?;
+    let config = AppConfig::load_with_home(Some(home.path().to_path_buf()))?;
+    let default_agent_id = config.default_agent_id.clone();
+    let host = RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done")))?;
+
+    for index in 0..EXTRA_AGENTS {
+        host.create_public_named_agent(&format!("http-bench-agent-{index:03}"), None, None, None)
+            .await?;
+    }
+
+    let runtime = host.get_or_create_agent(&default_agent_id).await?;
+    for index in 0..WORK_ITEMS {
+        runtime
+            .create_work_item(
+                format!("HTTP benchmark work item {index}"),
+                None,
+                None,
+                Vec::new(),
+            )
+            .await?;
+    }
+
+    let app = router(AppState::for_unix(host.clone()));
+    validate_json_array(&app, "/api/agents/list", EXTRA_AGENTS + 1).await?;
+    validate_json_array(
+        &app,
+        &format!("/api/agents/{default_agent_id}/work-items?limit={WORK_ITEMS}"),
+        WORK_ITEMS,
+    )
+    .await?;
+    validate_json_object(&app, "/api/control/runtime/performance").await?;
+
+    Ok(HttpFixture {
+        _home: home,
+        app,
+        host,
+        default_agent_id,
+    })
+}
+
+fn run_benchmarks(
+    runtime: &tokio::runtime::Runtime,
+    fixture: &HttpFixture,
+    samples: usize,
+    filter: &[String],
+) -> Result<Vec<BenchmarkResult>> {
+    let work_items_uri = format!(
+        "/api/agents/{}/work-items?limit={WORK_ITEMS}",
+        fixture.default_agent_id
+    );
+    let mut results = Vec::new();
+    for (uri, miss_id, hit_id) in [
+        (
+            "/api/agents/list".to_owned(),
+            "http.agents_list.gate_miss",
+            "http.agents_list.gate_hit",
+        ),
+        (
+            format!("/api/agents/{}/state", fixture.default_agent_id),
+            "http.agent_state.gate_miss",
+            "http.agent_state.gate_hit",
+        ),
+    ] {
+        if benchmark_selected(filter, miss_id) || benchmark_selected(filter, hit_id) {
+            let pair = measure_projection_gate(runtime, fixture, &uri, samples, miss_id, hit_id)?;
+            results.extend(
+                pair.into_iter()
+                    .filter(|result| benchmark_selected(filter, result.benchmark_id)),
+            );
+        }
+    }
+    if benchmark_selected(filter, "http.runtime_performance.100") {
+        results.push(measure(
+            "http.runtime_performance.100",
+            samples,
+            PERFORMANCE_REQUESTS_PER_SAMPLE,
+            || {
+                runtime.block_on(repeat_request(
+                    &fixture.app,
+                    "/api/control/runtime/performance",
+                    PERFORMANCE_REQUESTS_PER_SAMPLE,
+                ))
+            },
+        )?);
+    }
+    if benchmark_selected(filter, "http.agents_list.101") {
+        results.push(measure("http.agents_list.101", samples, 1, || {
+            runtime.block_on(repeat_request(&fixture.app, "/api/agents/list", 1))
+        })?);
+    }
+    if benchmark_selected(filter, "http.work_items.200") {
+        results.push(measure("http.work_items.200", samples, 1, || {
+            runtime.block_on(repeat_request(&fixture.app, &work_items_uri, 1))
+        })?);
+    }
+    if benchmark_selected(filter, "http.work_items.200x10") {
+        results.push(measure(
+            "http.work_items.200x10",
+            samples,
+            WORK_ITEM_REQUESTS_PER_SAMPLE,
+            || {
+                runtime.block_on(repeat_request(
+                    &fixture.app,
+                    &work_items_uri,
+                    WORK_ITEM_REQUESTS_PER_SAMPLE,
+                ))
+            },
+        )?);
+    }
+    Ok(results)
+}
+
+// Reset only the HTTP byte cache, not SQLite/OS or host caches. Constructing the
+// router and checking gate counters happen outside the measured requests.
+fn measure_projection_gate(
+    runtime: &tokio::runtime::Runtime,
+    fixture: &HttpFixture,
+    uri: &str,
+    repetitions: usize,
+    miss_id: &'static str,
+    hit_id: &'static str,
+) -> Result<Vec<BenchmarkResult>> {
+    let mut samples = [Vec::new(), Vec::new()];
+    for iteration in 0..(repetitions + WARMUP_SAMPLES) {
+        let app = router(AppState::for_unix(fixture.host.clone()));
+        for (index, bucket) in samples.iter_mut().enumerate() {
+            let before = holon::diagnostics::performance_snapshot().projection_gate;
+            let resources_before = resource_usage();
+            let started = Instant::now();
+            runtime.block_on(repeat_request(&app, uri, 1))?;
+            let wall_time = started.elapsed();
+            let resources_after = resource_usage();
+            let after = holon::diagnostics::performance_snapshot().projection_gate;
+            if index == 0 {
+                anyhow::ensure!(after.leaders == before.leaders + 1, "expected cache miss");
+            } else {
+                anyhow::ensure!(
+                    after.cache_hits == before.cache_hits + 1 && after.leaders == before.leaders,
+                    "expected immediate cache hit"
+                );
+            }
+            if iteration >= WARMUP_SAMPLES {
+                bucket.push(Sample {
+                    iteration: iteration - WARMUP_SAMPLES + 1,
+                    wall_time_ns: wall_time.as_nanos(),
+                    user_cpu_ns: duration_delta(
+                        resources_after.user_cpu,
+                        resources_before.user_cpu,
+                    )
+                    .as_nanos(),
+                    system_cpu_ns: duration_delta(
+                        resources_after.system_cpu,
+                        resources_before.system_cpu,
+                    )
+                    .as_nanos(),
+                    peak_rss_kb: resources_after.peak_rss_kb,
+                    exit_status: "ok",
+                });
+            }
+        }
+    }
+    Ok([miss_id, hit_id]
+        .into_iter()
+        .zip(samples)
+        .map(|(benchmark_id, samples)| BenchmarkResult {
+            benchmark_id,
+            operations_per_sample: 1,
+            summary: summarize(&samples, 1),
+            samples,
+        })
+        .collect())
+}
+
+async fn repeat_request(app: &Router, uri: &str, repetitions: usize) -> Result<()> {
+    for _ in 0..repetitions {
+        let response = app
+            .clone()
+            .oneshot(Request::builder().uri(uri).body(Body::empty())?)
+            .await
+            .expect("axum router is infallible");
+        anyhow::ensure!(
+            response.status() == StatusCode::OK,
+            "{uri} returned {}",
+            response.status()
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await?;
+        anyhow::ensure!(!body.is_empty(), "{uri} returned an empty body");
+        black_box(body);
+    }
+    Ok(())
+}
+
+async fn validate_json_array(app: &Router, uri: &str, expected_len: usize) -> Result<()> {
+    let value = request_json(app, uri).await?;
+    anyhow::ensure!(
+        value.as_array().map(Vec::len) == Some(expected_len),
+        "{uri} returned an unexpected array length"
+    );
+    Ok(())
+}
+
+async fn validate_json_object(app: &Router, uri: &str) -> Result<()> {
+    let value = request_json(app, uri).await?;
+    anyhow::ensure!(value.is_object(), "{uri} did not return a JSON object");
+    Ok(())
+}
+
+async fn request_json(app: &Router, uri: &str) -> Result<Value> {
+    let response = app
+        .clone()
+        .oneshot(Request::builder().uri(uri).body(Body::empty())?)
+        .await
+        .expect("axum router is infallible");
+    anyhow::ensure!(
+        response.status() == StatusCode::OK,
+        "{uri} returned {}",
+        response.status()
+    );
+    let body = to_bytes(response.into_body(), usize::MAX).await?;
+    serde_json::from_slice(&body).with_context(|| format!("parsing JSON response from {uri}"))
+}
+
+fn measure(
+    benchmark_id: &'static str,
+    repetitions: usize,
+    operations_per_sample: usize,
+    mut operation: impl FnMut() -> Result<()>,
+) -> Result<BenchmarkResult> {
+    for _ in 0..WARMUP_SAMPLES {
+        operation().with_context(|| format!("warming up {benchmark_id}"))?;
+    }
+
+    let mut samples = Vec::with_capacity(repetitions);
+    for iteration in 1..=repetitions {
+        let resources_before = resource_usage();
+        let started_at = Instant::now();
+        operation().with_context(|| format!("measuring {benchmark_id}"))?;
+        let wall_time = started_at.elapsed();
+        let resources_after = resource_usage();
+        samples.push(Sample {
+            iteration,
+            wall_time_ns: wall_time.as_nanos(),
+            user_cpu_ns: duration_delta(resources_after.user_cpu, resources_before.user_cpu)
+                .as_nanos(),
+            system_cpu_ns: duration_delta(resources_after.system_cpu, resources_before.system_cpu)
+                .as_nanos(),
+            peak_rss_kb: resources_after.peak_rss_kb,
+            exit_status: "ok",
+        });
+    }
+
+    let summary = summarize(&samples, operations_per_sample);
+    Ok(BenchmarkResult {
+        benchmark_id,
+        operations_per_sample,
+        samples,
+        summary,
+    })
+}
+
+fn summarize(samples: &[Sample], operations_per_sample: usize) -> Summary {
+    let mut values: Vec<u128> = samples.iter().map(|sample| sample.wall_time_ns).collect();
+    values.sort_unstable();
+    let median_value = median(&values);
+    let mut deviations: Vec<u128> = values
+        .iter()
+        .map(|value| value.abs_diff(median_value))
+        .collect();
+    deviations.sort_unstable();
+    Summary {
+        median_wall_time_ns: median_value,
+        min_wall_time_ns: values[0],
+        max_wall_time_ns: values[values.len() - 1],
+        median_absolute_deviation_ns: median(&deviations),
+        median_operations_per_second: operations_per_sample as f64 * 1_000_000_000.0
+            / median_value as f64,
+    }
+}
+
+fn median(values: &[u128]) -> u128 {
+    let middle = values.len() / 2;
+    if values.len() % 2 == 0 {
+        (values[middle - 1] + values[middle]) / 2
+    } else {
+        values[middle]
+    }
+}
+
+#[derive(Default)]
+struct ResourceUsage {
+    user_cpu: Duration,
+    system_cpu: Duration,
+    peak_rss_kb: u64,
+}
+
+#[cfg(unix)]
+fn resource_usage() -> ResourceUsage {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    // SAFETY: getrusage initializes the supplied rusage on success.
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
+        return ResourceUsage::default();
+    }
+    // SAFETY: getrusage returned success.
+    let usage = unsafe { usage.assume_init() };
+    ResourceUsage {
+        user_cpu: timeval_duration(usage.ru_utime),
+        system_cpu: timeval_duration(usage.ru_stime),
+        peak_rss_kb: usage.ru_maxrss as u64,
+    }
+}
+
+#[cfg(not(unix))]
+fn resource_usage() -> ResourceUsage {
+    ResourceUsage::default()
+}
+
+#[cfg(unix)]
+fn timeval_duration(value: libc::timeval) -> Duration {
+    Duration::new(value.tv_sec as u64, (value.tv_usec as u32) * 1_000)
+}
+
+fn duration_delta(after: Duration, before: Duration) -> Duration {
+    after.checked_sub(before).unwrap_or_default()
+}
+
+fn environment() -> Environment {
+    Environment {
+        git_revision: command_output("git", &["rev-parse", "HEAD"]),
+        git_dirty: command_output("git", &["status", "--porcelain"])
+            .map(|output| !output.is_empty()),
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        cpu_model: cpu_model(),
+        logical_cpus: thread::available_parallelism().ok().map(usize::from),
+        rustc_version: command_output("rustc", &["--version"]),
+        build_profile: "bench",
+        network_mode: "disabled",
+    }
+}
+
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn cpu_model() -> Option<String> {
+    let cpu_info = std::fs::read_to_string("/proc/cpuinfo").ok()?;
+    cpu_info.lines().find_map(|line| {
+        line.strip_prefix("model name")
+            .and_then(|value| value.split_once(':'))
+            .map(|(_, value)| value.trim().to_string())
+    })
+}

--- a/benches/memory_lifecycle.rs
+++ b/benches/memory_lifecycle.rs
@@ -1,0 +1,324 @@
+use std::{
+    fs,
+    hint::black_box,
+    path::Path,
+    process::{Command, Stdio},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use holon::{
+    runtime_db::RuntimeDb,
+    storage::AppStorage,
+    types::{AgentState, AuditEvent, BriefKind, BriefRecord},
+};
+use serde::{Deserialize, Serialize};
+
+const AGENT_ID: &str = "memory-benchmark-agent";
+const DEFAULT_SAMPLES: usize = 5;
+const WARMUP_SAMPLES: usize = 1;
+const EVENT_COUNT: usize = 1_000;
+const EVENT_PAYLOAD_BYTES: usize = 1_024;
+const BRIEF_COUNT: usize = 100;
+const BRIEF_PAYLOAD_BYTES: usize = 2_048;
+const PROJECTION_REPETITIONS: usize = 20;
+const WORKER_ENV: &str = "HOLON_MEMORY_BENCH_WORKER";
+
+#[derive(Serialize)]
+struct BenchmarkArtifact {
+    schema_version: &'static str,
+    benchmark_suite: &'static str,
+    workload_version: &'static str,
+    started_at: String,
+    environment: Environment,
+    config: BenchmarkConfig,
+    results: Vec<BenchmarkResult>,
+}
+
+#[derive(Serialize)]
+struct Environment {
+    git_revision: Option<String>,
+    git_dirty: Option<bool>,
+    os: &'static str,
+    arch: &'static str,
+    cpu_model: Option<String>,
+    logical_cpus: Option<usize>,
+    rustc_version: Option<String>,
+    build_profile: &'static str,
+    network_mode: &'static str,
+}
+
+#[derive(Serialize)]
+struct BenchmarkConfig {
+    warmup_repetitions: usize,
+    measured_repetitions: usize,
+    event_count: usize,
+    event_payload_bytes: usize,
+    brief_count: usize,
+    brief_payload_bytes: usize,
+    projection_repetitions: usize,
+    process_isolation: bool,
+}
+
+#[derive(Serialize)]
+struct BenchmarkResult {
+    benchmark_id: &'static str,
+    samples: Vec<Sample>,
+    summary: Summary,
+}
+
+#[derive(Serialize)]
+struct Sample {
+    iteration: usize,
+    wall_time_ns: u128,
+    baseline_rss_kb: u64,
+    after_write_rss_kb: u64,
+    after_projection_rss_kb: u64,
+    after_drop_rss_kb: u64,
+    peak_rss_kb: u64,
+    retained_rss_delta_kb: i64,
+    peak_rss_delta_kb: u64,
+    database_bytes: u64,
+    exit_status: &'static str,
+}
+
+#[derive(Serialize)]
+struct Summary {
+    median_wall_time_ns: u128,
+    median_retained_rss_delta_kb: i64,
+    median_peak_rss_delta_kb: u64,
+    median_database_bytes: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+struct WorkerResult {
+    baseline_rss_kb: u64,
+    after_write_rss_kb: u64,
+    after_projection_rss_kb: u64,
+    after_drop_rss_kb: u64,
+    peak_rss_kb: u64,
+    database_bytes: u64,
+}
+
+fn main() -> Result<()> {
+    if std::env::var_os(WORKER_ENV).is_some() {
+        println!("{}", serde_json::to_string(&run_worker()?)?);
+        return Ok(());
+    }
+
+    let samples = std::env::var("HOLON_BENCH_SAMPLES")
+        .ok()
+        .map(|value| value.parse::<usize>())
+        .transpose()
+        .context("HOLON_BENCH_SAMPLES must be a positive integer")?
+        .unwrap_or(DEFAULT_SAMPLES);
+    anyhow::ensure!(samples > 0, "HOLON_BENCH_SAMPLES must be positive");
+
+    for _ in 0..WARMUP_SAMPLES {
+        black_box(run_isolated_worker()?);
+    }
+
+    let mut measured = Vec::with_capacity(samples);
+    for iteration in 1..=samples {
+        let started = Instant::now();
+        let worker = run_isolated_worker()?;
+        let retained_rss_delta_kb = worker.after_drop_rss_kb as i64 - worker.baseline_rss_kb as i64;
+        measured.push(Sample {
+            iteration,
+            wall_time_ns: started.elapsed().as_nanos(),
+            baseline_rss_kb: worker.baseline_rss_kb,
+            after_write_rss_kb: worker.after_write_rss_kb,
+            after_projection_rss_kb: worker.after_projection_rss_kb,
+            after_drop_rss_kb: worker.after_drop_rss_kb,
+            peak_rss_kb: worker.peak_rss_kb,
+            retained_rss_delta_kb,
+            peak_rss_delta_kb: worker.peak_rss_kb.saturating_sub(worker.baseline_rss_kb),
+            database_bytes: worker.database_bytes,
+            exit_status: "ok",
+        });
+    }
+
+    let artifact = BenchmarkArtifact {
+        schema_version: "holon.performance.v0",
+        benchmark_suite: "memory_lifecycle",
+        workload_version: "v1",
+        started_at: Utc::now().to_rfc3339(),
+        environment: environment(),
+        config: BenchmarkConfig {
+            warmup_repetitions: WARMUP_SAMPLES,
+            measured_repetitions: samples,
+            event_count: EVENT_COUNT,
+            event_payload_bytes: EVENT_PAYLOAD_BYTES,
+            brief_count: BRIEF_COUNT,
+            brief_payload_bytes: BRIEF_PAYLOAD_BYTES,
+            projection_repetitions: PROJECTION_REPETITIONS,
+            process_isolation: true,
+        },
+        results: vec![BenchmarkResult {
+            benchmark_id: "memory.long_session.events_1000_briefs_100",
+            summary: summarize(&measured),
+            samples: measured,
+        }],
+    };
+
+    println!("{}", serde_json::to_string_pretty(&artifact)?);
+    Ok(())
+}
+
+fn run_isolated_worker() -> Result<WorkerResult> {
+    let output = Command::new(std::env::current_exe()?)
+        .env(WORKER_ENV, "1")
+        .stdin(Stdio::null())
+        .stderr(Stdio::inherit())
+        .output()
+        .context("running isolated memory benchmark worker")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "memory benchmark worker exited with {}",
+        output.status
+    );
+    serde_json::from_slice(&output.stdout).context("parsing memory benchmark worker output")
+}
+
+fn run_worker() -> Result<WorkerResult> {
+    let root = tempfile::tempdir().context("creating memory benchmark root")?;
+    let database_root = root.path().join(".holon/state");
+    let runtime_db = RuntimeDb::open_and_migrate(
+        database_root.join("runtime.sqlite"),
+        database_root.join("runtime.lock"),
+    )?;
+    let storage = AppStorage::new_for_agent(root.path(), AGENT_ID, runtime_db)?;
+    storage.write_agent(&AgentState::new(AGENT_ID))?;
+    let baseline_rss_kb = current_rss_kb()?;
+
+    let event_payload = "e".repeat(EVENT_PAYLOAD_BYTES);
+    for index in 0..EVENT_COUNT {
+        storage.append_event(&AuditEvent::legacy(
+            format!("memory_benchmark_event_{index}"),
+            serde_json::json!({"index": index, "payload": event_payload}),
+        ))?;
+    }
+    let brief_payload = "b".repeat(BRIEF_PAYLOAD_BYTES);
+    for index in 0..BRIEF_COUNT {
+        storage.append_brief(&BriefRecord::new(
+            AGENT_ID,
+            BriefKind::Result,
+            format!("memory benchmark brief {index}: {brief_payload}"),
+            None,
+            None,
+        ))?;
+    }
+    let after_write_rss_kb = current_rss_kb()?;
+
+    for _ in 0..PROJECTION_REPETITIONS {
+        let events = storage.read_recent_events(100)?;
+        let briefs = storage.read_recent_briefs(50)?;
+        black_box((events, briefs));
+    }
+    let after_projection_rss_kb = current_rss_kb()?;
+    let database_bytes = directory_bytes(&database_root)?;
+
+    drop(storage);
+    let after_drop_rss_kb = current_rss_kb()?;
+    Ok(WorkerResult {
+        baseline_rss_kb,
+        after_write_rss_kb,
+        after_projection_rss_kb,
+        after_drop_rss_kb,
+        peak_rss_kb: peak_rss_kb()?,
+        database_bytes,
+    })
+}
+
+fn current_rss_kb() -> Result<u64> {
+    status_memory_kb("VmRSS:")
+}
+
+fn peak_rss_kb() -> Result<u64> {
+    status_memory_kb("VmHWM:")
+}
+
+fn status_memory_kb(field: &str) -> Result<u64> {
+    let status = fs::read_to_string("/proc/self/status").context("reading /proc/self/status")?;
+    let line = status
+        .lines()
+        .find(|line| line.starts_with(field))
+        .with_context(|| format!("{field} is missing from /proc/self/status"))?;
+    line.split_whitespace()
+        .nth(1)
+        .with_context(|| format!("{field} value is missing"))?
+        .parse()
+        .with_context(|| format!("parsing {field}"))
+}
+
+fn directory_bytes(path: &Path) -> Result<u64> {
+    let mut total = 0_u64;
+    for entry in fs::read_dir(path).with_context(|| format!("reading {}", path.display()))? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        if metadata.is_file() {
+            total = total.saturating_add(metadata.len());
+        }
+    }
+    Ok(total)
+}
+
+fn summarize(samples: &[Sample]) -> Summary {
+    let mut wall_times = samples
+        .iter()
+        .map(|sample| sample.wall_time_ns)
+        .collect::<Vec<_>>();
+    let mut retained = samples
+        .iter()
+        .map(|sample| sample.retained_rss_delta_kb)
+        .collect::<Vec<_>>();
+    let mut peak = samples
+        .iter()
+        .map(|sample| sample.peak_rss_delta_kb)
+        .collect::<Vec<_>>();
+    let mut database = samples
+        .iter()
+        .map(|sample| sample.database_bytes)
+        .collect::<Vec<_>>();
+    wall_times.sort_unstable();
+    retained.sort_unstable();
+    peak.sort_unstable();
+    database.sort_unstable();
+    Summary {
+        median_wall_time_ns: median(&wall_times),
+        median_retained_rss_delta_kb: median(&retained),
+        median_peak_rss_delta_kb: median(&peak),
+        median_database_bytes: median(&database),
+    }
+}
+
+fn median<T: Copy>(values: &[T]) -> T {
+    values[values.len() / 2]
+}
+
+fn environment() -> Environment {
+    Environment {
+        git_revision: command_output("git", &["rev-parse", "HEAD"]),
+        git_dirty: command_output("git", &["status", "--porcelain"])
+            .map(|output| !output.is_empty()),
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        cpu_model: fs::read_to_string("/proc/cpuinfo").ok().and_then(|text| {
+            text.lines()
+                .find_map(|line| line.strip_prefix("model name\t: ").map(str::to_owned))
+        }),
+        logical_cpus: std::thread::available_parallelism().ok().map(usize::from),
+        rustc_version: command_output("rustc", &["--version"]),
+        build_profile: "bench",
+        network_mode: "disabled",
+    }
+}
+
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}

--- a/benches/performance_attribution.rs
+++ b/benches/performance_attribution.rs
@@ -1,0 +1,352 @@
+use std::{hint::black_box, sync::Barrier, thread, time::Instant};
+
+use anyhow::{ensure, Context, Result};
+use chrono::Utc;
+use holon::{
+    diagnostics::performance_snapshot,
+    runtime_db::RuntimeDb,
+    storage::AppStorage,
+    types::{
+        AgentState, WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource,
+        WorkItemPlanStatus, WorkItemRecord, WorkItemState,
+    },
+};
+use serde::Serialize;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+const AGENT: &str = "attribution";
+const OTHER: &str = "other";
+
+struct Fixture {
+    storage: AppStorage,
+    db: RuntimeDb,
+    // Keep the directory alive until all database handles have been dropped.
+    _root: TempDir,
+}
+
+impl Fixture {
+    fn new(own_completed: usize, other_completed: usize, other_waits: usize) -> Result<Self> {
+        let root = tempfile::tempdir()?;
+        let db = RuntimeDb::open_and_migrate(
+            root.path().join("runtime.sqlite"),
+            root.path().join("runtime.lock"),
+        )?;
+        let storage = AppStorage::new_for_agent(root.path(), AGENT, db.clone())?;
+        storage.write_agent(&AgentState::new(AGENT))?;
+        let other = AppStorage::new_for_agent(root.path(), OTHER, db.clone())?;
+        other.write_agent(&AgentState::new(OTHER))?;
+        for (store, agent, count) in [
+            (&storage, AGENT, own_completed),
+            (&other, OTHER, other_completed),
+        ] {
+            for index in 0..count {
+                let mut item = WorkItemRecord::new(agent, "completed", WorkItemState::Completed);
+                item.id = format!("{agent}-completed-{index}");
+                store.append_work_item(&item)?;
+            }
+        }
+        let mut runnable = WorkItemRecord::new(AGENT, "runnable", WorkItemState::Open);
+        runnable.id = "own-runnable".into();
+        runnable.plan_status = WorkItemPlanStatus::Ready;
+        storage.append_work_item(&runnable)?;
+        for index in 0..other_waits {
+            let mut item = WorkItemRecord::new(OTHER, "waiting", WorkItemState::Open);
+            item.id = format!("other-waiting-{index}");
+            item.plan_status = WorkItemPlanStatus::Ready;
+            item.blocked_by = Some("operator_input".into());
+            other.append_work_item(&item)?;
+            let now = Utc::now();
+            other.append_wait_condition(&WaitConditionRecord {
+                id: format!("wait-{index}"),
+                agent_id: OTHER.into(),
+                work_item_id: Some(item.id),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::Operator,
+                source: None,
+                subject_ref: None,
+                waiting_for: "operator_input".into(),
+                wake_sources: vec![WakeSource::OperatorInput],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
+                turn_id: None,
+                trigger_message_id: None,
+                triggered_at: None,
+            })?;
+        }
+        Ok(Self {
+            storage,
+            db,
+            _root: root,
+        })
+    }
+
+    fn verify_rows(&self, own: usize, other: usize, waits: usize) -> Result<Value> {
+        let connection = self.db.connection()?;
+        let count =
+            |sql: &str| -> Result<usize> { Ok(connection.query_row(sql, [], |row| row.get(0))?) };
+        let work_items = count("SELECT count(*) FROM work_items")?;
+        let completed = count("SELECT count(*) FROM work_items WHERE state = 'completed'")?;
+        let own_completed = count(
+            "SELECT count(*) FROM work_items WHERE agent_id = 'attribution' AND state = 'completed'",
+        )?;
+        let active_waits = count("SELECT count(*) FROM wait_conditions WHERE status = 'active'")?;
+        let linked_waits = count(
+            "SELECT count(DISTINCT w.work_item_id) FROM wait_conditions w
+             JOIN work_items i ON i.work_item_id = w.work_item_id
+             WHERE w.status = 'active' AND i.state = 'open'
+             AND w.agent_id = 'other' AND i.agent_id = 'other'",
+        )?;
+        ensure!(work_items == 1 + own + other + waits, "work item row count");
+        ensure!(
+            completed == own + other && own_completed == own,
+            "completed row count"
+        );
+        ensure!(
+            active_waits == waits && linked_waits == waits,
+            "active wait linkage"
+        );
+        verify_queue(&self.storage, own + 1)?;
+        Ok(json!({
+            "work_items": work_items, "own_completed": own_completed,
+            "other_completed": completed - own_completed, "active_waits": active_waits,
+            "distinct_linked_open_items": linked_waits, "projected_items": own + 1,
+        }))
+    }
+}
+
+fn verify_queue(storage: &AppStorage, expected: usize) -> Result<()> {
+    let queue = storage.work_queue_read_model()?;
+    ensure!(queue.items.len() == expected, "projection item count");
+    let runnable: Vec<_> = queue.items.iter().filter(|item| item.is_runnable).collect();
+    ensure!(
+        runnable.len() == 1 && runnable[0].id == "own-runnable",
+        "projection runnable isolation"
+    );
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct Sample {
+    worker: usize,
+    operation: usize,
+    wall_time_ns: u128,
+}
+
+fn fd_count() -> Option<usize> {
+    // Subtract the descriptor opened by read_dir itself.
+    std::fs::read_dir("/proc/self/fd")
+        .ok()
+        .map(|entries| entries.count().saturating_sub(1))
+}
+
+fn summary(samples: &[Sample]) -> Value {
+    let mut values: Vec<_> = samples.iter().map(|sample| sample.wall_time_ns).collect();
+    values.sort_unstable();
+    let percentile = |percent: usize| values[(values.len() * percent).div_ceil(100) - 1];
+    json!({
+        "count": values.len(), "p50_ns": percentile(50),
+        "p95_ns": percentile(95), "p99_ns": percentile(99),
+        "percentile_method": "nearest_rank",
+    })
+}
+
+fn connection_case(extra_fds: usize, operations: usize) -> Result<Value> {
+    let fixture = Fixture::new(0, 0, 0)?;
+    let rows = fixture.verify_rows(0, 0, 0)?;
+    // Avoid last-connection-close checkpoint effects throughout measurement.
+    let _held_connection = fixture.db.connection()?;
+    let baseline_fds = fd_count();
+    let files = (0..extra_fds)
+        .map(|_| std::fs::File::open("/dev/null"))
+        .collect::<std::io::Result<Vec<_>>>()?;
+    drop(fixture.db.connection()?); // Warm up outside the diagnostic interval.
+    let before_fds = fd_count();
+    if let (Some(base), Some(before)) = (baseline_fds, before_fds) {
+        ensure!(before == base + extra_fds, "extra descriptor count");
+    }
+    let before = performance_snapshot();
+    let mut samples = Vec::with_capacity(operations);
+    for operation in 0..operations {
+        let start = Instant::now();
+        let connection = fixture.db.connection()?;
+        let elapsed = start.elapsed().as_nanos();
+        samples.push(Sample {
+            worker: 0,
+            operation,
+            wall_time_ns: elapsed,
+        });
+        drop(black_box(connection)); // Connection close is not timed.
+    }
+    let after = performance_snapshot();
+    let after_fds = fd_count();
+    ensure!(
+        before_fds == after_fds,
+        "descriptor count changed in connection case extra_fds={extra_fds}: before={before_fds:?}, after={after_fds:?}"
+    );
+    fixture.verify_rows(0, 0, 0)?;
+    black_box(&files);
+    Ok(json!({
+        "dimension": "connection_extra_fds", "extra_fds": extra_fds,
+        "fd_baseline": baseline_fds, "fd_before": before_fds, "fd_after": after_fds,
+        "rows": rows, "diagnostics_before": before, "diagnostics_after": after,
+        "summary": summary(&samples), "samples": samples,
+    }))
+}
+
+fn queue_case(
+    dimension: &str,
+    own: usize,
+    other: usize,
+    waits: usize,
+    workers: usize,
+    operations: usize,
+) -> Result<Value> {
+    let fixture = Fixture::new(own, other, waits)?;
+    let rows = fixture.verify_rows(own, other, waits)?;
+    let _held_connection = fixture.db.connection()?;
+    verify_queue(&fixture.storage, own + 1)?;
+    let warmup_barrier = Barrier::new(workers);
+    thread::scope(|scope| -> Result<()> {
+        let handles: Vec<_> = (0..workers)
+            .map(|_| {
+                let db = &fixture.db;
+                let storage = &fixture.storage;
+                let barrier = &warmup_barrier;
+                scope.spawn(move || -> Result<()> {
+                    let connection = db.connection()?;
+                    barrier.wait();
+                    verify_queue(storage, own + 1)?;
+                    drop(connection);
+                    Ok(())
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle
+                .join()
+                .map_err(|_| anyhow::anyhow!("warmup reader panicked"))??;
+        }
+        Ok(())
+    })?;
+    let before_fds = fd_count();
+    let before = performance_snapshot();
+    let barrier = Barrier::new(workers);
+    let samples = thread::scope(|scope| -> Result<Vec<Sample>> {
+        let handles: Vec<_> = (0..workers)
+            .map(|worker| {
+                let storage = &fixture.storage;
+                let barrier = &barrier;
+                scope.spawn(move || -> Result<Vec<Sample>> {
+                    let mut samples = Vec::with_capacity(operations / workers);
+                    barrier.wait();
+                    for operation in 0..operations / workers {
+                        let start = Instant::now();
+                        let queue = storage.work_queue_read_model()?;
+                        let elapsed = start.elapsed().as_nanos();
+                        ensure!(queue.items.len() == own + 1, "measured projection count");
+                        black_box(queue);
+                        samples.push(Sample {
+                            worker,
+                            operation,
+                            wall_time_ns: elapsed,
+                        });
+                    }
+                    Ok(samples)
+                })
+            })
+            .collect();
+        let mut samples = Vec::with_capacity(operations);
+        for handle in handles {
+            samples.extend(
+                handle
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("reader panicked"))??,
+            );
+        }
+        Ok(samples)
+    })?;
+    let after = performance_snapshot();
+    let after_fds = fd_count();
+    ensure!(samples.len() == operations, "operation count");
+    ensure!(
+        before_fds == after_fds,
+        "descriptor count changed in queue case dimension={dimension} own={own} other={other} waits={waits} workers={workers}: before={before_fds:?}, after={after_fds:?}"
+    );
+    let rows_after = fixture.verify_rows(own, other, waits)?;
+    ensure!(rows == rows_after, "fixture changed");
+    Ok(json!({
+        "dimension": dimension, "own_completed": own, "other_completed": other,
+        "other_active_waits": waits, "workers": workers, "total_operations": operations,
+        "fd_before": before_fds, "fd_after": after_fds, "rows": rows,
+        "diagnostics_before": before, "diagnostics_after": after,
+        "summary": summary(&samples), "samples": samples,
+    }))
+}
+
+fn main() -> Result<()> {
+    let requested = std::env::var("HOLON_BENCH_SAMPLES")
+        .ok()
+        .map(|value| value.parse::<usize>())
+        .transpose()
+        .context("HOLON_BENCH_SAMPLES must be an integer >= 10")?
+        .unwrap_or(40);
+    ensure!(requested >= 10, "at least 10 samples are required");
+    // Equal total operations, divisible by all thread counts.
+    let operations = requested.checked_add(3).context("sample count overflow")? / 4 * 4;
+    let mut results = Vec::new();
+    if cfg!(target_os = "linux") {
+        for fds in [0, 128, 512] {
+            results.push(connection_case(fds, operations)?);
+        }
+    }
+    for count in [0, 100, 500] {
+        results.push(queue_case("own_completed", count, 0, 0, 1, operations)?);
+        results.push(queue_case("other_completed", 0, count, 0, 1, operations)?);
+    }
+    for waits in [0, 10, 100] {
+        results.push(queue_case(
+            "other_active_waits",
+            0,
+            0,
+            waits,
+            1,
+            operations,
+        )?);
+    }
+    for workers in [1, 2, 4] {
+        results.push(queue_case(
+            "concurrent_queue",
+            0,
+            0,
+            0,
+            workers,
+            operations,
+        )?);
+    }
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "schema_version": "holon.performance.attribution.v1",
+            "benchmark_suite": "performance_attribution",
+            "os": std::env::consts::OS, "arch": std::env::consts::ARCH,
+            "network_mode": "none", "requested_samples": requested,
+            "actual_operations_per_case": operations,
+            "connection_fd_dimension_skipped": !cfg!(target_os = "linux"),
+            "limitations": [
+                "Warm local temporary databases; no cold-cache or production workload claim.",
+                "Diagnostics are cumulative process-global snapshots, not reset per case.",
+                "Connection timing excludes close; queue timing excludes result destruction and assertions.",
+                "Concurrency reports per-operation latency, not throughput; thread startup is excluded.",
+                "Other-agent rows belong to one other agent; dimensions are not a factorial experiment.",
+                "Fixed case order and small samples can make tail percentiles noisy."
+            ],
+            "results": results,
+        }))?
+    );
+    Ok(())
+}

--- a/benches/performance_attribution.rs
+++ b/benches/performance_attribution.rs
@@ -17,6 +17,11 @@ use tempfile::TempDir;
 
 const AGENT: &str = "attribution";
 const OTHER: &str = "other";
+const WORK_QUEUE_TERMINAL_WINDOW: usize = 128;
+
+fn projected_item_count(own_completed: usize) -> usize {
+    own_completed.min(WORK_QUEUE_TERMINAL_WINDOW) + 1
+}
 
 struct Fixture {
     storage: AppStorage,
@@ -110,11 +115,12 @@ impl Fixture {
             active_waits == waits && linked_waits == waits,
             "active wait linkage"
         );
-        verify_queue(&self.storage, own + 1)?;
+        let projected_items = projected_item_count(own);
+        verify_queue(&self.storage, projected_items)?;
         Ok(json!({
             "work_items": work_items, "own_completed": own_completed,
             "other_completed": completed - own_completed, "active_waits": active_waits,
-            "distinct_linked_open_items": linked_waits, "projected_items": own + 1,
+            "distinct_linked_open_items": linked_waits, "projected_items": projected_items,
         }))
     }
 }
@@ -209,7 +215,7 @@ fn queue_case(
     let fixture = Fixture::new(own, other, waits)?;
     let rows = fixture.verify_rows(own, other, waits)?;
     let _held_connection = fixture.db.connection()?;
-    verify_queue(&fixture.storage, own + 1)?;
+    verify_queue(&fixture.storage, projected_item_count(own))?;
     let warmup_barrier = Barrier::new(workers);
     thread::scope(|scope| -> Result<()> {
         let handles: Vec<_> = (0..workers)
@@ -220,7 +226,7 @@ fn queue_case(
                 scope.spawn(move || -> Result<()> {
                     let connection = db.connection()?;
                     barrier.wait();
-                    verify_queue(storage, own + 1)?;
+                    verify_queue(storage, projected_item_count(own))?;
                     drop(connection);
                     Ok(())
                 })
@@ -248,7 +254,10 @@ fn queue_case(
                         let start = Instant::now();
                         let queue = storage.work_queue_read_model()?;
                         let elapsed = start.elapsed().as_nanos();
-                        ensure!(queue.items.len() == own + 1, "measured projection count");
+                        ensure!(
+                            queue.items.len() == projected_item_count(own),
+                            "measured projection count"
+                        );
                         black_box(queue);
                         samples.push(Sample {
                             worker,

--- a/benches/runtime_db.rs
+++ b/benches/runtime_db.rs
@@ -1,0 +1,389 @@
+use std::{
+    hint::black_box,
+    process::Command,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use holon::{
+    runtime_db::RuntimeDb,
+    storage::AppStorage,
+    types::{AgentState, AuditEvent, BriefKind, BriefRecord},
+};
+use serde::Serialize;
+use tempfile::TempDir;
+
+const AGENT_ID: &str = "benchmark-agent";
+const DEFAULT_SAMPLES: usize = 10;
+const WARMUP_SAMPLES: usize = 1;
+
+#[derive(Serialize)]
+struct BenchmarkArtifact {
+    schema_version: &'static str,
+    benchmark_suite: &'static str,
+    workload_version: &'static str,
+    started_at: String,
+    environment: Environment,
+    config: BenchmarkConfig,
+    results: Vec<BenchmarkResult>,
+}
+
+#[derive(Serialize)]
+struct Environment {
+    git_revision: Option<String>,
+    git_dirty: Option<bool>,
+    os: &'static str,
+    arch: &'static str,
+    cpu_model: Option<String>,
+    logical_cpus: Option<usize>,
+    rustc_version: Option<String>,
+    build_profile: &'static str,
+    network_mode: &'static str,
+}
+
+#[derive(Serialize)]
+struct BenchmarkConfig {
+    warmup_repetitions: usize,
+    measured_repetitions: usize,
+    brief_count: usize,
+    event_count: usize,
+    task_count: usize,
+    concurrency: usize,
+}
+
+#[derive(Serialize)]
+struct BenchmarkResult {
+    benchmark_id: &'static str,
+    samples: Vec<Sample>,
+    summary: Summary,
+}
+
+#[derive(Clone, Serialize)]
+struct Sample {
+    iteration: usize,
+    wall_time_ns: u128,
+    user_cpu_ns: u128,
+    system_cpu_ns: u128,
+    peak_rss_kb: u64,
+    exit_status: &'static str,
+}
+
+#[derive(Serialize)]
+struct Summary {
+    median_wall_time_ns: u128,
+    min_wall_time_ns: u128,
+    max_wall_time_ns: u128,
+    median_absolute_deviation_ns: u128,
+}
+
+fn main() -> Result<()> {
+    let samples = std::env::var("HOLON_BENCH_SAMPLES")
+        .ok()
+        .map(|value| value.parse::<usize>())
+        .transpose()
+        .context("HOLON_BENCH_SAMPLES must be a positive integer")?
+        .unwrap_or(DEFAULT_SAMPLES);
+    anyhow::ensure!(samples > 0, "HOLON_BENCH_SAMPLES must be positive");
+
+    let filter = benchmark_filter();
+    let results = run_benchmarks(samples, &filter)?;
+    anyhow::ensure!(
+        !results.is_empty(),
+        "HOLON_BENCH_FILTER selected no workloads"
+    );
+    let artifact = BenchmarkArtifact {
+        schema_version: "holon.performance.v0",
+        benchmark_suite: "runtime_db",
+        workload_version: "v1",
+        started_at: Utc::now().to_rfc3339(),
+        environment: environment(),
+        config: BenchmarkConfig {
+            warmup_repetitions: WARMUP_SAMPLES,
+            measured_repetitions: samples,
+            brief_count: 50,
+            event_count: 100,
+            task_count: 0,
+            concurrency: 1,
+        },
+        results,
+    };
+
+    println!("{}", serde_json::to_string_pretty(&artifact)?);
+    Ok(())
+}
+
+fn benchmark_filter() -> Vec<String> {
+    std::env::var("HOLON_BENCH_FILTER")
+        .ok()
+        .into_iter()
+        .flat_map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn benchmark_selected(filter: &[String], benchmark_id: &str) -> bool {
+    filter.is_empty() || filter.iter().any(|selected| selected == benchmark_id)
+}
+
+fn run_benchmarks(samples: usize, filter: &[String]) -> Result<Vec<BenchmarkResult>> {
+    let root = tempfile::tempdir().context("creating runtime_db benchmark root")?;
+    let existing = root.path().join("existing");
+    let existing_db = existing.join("runtime.sqlite");
+    let existing_lock = existing.join("runtime.lock");
+    drop(RuntimeDb::open_and_migrate(&existing_db, &existing_lock)?);
+
+    let projection_root = root.path().join("projection");
+    let projection_db = projection_root.join(".holon/state/runtime.sqlite");
+    let projection_lock = projection_root.join(".holon/state/runtime.lock");
+    let runtime_db = RuntimeDb::open_and_migrate(&projection_db, &projection_lock)?;
+    let storage = AppStorage::new_for_agent(&projection_root, AGENT_ID, runtime_db)?;
+    let agent = AgentState::new(AGENT_ID);
+    storage.write_agent(&agent)?;
+    for index in 0..100 {
+        storage.append_event(&AuditEvent::legacy(
+            format!("benchmark_event_{index}"),
+            serde_json::json!({"index": index}),
+        ))?;
+    }
+    for index in 0..50 {
+        storage.append_brief(&BriefRecord::new(
+            AGENT_ID,
+            BriefKind::Result,
+            format!("benchmark brief {index}"),
+            None,
+            None,
+        ))?;
+    }
+
+    let mut results = Vec::new();
+    if benchmark_selected(filter, "runtime_db.open_and_migrate.fresh") {
+        results.push(measure(
+            "runtime_db.open_and_migrate.fresh",
+            samples,
+            || {
+                let sample_root = TempDir::new_in(root.path())?;
+                let db = RuntimeDb::open_and_migrate(
+                    sample_root.path().join("runtime.sqlite"),
+                    sample_root.path().join("runtime.lock"),
+                )?;
+                black_box(db.current_schema_version()?);
+                Ok(())
+            },
+        )?);
+    }
+    if benchmark_selected(filter, "runtime_db.open_and_migrate.existing") {
+        results.push(measure(
+            "runtime_db.open_and_migrate.existing",
+            samples,
+            || {
+                let db = RuntimeDb::open_and_migrate(&existing_db, &existing_lock)?;
+                black_box(db.current_schema_version()?);
+                Ok(())
+            },
+        )?);
+    }
+    if benchmark_selected(filter, "projection.work_queue.empty") {
+        results.push(measure("projection.work_queue.empty", samples, || {
+            black_box(storage.work_queue_read_model()?);
+            Ok(())
+        })?);
+    }
+    if benchmark_selected(filter, "projection.agent_posture.empty") {
+        results.push(measure("projection.agent_posture.empty", samples, || {
+            black_box(storage.agent_posture_projection(&agent)?);
+            Ok(())
+        })?);
+    }
+    if benchmark_selected(filter, "projection.recent_briefs.50") {
+        results.push(measure("projection.recent_briefs.50", samples, || {
+            black_box(storage.read_recent_briefs(50)?);
+            Ok(())
+        })?);
+    }
+    if benchmark_selected(filter, "projection.recent_events.100") {
+        results.push(measure("projection.recent_events.100", samples, || {
+            black_box(storage.read_recent_events(100)?);
+            Ok(())
+        })?);
+    }
+    if benchmark_selected(
+        filter,
+        "projection.agent_summary_storage.50_briefs_100_events",
+    ) {
+        results.push(measure(
+            "projection.agent_summary_storage.50_briefs_100_events",
+            samples,
+            || {
+                let active_tasks = storage.active_task_count_for_agent(AGENT_ID)?;
+                let work_queue = storage.work_queue_read_model()?;
+                let posture =
+                    storage.agent_posture_projection_with_work_queue(&agent, &work_queue)?;
+                let briefs = storage.read_recent_briefs(50)?;
+                let events = storage.read_recent_events(100)?;
+                black_box((active_tasks, posture, briefs.len(), events.len()));
+                Ok(())
+            },
+        )?);
+    }
+    Ok(results)
+}
+
+fn measure(
+    benchmark_id: &'static str,
+    repetitions: usize,
+    mut operation: impl FnMut() -> Result<()>,
+) -> Result<BenchmarkResult> {
+    for _ in 0..WARMUP_SAMPLES {
+        operation().with_context(|| format!("warming up {benchmark_id}"))?;
+    }
+
+    let mut samples = Vec::with_capacity(repetitions);
+    for iteration in 1..=repetitions {
+        let resources_before = resource_usage();
+        let started_at = Instant::now();
+        operation().with_context(|| format!("measuring {benchmark_id}"))?;
+        let wall_time = started_at.elapsed();
+        let resources_after = resource_usage();
+        samples.push(Sample {
+            iteration,
+            wall_time_ns: wall_time.as_nanos(),
+            user_cpu_ns: duration_delta(resources_after.user_cpu, resources_before.user_cpu)
+                .as_nanos(),
+            system_cpu_ns: duration_delta(resources_after.system_cpu, resources_before.system_cpu)
+                .as_nanos(),
+            peak_rss_kb: resources_after.peak_rss_kb,
+            exit_status: "ok",
+        });
+    }
+
+    let summary = summarize(&samples);
+    Ok(BenchmarkResult {
+        benchmark_id,
+        samples,
+        summary,
+    })
+}
+
+fn summarize(samples: &[Sample]) -> Summary {
+    let mut values: Vec<u128> = samples.iter().map(|sample| sample.wall_time_ns).collect();
+    values.sort_unstable();
+    let median_value = median(&values);
+    let mut deviations: Vec<u128> = values
+        .iter()
+        .map(|value| value.abs_diff(median_value))
+        .collect();
+    deviations.sort_unstable();
+    Summary {
+        median_wall_time_ns: median_value,
+        min_wall_time_ns: values[0],
+        max_wall_time_ns: values[values.len() - 1],
+        median_absolute_deviation_ns: median(&deviations),
+    }
+}
+
+fn median(values: &[u128]) -> u128 {
+    let middle = values.len() / 2;
+    if values.len() % 2 == 0 {
+        (values[middle - 1] + values[middle]) / 2
+    } else {
+        values[middle]
+    }
+}
+
+#[derive(Default)]
+struct ResourceUsage {
+    user_cpu: Duration,
+    system_cpu: Duration,
+    peak_rss_kb: u64,
+}
+
+#[cfg(unix)]
+fn resource_usage() -> ResourceUsage {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    // SAFETY: getrusage initializes the supplied rusage on success.
+    let result = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+    if result != 0 {
+        return ResourceUsage::default();
+    }
+    // SAFETY: getrusage returned success, so usage is initialized.
+    let usage = unsafe { usage.assume_init() };
+    ResourceUsage {
+        user_cpu: timeval_duration(usage.ru_utime),
+        system_cpu: timeval_duration(usage.ru_stime),
+        peak_rss_kb: peak_rss_kb(usage.ru_maxrss),
+    }
+}
+
+#[cfg(not(unix))]
+fn resource_usage() -> ResourceUsage {
+    ResourceUsage::default()
+}
+
+#[cfg(unix)]
+fn timeval_duration(value: libc::timeval) -> Duration {
+    Duration::new(
+        value.tv_sec.max(0) as u64,
+        (value.tv_usec.max(0) as u32) * 1_000,
+    )
+}
+
+#[cfg(all(unix, target_os = "macos"))]
+fn peak_rss_kb(value: libc::c_long) -> u64 {
+    value.max(0) as u64 / 1024
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn peak_rss_kb(value: libc::c_long) -> u64 {
+    value.max(0) as u64
+}
+
+fn duration_delta(after: Duration, before: Duration) -> Duration {
+    after.checked_sub(before).unwrap_or_default()
+}
+
+fn environment() -> Environment {
+    Environment {
+        git_revision: command_output("git", &["rev-parse", "HEAD"]),
+        git_dirty: command_output("git", &["status", "--porcelain"])
+            .map(|output| !output.is_empty()),
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        cpu_model: cpu_model(),
+        logical_cpus: std::thread::available_parallelism().ok().map(usize::from),
+        rustc_version: command_output("rustc", &["--version"]),
+        build_profile: if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "bench"
+        },
+        network_mode: "disabled",
+    }
+}
+
+fn command_output(command: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(command).args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn cpu_model() -> Option<String> {
+    std::fs::read_to_string("/proc/cpuinfo")
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("model name\t: ").map(str::to_string))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn cpu_model() -> Option<String> {
+    None
+}

--- a/benches/scheduler.rs
+++ b/benches/scheduler.rs
@@ -1,0 +1,444 @@
+use std::{
+    hint::black_box,
+    process::Command,
+    thread,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result};
+use chrono::{Duration as ChronoDuration, Utc};
+use holon::{
+    runtime_db::RuntimeDb,
+    storage::AppStorage,
+    types::{
+        AgentState, WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource,
+        WorkItemPlanStatus, WorkItemRecord, WorkItemState,
+    },
+};
+use serde::Serialize;
+
+const AGENT_ID: &str = "benchmark-agent";
+const DEFAULT_SAMPLES: usize = 10;
+const WARMUP_SAMPLES: usize = 1;
+const RUNNABLE_ITEMS: usize = 100;
+const BLOCKED_ITEMS: usize = 50;
+const WAITING_ITEMS: usize = 50;
+const CONCURRENT_READERS: usize = 8;
+const READS_PER_READER: usize = 25;
+
+#[derive(Serialize)]
+struct BenchmarkArtifact {
+    schema_version: &'static str,
+    benchmark_suite: &'static str,
+    workload_version: &'static str,
+    started_at: String,
+    environment: Environment,
+    config: BenchmarkConfig,
+    results: Vec<BenchmarkResult>,
+}
+
+#[derive(Serialize)]
+struct Environment {
+    git_revision: Option<String>,
+    git_dirty: Option<bool>,
+    os: &'static str,
+    arch: &'static str,
+    cpu_model: Option<String>,
+    logical_cpus: Option<usize>,
+    rustc_version: Option<String>,
+    build_profile: &'static str,
+    network_mode: &'static str,
+}
+
+#[derive(Serialize)]
+struct BenchmarkConfig {
+    warmup_repetitions: usize,
+    measured_repetitions: usize,
+    runnable_work_items: usize,
+    blocked_work_items: usize,
+    waiting_work_items: usize,
+    concurrency: usize,
+    operations_per_concurrent_sample: usize,
+}
+
+#[derive(Serialize)]
+struct BenchmarkResult {
+    benchmark_id: &'static str,
+    operations_per_sample: usize,
+    samples: Vec<Sample>,
+    summary: Summary,
+}
+
+#[derive(Clone, Serialize)]
+struct Sample {
+    iteration: usize,
+    wall_time_ns: u128,
+    user_cpu_ns: u128,
+    system_cpu_ns: u128,
+    peak_rss_kb: u64,
+    exit_status: &'static str,
+}
+
+#[derive(Serialize)]
+struct Summary {
+    median_wall_time_ns: u128,
+    min_wall_time_ns: u128,
+    max_wall_time_ns: u128,
+    median_absolute_deviation_ns: u128,
+    median_operations_per_second: f64,
+}
+
+fn main() -> Result<()> {
+    let samples = std::env::var("HOLON_BENCH_SAMPLES")
+        .ok()
+        .map(|value| value.parse::<usize>())
+        .transpose()
+        .context("HOLON_BENCH_SAMPLES must be a positive integer")?
+        .unwrap_or(DEFAULT_SAMPLES);
+    anyhow::ensure!(samples > 0, "HOLON_BENCH_SAMPLES must be positive");
+
+    let filter = benchmark_filter();
+    let results = run_benchmarks(samples, &filter)?;
+    anyhow::ensure!(
+        !results.is_empty(),
+        "HOLON_BENCH_FILTER selected no workloads"
+    );
+    let artifact = BenchmarkArtifact {
+        schema_version: "holon.performance.v0",
+        benchmark_suite: "scheduler",
+        workload_version: "v1",
+        started_at: Utc::now().to_rfc3339(),
+        environment: environment(),
+        config: BenchmarkConfig {
+            warmup_repetitions: WARMUP_SAMPLES,
+            measured_repetitions: samples,
+            runnable_work_items: RUNNABLE_ITEMS,
+            blocked_work_items: BLOCKED_ITEMS,
+            waiting_work_items: WAITING_ITEMS,
+            concurrency: CONCURRENT_READERS,
+            operations_per_concurrent_sample: CONCURRENT_READERS * READS_PER_READER,
+        },
+        results,
+    };
+
+    println!("{}", serde_json::to_string_pretty(&artifact)?);
+    Ok(())
+}
+
+fn benchmark_filter() -> Vec<String> {
+    std::env::var("HOLON_BENCH_FILTER")
+        .ok()
+        .into_iter()
+        .flat_map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn benchmark_selected(filter: &[String], benchmark_id: &str) -> bool {
+    filter.is_empty() || filter.iter().any(|selected| selected == benchmark_id)
+}
+
+fn run_benchmarks(samples: usize, filter: &[String]) -> Result<Vec<BenchmarkResult>> {
+    let root = tempfile::tempdir().context("creating scheduler benchmark root")?;
+    let db = RuntimeDb::open_and_migrate(
+        root.path().join(".holon/state/runtime.sqlite"),
+        root.path().join(".holon/state/runtime.lock"),
+    )?;
+    let storage = AppStorage::new_for_agent(root.path(), AGENT_ID, db)?;
+    let now = Utc::now();
+    let runnable_ids = seed_scheduler_state(&storage, now)?;
+
+    let mut results = Vec::new();
+    if benchmark_selected(filter, "scheduler.work_queue_read_model.200") {
+        results.push(measure(
+            "scheduler.work_queue_read_model.200",
+            samples,
+            1,
+            || verify_fifo_projection(&storage, &runnable_ids),
+        )?);
+    }
+    if benchmark_selected(filter, "scheduler.due_rechecks.50") {
+        results.push(measure("scheduler.due_rechecks.50", samples, 1, || {
+            let due = storage.due_blocked_work_item_rechecks(AGENT_ID, now)?;
+            anyhow::ensure!(due.len() == BLOCKED_ITEMS, "expected 50 due rechecks");
+            black_box(due);
+            Ok(())
+        })?);
+    }
+    if benchmark_selected(filter, "scheduler.active_waits.50") {
+        results.push(measure("scheduler.active_waits.50", samples, 1, || {
+            let waits = storage.active_wait_conditions_for_agent(AGENT_ID)?;
+            anyhow::ensure!(waits.len() == WAITING_ITEMS, "expected 50 active waits");
+            black_box(waits);
+            Ok(())
+        })?);
+    }
+    if benchmark_selected(filter, "scheduler.work_queue_read_model.concurrent_8x25") {
+        results.push(measure(
+            "scheduler.work_queue_read_model.concurrent_8x25",
+            samples,
+            CONCURRENT_READERS * READS_PER_READER,
+            || {
+                thread::scope(|scope| -> Result<()> {
+                    let mut readers = Vec::with_capacity(CONCURRENT_READERS);
+                    for _ in 0..CONCURRENT_READERS {
+                        let storage = storage.clone();
+                        let runnable_ids = &runnable_ids;
+                        readers.push(scope.spawn(move || -> Result<()> {
+                            for _ in 0..READS_PER_READER {
+                                verify_fifo_projection(&storage, runnable_ids)?;
+                            }
+                            Ok(())
+                        }));
+                    }
+                    for reader in readers {
+                        reader
+                            .join()
+                            .expect("scheduler benchmark reader panicked")?;
+                    }
+                    Ok(())
+                })
+            },
+        )?);
+    }
+    Ok(results)
+}
+
+fn seed_scheduler_state(storage: &AppStorage, now: chrono::DateTime<Utc>) -> Result<Vec<String>> {
+    let mut agent = AgentState::new(AGENT_ID);
+    let mut runnable_ids = Vec::with_capacity(RUNNABLE_ITEMS);
+
+    for index in 0..RUNNABLE_ITEMS {
+        let mut item = WorkItemRecord::new(
+            AGENT_ID,
+            format!("runnable benchmark work item {index}"),
+            WorkItemState::Open,
+        );
+        item.id = format!("work_runnable_{index:03}");
+        item.plan_status = WorkItemPlanStatus::Ready;
+        item.created_at = now - ChronoDuration::milliseconds((RUNNABLE_ITEMS - index) as i64);
+        item.updated_at = item.created_at;
+        if index == 0 {
+            agent.current_work_item_id = Some(item.id.clone());
+        } else {
+            runnable_ids.push(item.id.clone());
+        }
+        storage.append_work_item(&item)?;
+    }
+
+    for index in 0..BLOCKED_ITEMS {
+        let mut item = WorkItemRecord::new(
+            AGENT_ID,
+            format!("blocked benchmark work item {index}"),
+            WorkItemState::Open,
+        );
+        item.id = format!("work_blocked_{index:03}");
+        item.plan_status = WorkItemPlanStatus::Ready;
+        item.blocked_by = Some("benchmark_recheck".into());
+        item.recheck_at = Some(now - ChronoDuration::seconds(1));
+        storage.append_work_item(&item)?;
+    }
+
+    for index in 0..WAITING_ITEMS {
+        let mut item = WorkItemRecord::new(
+            AGENT_ID,
+            format!("waiting benchmark work item {index}"),
+            WorkItemState::Open,
+        );
+        item.id = format!("work_waiting_{index:03}");
+        item.plan_status = WorkItemPlanStatus::Ready;
+        item.blocked_by = Some("operator_input".into());
+        storage.append_work_item(&item)?;
+        storage.append_wait_condition(&WaitConditionRecord {
+            id: format!("wait_benchmark_{index:03}"),
+            agent_id: AGENT_ID.into(),
+            work_item_id: Some(item.id),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::Operator,
+            source: None,
+            subject_ref: None,
+            waiting_for: "operator_input".into(),
+            wake_sources: vec![WakeSource::OperatorInput],
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+            trigger_message_id: None,
+            triggered_at: None,
+        })?;
+    }
+
+    storage.write_agent(&agent)?;
+    Ok(runnable_ids)
+}
+
+fn verify_fifo_projection(storage: &AppStorage, expected_ids: &[String]) -> Result<()> {
+    let projection = storage.work_queue_read_model()?;
+    anyhow::ensure!(
+        projection.items.len() == RUNNABLE_ITEMS + BLOCKED_ITEMS + WAITING_ITEMS,
+        "scheduler projection lost work items"
+    );
+    let actual_ids = projection
+        .items
+        .iter()
+        .filter(|item| item.is_runnable && !item.is_current)
+        .map(|item| item.id.as_str())
+        .collect::<Vec<_>>();
+    anyhow::ensure!(
+        actual_ids.len() == expected_ids.len(),
+        "scheduler projection changed runnable candidate count"
+    );
+    anyhow::ensure!(
+        actual_ids
+            .iter()
+            .zip(expected_ids)
+            .all(|(actual, expected)| *actual == expected),
+        "scheduler projection changed FIFO candidate order"
+    );
+    black_box(projection);
+    Ok(())
+}
+
+fn measure(
+    benchmark_id: &'static str,
+    repetitions: usize,
+    operations_per_sample: usize,
+    mut operation: impl FnMut() -> Result<()>,
+) -> Result<BenchmarkResult> {
+    for _ in 0..WARMUP_SAMPLES {
+        operation().with_context(|| format!("warming up {benchmark_id}"))?;
+    }
+
+    let mut samples = Vec::with_capacity(repetitions);
+    for iteration in 1..=repetitions {
+        let resources_before = resource_usage();
+        let started_at = Instant::now();
+        operation().with_context(|| format!("measuring {benchmark_id}"))?;
+        let wall_time = started_at.elapsed();
+        let resources_after = resource_usage();
+        samples.push(Sample {
+            iteration,
+            wall_time_ns: wall_time.as_nanos(),
+            user_cpu_ns: duration_delta(resources_after.user_cpu, resources_before.user_cpu)
+                .as_nanos(),
+            system_cpu_ns: duration_delta(resources_after.system_cpu, resources_before.system_cpu)
+                .as_nanos(),
+            peak_rss_kb: resources_after.peak_rss_kb,
+            exit_status: "ok",
+        });
+    }
+
+    let summary = summarize(&samples, operations_per_sample);
+    Ok(BenchmarkResult {
+        benchmark_id,
+        operations_per_sample,
+        samples,
+        summary,
+    })
+}
+
+fn summarize(samples: &[Sample], operations_per_sample: usize) -> Summary {
+    let mut values: Vec<u128> = samples.iter().map(|sample| sample.wall_time_ns).collect();
+    values.sort_unstable();
+    let median_value = median(&values);
+    let mut deviations: Vec<u128> = values
+        .iter()
+        .map(|value| value.abs_diff(median_value))
+        .collect();
+    deviations.sort_unstable();
+    Summary {
+        median_wall_time_ns: median_value,
+        min_wall_time_ns: values[0],
+        max_wall_time_ns: values[values.len() - 1],
+        median_absolute_deviation_ns: median(&deviations),
+        median_operations_per_second: operations_per_sample as f64 * 1_000_000_000.0
+            / median_value as f64,
+    }
+}
+
+fn median(values: &[u128]) -> u128 {
+    let middle = values.len() / 2;
+    if values.len() % 2 == 0 {
+        (values[middle - 1] + values[middle]) / 2
+    } else {
+        values[middle]
+    }
+}
+
+#[derive(Default)]
+struct ResourceUsage {
+    user_cpu: Duration,
+    system_cpu: Duration,
+    peak_rss_kb: u64,
+}
+
+#[cfg(unix)]
+fn resource_usage() -> ResourceUsage {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    // SAFETY: getrusage initializes the supplied rusage on success.
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
+        return ResourceUsage::default();
+    }
+    // SAFETY: getrusage returned success.
+    let usage = unsafe { usage.assume_init() };
+    ResourceUsage {
+        user_cpu: timeval_duration(usage.ru_utime),
+        system_cpu: timeval_duration(usage.ru_stime),
+        peak_rss_kb: usage.ru_maxrss as u64,
+    }
+}
+
+#[cfg(not(unix))]
+fn resource_usage() -> ResourceUsage {
+    ResourceUsage::default()
+}
+
+#[cfg(unix)]
+fn timeval_duration(value: libc::timeval) -> Duration {
+    Duration::new(value.tv_sec as u64, (value.tv_usec as u32) * 1_000)
+}
+
+fn duration_delta(after: Duration, before: Duration) -> Duration {
+    after.checked_sub(before).unwrap_or_default()
+}
+
+fn environment() -> Environment {
+    Environment {
+        git_revision: command_output("git", &["rev-parse", "HEAD"]),
+        git_dirty: command_output("git", &["status", "--porcelain"])
+            .map(|output| !output.is_empty()),
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        cpu_model: cpu_model(),
+        logical_cpus: thread::available_parallelism().ok().map(usize::from),
+        rustc_version: command_output("rustc", &["--version"]),
+        build_profile: "bench",
+        network_mode: "disabled",
+    }
+}
+
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn cpu_model() -> Option<String> {
+    let cpu_info = std::fs::read_to_string("/proc/cpuinfo").ok()?;
+    cpu_info.lines().find_map(|line| {
+        line.strip_prefix("model name")
+            .and_then(|value| value.split_once(':'))
+            .map(|(_, value)| value.trim().to_string())
+    })
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -68,3 +68,37 @@ To push benchmark branches and create draft PRs, either:
 
 - set `pr.submit_pr: true` and `pr.draft_pr: true` in the suite file, or
 - override on the CLI with `--push-branch --github-pr`.
+
+## Local runtime performance baseline
+
+The Rust runtime database and summary-storage projection baseline is local and
+does not use provider traffic:
+
+```bash
+cargo bench --bench runtime_db
+cargo bench --bench scheduler
+cargo bench --bench http_control
+cargo bench --bench memory_lifecycle
+```
+
+It emits one JSON artifact to stdout. Set `HOLON_BENCH_SAMPLES` to change the
+default ten measured repetitions; each benchmark also performs one warmup.
+The multi-workload targets accept `HOLON_BENCH_FILTER` as a comma-separated
+list of exact benchmark IDs, and do not execute unselected workloads. The
+scheduler suite covers SQLite-backed work-queue projection, due recheck and
+active wait scans, plus concurrent projection reads with FIFO-order validation.
+The HTTP suite constructs 101 visible agents and 200 work items before timing,
+then covers the runtime performance snapshot, agent roster, and single or
+repeated large work-item responses through in-process `Router::oneshot`
+requests. It does not bind a socket or include network transfer time.
+The memory suite isolates every sample in a child process, grows a session with
+1,000 events and 100 briefs, repeatedly reads bounded history windows, and
+records current/peak RSS plus SQLite directory growth before and after dropping
+the runtime storage handle.
+
+`Benchmark CI` runs a stable subset with broad catastrophic-regression limits.
+It excludes the scheduler `concurrent_8x25` workload because its runtime and
+variance are strongly machine-dependent. JSON artifacts are uploaded for trend
+analysis; initial hard limits catch order-of-magnitude wall-time,
+retained-memory, or database-size regressions rather than small cross-run
+changes.

--- a/docs/rfcs/read-side-performance-attribution.md
+++ b/docs/rfcs/read-side-performance-attribution.md
@@ -1,0 +1,44 @@
+# Read-side performance attribution
+
+Status: diagnostic implementation, not a scheduling or persistence change.
+
+## Contract
+
+The performance diagnostics snapshot adds `attribution`, a fixed-size set of
+named stage counters. Each reports attempts, total/max nanoseconds and rows.
+Existing millisecond metrics retain their old meaning. Nanoseconds avoid
+per-operation millisecond truncation; they do not imply clock accuracy.
+
+Timers include failed/cancelled attempts. Row counts report successfully
+materialized rows (latest work items), or rows entering wait filtering.
+Query stages include connection acquisition, SQL execution and decoding;
+they are not SQL-engine-only timers. The live-scope filter and per-item lookup
+timers make global scan and N+1 amplification observable.
+
+Connection stages distinguish SQLite opening, configuration and the two Linux
+sidecar consistency checks. Safety checks remain unchanged. Agent lock wait and
+state cloning are distinct; lightweight state projection additionally times
+posture, closure, children, identity and active task reads.
+
+Counters are process-global relaxed atomics, not a request-level transaction.
+Nested stages overlap and must not be summed as independent wall time.
+Concurrent stage totals can exceed interval wall time. Snapshot subtraction
+should use count, total_ns and rows, not subtract cumulative maxima.
+
+`holon::performance=trace` emits only fixed stage names, elapsed nanoseconds
+and numeric row counts, in the caller's tracing context where available.
+No message bodies, SQL values, agent IDs or database paths are emitted.
+Per-operation trace logging is opt-in and can perturb measured performance.
+There is no promise of end-to-end request correlation yet.
+
+## Verification and limits
+
+Isolated benchmarks report raw operation samples and quantiles, together with
+diagnostic deltas. Live counters intentionally do not maintain a percentile
+reservoir: no unbounded cardinality, storage or background sampler is added.
+Small benchmark sample p95/p99 values are descriptive order statistics, not
+reliable production tail estimates.
+
+Scale one dimension per fixture before combining growth and contention.
+Temporary databases must not read production records. A synthetic result can
+validate a mechanism but cannot establish its contribution to live latency.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -5890,6 +5890,45 @@
       },
       "PerformanceDiagnosticsSnapshot": {
         "properties": {
+          "attribution": {
+            "default": [],
+            "items": {
+              "properties": {
+                "count": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "max_ns": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "rows": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "total_ns": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name",
+                "count",
+                "total_ns",
+                "max_ns",
+                "rows"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "captured_at": {
             "type": "string"
           },

--- a/scripts/check-performance-gate.py
+++ b/scripts/check-performance-gate.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+
+EXPECTED = {
+    "runtime_db.json": {
+        "samples": 5,
+        "limits_ns": {
+            "runtime_db.open_and_migrate.fresh": 5_000_000_000,
+            "projection.agent_summary_storage.50_briefs_100_events": 2_000_000_000,
+        },
+    },
+    "scheduler.json": {
+        "samples": 5,
+        "limits_ns": {
+            "scheduler.work_queue_read_model.200": 5_000_000_000,
+            "scheduler.due_rechecks.50": 2_000_000_000,
+            "scheduler.active_waits.50": 5_000_000_000,
+        },
+    },
+    "http_control.json": {
+        "samples": 5,
+        "limits_ns": {
+            "http.runtime_performance.100": 2_000_000_000,
+            "http.work_items.200x10": 10_000_000_000,
+        },
+    },
+    "memory_lifecycle.json": {
+        "samples": 3,
+        "limits_ns": {
+            "memory.long_session.events_1000_briefs_100": 30_000_000_000,
+        },
+    },
+}
+
+MAX_MEMORY_DELTA_KB = 64 * 1024
+MAX_DATABASE_BYTES = 128 * 1024 * 1024
+
+
+def load_artifact(path: Path) -> dict:
+    artifact = json.loads(path.read_text())
+    if artifact.get("schema_version") != "holon.performance.v0":
+        raise AssertionError(f"{path}: unsupported schema")
+    return artifact
+
+
+def check_artifact(path: Path, expected: dict) -> list[str]:
+    artifact = load_artifact(path)
+    results = {result["benchmark_id"]: result for result in artifact.get("results", [])}
+    if set(results) != set(expected["limits_ns"]):
+        raise AssertionError(
+            f"{path}: expected {sorted(expected['limits_ns'])}, got {sorted(results)}"
+        )
+
+    lines = []
+    for benchmark_id, limit_ns in expected["limits_ns"].items():
+        result = results[benchmark_id]
+        samples = result.get("samples", [])
+        if len(samples) != expected["samples"]:
+            raise AssertionError(
+                f"{benchmark_id}: expected {expected['samples']} samples, got {len(samples)}"
+            )
+        if any(sample.get("exit_status") != "ok" for sample in samples):
+            raise AssertionError(f"{benchmark_id}: non-ok sample")
+        median_ns = result["summary"]["median_wall_time_ns"]
+        if median_ns > limit_ns:
+            raise AssertionError(
+                f"{benchmark_id}: median {median_ns} ns exceeds {limit_ns} ns"
+            )
+        lines.append(f"- `{benchmark_id}`: {median_ns / 1_000_000:.3f} ms")
+
+        if benchmark_id.startswith("memory."):
+            for sample in samples:
+                rss = [
+                    sample[key]
+                    for key in (
+                        "baseline_rss_kb",
+                        "after_write_rss_kb",
+                        "after_projection_rss_kb",
+                        "after_drop_rss_kb",
+                    )
+                ]
+                if sample["peak_rss_kb"] < max(rss):
+                    raise AssertionError(f"{benchmark_id}: peak RSS is below current RSS")
+                if sample["retained_rss_delta_kb"] > MAX_MEMORY_DELTA_KB:
+                    raise AssertionError(f"{benchmark_id}: retained RSS delta exceeds 64 MiB")
+                if sample["peak_rss_delta_kb"] > MAX_MEMORY_DELTA_KB:
+                    raise AssertionError(f"{benchmark_id}: peak RSS delta exceeds 64 MiB")
+                if sample["database_bytes"] > MAX_DATABASE_BYTES:
+                    raise AssertionError(f"{benchmark_id}: database exceeds 128 MiB")
+    return lines
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("artifact_dir", type=Path)
+    args = parser.parse_args()
+
+    summary = ["## Rust performance gate", ""]
+    for filename, expected in EXPECTED.items():
+        summary.extend(check_artifact(args.artifact_dir / filename, expected))
+    print("\n".join(summary))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -6,6 +6,8 @@ use chrono::Utc;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+pub mod attribution;
+
 static PROCESS_STARTED_AT: OnceLock<Instant> = OnceLock::new();
 
 static HTTP_ALL: MetricAccumulator = MetricAccumulator::new("http.json.all");
@@ -113,6 +115,8 @@ pub struct PerformanceDiagnosticsSnapshot {
     pub scheduler: Vec<MetricSnapshot>,
     pub turn: Vec<MetricSnapshot>,
     pub provider: Vec<MetricSnapshot>,
+    #[serde(default)]
+    pub attribution: Vec<attribution::StageSnapshot>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -470,6 +474,7 @@ pub fn record_projection_gate_leader_finished() {
 pub fn performance_snapshot() -> PerformanceDiagnosticsSnapshot {
     let started_at = process_started_at();
     PerformanceDiagnosticsSnapshot {
+        attribution: attribution::snapshot(),
         captured_at: Utc::now().to_rfc3339(),
         process_uptime_ms: started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
         http: vec![

--- a/src/diagnostics/attribution.rs
+++ b/src/diagnostics/attribution.rs
@@ -1,0 +1,129 @@
+//! Bounded, content-free read-side timings. Nested stages overlap; timers count
+//! attempts including errors/cancellation. Snapshots are not transactional.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub(crate) struct Stage {
+    name: &'static str,
+    count: AtomicU64,
+    total_ns: AtomicU64,
+    max_ns: AtomicU64,
+    rows: AtomicU64,
+}
+
+impl Stage {
+    const fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            count: AtomicU64::new(0),
+            total_ns: AtomicU64::new(0),
+            max_ns: AtomicU64::new(0),
+            rows: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn start(&'static self) -> Timer {
+        Timer {
+            stage: self,
+            started: Instant::now(),
+            rows: 0,
+        }
+    }
+
+    fn snapshot(&self) -> StageSnapshot {
+        StageSnapshot {
+            name: self.name.to_owned(),
+            count: self.count.load(Ordering::Relaxed),
+            total_ns: self.total_ns.load(Ordering::Relaxed),
+            max_ns: self.max_ns.load(Ordering::Relaxed),
+            rows: self.rows.load(Ordering::Relaxed),
+        }
+    }
+}
+
+pub(crate) struct Timer {
+    stage: &'static Stage,
+    started: Instant,
+    rows: u64,
+}
+
+impl Timer {
+    pub(crate) fn rows(&mut self, rows: usize) {
+        self.rows = rows as u64;
+    }
+}
+
+impl Drop for Timer {
+    fn drop(&mut self) {
+        let elapsed_ns = self.started.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64;
+        self.stage.total_ns.fetch_add(elapsed_ns, Ordering::Relaxed);
+        self.stage.max_ns.fetch_max(elapsed_ns, Ordering::Relaxed);
+        self.stage.rows.fetch_add(self.rows, Ordering::Relaxed);
+        self.stage.count.fetch_add(1, Ordering::Relaxed);
+        tracing::trace!(
+            target: "holon::performance",
+            stage = self.stage.name, elapsed_ns, rows = self.rows,
+            "read-side stage completed"
+        );
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct StageSnapshot {
+    pub name: String,
+    pub count: u64,
+    pub total_ns: u64,
+    pub max_ns: u64,
+    pub rows: u64,
+}
+
+macro_rules! stages {
+    ($($id:ident => $name:literal),+ $(,)?) => {
+        $(pub(crate) static $id: Stage = Stage::new($name);)+
+        pub fn snapshot() -> Vec<StageSnapshot> {
+            vec![$($id.snapshot()),+]
+        }
+    };
+}
+
+stages! {
+    CONNECTION => "db.connection.attempt",
+    SIDECAR => "db.connection.sidecar_check",
+    SQLITE_OPEN => "db.connection.sqlite_open",
+    CONFIGURE => "db.connection.configure",
+    WORK_QUEUE => "projection.work_queue",
+    WORK_ITEMS => "projection.work_queue.latest_items",
+    WAIT_QUERY => "projection.waits.active_all_query",
+    WAIT_FILTER => "projection.waits.live_scope_filter",
+    WAIT_ITEM => "projection.waits.work_item_lookup",
+    AGENT_LOCK => "projection.agent_state.lock_wait",
+    AGENT_CLONE => "projection.agent_state.clone",
+    POSTURE => "projection.state.posture",
+    CLOSURE => "projection.state.closure",
+    CHILDREN => "projection.state.children",
+    IDENTITY => "projection.state.identity",
+    ACTIVE_TASKS => "projection.state.active_tasks",
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timer_records_attempt_rows_and_submillisecond_precision() {
+        static STAGE: Stage = Stage::new("test");
+        let mut timer = STAGE.start();
+        timer.rows(7);
+        timer.started = Instant::now() - std::time::Duration::from_micros(100);
+        drop(timer);
+        let snapshot = STAGE.snapshot();
+        assert_eq!(snapshot.count, 1);
+        assert_eq!(snapshot.rows, 7);
+        assert!(snapshot.total_ns >= 100_000);
+        assert_eq!(snapshot.total_ns, snapshot.max_ns);
+    }
+}

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1,6 +1,7 @@
 use super::*;
 use std::path::{Path, PathBuf};
 
+use crate::diagnostics::attribution;
 use crate::runtime::closure::{derive_closure_decision, ClosureFacts};
 use crate::storage::AppStorage;
 use crate::types::{
@@ -434,7 +435,10 @@ impl RuntimeHandle {
     }
 
     pub async fn agent_state(&self) -> Result<AgentState> {
+        let lock_wait = attribution::AGENT_LOCK.start();
         let guard = self.inner.agent.lock().await;
+        drop(lock_wait);
+        let _clone = attribution::AGENT_CLONE.start();
         Ok(guard.state.clone())
     }
 
@@ -511,21 +515,33 @@ impl RuntimeHandle {
     ) -> Result<LightweightAgentStateProjection> {
         let agent = self.agent_state().await?;
         let work_queue = self.inner.storage.work_queue_read_model()?;
+        let posture_timer = attribution::POSTURE.start();
         let scheduling_posture = self
             .inner
             .storage
             .agent_posture_projection_with_work_queue(&agent, &work_queue)?;
+        drop(posture_timer);
+        let closure_timer = attribution::CLOSURE.start();
         let closure = self
             .closure_decision_for_state_with_work_queue(&agent, None, work_queue.clone())
             .await?;
+        drop(closure_timer);
+        let children_timer = attribution::CHILDREN.start();
         let active_children = if let Some(bridge) = self.inner.host_bridge.as_ref() {
             bridge.child_summaries(&agent.id).await?
         } else {
             Vec::new()
         };
+        drop(children_timer);
+        let identity_timer = attribution::IDENTITY.start();
+        let identity = self.agent_identity_view().await?;
+        drop(identity_timer);
+        let tasks_timer = attribution::ACTIVE_TASKS.start();
+        let active_task_count = self.inner.storage.active_task_count_for_agent(&agent.id)?;
+        drop(tasks_timer);
         Ok(LightweightAgentStateProjection {
-            identity: self.agent_identity_view().await?,
-            active_task_count: self.inner.storage.active_task_count_for_agent(&agent.id)?,
+            identity,
+            active_task_count,
             lifecycle: crate::types::AgentLifecycleHint::from_status(
                 &agent.id,
                 agent.status.clone(),

--- a/src/runtime_db/connection.rs
+++ b/src/runtime_db/connection.rs
@@ -26,16 +26,22 @@ pub(crate) enum LockMode {
 }
 
 pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
+    use crate::diagnostics::attribution;
+    let _attempt = attribution::CONNECTION.start();
     let started_at = Instant::now();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("creating runtime db directory {}", parent.display()))?;
     }
     ensure_runtime_db_sidecars_are_consistent(path)?;
+    let sqlite_open = attribution::SQLITE_OPEN.start();
     let connection =
         Connection::open(path).with_context(|| format!("opening runtime db {}", path.display()))?;
+    drop(sqlite_open);
+    let configure = attribution::CONFIGURE.start();
     enable_persistent_wal(&connection, path)?;
     configure_connection(&connection)?;
+    drop(configure);
     ensure_runtime_db_sidecars_are_consistent(path)?;
     crate::diagnostics::record_runtime_db_connection_open(started_at.elapsed());
     Ok(connection)
@@ -98,6 +104,7 @@ fn bail_persistent_wal_not_enabled(path: &Path, current: i32) -> Result<()> {
 
 #[cfg(target_os = "linux")]
 fn ensure_runtime_db_sidecars_are_consistent(path: &Path) -> Result<()> {
+    let _timer = crate::diagnostics::attribution::SIDECAR.start();
     let db_path = match path.canonicalize() {
         Ok(path) => path,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {

--- a/src/storage/read_models.rs
+++ b/src/storage/read_models.rs
@@ -4,6 +4,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use anyhow::Result;
 
+use crate::diagnostics::attribution;
+
 use crate::{
     runtime_db::RuntimeDb,
     types::{
@@ -42,11 +44,13 @@ impl RuntimeReadModels {
     }
 
     pub fn work_queue(&self) -> Result<WorkQueueReadModel> {
+        let _timer = attribution::WORK_QUEUE.start();
         let current_work_item_id = self
             .read_agent()?
             .and_then(|agent| agent.current_work_item_id);
         let mut latest = HashMap::<String, WorkItemRecord>::new();
         if let Some(agent_id) = self.agent_id.as_deref() {
+            let mut timer = attribution::WORK_ITEMS.start();
             for record in self.runtime_db.work_items().open_for_agent(agent_id)? {
                 latest.insert(record.id.clone(), record);
             }
@@ -57,6 +61,7 @@ impl RuntimeReadModels {
             {
                 latest.insert(record.id.clone(), record);
             }
+            timer.rows(latest.len());
         }
 
         let current = current_work_item_id
@@ -419,7 +424,10 @@ impl RuntimeReadModels {
     }
 
     pub(crate) fn active_wait_conditions(&self) -> Result<Vec<WaitConditionRecord>> {
+        let mut timer = attribution::WAIT_QUERY.start();
         let records = self.runtime_db.wait_conditions().active_all()?;
+        timer.rows(records.len());
+        drop(timer);
         self.filter_active_wait_conditions_for_live_scope(records)
     }
 
@@ -427,19 +435,26 @@ impl RuntimeReadModels {
         &self,
         records: Vec<WaitConditionRecord>,
     ) -> Result<Vec<WaitConditionRecord>> {
+        let mut timer = attribution::WAIT_FILTER.start();
+        timer.rows(records.len());
         let referenced_ids = records
             .iter()
             .filter_map(|record| record.work_item_id.clone())
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
-        let work_item_is_open = self
-            .runtime_db
-            .work_items()
-            .latest_many(&referenced_ids)?
-            .into_iter()
-            .map(|item| (item.id, item.state == WorkItemState::Open))
-            .collect::<BTreeMap<_, _>>();
+        let work_item_is_open = {
+            let mut lookup = attribution::WAIT_ITEM.start();
+            let items = self
+                .runtime_db
+                .work_items()
+                .latest_many(&referenced_ids)?;
+            lookup.rows(items.len());
+            items
+                .into_iter()
+                .map(|item| (item.id, item.state == WorkItemState::Open))
+                .collect::<BTreeMap<_, _>>()
+        };
         let mut live = Vec::new();
         for record in records {
             let Some(work_item_id) = record.work_item_id.as_deref() else {

--- a/src/storage/read_models.rs
+++ b/src/storage/read_models.rs
@@ -445,10 +445,7 @@ impl RuntimeReadModels {
             .collect::<Vec<_>>();
         let work_item_is_open = {
             let mut lookup = attribution::WAIT_ITEM.start();
-            let items = self
-                .runtime_db
-                .work_items()
-                .latest_many(&referenced_ids)?;
+            let items = self.runtime_db.work_items().latest_many(&referenced_ids)?;
             lookup.rows(items.len());
             items
                 .into_iter()


### PR DESCRIPTION
## Summary

- add content-free, process-global read-side attribution counters and optional trace output for SQLite connection/sidecar checks, work-queue projection, waits, per-item lookups, and agent-state locking/cloning
- add reproducible benchmarks for runtime DB, scheduler, HTTP control, lifecycle memory, and orthogonal read-side attribution cases
- add a fast CI performance gate plus an RFC documenting the measurement contract and limitations

The attribution benchmark isolates two priority amplification paths:

- 512 unrelated open FDs increased connection p50 from 0.222 ms to 8.261 ms, with nearly all added time in WAL/SHM sidecar FD scans
- 100 other-agent active waits increased work-queue p50 from 5.640 ms to 116.810 ms and caused 100 per-item lookups per projection read

Related to #2888. This PR supplies the diagnostic and reproducibility foundation; the runtime optimizations proposed there remain follow-up work.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --locked --all-targets`
- `cargo test --locked diagnostics::attribution::tests::`
- `HOLON_BENCH_SAMPLES=10 cargo bench --locked --bench performance_attribution`
- CI-equivalent fast performance gate: all 8 configured workloads passed after rebasing onto current `origin/main`

## Measurement scope

The measurements use warm local temporary SQLite databases with no provider or network traffic. Diagnostics are cumulative process-level counters; benchmark cases report snapshot deltas. See the RFC and #2888 for full results and limitations.
