### PR TITLE
perf: scope wait-condition loads to agent instead of full-table scans

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1070,11 +1070,10 @@ fn execution_protocol_settlement_transition_from_facts(
         }
         ExecutionBinding::Conversation { .. } | ExecutionBinding::AgentLifecycle { .. } => {
             let active_waits = storage
-                .latest_wait_conditions()?
+                .latest_wait_conditions_for_agent(&record.agent_id)?
                 .into_iter()
                 .filter(|wait| {
-                    wait.agent_id == record.agent_id
-                        && wait.work_item_id.is_none()
+                    wait.work_item_id.is_none()
                         && wait.turn_id.as_deref() == Some(terminal_turn.turn_id.as_str())
                         && wait.status == crate::types::WaitConditionStatus::Active
                 })
@@ -1151,11 +1150,10 @@ fn exact_task_result_wait_with_status(
     status_matches: impl Fn(&WaitConditionStatus) -> bool,
 ) -> Result<Option<WaitConditionRecord>> {
     let matching_waits = storage
-        .latest_wait_conditions()?
+        .latest_wait_conditions_for_agent(&message.agent_id)?
         .into_iter()
         .filter(|wait| {
-            wait.agent_id == message.agent_id
-                && wait.work_item_id.as_deref() == Some(work_item_id)
+            wait.work_item_id.as_deref() == Some(work_item_id)
                 && status_matches(&wait.status)
                 && wait.kind == crate::types::WaitConditionKind::Task
                 && wait.trigger_message_id() == Some(message.id.as_str())
@@ -1197,11 +1195,10 @@ fn exact_agent_scope_task_result_wait(
     task_id: &str,
 ) -> Result<Option<WaitConditionRecord>> {
     let matching_waits = storage
-        .latest_wait_conditions()?
+        .latest_wait_conditions_for_agent(&message.agent_id)?
         .into_iter()
         .filter(|wait| {
-            wait.agent_id == message.agent_id
-                && wait.work_item_id.is_none()
+            wait.work_item_id.is_none()
                 && matches!(
                     wait.status,
                     WaitConditionStatus::Triggered | WaitConditionStatus::Resolved
@@ -1301,11 +1298,10 @@ fn exact_task_result_claim_recovery(
         });
     }
     let matching_waits = storage
-        .latest_wait_conditions()?
+        .latest_wait_conditions_for_agent(&message.agent_id)?
         .into_iter()
         .filter(|wait| {
-            wait.agent_id == message.agent_id
-                && wait.work_item_id.as_deref() == Some(work_item_id)
+            wait.work_item_id.as_deref() == Some(work_item_id)
                 && matches!(
                     wait.status,
                     WaitConditionStatus::Resolved | WaitConditionStatus::Cancelled

--- a/src/runtime/repair.rs
+++ b/src/runtime/repair.rs
@@ -97,9 +97,9 @@ impl RuntimeHandle {
                 let current = self
                     .inner
                     .storage
-                    .latest_wait_conditions()?
+                    .latest_wait_conditions_for_agent(&agent_id)?
                     .into_iter()
-                    .find(|wait| wait.id == wait_id && wait.agent_id == agent_id)
+                    .find(|wait| wait.id == wait_id)
                     .ok_or_else(|| anyhow!("wait condition {wait_id} not found"))?;
                 if current.status != expected_status || current.updated_at != expected_updated_at {
                     bail!("wait condition {wait_id} changed before scheduler repair");

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -312,9 +312,8 @@ impl SchedulerProjection {
             waiting_work_item_projection.map(|item| item.scheduling_state);
         let active_wait_conditions = storage.active_wait_conditions_for_agent(&snapshot.id)?;
         let activation_waits = storage
-            .latest_wait_conditions()?
+            .latest_wait_conditions_for_agent(&snapshot.id)?
             .into_iter()
-            .filter(|condition| condition.agent_id == snapshot.id)
             .filter(|condition| {
                 condition.status == WaitConditionStatus::Active
                     || condition.status == WaitConditionStatus::Triggered

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -806,11 +806,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .runtime
             .inner
             .storage
-            .latest_wait_conditions()?
+            .latest_wait_conditions_for_agent(&message.agent_id)?
             .into_iter()
             .find(|condition| {
                 condition.id == *wait_id
-                    && condition.agent_id == message.agent_id
                     && condition.work_item_id.as_deref() == expected_work_item_id.as_deref()
             });
         if durable_wait.as_ref().is_none_or(|condition| {
@@ -890,11 +889,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 .runtime
                 .inner
                 .storage
-                .latest_wait_conditions()?
+                .latest_wait_conditions_for_agent(&message.agent_id)?
                 .into_iter()
                 .any(|condition| {
-                    condition.agent_id == message.agent_id
-                        && condition.work_item_id.as_deref() == Some(work_item_id.as_str())
+                    condition.work_item_id.as_deref() == Some(work_item_id.as_str())
                         && matches!(
                             condition.status,
                             crate::types::WaitConditionStatus::Active
@@ -922,11 +920,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             .runtime
             .inner
             .storage
-            .latest_wait_conditions()?
+            .latest_wait_conditions_for_agent(&message.agent_id)?
             .into_iter()
             .find(|condition| {
                 condition.id == wait.wait_id
-                    && condition.agent_id == message.agent_id
                     && condition.work_item_id.as_deref() == Some(work_item_id.as_str())
             });
         Ok(current_wait.is_none_or(|condition| {
@@ -1074,11 +1071,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     .runtime
                     .inner
                     .storage
-                    .latest_wait_conditions()?
+                    .latest_wait_conditions_for_agent(&message.agent_id)?
                     .into_iter()
                     .filter(|condition| {
-                        condition.agent_id == message.agent_id
-                            && condition.work_item_id.as_deref() == Some(work_item_id.as_str())
+                        condition.work_item_id.as_deref() == Some(work_item_id.as_str())
                             && condition.status == crate::types::WaitConditionStatus::Resolved
                             && condition.kind == crate::types::WaitConditionKind::Task
                             && scheduler::message_matches_wait_condition(message, condition)
@@ -1407,11 +1403,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     .runtime
                     .inner
                     .storage
-                    .latest_wait_conditions()?
+                    .latest_wait_conditions_for_agent(&message.agent_id)?
                     .into_iter()
                     .find(|condition| {
                         condition.id == *wait_id
-                            && condition.agent_id == message.agent_id
                             && condition.work_item_id.is_none()
                             && matches!(
                                 condition.status,

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -112,6 +112,64 @@ impl WorkItemRepository<'_> {
         rows.map(|row| decode_work_item_payload(&row?)).collect()
     }
 
+    /// All open work items for one agent. Open items are scheduler candidates,
+    /// so this set is naturally bounded by live scheduling state.
+    pub fn open_for_agent(&self, agent_id: &str) -> Result<Vec<WorkItemRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM work_items
+             WHERE agent_id = ?1 AND state = 'open'",
+        )?;
+        let rows = statement.query_map([agent_id], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_work_item_payload(&row?)).collect()
+    }
+
+    /// Most recent non-open work items for one agent, bounded by `limit`.
+    /// Projections only surface a small window of terminal history.
+    pub fn latest_non_open_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<WorkItemRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM work_items
+             WHERE agent_id = ?1 AND state != 'open'
+             ORDER BY updated_at DESC, created_at DESC, work_item_id ASC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_work_item_payload(&row?)).collect()
+    }
+
+    /// Batched lookup of work items by id, replacing per-id connections on
+    /// projection paths. Ids without a row are silently absent.
+    pub fn latest_many(&self, work_item_ids: &[String]) -> Result<Vec<WorkItemRecord>> {
+        let mut records = Vec::with_capacity(work_item_ids.len());
+        for chunk in work_item_ids.chunks(128) {
+            let placeholders = (0..chunk.len()).map(|_| "?").collect::<Vec<_>>().join(",");
+            let sql = format!(
+                "SELECT payload_json FROM work_items WHERE work_item_id IN ({placeholders})"
+            );
+            let connection = self.db.connection()?;
+            let mut statement = connection.prepare(&sql)?;
+            let params: Vec<&dyn rusqlite::ToSql> =
+                chunk.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
+            let rows = statement.query_map(params.as_slice(), |row| row.get::<_, String>(0))?;
+            records.extend(
+                rows.map(|row| decode_work_item_payload(&row?))
+                    .collect::<Result<Vec<_>>>()?,
+            );
+        }
+        Ok(records)
+    }
+
     pub fn latest_all(&self) -> Result<Vec<WorkItemRecord>> {
         let connection = self.db.connection()?;
         let mut statement = connection.prepare(
@@ -1787,6 +1845,28 @@ impl WaitConditionRepository<'_> {
              ORDER BY wait_condition_id ASC",
         )?;
         let rows = statement.query_map([], |row| {
+            decode_wait_condition_row(row).map_err(wait_condition_decode_error)
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))
+    }
+
+    /// All wait conditions for one agent, in the same id order as
+    /// [`WaitConditionRepository::latest_all`], so downstream filters and
+    /// `find` selections keep identical semantics while skipping the
+    /// full-table decode of every other agent's rows.
+    pub fn latest_for_agent(&self, agent_id: &str) -> Result<Vec<WaitConditionRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
+                subject_ref, waiting_for, created_at, updated_at, expires_at,
+                resolved_at, cancelled_at, last_turn_id, trigger_message_id, triggered_at,
+                wake_sources_json, continuation_json
+             FROM wait_conditions
+             WHERE agent_id = ?1
+             ORDER BY wait_condition_id ASC",
+        )?;
+        let rows = statement.query_map([agent_id], |row| {
             decode_wait_condition_row(row).map_err(wait_condition_decode_error)
         })?;
         rows.collect::<std::result::Result<Vec<_>, _>>()

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1137,6 +1137,17 @@ impl AppStorage {
         return runtime_db.wait_conditions().latest_all();
     }
 
+    /// Agent-scoped counterpart of [`AppStorage::latest_wait_conditions`].
+    /// Use this whenever the caller filters by agent id, so the repository can
+    /// skip decoding every other agent's wait conditions.
+    pub fn latest_wait_conditions_for_agent(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<WaitConditionRecord>> {
+        let runtime_db = self.runtime_db.clone();
+        return runtime_db.wait_conditions().latest_for_agent(agent_id);
+    }
+
     pub fn latest_external_triggers(&self) -> Result<Vec<ExternalTriggerRecord>> {
         let runtime_db = self.runtime_db.clone();
         if let Some(agent_id) = self.current_agent_id()? {
@@ -1257,6 +1268,7 @@ mod tests {
     use tempfile::tempdir;
     use tokio::sync::{broadcast, Notify};
 
+    use crate::storage::read_models::WORK_QUEUE_NON_OPEN_WINDOW;
     use chrono::Utc;
 
     fn truncate_to_millis(dt: DateTime<Utc>) -> DateTime<Utc> {
@@ -3421,6 +3433,106 @@ mod tests {
         );
         assert!(!completed.has_active_waits);
         assert!(!completed.has_active_task_waits);
+    }
+
+    #[test]
+    fn latest_wait_conditions_for_agent_matches_latest_all_filter() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let now = Utc::now();
+        // Respect the unresolved-owner uniqueness invariants: at most one
+        // active/triggered wait per agent without a work item, and at most one
+        // per (agent, work item).
+        for (id, agent_id, work_item_id, status) in [
+            ("wait-a", "default", None, WaitConditionStatus::Active),
+            ("wait-b", "other-agent", None, WaitConditionStatus::Active),
+            (
+                "wait-c",
+                "default",
+                Some("wi-default-1"),
+                WaitConditionStatus::Active,
+            ),
+            (
+                "wait-d",
+                "other-agent",
+                Some("wi-other-1"),
+                WaitConditionStatus::Resolved,
+            ),
+            (
+                "wait-e",
+                "default",
+                Some("wi-default-2"),
+                WaitConditionStatus::Cancelled,
+            ),
+        ] {
+            storage
+                .append_wait_condition(&WaitConditionRecord {
+                    id: id.into(),
+                    agent_id: agent_id.into(),
+                    work_item_id: work_item_id.map(Into::into),
+                    status,
+                    kind: WaitConditionKind::Task,
+                    source: None,
+                    subject_ref: Some("task-1".into()),
+                    waiting_for: "task result".into(),
+                    wake_sources: vec![WakeSource::TaskResult {
+                        task_id: "task-1".into(),
+                    }],
+                    continuation: None,
+                    created_at: now,
+                    updated_at: now,
+                    expires_at: None,
+                    resolved_at: None,
+                    cancelled_at: None,
+                    turn_id: None,
+                    trigger_message_id: None,
+                    triggered_at: None,
+                })
+                .unwrap();
+        }
+
+        let scoped_ids = storage
+            .latest_wait_conditions_for_agent("default")
+            .unwrap()
+            .into_iter()
+            .map(|wait| wait.id)
+            .collect::<Vec<_>>();
+        let filtered_ids = storage
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .filter(|wait| wait.agent_id == "default")
+            .map(|wait| wait.id)
+            .collect::<Vec<_>>();
+        assert_eq!(scoped_ids, vec!["wait-a", "wait-c", "wait-e"]);
+        assert_eq!(scoped_ids, filtered_ids);
+    }
+
+    #[test]
+    fn work_queue_projection_bounds_terminal_history_to_window() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let open = WorkItemRecord::new("default", "open item", WorkItemState::Open);
+        storage.append_work_item(&open).unwrap();
+        let total_terminal = WORK_QUEUE_NON_OPEN_WINDOW + 10;
+        for index in 0..total_terminal {
+            let mut completed = WorkItemRecord::new(
+                "default",
+                format!("completed {index}"),
+                WorkItemState::Completed,
+            );
+            completed.updated_at = Utc::now() + chrono::Duration::milliseconds(index as i64);
+            storage.append_work_item(&completed).unwrap();
+        }
+
+        let queue = storage.work_queue_read_model().unwrap();
+        let terminal_count = queue
+            .items
+            .iter()
+            .filter(|item| item.work_item.state != WorkItemState::Open)
+            .count();
+        assert_eq!(terminal_count, WORK_QUEUE_NON_OPEN_WINDOW);
+        assert!(queue.items.iter().any(|item| item.work_item.id == open.id));
     }
 
     #[test]

--- a/src/storage/read_models.rs
+++ b/src/storage/read_models.rs
@@ -22,6 +22,11 @@ use super::{
     },
 };
 
+/// Terminal work items retained in scheduling projections. Must cover the
+/// HTTP state bootstrap slice (`STATE_BOOTSTRAP_WORK_ITEM_LIMIT`) plus the
+/// small per-class windows the read model surfaces.
+pub(crate) const WORK_QUEUE_NON_OPEN_WINDOW: usize = 128;
+
 #[derive(Debug, Clone)]
 pub struct RuntimeReadModels {
     runtime_db: RuntimeDb,
@@ -42,10 +47,13 @@ impl RuntimeReadModels {
             .and_then(|agent| agent.current_work_item_id);
         let mut latest = HashMap::<String, WorkItemRecord>::new();
         if let Some(agent_id) = self.agent_id.as_deref() {
+            for record in self.runtime_db.work_items().open_for_agent(agent_id)? {
+                latest.insert(record.id.clone(), record);
+            }
             for record in self
                 .runtime_db
                 .work_items()
-                .latest_for_agent(agent_id, usize::MAX)?
+                .latest_non_open_for_agent(agent_id, WORK_QUEUE_NON_OPEN_WINDOW)?
             {
                 latest.insert(record.id.clone(), record);
             }
@@ -419,26 +427,29 @@ impl RuntimeReadModels {
         &self,
         records: Vec<WaitConditionRecord>,
     ) -> Result<Vec<WaitConditionRecord>> {
-        let mut work_item_is_open = BTreeMap::<String, bool>::new();
+        let referenced_ids = records
+            .iter()
+            .filter_map(|record| record.work_item_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let work_item_is_open = self
+            .runtime_db
+            .work_items()
+            .latest_many(&referenced_ids)?
+            .into_iter()
+            .map(|item| (item.id, item.state == WorkItemState::Open))
+            .collect::<BTreeMap<_, _>>();
         let mut live = Vec::new();
         for record in records {
             let Some(work_item_id) = record.work_item_id.as_deref() else {
                 live.push(record);
                 continue;
             };
-            let is_open = match work_item_is_open.get(work_item_id) {
-                Some(is_open) => *is_open,
-                None => {
-                    let is_open = self
-                        .runtime_db
-                        .work_items()
-                        .latest(work_item_id)?
-                        .is_some_and(|item| item.state == WorkItemState::Open);
-                    work_item_is_open.insert(work_item_id.to_string(), is_open);
-                    is_open
-                }
-            };
-            if is_open {
+            if work_item_is_open
+                .get(work_item_id)
+                .is_some_and(|is_open| *is_open)
+            {
                 live.push(record);
             }
         }


### PR DESCRIPTION
## Runtime concept

Wait-condition reads and the work-queue read model. This changes **where wait-condition state is loaded from**, not how waits are registered or settled: every load is now scoped by `agent_id` at the SQL layer, using the existing `idx_wait_conditions_agent_status(agent_id, status)` index.

## Why

Long-running Web GUI observation of the local daemon (15-min window) showed 139 `ERR_ABORTED` on `/api/agents/{id}/state` + snapshot, 572 slow (>2s) API calls, and 503s, with the daemon at 325%+ CPU / 6.1 GB RSS. Root cause chain:

- `WaitConditionRepository::latest_all()` loads **every** `wait_conditions` row (production: 28,315 rows, 99.9% terminal), JSON+RFC3339-decodes all of them, then filters by `agent_id` in memory. The same path is hit by `/state` polling (every 10s), scheduler ticks, and memory refresh.
- `filter_active_wait_conditions_for_live_scope` issues one `work_items().latest()` per distinct `work_item_id`, opening a new connection each time.
- `work_queue()` flows through `latest_for_agent(agent_id, usize::MAX)`, unbounded-loading all work items (including mass terminal history) per call.

This absorbs the overlapping proposals from #2888 (agent-scope wait-condition query, work-queue N+1).

## Changes

- `WaitConditionRepository::latest_for_agent(agent_id)`: all statuses, `ORDER BY wait_condition_id ASC` (same ordering contract as `latest_all`, so downstream filter/find selection order is unchanged), served by the existing index.
- `AppStorage::latest_wait_conditions_for_agent(agent_id)` wrapper.
- All production call sites that previously called `latest_all()` then filtered by agent (`runtime.rs`, `scheduler_executor.rs`, `scheduler.rs`, `repair.rs`) now use the scoped query; in-memory agent filters removed.
- `WorkItemRepository::latest_many(ids)`: chunked (≤128) `IN` query so `filter_active_wait_conditions_for_live_scope` resolves distinct work items in one batched query instead of per-id connections.
- `work_queue()` bounds terminal history to a recent window instead of `usize::MAX`, so turn-context/memory-refresh/scheduler-tick reads no longer derive scheduling classification over the full historical work-item set.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib`: 3102 passed, 0 failed (4 ignored) — includes new coverage:
  - `wait_condition_latest_for_agent_scopes_rows_and_preserves_order`
  - `latest_many_returns_latest_records_for_requested_ids`
  - `work_queue_projection_bounds_terminal_history_to_window`

Complements #2888 (storage-layer per-connection overhead); the non-overlapping parts there remain tracked separately.