### PR TITLE
fix: cap sidebar agent rows at two lines with summarized work objectives

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -54,6 +54,7 @@ import {
 import { useAgentDetail } from "../runtime/useAgentDetail";
 import { useRuntimeDashboard } from "../runtime/useRuntimeDashboard";
 import type { AgentSummary, DisplayLevel, RouteKey, RuntimeConnection, RuntimeConnectionConfig, RuntimeConnectionProfile } from "../runtime/types";
+import { truncateToWidth } from "../lib/utils";
 import { pushBrowserRoute, replaceBrowserRoute, routeFromLocation } from "./routes";
 
 const globalRoutes: Array<{ key: RouteKey; labelKey: string; icon: LucideIcon }> = [
@@ -65,6 +66,11 @@ const globalRoutes: Array<{ key: RouteKey; labelKey: string; icon: LucideIcon }>
 ];
 
 const APP_WINDOW_TITLE = "Holon";
+
+// Sidebar agent rows cap at two lines: the second line is either the current
+// work-item objective (width-truncated) or, when idle, the agent id for named
+// agents. 40 units ~= 40 latin or 20 CJK glyphs at the 11px meta font.
+const AGENT_ROW_SUMMARY_MAX_WIDTH = 40;
 
 export function App() {
   const { bootstrap, loading, refresh } = useRuntimeDashboard();
@@ -598,7 +604,7 @@ export function App() {
                 <button
                   className={`agent-row ${selectedAgentId === agent.id ? "is-selected" : ""} ${agent.lifecycle}`}
                   key={agent.id}
-                  title={`${agent.name ? `${agent.name} (${agent.id})` : agent.id} · ${agent.focusSummary} · ${status.title}`}
+                  title={`${agent.name ? `${agent.name} (${agent.id})` : agent.id} · ${agent.focusSummary} · ${status.title}${workSummary ? ` · ${workSummary}` : ""}`}
                   type="button"
                   onClick={() => navigateAgent(agent.id)}
                 >
@@ -623,11 +629,12 @@ export function App() {
                         <StatusDotIcon tone={status.tone} />
                       </span>
                     </span>
-                    {agent.name ? <small>{agent.id}</small> : null}
                     {workSummary ? (
                       <span className="agent-row-meta">
-                        <span>{workSummary}</span>
+                        <span>{truncateToWidth(workSummary, AGENT_ROW_SUMMARY_MAX_WIDTH)}</span>
                       </span>
+                    ) : agent.name ? (
+                      <small>{agent.id}</small>
                     ) : null}
                   </span>
                 </button>

--- a/web-gui/app/src/lib/utils.test.ts
+++ b/web-gui/app/src/lib/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { truncateToWidth } from "./utils";
+
+describe("truncateToWidth", () => {
+  it("keeps text that fits unchanged", () => {
+    expect(truncateToWidth("holon-web", 40)).toBe("holon-web");
+    expect(truncateToWidth("汉".repeat(20), 40)).toBe("汉".repeat(20));
+  });
+
+  it("truncates long latin text at the width limit", () => {
+    expect(truncateToWidth("a".repeat(45), 40)).toBe(`${"a".repeat(40)}…`);
+  });
+
+  it("counts CJK glyphs as double width", () => {
+    const output = truncateToWidth("汉".repeat(30), 40);
+    expect(output).toBe(`${"汉".repeat(20)}…`);
+  });
+
+  it("cuts mixed text at the combined width", () => {
+    const output = truncateToWidth(`${"汉".repeat(10)}${"a".repeat(30)}`, 40);
+    expect(output).toBe(`${"汉".repeat(10)}${"a".repeat(20)}…`);
+  });
+
+  it("trims trailing spaces before appending the ellipsis", () => {
+    expect(truncateToWidth(`${"a".repeat(39)} bbbbb`, 40)).toBe(`${"a".repeat(39)}…`);
+  });
+});

--- a/web-gui/app/src/lib/utils.ts
+++ b/web-gui/app/src/lib/utils.ts
@@ -1,3 +1,23 @@
 export function cn(...classes: Array<string | false | null | undefined>): string {
   return classes.filter(Boolean).join(" ");
 }
+
+// Width-aware truncation for compact one-line summaries: CJK and other wide
+// glyphs count as double so mixed-language text cuts at a similar rendered
+// width instead of a fixed character count.
+const WIDE_GLYPH = /[\u1100-\u115F\u2E80-\uA4CF\uAC00-\uD7A3\uF900-\uFAFF\uFE30-\uFE6F\uFF00-\uFF60\uFFE0-\uFFE6]/;
+
+export function truncateToWidth(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) {
+    return "";
+  }
+  const chars = Array.from(text);
+  let width = 0;
+  for (let index = 0; index < chars.length; index += 1) {
+    width += WIDE_GLYPH.test(chars[index]) ? 2 : 1;
+    if (width > maxWidth) {
+      return `${chars.slice(0, index).join("").trimEnd()}…`;
+    }
+  }
+  return text;
+}


### PR DESCRIPTION
## Summary
- Sidebar agent rows stacked three text lines once an agent had both a display name and a current work item (name / id / full objective). Row height grew to ~72-78px, the muted id line visually merged with the faint objective line of neighboring rows, and long objectives collapsed into meaningless CSS-truncated fragments — the sidebar's job of scanning to locate an agent got buried in detail-level text.
- Rows now cap at two lines with a mutually exclusive second line:
  - current work item → objective summarized by `truncateToWidth` (width-aware: CJK glyphs count double; 40 width units ≈ 40 latin / 20 CJK glyphs, sized to the 306px sidebar content area at the 11px meta font)
  - no work item + named agent → agent id (behavior kept from #2886)
  - unnamed agent → id already in the title line, no second line
- The full objective text remains available in the row tooltip.

Follow-up to #2886 (agent display name + id in sidebar).

## Verification
- `npm test`: 538 tests / 44 files passed, including new `lib/utils.test.ts` coverage for width-aware truncation.
- `npm run typecheck` and `npm run build` pass.
