### PR TITLE
fix: bound timer wake admission

### DIFF
--- a/docs/rfcs/scheduler-wait-state.md
+++ b/docs/rfcs/scheduler-wait-state.md
@@ -207,6 +207,24 @@ Blocked WorkItem `recheck_at` deadlines are not part of `WaitingTimer`; they
 remain `Blocked` and only create a fallback reminder for the owning agent to
 inspect the blocker.
 
+Timer wait registration and timer wake execution use a durable per-wake
+admission fence:
+
+- an active timer may accept a new wait normally
+- a completed one-shot timer may accept a wait only while its unique pending
+  wake is still valid
+- a cancelled timer, or a completed timer with no pending wake, cannot create
+  an unresolvable wait
+- queue dequeue alone is not authority to run; the queue claim, wait
+  resolution, timer-wake incorporation, and execution admission must commit
+  atomically
+
+Repeating timer ticks are coalesced while a prior wake remains pending
+execution admission. Once that wake is incorporated into an execution, a later
+fire may create one further pending wake. Cancellation invalidates only wakes
+that have not crossed this admission fence and does not abort an execution
+that already crossed it.
+
 ### WaitingSystem
 
 A WorkItem is waiting for a runtime-owned system tick when progress should

--- a/docs/rfcs/waiting-plane-and-reactivation.md
+++ b/docs/rfcs/waiting-plane-and-reactivation.md
@@ -140,6 +140,36 @@ than to:
 That is why `sleep_job` should not remain the long-term center of timer-based
 waiting semantics.
 
+### Timer Wake Delivery
+
+A timer fire records a clock fact, but its queued wake is a level-triggered
+reactivation hint rather than an obligation to execute one model turn per
+elapsed interval.
+
+The runtime therefore preserves these invariants:
+
+- each timer has at most one wake that is pending execution admission
+- a repeating timer may record additional fires while that wake is pending,
+  but those fires do not create an unbounded queue backlog
+- after one wake is admitted, a later fire may create one new pending wake, so
+  a running turn and one future wake can coexist
+- different timers are never coalesced with each other
+- `fire_count` counts actual timer fires, not queued messages or model turns
+
+Timer cancellation and execution admission compete through one durable wake
+fence. If cancellation wins, pending wakes for that timer become invalid and
+cannot start a new turn. If execution admission wins, cancellation does not
+interrupt the turn that has already started.
+
+A completed one-shot timer can still own one valid pending wake. A later
+`WaitFor(wake=timer)` registration may consume that wake immediately. A
+cancelled timer, or a completed timer whose wake was already consumed, must
+return a diagnostic instead of creating a wait that can never resolve.
+
+Recovery applies the same rules: retain at most one valid pending wake per
+timer, discard pending wakes for cancelled timers, and do not replay every
+historical fire.
+
 ## Callback-Backed Waiting
 
 Callback-backed waiting should also belong to the waiting plane.

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -1166,6 +1166,25 @@ fn prepare_runtime_storage(
     }
 
     storage.legacy_importer().import_runtime_domains()?;
+    let timer_wake_recovery = runtime_db
+        .timers()
+        .normalize_wakes_for_recovery(&agent_id)?;
+    if timer_wake_recovery.retained_wakes > 0
+        || timer_wake_recovery.created_wakes > 0
+        || timer_wake_recovery.invalidated_wakes > 0
+        || !timer_wake_recovery.dropped_message_ids.is_empty()
+    {
+        storage.append_event(&AuditEvent::legacy(
+            "timer_wakes_recovered",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "retained_wakes": timer_wake_recovery.retained_wakes,
+                "created_wakes": timer_wake_recovery.created_wakes,
+                "invalidated_wakes": timer_wake_recovery.invalidated_wakes,
+                "dropped_message_ids": timer_wake_recovery.dropped_message_ids,
+            }),
+        ))?;
+    }
 
     let snapshot = storage.recovery_snapshot(&agent_id)?;
     let mut queue = RuntimeQueue::default();

--- a/src/runtime/repair.rs
+++ b/src/runtime/repair.rs
@@ -136,6 +136,7 @@ impl RuntimeHandle {
                                 },
                             ],
                             wait_conditions: vec![cancelled],
+                            timer_wake: None,
                             agent_state: None,
                             audit_events: vec![AuditEvent::legacy(
                                 "scheduler_wait_repaired",

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -678,6 +678,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     &mut execution_protocol,
                     wait_transition.as_ref(),
                 )?;
+                let timer_wake_claim = timer_wake_claim_for_message(
+                    &self.runtime.inner.runtime_db,
+                    &persisted_message,
+                )?;
                 let mut attempt_audit_events = claim_audit_events.clone();
                 if let Some(wait_transition) = wait_transition.as_ref() {
                     attempt_audit_events.push(AuditEvent::legacy(
@@ -719,6 +723,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         },
                         &execution_protocol,
                         wait_transition.as_ref(),
+                        timer_wake_claim.as_ref(),
                     );
                 let mut commit = match commit_result {
                     Ok(commit) => commit,
@@ -1964,6 +1969,26 @@ impl<'a> SchedulerDecisionExecutor<'a> {
 
 pub(super) fn canonical_activation_id(message_id: &str) -> String {
     format!("activation:message:{message_id}")
+}
+
+fn timer_wake_claim_for_message(
+    runtime_db: &crate::runtime_db::RuntimeDb,
+    message: &MessageEnvelope,
+) -> Result<Option<crate::runtime_db::transitions::TimerWakeClaim>> {
+    let MessageOrigin::Timer { timer_id } = &message.origin else {
+        return Ok(None);
+    };
+    let Some(wake) = runtime_db.timers().pending_wake(timer_id)? else {
+        return Ok(None);
+    };
+    if wake.message_id != message.id {
+        return Ok(None);
+    }
+    Ok(Some(crate::runtime_db::transitions::TimerWakeClaim {
+        timer_id: timer_id.clone(),
+        message_id: message.id.clone(),
+        fire_count: wake.fire_count,
+    }))
 }
 
 fn scheduler_work_item_claim_conflict(error: &anyhow::Error) -> bool {

--- a/src/runtime/tests/timers.rs
+++ b/src/runtime/tests/timers.rs
@@ -243,3 +243,413 @@ async fn timer_message_binds_the_unique_matching_wait_work_item() {
     assert_eq!(message.work_item_id.as_deref(), Some(work.id.as_str()));
     assert_eq!(message.source_refs.get("timer_id"), Some(&timer.id));
 }
+
+#[tokio::test(start_paused = true)]
+async fn repeating_timer_coalesces_to_one_pending_wake() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let clock = controlled_clock();
+    let runtime = RuntimeHandle::new_with_clock(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("timer done")),
+        "default".into(),
+        context_config(),
+        clock,
+    )
+    .unwrap();
+    let mut timer = runtime
+        .schedule_timer(10_000, Some(10_000), Some("coalesced timer".into()))
+        .await
+        .unwrap();
+
+    for _ in 0..25 {
+        runtime.fire_timer_record(&mut timer).await.unwrap();
+    }
+
+    let persisted = runtime
+        .recent_timers(10)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|record| record.id == timer.id)
+        .unwrap();
+    assert_eq!(persisted.fire_count, 25);
+    let messages = runtime
+        .storage()
+        .read_recent_messages(100)
+        .unwrap()
+        .into_iter()
+        .filter(|message| {
+            matches!(
+                &message.origin,
+                MessageOrigin::Timer { timer_id } if timer_id == &timer.id
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(messages.len(), 1);
+    let wake = runtime
+        .inner
+        .runtime_db
+        .timers()
+        .pending_wake(&timer.id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(wake.message_id, messages[0].id);
+    assert_eq!(wake.fire_count, 1);
+    assert_eq!(runtime.agent_state().await.unwrap().pending, 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn cancelling_timer_drops_pending_wake_and_stale_fire_cannot_revive_it() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let clock = controlled_clock();
+    let runtime = RuntimeHandle::new_with_clock(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("timer done")),
+        "default".into(),
+        context_config(),
+        clock,
+    )
+    .unwrap();
+    let mut stale_timer = runtime
+        .schedule_timer(10_000, Some(10_000), Some("cancel timer".into()))
+        .await
+        .unwrap();
+    runtime.fire_timer_record(&mut stale_timer).await.unwrap();
+    let wake = runtime
+        .inner
+        .runtime_db
+        .timers()
+        .pending_wake(&stale_timer.id)
+        .unwrap()
+        .unwrap();
+
+    let cancelled = runtime.cancel_timer(&stale_timer.id).await.unwrap();
+    assert_eq!(cancelled.status, TimerStatus::Cancelled);
+    assert!(runtime
+        .inner
+        .runtime_db
+        .timers()
+        .pending_wake(&stale_timer.id)
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(&wake.message_id)
+            .unwrap()
+            .unwrap()
+            .status,
+        QueueEntryStatus::Dropped
+    );
+    assert_eq!(runtime.agent_state().await.unwrap().pending, 0);
+
+    runtime.fire_timer_record(&mut stale_timer).await.unwrap();
+    let persisted = runtime
+        .recent_timers(10)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|record| record.id == stale_timer.id)
+        .unwrap();
+    assert_eq!(persisted.status, TimerStatus::Cancelled);
+    assert_eq!(persisted.fire_count, 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn completed_one_shot_wait_binds_existing_pending_wake() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let clock = controlled_clock();
+    let provider = Arc::new(CountingProvider {
+        calls: Mutex::new(0),
+        reply: "timer handled",
+    });
+    let runtime = RuntimeHandle::new_with_clock(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        context_config(),
+        clock,
+    )
+    .unwrap();
+    let work = runtime
+        .create_work_item("late timer wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work.id.clone()).await.unwrap();
+    let mut work_message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "run before late timer wait".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    bind_autonomous_work_queue_tick(&mut work_message, &work, "continue_active");
+    work_message.turn_id = Some("turn-late-one-shot-wait".into());
+    let work_message = runtime.enqueue(work_message).await.unwrap();
+    assert!(matches!(
+        scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+            .poll()
+            .await
+            .unwrap(),
+        scheduler_executor::RunLoopPoll::Message(_)
+    ));
+
+    let mut timer = runtime
+        .schedule_timer(10_000, None, Some("one shot".into()))
+        .await
+        .unwrap();
+    runtime.fire_timer_record(&mut timer).await.unwrap();
+    let wake = runtime
+        .inner
+        .runtime_db
+        .timers()
+        .pending_wake(&timer.id)
+        .unwrap()
+        .unwrap();
+
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work.id.clone()),
+            WaitForWakeKind::Timer,
+            Some(timer.id.clone()),
+            "wait registered after fire".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        registration.condition.status,
+        WaitConditionStatus::Triggered
+    );
+    assert_eq!(
+        registration.condition.trigger_message_id(),
+        Some(wake.message_id.as_str())
+    );
+
+    finish_claimed_test_run(&runtime).await;
+    let terminal = terminal_transition(&work_message, Some(&work.id));
+    runtime
+        .commit_queue_terminal_settlement(
+            QueueEntryRecord {
+                message_id: work_message.id.clone(),
+                agent_id: work_message.agent_id.clone(),
+                priority: work_message.priority,
+                status: QueueEntryStatus::Processed,
+                created_at: work_message.created_at,
+                updated_at: Utc::now(),
+            },
+            Vec::new(),
+            true,
+            Some(&terminal),
+        )
+        .await
+        .unwrap();
+    let runtime_task = tokio::spawn(runtime.clone().run());
+    wait_for_audit_events(
+        &runtime,
+        200,
+        |events| {
+            events.iter().any(|event| {
+                event.kind == "queue_entry_settled"
+                    && event.data["message_id"] == wake.message_id.as_str()
+            })
+        },
+        "late one-shot timer wait settlement",
+    )
+    .await;
+    runtime_task.abort();
+
+    assert_eq!(provider.call_count().await, 1);
+    let condition = runtime
+        .storage()
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| condition.id == registration.condition.id)
+        .unwrap();
+    assert_eq!(condition.status, WaitConditionStatus::Resolved);
+    let work = runtime
+        .inner
+        .runtime_db
+        .work_items()
+        .latest(&work.id)
+        .unwrap()
+        .unwrap();
+    assert!(work.blocked_by.is_none());
+}
+
+#[tokio::test(start_paused = true)]
+async fn recovery_normalizes_legacy_timer_backlog_idempotently() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let clock = controlled_clock();
+    let now = clock.now();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
+    let active_timer = TimerRecord {
+        id: "legacy-active-timer".into(),
+        agent_id: "default".into(),
+        created_at: now,
+        duration_ms: 10_000,
+        interval_ms: Some(10_000),
+        repeat: true,
+        status: TimerStatus::Active,
+        summary: Some("legacy active".into()),
+        next_fire_at: Some(now + chrono::Duration::seconds(10)),
+        last_fired_at: Some(now),
+        fire_count: 3,
+    };
+    let cancelled_timer = TimerRecord {
+        id: "legacy-cancelled-timer".into(),
+        status: TimerStatus::Cancelled,
+        next_fire_at: None,
+        summary: Some("legacy cancelled".into()),
+        ..active_timer.clone()
+    };
+    storage.append_timer(&active_timer).unwrap();
+    storage.append_timer(&cancelled_timer).unwrap();
+
+    let mut active_message_ids = Vec::new();
+    let mut cancelled_message_ids = Vec::new();
+    for (timer, ids) in [
+        (&active_timer, &mut active_message_ids),
+        (&cancelled_timer, &mut cancelled_message_ids),
+    ] {
+        for _ in 0..3 {
+            let message = MessageEnvelope {
+                metadata: Some(serde_json::json!({ "timer_id": timer.id })),
+                ..MessageEnvelope::new(
+                    "default",
+                    MessageKind::TimerTick,
+                    MessageOrigin::Timer {
+                        timer_id: timer.id.clone(),
+                    },
+                    AuthorityClass::RuntimeInstruction,
+                    Priority::Next,
+                    MessageBody::Text {
+                        text: "legacy timer tick".into(),
+                    },
+                )
+                .with_admission(
+                    MessageDeliverySurface::TimerScheduler,
+                    AdmissionContext::RuntimeOwned,
+                )
+            };
+            storage.append_message(&message).unwrap();
+            storage
+                .append_queue_entry(&QueueEntryRecord {
+                    message_id: message.id.clone(),
+                    agent_id: "default".into(),
+                    priority: Priority::Next,
+                    status: QueueEntryStatus::Queued,
+                    created_at: message.created_at,
+                    updated_at: message.created_at,
+                })
+                .unwrap();
+            ids.push(message.id);
+        }
+    }
+
+    let make_runtime = || {
+        RuntimeHandle::new_with_clock(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(StubProvider::new("timer done")),
+            "default".into(),
+            context_config(),
+            clock.clone(),
+        )
+        .unwrap()
+    };
+    let runtime = make_runtime();
+    let active_statuses = active_message_ids
+        .iter()
+        .map(|message_id| {
+            runtime
+                .inner
+                .runtime_db
+                .queue_entries()
+                .latest(message_id)
+                .unwrap()
+                .unwrap()
+                .status
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        active_statuses
+            .iter()
+            .filter(|status| **status == QueueEntryStatus::Queued)
+            .count(),
+        1
+    );
+    assert_eq!(
+        active_statuses
+            .iter()
+            .filter(|status| **status == QueueEntryStatus::Dropped)
+            .count(),
+        2
+    );
+    assert!(cancelled_message_ids.iter().all(|message_id| {
+        runtime
+            .inner
+            .runtime_db
+            .queue_entries()
+            .latest(message_id)
+            .unwrap()
+            .unwrap()
+            .status
+            == QueueEntryStatus::Dropped
+    }));
+    let wake = runtime
+        .inner
+        .runtime_db
+        .timers()
+        .pending_wake(&active_timer.id)
+        .unwrap()
+        .unwrap();
+    assert!(active_message_ids.contains(&wake.message_id));
+    assert!(runtime
+        .inner
+        .runtime_db
+        .timers()
+        .pending_wake(&cancelled_timer.id)
+        .unwrap()
+        .is_none());
+    assert_eq!(runtime.agent_state().await.unwrap().pending, 1);
+
+    let recovered_again = make_runtime();
+    let wake_again = recovered_again
+        .inner
+        .runtime_db
+        .timers()
+        .pending_wake(&active_timer.id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(wake_again.message_id, wake.message_id);
+    assert_eq!(recovered_again.agent_state().await.unwrap().pending, 1);
+}

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -273,27 +273,42 @@ impl RuntimeHandle {
         }
 
         let now = self.now();
-        let timer_wake_at = if wake == WaitForWakeKind::Timer {
-            let timer_id = wait_resource_required(wake, resource.clone())?;
-            let timer = self
-                .inner
-                .storage
-                .latest_timer_record(&timer_id)?
-                .ok_or_else(|| anyhow!("wait_for timer does not exist: {timer_id}"))?;
-            if timer.agent_id != agent_id {
-                return Err(anyhow!("wait_for timer agent mismatch: {timer_id}"));
-            }
-            if timer.status != TimerStatus::Active {
-                return Err(anyhow!("wait_for timer is not active: {timer_id}"));
-            }
-            Some(
-                timer
-                    .next_fire_at
-                    .ok_or_else(|| anyhow!("wait_for timer has no next fire time: {timer_id}"))?,
-            )
-        } else {
-            None
-        };
+        let mut pending_timer_wake = None;
+        let timer_wake_at =
+            if wake == WaitForWakeKind::Timer {
+                let timer_id = wait_resource_required(wake, resource.clone())?;
+                let timer = self
+                    .inner
+                    .storage
+                    .latest_timer_record(&timer_id)?
+                    .ok_or_else(|| anyhow!("wait_for timer does not exist: {timer_id}"))?;
+                if timer.agent_id != agent_id {
+                    return Err(anyhow!("wait_for timer agent mismatch: {timer_id}"));
+                }
+                match timer.status {
+                    TimerStatus::Active => Some(timer.next_fire_at.ok_or_else(|| {
+                        anyhow!("wait_for timer has no next fire time: {timer_id}")
+                    })?),
+                    TimerStatus::Completed => {
+                        let timer_wake = self
+                            .inner
+                            .runtime_db
+                            .timers()
+                            .pending_wake(&timer_id)?
+                            .ok_or_else(|| {
+                                anyhow!("wait_for timer wake was already consumed: {timer_id}")
+                            })?;
+                        let wake_at = timer_wake.created_at;
+                        pending_timer_wake = Some(timer_wake);
+                        Some(wake_at)
+                    }
+                    TimerStatus::Cancelled => {
+                        return Err(anyhow!("wait_for timer is cancelled: {timer_id}"))
+                    }
+                }
+            } else {
+                None
+            };
         let external_trigger_id = if wake == WaitForWakeKind::External {
             self.inner
                 .runtime_db
@@ -420,7 +435,7 @@ impl RuntimeHandle {
             work_item = Some(updated);
         }
 
-        let condition = WaitConditionRecord {
+        let mut condition = WaitConditionRecord {
             id: crate::ids::wait_condition_id(),
             agent_id: agent_id.to_string(),
             work_item_id: work_item_id.clone(),
@@ -451,6 +466,9 @@ impl RuntimeHandle {
             trigger_message_id: None,
             triggered_at: None,
         };
+        if let Some(timer_wake) = pending_timer_wake.as_ref() {
+            condition.mark_triggered(&timer_wake.message_id, now);
+        }
         wait_conditions.push(condition.clone());
         audit_events.extend(
             self.inner
@@ -478,6 +496,13 @@ impl RuntimeHandle {
             work_items,
             expected_wait_conditions: Vec::new(),
             wait_conditions,
+            timer_wake: pending_timer_wake.as_ref().map(|wake| {
+                crate::runtime_db::transitions::TimerWakeClaim {
+                    timer_id: wake.timer_id.clone(),
+                    message_id: wake.message_id.clone(),
+                    fire_count: wake.fire_count,
+                }
+            }),
             agent_state: committed_agent_state.map(|record| {
                 crate::runtime_db::transitions::AgentStateMutation {
                     expected: Some(Box::new(expected_state)),
@@ -529,6 +554,21 @@ impl RuntimeHandle {
                             return Err(error);
                         }
                         expected_task = Some(task_expectation(&task));
+                    }
+                    Err(error)
+                        if pending_timer_wake.is_some()
+                            && error
+                                .downcast_ref::<crate::runtime_db::RuntimeStateTransitionConflict>()
+                                .is_some_and(|conflict| conflict.domain() == "timer_wait") =>
+                    {
+                        let timer_id = pending_timer_wake
+                            .as_ref()
+                            .expect("pending timer wake exists")
+                            .timer_id
+                            .as_str();
+                        return Err(anyhow!(
+                            "wait_for timer wake was already consumed: {timer_id}"
+                        ));
                     }
                     Err(error) => return Err(error),
                 }
@@ -1184,48 +1224,110 @@ impl RuntimeHandle {
     }
 
     pub async fn cancel_timer(&self, timer_id: &str) -> Result<TimerRecord> {
-        let mut timer = self
-            .inner
-            .storage
-            .latest_timer_record(timer_id)?
-            .ok_or_else(|| {
-                RuntimeError::not_found("timer_not_found", format!("timer {timer_id} not found"))
+        let agent_id = self.agent_id().await?;
+        for attempt in 0..super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
+            let expected = self
+                .inner
+                .storage
+                .latest_timer_record(timer_id)?
+                .ok_or_else(|| {
+                    RuntimeError::not_found(
+                        "timer_not_found",
+                        format!("timer {timer_id} not found"),
+                    )
                     .with_safe_context("timer_id", timer_id)
-            })?;
-        if timer.agent_id != self.agent_id().await? {
-            return Err(RuntimeError::not_found(
-                "timer_not_found",
-                format!("timer {timer_id} not found"),
-            )
-            .with_safe_context("timer_id", timer_id)
-            .into());
-        }
-        match timer.status {
-            TimerStatus::Cancelled => return Ok(timer),
-            TimerStatus::Completed => {
-                return Err(RuntimeError::validation(
-                    "timer_completed",
-                    format!("cannot cancel completed timer {timer_id}"),
+                })?;
+            if expected.agent_id != agent_id {
+                return Err(RuntimeError::not_found(
+                    "timer_not_found",
+                    format!("timer {timer_id} not found"),
                 )
                 .with_safe_context("timer_id", timer_id)
-                .into())
+                .into());
             }
-            TimerStatus::Active => {}
-        }
+            match expected.status {
+                TimerStatus::Cancelled => return Ok(expected),
+                TimerStatus::Completed => {
+                    return Err(RuntimeError::validation(
+                        "timer_completed",
+                        format!("cannot cancel completed timer {timer_id}"),
+                    )
+                    .with_safe_context("timer_id", timer_id)
+                    .into())
+                }
+                TimerStatus::Active => {}
+            }
 
-        timer.status = TimerStatus::Cancelled;
-        timer.next_fire_at = None;
-        self.record_timer_projection(&timer).await?;
-        self.inner.storage.append_event(&AuditEvent::legacy(
-            "timer_cancelled",
-            serde_json::json!({
-                "timer_id": timer.id,
-                "status": timer.status,
-                "fire_count": timer.fire_count,
-            }),
-        ))?;
-        self.inner.notify.notify_waiters();
-        Ok(timer)
+            let pending_wake = self.inner.runtime_db.timers().pending_wake(timer_id)?;
+            let mut timer = expected.clone();
+            timer.status = TimerStatus::Cancelled;
+            timer.next_fire_at = None;
+
+            let mut guard = self.inner.agent.lock().await;
+            let pending_message_in_memory = pending_wake.as_ref().is_some_and(|wake| {
+                guard
+                    .queue
+                    .peek_next_matching(|message| message.id == wake.message_id)
+                    .is_some()
+            });
+            let expected_state = guard.last_persisted_state.clone();
+            let mut committed_state = guard.state.clone();
+            committed_state.pending = guard
+                .queue
+                .len()
+                .saturating_sub(usize::from(pending_message_in_memory));
+            let command = crate::runtime_db::TimerCancel {
+                expected,
+                record: timer.clone(),
+                agent_state: pending_wake
+                    .as_ref()
+                    .map(|_| (expected_state, committed_state.clone())),
+            };
+            match self.inner.runtime_db.timers().cancel(&command) {
+                Ok(result) if result.cancelled => {
+                    if let Some(message_id) = result.dropped_message_id.as_deref() {
+                        guard
+                            .queue
+                            .pop_next_matching(|message| message.id == message_id);
+                    }
+                    if pending_wake.is_some() {
+                        guard.state = committed_state.clone();
+                        guard.last_persisted_state = committed_state;
+                    }
+                    drop(guard);
+                    self.inner
+                        .projection_cache
+                        .lock()
+                        .await
+                        .upsert_timer(timer.clone());
+                    self.inner.storage.append_event(&AuditEvent::legacy(
+                        "timer_cancelled",
+                        serde_json::json!({
+                            "timer_id": timer.id,
+                            "status": timer.status,
+                            "fire_count": timer.fire_count,
+                            "dropped_message_id": result.dropped_message_id,
+                        }),
+                    ))?;
+                    self.inner.notify.notify_waiters();
+                    return Ok(timer);
+                }
+                Ok(_) => {
+                    drop(guard);
+                    continue;
+                }
+                Err(error) => {
+                    drop(guard);
+                    let can_retry = attempt + 1 < super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
+                        && super::retryable_enqueue_conflict(&error, &agent_id)
+                        && self.refresh_enqueue_agent_state_baseline(&agent_id).await?;
+                    if !can_retry {
+                        return Err(error);
+                    }
+                }
+            }
+        }
+        unreachable!("timer cancellation attempts always return or retry")
     }
 
     pub(crate) async fn recover_active_timers(&self, timers: Vec<TimerRecord>) -> Result<()> {
@@ -1281,20 +1383,40 @@ impl RuntimeHandle {
         Ok(())
     }
 
-    async fn fire_timer_record(&self, timer: &mut TimerRecord) -> Result<()> {
-        if let Some(latest) = self.inner.storage.latest_timer_record(&timer.id)? {
-            if latest.status != TimerStatus::Active {
-                *timer = latest;
-                return Ok(());
-            }
+    pub(super) async fn fire_timer_record(&self, timer: &mut TimerRecord) -> Result<()> {
+        let expected = self
+            .inner
+            .storage
+            .latest_timer_record(&timer.id)?
+            .unwrap_or_else(|| timer.clone());
+        if expected.status != TimerStatus::Active {
+            *timer = expected;
+            return Ok(());
         }
-
         let scheduled_fire_at = timer.next_fire_at;
         let work_item_id = self
             .wait_condition_work_item_id_for_timer(&timer.id)
             .await?;
+        let fired_at = self.now();
+        let mut record = expected.clone();
+        record.last_fired_at = Some(fired_at);
+        record.fire_count += 1;
+        if let Some(interval_ms) = record.interval_ms {
+            record.status = TimerStatus::Active;
+            record.next_fire_at = Some(next_repeating_fire_at(
+                scheduled_fire_at.unwrap_or(fired_at),
+                fired_at,
+                interval_ms,
+            )?);
+        } else {
+            record.status = TimerStatus::Completed;
+            record.next_fire_at = None;
+        }
         let mut message = MessageEnvelope {
-            metadata: Some(serde_json::json!({ "timer_id": timer.id })),
+            metadata: Some(serde_json::json!({
+                "timer_id": timer.id,
+                "timer_fire_count": record.fire_count,
+            })),
             ..MessageEnvelope::new(
                 timer.agent_id.clone(),
                 MessageKind::TimerTick,
@@ -1316,37 +1438,90 @@ impl RuntimeHandle {
             )
         };
         message.work_item_id = work_item_id;
+        message.turn_id = Some(crate::ids::turn_id());
         message
             .source_refs
             .insert("timer_id".into(), timer.id.clone());
-        self.enqueue(message).await?;
+        message.normalize_admission_fields();
 
-        let fired_at = self.now();
-        timer.last_fired_at = Some(fired_at);
-        timer.fire_count += 1;
-        if let Some(interval_ms) = timer.interval_ms {
-            timer.status = TimerStatus::Active;
-            timer.next_fire_at = Some(next_repeating_fire_at(
-                scheduled_fire_at.unwrap_or(fired_at),
-                fired_at,
-                interval_ms,
-            )?);
-        } else {
-            timer.status = TimerStatus::Completed;
-            timer.next_fire_at = None;
+        for attempt in 0..super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
+            let mut guard = self.inner.agent.lock().await;
+            let expected_state = guard.last_persisted_state.clone();
+            let mut committed_state = guard.state.clone();
+            committed_state.pending = guard.queue.len().saturating_add(1);
+            committed_state.last_wake_reason = Some(format!("{:?}", message.kind));
+            committed_state.total_message_count =
+                self.inner.storage.count_messages()?.saturating_add(1);
+            scheduler::apply_message_wake_projection(&mut committed_state);
+            let result = self
+                .inner
+                .runtime_db
+                .timers()
+                .fire(&crate::runtime_db::TimerFire {
+                    expected: expected.clone(),
+                    record: record.clone(),
+                    message: message.clone(),
+                    queue_entry: QueueEntryRecord {
+                        message_id: message.id.clone(),
+                        agent_id: message.agent_id.clone(),
+                        priority: message.priority.clone(),
+                        status: QueueEntryStatus::Queued,
+                        created_at: message.created_at,
+                        updated_at: fired_at,
+                    },
+                    agent_state: (expected_state, committed_state.clone()),
+                });
+            match result {
+                Ok(result) if result.advanced => {
+                    if let Some(message) = result.message {
+                        guard.queue.push(message);
+                        guard.state = committed_state.clone();
+                        guard.last_persisted_state = committed_state;
+                    }
+                    drop(guard);
+                    self.inner
+                        .projection_cache
+                        .lock()
+                        .await
+                        .upsert_timer(record.clone());
+                    *timer = record.clone();
+                    self.inner.storage.append_event(&AuditEvent::legacy(
+                        "timer_fired",
+                        serde_json::json!({
+                            "timer_id": timer.id,
+                            "summary": timer.summary.clone(),
+                            "status": timer.status,
+                            "fire_count": timer.fire_count,
+                            "next_fire_at": timer.next_fire_at,
+                            "wake_created": result.wake_created,
+                        }),
+                    ))?;
+                    if result.wake_created {
+                        self.inner.notify.notify_one();
+                    }
+                    return Ok(());
+                }
+                Ok(_) => {
+                    drop(guard);
+                    if let Some(latest) = self.inner.storage.latest_timer_record(&timer.id)? {
+                        *timer = latest;
+                    }
+                    return Ok(());
+                }
+                Err(error) => {
+                    drop(guard);
+                    let can_retry = attempt + 1 < super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS
+                        && super::retryable_enqueue_conflict(&error, &record.agent_id)
+                        && self
+                            .refresh_enqueue_agent_state_baseline(&record.agent_id)
+                            .await?;
+                    if !can_retry {
+                        return Err(error);
+                    }
+                }
+            }
         }
-        self.record_timer_projection(timer).await?;
-        self.inner.storage.append_event(&AuditEvent::legacy(
-            "timer_fired",
-            serde_json::json!({
-                "timer_id": timer.id,
-                "summary": timer.summary.clone(),
-                "status": timer.status,
-                "fire_count": timer.fire_count,
-                "next_fire_at": timer.next_fire_at,
-            }),
-        ))?;
-        Ok(())
+        unreachable!("timer fire attempts always return or retry")
     }
 
     pub async fn latest_external_triggers(&self) -> Result<Vec<ExternalTriggerRecord>> {
@@ -1769,6 +1944,7 @@ impl RuntimeHandle {
                 work_items,
                 expected_wait_conditions: Vec::new(),
                 wait_conditions: resolved_conditions,
+                timer_wake: None,
                 agent_state: None,
                 audit_events,
                 index_changes,

--- a/src/runtime_db/agent_relations/tests.rs
+++ b/src/runtime_db/agent_relations/tests.rs
@@ -682,7 +682,7 @@ fn backfill_report_does_not_migrate_and_apply_can_record_pre_migration_backup() 
         5,
         Some(backup_path.clone()),
     )?;
-    assert_eq!(migrated.current_schema_version()?, 61);
+    assert_eq!(migrated.current_schema_version()?, 62);
     assert_eq!(applied.backup_path.as_deref(), Some(backup_path.as_str()));
     Ok(())
 }

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3455,6 +3455,25 @@ CREATE INDEX IF NOT EXISTS idx_agent_relation_backfill_outcomes_agent
   ON agent_relation_backfill_outcomes(agent_id, updated_at);
 "#,
     },
+    Migration {
+        version: 62,
+        name: "durable_timer_wakes",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS timer_wakes (
+  timer_id TEXT NOT NULL REFERENCES timers(timer_id),
+  message_id TEXT NOT NULL UNIQUE,
+  fire_count INTEGER NOT NULL CHECK (fire_count > 0),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'incorporated', 'cancelled')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  incorporated_at TEXT,
+  cancelled_at TEXT,
+  PRIMARY KEY (timer_id, message_id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_timer_wakes_one_pending_per_timer
+  ON timer_wakes(timer_id) WHERE status = 'pending';
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -63,9 +63,11 @@ pub use crate::runtime_db::types::{
     ContextEpisodeRepository, EvidenceRepository, ExecutionRootEntryRepository,
     ExternalTriggerRepository, MessageRepository, OperatorDeliveryRepository,
     OperatorNotificationRepository, OperatorTransportBindingRepository, QueueEntryRepository,
-    TaskRepository, TimerRepository, TranscriptRepository, TurnRecordRepository,
-    WaitConditionRepository, WorkItemContinuationRepository, WorkItemDelegationRepository,
-    WorkItemRepository, WorkspaceEntryRepository, WorkspaceOccupancyRepository,
+    TaskRepository, TimerCancel, TimerCancelResult, TimerFire, TimerFireResult, TimerRepository,
+    TimerWakeRecord, TimerWakeRecoveryResult, TimerWakeStatus, TranscriptRepository,
+    TurnRecordRepository, WaitConditionRepository, WorkItemContinuationRepository,
+    WorkItemDelegationRepository, WorkItemRepository, WorkspaceEntryRepository,
+    WorkspaceOccupancyRepository,
 };
 #[cfg(test)]
 mod tests;

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -2079,6 +2079,352 @@ impl QueueEntryRepository<'_> {
 }
 
 impl TimerRepository<'_> {
+    pub fn pending_wake(&self, timer_id: &str) -> Result<Option<TimerWakeRecord>> {
+        let connection = self.db.connection()?;
+        let row = connection
+            .query_row(
+                "SELECT timer_id, message_id, fire_count, status, created_at, updated_at,
+                        incorporated_at, cancelled_at
+                 FROM timer_wakes
+                 WHERE timer_id = ?1 AND status = 'pending'",
+                [timer_id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, String>(5)?,
+                        row.get::<_, Option<String>>(6)?,
+                        row.get::<_, Option<String>>(7)?,
+                    ))
+                },
+            )
+            .optional()?;
+        row.map(
+            |(
+                timer_id,
+                message_id,
+                fire_count,
+                created_at,
+                updated_at,
+                incorporated_at,
+                cancelled_at,
+            )| {
+                Ok(TimerWakeRecord {
+                    timer_id,
+                    message_id,
+                    fire_count: u64::try_from(fire_count)
+                        .context("timer wake fire_count is negative")?,
+                    status: TimerWakeStatus::Pending,
+                    created_at: parse_timestamp(&created_at)?,
+                    updated_at: parse_timestamp(&updated_at)?,
+                    incorporated_at: incorporated_at
+                        .map(|value| parse_timestamp(&value))
+                        .transpose()?,
+                    cancelled_at: cancelled_at
+                        .map(|value| parse_timestamp(&value))
+                        .transpose()?,
+                })
+            },
+        )
+        .transpose()
+    }
+
+    pub fn normalize_wakes_for_recovery(&self, agent_id: &str) -> Result<TimerWakeRecoveryResult> {
+        self.db.transaction(|tx| {
+            let live_messages = {
+                let mut statement = tx.prepare(
+                    "SELECT q.payload_json, m.payload_json
+                     FROM queue_entries q
+                     JOIN messages m ON m.message_id = q.message_id
+                     WHERE q.agent_id = ?1 AND q.status IN ('queued', 'interrupted')
+                     ORDER BY q.created_at ASC, q.message_id ASC",
+                )?;
+                let rows = statement.query_map([agent_id], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?;
+                rows.map(|row| {
+                    let (queue_payload, message_payload) = row?;
+                    Ok((
+                        decode_queue_entry_payload(&queue_payload)?,
+                        decode_message_payload(&message_payload)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?
+            };
+            let pending_wakes = {
+                let mut statement = tx.prepare(
+                    "SELECT w.timer_id, w.message_id, w.fire_count
+                     FROM timer_wakes w
+                     JOIN timers t ON t.timer_id = w.timer_id
+                     WHERE t.agent_id = ?1 AND w.status = 'pending'",
+                )?;
+                let rows = statement.query_map([agent_id], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                })?;
+                rows.collect::<std::result::Result<Vec<_>, _>>()?
+            };
+
+            let mut result = TimerWakeRecoveryResult::default();
+            let mut wakes_by_timer = pending_wakes
+                .into_iter()
+                .map(|(timer_id, message_id, fire_count)| (timer_id, (message_id, fire_count)))
+                .collect::<BTreeMap<_, _>>();
+            let mut messages_by_timer =
+                BTreeMap::<String, Vec<(QueueEntryRecord, MessageEnvelope)>>::new();
+            for (entry, message) in live_messages {
+                let MessageOrigin::Timer { timer_id } = &message.origin else {
+                    continue;
+                };
+                messages_by_timer
+                    .entry(timer_id.clone())
+                    .or_default()
+                    .push((entry, message));
+            }
+
+            for (timer_id, messages) in messages_by_timer {
+                let timer = timer_tx(tx, &timer_id)?;
+                let timer_accepts_wake = timer.as_ref().is_some_and(|timer| {
+                    matches!(timer.status, TimerStatus::Active | TimerStatus::Completed)
+                });
+                let existing_wake = wakes_by_timer.remove(&timer_id);
+                let keep_index = if timer_accepts_wake {
+                    existing_wake
+                        .as_ref()
+                        .and_then(|(message_id, _)| {
+                            messages
+                                .iter()
+                                .position(|(_, message)| message.id == *message_id)
+                        })
+                        .or(Some(0))
+                } else {
+                    None
+                };
+
+                for (index, (mut entry, _)) in messages.iter().cloned().enumerate() {
+                    if Some(index) == keep_index {
+                        continue;
+                    }
+                    entry.status = QueueEntryStatus::Dropped;
+                    entry.updated_at = Utc::now();
+                    upsert_queue_entry_tx(tx, &entry)?;
+                    result.dropped_message_ids.push(entry.message_id);
+                }
+
+                match keep_index {
+                    Some(index) => {
+                        let (entry, message) = &messages[index];
+                        if existing_wake
+                            .as_ref()
+                            .is_some_and(|(message_id, _)| message_id == &message.id)
+                        {
+                            result.retained_wakes += 1;
+                            continue;
+                        }
+                        if existing_wake.is_some() {
+                            result.invalidated_wakes += tx.execute(
+                                "UPDATE timer_wakes
+                                 SET status = 'cancelled', updated_at = ?2, cancelled_at = ?2
+                                 WHERE timer_id = ?1 AND status = 'pending'",
+                                params![timer_id, timestamp(Utc::now())],
+                            )?;
+                        }
+                        let fire_count = message
+                            .metadata
+                            .as_ref()
+                            .and_then(|metadata| metadata.get("timer_fire_count"))
+                            .and_then(serde_json::Value::as_u64)
+                            .unwrap_or_else(|| {
+                                timer.as_ref().map_or(1, |timer| timer.fire_count.max(1))
+                            });
+                        let created_at = timestamp(entry.created_at);
+                        tx.execute(
+                            "INSERT INTO timer_wakes
+                             (timer_id, message_id, fire_count, status, created_at, updated_at)
+                             VALUES (?1, ?2, ?3, 'pending', ?4, ?4)",
+                            params![timer_id, message.id, fire_count as i64, created_at],
+                        )?;
+                        result.created_wakes += 1;
+                    }
+                    None => {
+                        if existing_wake.is_some() {
+                            result.invalidated_wakes += tx.execute(
+                                "UPDATE timer_wakes
+                                 SET status = 'cancelled', updated_at = ?2, cancelled_at = ?2
+                                 WHERE timer_id = ?1 AND status = 'pending'",
+                                params![timer_id, timestamp(Utc::now())],
+                            )?;
+                        }
+                    }
+                }
+            }
+
+            for (timer_id, _) in wakes_by_timer {
+                result.invalidated_wakes += tx.execute(
+                    "UPDATE timer_wakes
+                     SET status = 'cancelled', updated_at = ?2, cancelled_at = ?2
+                     WHERE timer_id = ?1 AND status = 'pending'",
+                    params![timer_id, timestamp(Utc::now())],
+                )?;
+            }
+            Ok(result)
+        })
+    }
+
+    pub fn fire(&self, command: &TimerFire) -> Result<TimerFireResult> {
+        self.db.transaction(|tx| {
+            if timer_tx(tx, &command.expected.id)?.as_ref() != Some(&command.expected)
+                || command.expected.status != TimerStatus::Active
+            {
+                return Ok(TimerFireResult {
+                    advanced: false,
+                    wake_created: false,
+                    message: None,
+                });
+            }
+            if command.record.id != command.expected.id
+                || command.record.agent_id != command.expected.agent_id
+                || command.record.fire_count != command.expected.fire_count + 1
+            {
+                return Err(anyhow!("invalid timer fire transition"));
+            }
+            upsert_timer_tx(tx, &command.record)?;
+            let pending = tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM timer_wakes WHERE timer_id = ?1 AND status = 'pending')",
+                [&command.record.id],
+                |row| row.get::<_, bool>(0),
+            )?;
+            if pending {
+                return Ok(TimerFireResult {
+                    advanced: true,
+                    wake_created: false,
+                    message: None,
+                });
+            }
+            let actual_agent_state = tx
+                .query_row(
+                    "SELECT payload_json FROM agent_states WHERE agent_id = ?1",
+                    [&command.record.agent_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .map(|value| serde_json::from_str::<AgentState>(&value))
+                .transpose()?;
+            if actual_agent_state.as_ref() != Some(&command.agent_state.0) {
+                return Err(RuntimeStateTransitionConflict::concurrent_mutation(
+                    "agent_state",
+                    &command.record.agent_id,
+                )
+                .into());
+            }
+            if command.message.id != command.queue_entry.message_id
+                || command.message.agent_id != command.record.agent_id
+                || command.queue_entry.agent_id != command.record.agent_id
+                || command.queue_entry.status != QueueEntryStatus::Queued
+            {
+                return Err(anyhow!("invalid timer wake message or queue entry"));
+            }
+            let (message, inserted) = append_message_tx(tx, &command.message)?;
+            if inserted {
+                insert_runtime_index_changes_tx(tx, &[RuntimeIndexChange::for_message(&message)])?;
+            }
+            upsert_queue_entry_tx(tx, &command.queue_entry)?;
+            let now = timestamp(command.queue_entry.updated_at);
+            tx.execute(
+                "INSERT INTO timer_wakes
+                 (timer_id, message_id, fire_count, status, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, 'pending', ?4, ?4)",
+                params![command.record.id, command.message.id, command.record.fire_count as i64, now],
+            )?;
+            upsert_agent_state_tx(tx, &command.agent_state.1)?;
+            Ok(TimerFireResult {
+                advanced: true,
+                wake_created: true,
+                message: Some(message),
+            })
+        })
+    }
+
+    pub fn cancel(&self, command: &TimerCancel) -> Result<TimerCancelResult> {
+        self.db.transaction(|tx| {
+            if timer_tx(tx, &command.expected.id)?.as_ref() != Some(&command.expected)
+                || command.expected.status != TimerStatus::Active
+            {
+                return Ok(TimerCancelResult {
+                    cancelled: false,
+                    dropped_message_id: None,
+                });
+            }
+            if command.record.id != command.expected.id
+                || command.record.agent_id != command.expected.agent_id
+                || command.record.status != TimerStatus::Cancelled
+                || command.record.fire_count != command.expected.fire_count
+            {
+                return Err(anyhow!("invalid timer cancellation transition"));
+            }
+            if let Some((expected, record)) = command.agent_state.as_ref() {
+                let actual = tx
+                    .query_row(
+                        "SELECT payload_json FROM agent_states WHERE agent_id = ?1",
+                        [&record.id],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()?
+                    .map(|value| serde_json::from_str::<AgentState>(&value))
+                    .transpose()?;
+                if actual.as_ref() != Some(expected) {
+                    return Err(RuntimeStateTransitionConflict::concurrent_mutation(
+                        "agent_state",
+                        &record.id,
+                    )
+                    .into());
+                }
+            }
+            upsert_timer_tx(tx, &command.record)?;
+            let now = timestamp(timer_updated_at(&command.record));
+            let message_id = tx
+                .query_row(
+                    "SELECT message_id FROM timer_wakes WHERE timer_id = ?1 AND status = 'pending'",
+                    [&command.record.id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            tx.execute(
+                "UPDATE timer_wakes SET status = 'cancelled', updated_at = ?2, cancelled_at = ?2
+                 WHERE timer_id = ?1 AND status = 'pending'",
+                params![command.record.id, now],
+            )?;
+            if let Some(message_id) = message_id.as_deref() {
+                let payload = tx
+                    .query_row(
+                        "SELECT payload_json FROM queue_entries WHERE message_id = ?1
+                     AND status IN ('queued', 'interrupted')",
+                        [message_id],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()?;
+                if let Some(payload) = payload {
+                    let mut entry = decode_queue_entry_payload(&payload)?;
+                    entry.status = QueueEntryStatus::Dropped;
+                    entry.updated_at = timer_updated_at(&command.record);
+                    upsert_queue_entry_tx(tx, &entry)?;
+                }
+            }
+            if let Some((_, record)) = command.agent_state.as_ref() {
+                upsert_agent_state_tx(tx, record)?;
+            }
+            Ok(TimerCancelResult {
+                cancelled: true,
+                dropped_message_id: message_id,
+            })
+        })
+    }
+
     pub fn import_legacy(&self, records: Vec<TimerRecord>) -> Result<()> {
         if self.db.storage_domain_is_complete("timers", "db")? {
             return Ok(());
@@ -4333,6 +4679,17 @@ fn try_transition_claimable_message_tx(
     Ok(changed == 1)
 }
 
+fn timer_tx(tx: &Transaction<'_>, timer_id: &str) -> Result<Option<TimerRecord>> {
+    tx.query_row(
+        "SELECT payload_json FROM timers WHERE timer_id = ?1",
+        [timer_id],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()?
+    .map(|payload| decode_timer_payload(&payload))
+    .transpose()
+}
+
 fn upsert_timer_tx(tx: &Transaction<'_>, record: &TimerRecord) -> Result<()> {
     let payload_json = serde_json::to_string(record)?;
     let status = enum_string(&record.status)?;
@@ -4356,8 +4713,10 @@ fn upsert_timer_tx(tx: &Transaction<'_>, record: &TimerRecord) -> Result<()> {
             fire_count = excluded.fire_count,
             updated_at = excluded.updated_at,
             payload_json = excluded.payload_json
-         WHERE excluded.fire_count > timers.fire_count
-            OR (
+         WHERE NOT (timers.status = 'cancelled' AND excluded.status = 'active')
+           AND (
+             excluded.fire_count > timers.fire_count
+             OR (
                 excluded.fire_count = timers.fire_count
                 AND (
                     CASE excluded.status
@@ -4377,7 +4736,8 @@ fn upsert_timer_tx(tx: &Transaction<'_>, record: &TimerRecord) -> Result<()> {
                         AND excluded.updated_at >= timers.updated_at
                     )
                 )
-            )",
+             )
+           )",
         params![
             record.id,
             record.agent_id,

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -9,7 +9,7 @@ pub(crate) use execution_protocol_repository::{authority_fences_tx, persist_stat
 
 use anyhow::{anyhow, bail, Context, Result};
 use chrono::Utc;
-use rusqlite::{OptionalExtension, Transaction};
+use rusqlite::{params, OptionalExtension, Transaction};
 use std::collections::BTreeMap;
 
 use crate::{
@@ -165,6 +165,7 @@ pub(crate) struct WaitTransitionCommand {
     pub work_items: Vec<WorkItemMutation>,
     pub expected_wait_conditions: Vec<WaitConditionExpectation>,
     pub wait_conditions: Vec<WaitConditionRecord>,
+    pub timer_wake: Option<TimerWakeClaim>,
     pub agent_state: Option<AgentStateMutation>,
     pub audit_events: Vec<AuditEvent>,
     pub index_changes: Vec<RuntimeIndexChange>,
@@ -226,6 +227,13 @@ pub(crate) struct QueueTransitionCommand {
     pub notify_scheduler: bool,
     pub fault: Option<TransitionFaultPoint>,
     pub brief_evidence: Vec<BriefRecord>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TimerWakeClaim {
+    pub timer_id: String,
+    pub message_id: String,
+    pub fire_count: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -960,6 +968,27 @@ impl RuntimeTransitionRepository<'_> {
             if let Some(task_expectation) = task_expectation {
                 validate_task_expectation_tx(tx, task_expectation)?;
             }
+            if let Some(timer_wake) = command.timer_wake.as_ref() {
+                let valid = tx.query_row(
+                    "SELECT EXISTS(
+                       SELECT 1 FROM timer_wakes w JOIN timers t ON t.timer_id = w.timer_id
+                       WHERE w.timer_id = ?1 AND w.message_id = ?2 AND w.fire_count = ?3
+                         AND w.status = 'pending' AND t.status IN ('active', 'completed'))",
+                    params![
+                        timer_wake.timer_id,
+                        timer_wake.message_id,
+                        timer_wake.fire_count as i64
+                    ],
+                    |row| row.get::<_, bool>(0),
+                )?;
+                if !valid {
+                    return Err(RuntimeStateTransitionConflict::concurrent_mutation(
+                        "timer_wait",
+                        &timer_wake.timer_id,
+                    )
+                    .into());
+                }
+            }
             validate_agent_state_mutation_tx(tx, command.agent_state.as_ref())?;
             let execution_protocol = execution_protocol_repository::validate_execution_commands_tx(
                 tx,
@@ -1024,6 +1053,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             &[],
             &[],
+            None,
         )
     }
 
@@ -1032,7 +1062,16 @@ impl RuntimeTransitionRepository<'_> {
         command: &QueueTransitionCommand,
         execution_protocol: &ExecutionProtocolTransition,
     ) -> Result<TransitionCommit> {
-        self.commit_queue_transaction(command, execution_protocol, None, None, None, &[], &[])
+        self.commit_queue_transaction(
+            command,
+            execution_protocol,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+        )
     }
 
     pub(crate) fn commit_scheduler_recovery(
@@ -1050,6 +1089,7 @@ impl RuntimeTransitionRepository<'_> {
             &[],
             None,
             DeliverySynchronization::IfAvailable,
+            None,
         )
     }
 
@@ -1067,6 +1107,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             terminal_tool_executions,
             &[],
+            None,
         )
     }
 
@@ -1083,6 +1124,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             &[],
             &[],
+            None,
         )
     }
 
@@ -1091,6 +1133,7 @@ impl RuntimeTransitionRepository<'_> {
         command: &QueueTransitionCommand,
         execution_protocol: &ExecutionProtocolTransition,
         wait_transition: Option<&QueueWaitTransition>,
+        timer_wake_claim: Option<&TimerWakeClaim>,
     ) -> Result<TransitionCommit> {
         self.commit_queue_transaction(
             command,
@@ -1100,6 +1143,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             &[],
             &[],
+            timer_wake_claim,
         )
     }
 
@@ -1118,6 +1162,7 @@ impl RuntimeTransitionRepository<'_> {
             None,
             &[],
             wait_conditions,
+            None,
         )
     }
 
@@ -1135,6 +1180,7 @@ impl RuntimeTransitionRepository<'_> {
             Some(completion),
             &[],
             &[],
+            None,
         )
     }
 
@@ -1154,6 +1200,7 @@ impl RuntimeTransitionRepository<'_> {
             &[],
             Some(delivery),
             DeliverySynchronization::Required,
+            None,
         )
     }
 
@@ -1166,6 +1213,7 @@ impl RuntimeTransitionRepository<'_> {
         completion: Option<&CompletionTransition>,
         terminal_tool_executions: &[ToolExecutionRecord],
         extra_wait_conditions: &[crate::types::WaitConditionRecord],
+        timer_wake_claim: Option<&TimerWakeClaim>,
     ) -> Result<TransitionCommit> {
         self.commit_queue_transaction_with_delivery(
             command,
@@ -1177,6 +1225,7 @@ impl RuntimeTransitionRepository<'_> {
             extra_wait_conditions,
             None,
             DeliverySynchronization::Required,
+            timer_wake_claim,
         )
     }
 
@@ -1192,6 +1241,7 @@ impl RuntimeTransitionRepository<'_> {
         extra_wait_conditions: &[crate::types::WaitConditionRecord],
         delivery: Option<&AgentMessageDeliveryRecord>,
         delivery_synchronization: DeliverySynchronization,
+        timer_wake_claim: Option<&TimerWakeClaim>,
     ) -> Result<TransitionCommit> {
         self.db.transaction(|tx| {
             let synchronize_delivery = match delivery_synchronization {
@@ -1225,6 +1275,23 @@ impl RuntimeTransitionRepository<'_> {
             }
             validate_queue_operation(command)?;
             validate_queue_mutation_tx(tx, &command.mutation)?;
+            if let Some(timer_wake_claim) = timer_wake_claim {
+                let valid = tx.query_row(
+                    "SELECT EXISTS(
+                       SELECT 1 FROM timer_wakes w JOIN timers t ON t.timer_id = w.timer_id
+                       WHERE w.timer_id = ?1 AND w.message_id = ?2 AND w.fire_count = ?3
+                         AND w.status = 'pending' AND t.status IN ('active', 'completed'))",
+                    params![
+                        timer_wake_claim.timer_id,
+                        timer_wake_claim.message_id,
+                        timer_wake_claim.fire_count as i64
+                    ],
+                    |row| row.get::<_, bool>(0),
+                )?;
+                if !valid {
+                    return Ok(TransitionCommit::default());
+                }
+            }
             if let Some(wait_transition) = wait_transition {
                 validate_wait_condition_expectation_tx(tx, &wait_transition.expected)?;
                 validate_wait_condition_tx(tx, &wait_transition.record)?;
@@ -1360,6 +1427,23 @@ impl RuntimeTransitionRepository<'_> {
             };
             if !matches!(&command.mutation, QueueMutation::Upsert(_)) && !mutation_applied {
                 return Ok(TransitionCommit::default());
+            }
+            if let Some(timer_wake_claim) = timer_wake_claim {
+                let changed = tx.execute(
+                    "UPDATE timer_wakes SET status = 'incorporated', updated_at = ?4,
+                       incorporated_at = ?4
+                     WHERE timer_id = ?1 AND message_id = ?2 AND fire_count = ?3
+                       AND status = 'pending'",
+                    params![
+                        timer_wake_claim.timer_id,
+                        timer_wake_claim.message_id,
+                        timer_wake_claim.fire_count as i64,
+                        Utc::now().to_rfc3339(),
+                    ],
+                )?;
+                if changed != 1 {
+                    return Err(anyhow!("timer wake changed during queue claim"));
+                }
             }
             if synchronize_delivery {
                 advance_delivery_for_queue_transition_tx(
@@ -3304,6 +3388,7 @@ mod tests {
                 }],
                 expected_wait_conditions: Vec::new(),
                 wait_conditions: vec![wait],
+                timer_wake: None,
                 agent_state: None,
                 audit_events: vec![AuditEvent::legacy("wait_registered", serde_json::json!({}))],
                 index_changes: vec![index_change("work_item", &initial.id)],
@@ -3866,6 +3951,7 @@ mod tests {
                         work_items: Vec::new(),
                         expected_wait_conditions: Vec::new(),
                         wait_conditions: vec![wait.clone()],
+                        timer_wake: None,
                         agent_state: None,
                         audit_events: Vec::new(),
                         index_changes: Vec::new(),
@@ -3892,6 +3978,7 @@ mod tests {
                     work_items: Vec::new(),
                     expected_wait_conditions: Vec::new(),
                     wait_conditions: vec![wait],
+                    timer_wake: None,
                     agent_state: None,
                     audit_events: Vec::new(),
                     index_changes: Vec::new(),

--- a/src/runtime_db/types.rs
+++ b/src/runtime_db/types.rs
@@ -1,6 +1,64 @@
 //! Public types for runtime_db repositories.
 
 use crate::runtime_db::RuntimeDb;
+use crate::types::{AgentState, MessageEnvelope, QueueEntryRecord, TimerRecord};
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimerWakeStatus {
+    Pending,
+    Incorporated,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimerWakeRecord {
+    pub timer_id: String,
+    pub message_id: String,
+    pub fire_count: u64,
+    pub status: TimerWakeStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub incorporated_at: Option<DateTime<Utc>>,
+    pub cancelled_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TimerFire {
+    pub expected: TimerRecord,
+    pub record: TimerRecord,
+    pub message: MessageEnvelope,
+    pub queue_entry: QueueEntryRecord,
+    pub agent_state: (AgentState, AgentState),
+}
+
+#[derive(Debug, Clone)]
+pub struct TimerCancel {
+    pub expected: TimerRecord,
+    pub record: TimerRecord,
+    pub agent_state: Option<(AgentState, AgentState)>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TimerFireResult {
+    pub advanced: bool,
+    pub wake_created: bool,
+    pub message: Option<MessageEnvelope>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimerCancelResult {
+    pub cancelled: bool,
+    pub dropped_message_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TimerWakeRecoveryResult {
+    pub retained_wakes: usize,
+    pub created_wakes: usize,
+    pub invalidated_wakes: usize,
+    pub dropped_message_ids: Vec<String>,
+}
 
 pub struct WorkItemRepository<'a> {
     pub(crate) db: &'a RuntimeDb,


### PR DESCRIPTION
## Summary

- add a durable `timer_wakes` admission fence so each timer has at most one pending wake and fire/cancel/scheduler claim serialize in the runtime DB
- invalidate unclaimed timer messages on cancellation without interrupting an already admitted turn
- let a completed one-shot timer bind a still-pending wake to a late `WaitFor`, while returning an explicit consumed diagnostic if scheduler admission already won
- normalize legacy timer queue buildup during startup, dropping cancelled or duplicate ticks and preserving one valid pending wake per timer
- document the coalescing, cancellation linearization, and recovery contracts

## Runtime contract

Repeated timer fires still advance the canonical timer `fire_count`, but they no longer create an unbounded message backlog. Scheduler admission claims the durable wake in the same transaction as queue admission, so cancellation and execution start have one durable ordering boundary.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
- timer regression coverage for bounded repeated fires, cancellation invalidation, late one-shot `WaitFor`, and idempotent legacy backlog recovery

Closes #2876
