### PR TITLE
fix: activate timer-only owners during startup recovery

### DIFF
--- a/docs/rfcs/runtime-host-activation-admission-and-read-projections.md
+++ b/docs/rfcs/runtime-host-activation-admission-and-read-projections.md
@@ -104,7 +104,14 @@ posture, or heuristic threshold is sufficient evidence.
 The same pre-listener pass discovers distinct owner agents for durable active
 tasks (`queued`, `running`, or `cancelling`) directly from the shared runtime
 database. It does not enumerate agent directories or use read APIs to
-materialize runtimes.
+materialize runtimes. Timer ownership is discovered the same way: an agent is a
+recovery candidate when it owns at least one non-terminal timer (`active` or
+`scheduled`) or a pending `timer_wakes` admission. Queue, task, and timer
+candidate sets are merged and deduplicated before activation so an agent with
+several durable signals is activated exactly once.
+
+Timer ownership alone does not bypass the stopped-owner gate: a
+lifecycle-stopped agent whose only durable signal is a timer remains lazy.
 
 Every affected owner is explicitly activated with the startup recovery reason,
 and the host waits for a one-shot bootstrap result before continuing. Bootstrap
@@ -128,6 +135,8 @@ Tests cover:
 - execution ingress after admission closes;
 - orphan `dequeued` recovery and idempotence;
 - active-task owner discovery for unloaded named and default agents;
+- timer-only owner discovery, including overdue catch-up fire and resolution
+  of the waiting condition bound to the recovered timer;
 - bootstrap completion before startup recovery returns;
 - stopped-owner task convergence without child reattach or model re-entry;
 - canonical or terminal ownership exclusions;

--- a/src/host.rs
+++ b/src/host.rs
@@ -1413,12 +1413,19 @@ impl RuntimeHost {
             .active_owner_agent_ids()?
             .into_iter()
             .collect::<std::collections::BTreeSet<_>>();
+        let active_timer_owner_ids = self
+            .runtime_db()
+            .timers()
+            .active_owner_agent_ids()?
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>();
         let mut recovery_agent_ids = recovered_queue_agent_ids
             .iter()
             .cloned()
             .collect::<std::collections::BTreeSet<_>>();
         recovery_agent_ids.extend(queue_recovery_candidate_ids.iter().cloned());
         recovery_agent_ids.extend(active_task_owner_ids.iter().cloned());
+        recovery_agent_ids.extend(active_timer_owner_ids.iter().cloned());
         for agent_id in recovery_agent_ids {
             let state = self
                 .agent_storage_read_only(&agent_id)?
@@ -6028,9 +6035,9 @@ mod tests {
             BriefRecord, ChildAgentWorkspaceMode, ControlAction, DeliverySummaryRecord,
             InvokeAgentRequest, InvokeAgentTarget, MessageBody, MessageEnvelope, MessageKind,
             MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus, TaskRecord,
-            TaskRecoverySpec, TaskStatus, TurnTerminalKind, WaitConditionKind, WaitConditionRecord,
-            WaitConditionStatus, WakeSource, WorkItemRecord, WorkItemState,
-            ACTOR_INVOCATION_TASK_KIND,
+            TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, TurnTerminalKind,
+            WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource,
+            WorkItemRecord, WorkItemState, ACTOR_INVOCATION_TASK_KIND,
         },
     };
 
@@ -10742,6 +10749,437 @@ mod tests {
             .read_message_by_id("message:task-restart:task-stopped-owner")
             .unwrap()
             .is_none());
+    }
+
+    fn startup_timer_fixture(
+        id: &str,
+        agent_id: &str,
+        status: TimerStatus,
+        interval_ms: Option<u64>,
+        next_fire_at: Option<chrono::DateTime<Utc>>,
+    ) -> TimerRecord {
+        TimerRecord {
+            id: id.into(),
+            agent_id: agent_id.into(),
+            created_at: Utc::now(),
+            duration_ms: 60_000,
+            interval_ms,
+            repeat: interval_ms.is_some(),
+            status,
+            summary: Some("startup timer summary".into()),
+            next_fire_at,
+            last_fired_at: None,
+            fire_count: 0,
+        }
+    }
+
+    fn assert_startup_timer_tick_count(storage: &AppStorage, timer_id: &str, expected: usize) {
+        let ticks = storage
+            .read_recent_messages(200)
+            .unwrap()
+            .iter()
+            .filter(|message| {
+                message.kind == MessageKind::TimerTick
+                    && matches!(&message.origin, MessageOrigin::Timer { timer_id: origin } if origin == timer_id)
+            })
+            .count();
+        assert_eq!(
+            ticks, expected,
+            "timer {timer_id} should have produced exactly {expected} TimerTick message(s)"
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_activates_timer_only_owner_and_resolves_waiting_timer() {
+        let (_home, host) = canonical_test_host();
+        let config = host.config().as_ref().clone();
+        let agent_id = "startup-timer-owner";
+        host.create_named_agent(agent_id, None).await.unwrap();
+        let storage = host.agent_storage(agent_id).unwrap();
+        let mut work_item = WorkItemRecord::new(agent_id, "wait for timer", WorkItemState::Open);
+        work_item.id = "work-startup-timer".into();
+        storage.append_work_item(&work_item).unwrap();
+        let now = Utc::now();
+        // The timer is created already overdue. Overdue state comes from
+        // wall-clock time passing while the agent is unloaded, not from a
+        // record rewrite: the timers upsert guard rejects writes whose
+        // effective updated_at (next_fire_at) moves backwards.
+        host.runtime_db()
+            .timers()
+            .upsert(&startup_timer_fixture(
+                "timer-startup-owner-1",
+                agent_id,
+                TimerStatus::Active,
+                None,
+                Some(now - chrono::Duration::minutes(30)),
+            ))
+            .unwrap();
+        // Register the wait through the live runtime so the durable wait
+        // condition and its timer wake binding are real, rather than a
+        // hand-written condition that skips wake admission state.
+        // Execution-protocol Waiting authority for the registered
+        // condition is seeded below.
+        let registration = host
+            .try_get_loaded_runtime(agent_id)
+            .await
+            .expect("created agent runtime should stay loaded")
+            .register_wait_for(
+                agent_id,
+                Some(work_item.id.clone()),
+                crate::runtime::WaitForWakeKind::Timer,
+                Some("timer-startup-owner-1".into()),
+                "timer catch-up".into(),
+                None,
+            )
+            .await
+            .unwrap();
+        // register_wait_for only records execution-protocol Waiting
+        // authority when a live execution attempt settles with a Wait
+        // outcome. Seed the same protocol state for the registered
+        // condition, mirroring what a waiting turn persists, so the
+        // recovered TimerTick can claim this work item back into an
+        // execution.
+        let registered_work_item = host
+            .runtime_db()
+            .work_items()
+            .latest(&work_item.id)
+            .unwrap()
+            .unwrap();
+        crate::runtime::tests::support::seed_waiting_work_execution(
+            &storage,
+            &registered_work_item,
+            &registration.condition.id,
+        );
+        host.unload_runtime(agent_id).await;
+
+        // The timer is the only recovery signal: no queue or task candidates exist.
+        assert!(storage.latest_queue_entries().unwrap().is_empty());
+        assert!(storage.latest_active_task_records(10).unwrap().is_empty());
+        assert!(host
+            .runtime_db()
+            .queue_entries()
+            .recovery_candidate_agent_ids()
+            .unwrap()
+            .is_empty());
+        assert!(host
+            .runtime_db()
+            .tasks()
+            .active_owner_agent_ids()
+            .unwrap()
+            .is_empty());
+        assert!(host.try_get_loaded_runtime(agent_id).await.is_none());
+        drop(storage);
+        drop(host);
+
+        let restarted =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
+        assert!(restarted
+            .recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap()
+            .is_empty());
+
+        restarted
+            .try_get_loaded_runtime(agent_id)
+            .await
+            .expect("startup recovery should activate the timer-only owner");
+        let storage = restarted.agent_storage(agent_id).unwrap();
+        let timer = storage
+            .latest_timer_record("timer-startup-owner-1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(timer.status, TimerStatus::Completed);
+        assert_eq!(timer.fire_count, 1);
+        assert_startup_timer_tick_count(&storage, "timer-startup-owner-1", 1);
+
+        let mut resolved = false;
+        for _ in 0..100 {
+            if storage
+                .active_wait_conditions_for_agent(agent_id)
+                .unwrap()
+                .is_empty()
+            {
+                resolved = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            resolved,
+            "the recovered TimerTick should resolve the waiting timer condition"
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_discovers_timer_only_owner_without_wait_records() {
+        let (_home, host) = canonical_test_host();
+        let agent_id = "startup-timer-no-wait";
+        host.create_named_agent(agent_id, None).await.unwrap();
+        host.unload_runtime(agent_id).await;
+        let storage = host.agent_storage(agent_id).unwrap();
+        let overdue = Utc::now() - chrono::Duration::minutes(5);
+        host.runtime_db()
+            .timers()
+            .upsert(&startup_timer_fixture(
+                "timer-startup-no-wait-1",
+                agent_id,
+                TimerStatus::Active,
+                None,
+                Some(overdue),
+            ))
+            .unwrap();
+
+        assert!(host.try_get_loaded_runtime(agent_id).await.is_none());
+        host.recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap();
+
+        assert!(host.try_get_loaded_runtime(agent_id).await.is_some());
+        let timer = storage
+            .latest_timer_record("timer-startup-no-wait-1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(timer.status, TimerStatus::Completed);
+        assert_eq!(timer.fire_count, 1);
+        assert_startup_timer_tick_count(&storage, "timer-startup-no-wait-1", 1);
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_overdue_repeating_timer_fires_once_and_keeps_cadence() {
+        let (_home, host) = canonical_test_host();
+        let agent_id = "startup-timer-repeating";
+        host.create_named_agent(agent_id, None).await.unwrap();
+        host.unload_runtime(agent_id).await;
+        let storage = host.agent_storage(agent_id).unwrap();
+        // Overdue by five hourly periods; recovery must catch up once, not replay all.
+        let overdue = Utc::now() - chrono::Duration::hours(5);
+        host.runtime_db()
+            .timers()
+            .upsert(&startup_timer_fixture(
+                "timer-startup-repeating-1",
+                agent_id,
+                TimerStatus::Active,
+                Some(3_600_000),
+                Some(overdue),
+            ))
+            .unwrap();
+
+        assert!(host.try_get_loaded_runtime(agent_id).await.is_none());
+        host.recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap();
+
+        let timer = storage
+            .latest_timer_record("timer-startup-repeating-1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(timer.status, TimerStatus::Active);
+        assert_eq!(timer.fire_count, 1);
+        assert!(timer
+            .next_fire_at
+            .is_some_and(|next_fire_at| next_fire_at > Utc::now()));
+        assert_startup_timer_tick_count(&storage, "timer-startup-repeating-1", 1);
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_keeps_terminal_timer_owner_and_unrelated_agents_unloaded() {
+        let (_home, host) = canonical_test_host();
+        let terminal_agent_id = "startup-timer-terminal";
+        let unrelated_agent_id = "startup-agent-no-timer";
+        for agent_id in [terminal_agent_id, unrelated_agent_id] {
+            host.create_named_agent(agent_id, None).await.unwrap();
+            host.unload_runtime(agent_id).await;
+        }
+        let storage = host.agent_storage(terminal_agent_id).unwrap();
+        let future = Utc::now() + chrono::Duration::hours(1);
+        host.runtime_db()
+            .timers()
+            .upsert(&startup_timer_fixture(
+                "timer-terminal-completed",
+                terminal_agent_id,
+                TimerStatus::Completed,
+                None,
+                None,
+            ))
+            .unwrap();
+        host.runtime_db()
+            .timers()
+            .upsert(&startup_timer_fixture(
+                "timer-terminal-cancelled",
+                terminal_agent_id,
+                TimerStatus::Cancelled,
+                None,
+                Some(future),
+            ))
+            .unwrap();
+
+        host.recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap();
+
+        assert!(host
+            .try_get_loaded_runtime(terminal_agent_id)
+            .await
+            .is_none());
+        assert!(host
+            .try_get_loaded_runtime(unrelated_agent_id)
+            .await
+            .is_none());
+        assert_startup_timer_tick_count(&storage, "timer-terminal-completed", 0);
+        assert_startup_timer_tick_count(&storage, "timer-terminal-cancelled", 0);
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_skips_stopped_timer_only_owner() {
+        let (_home, host) = canonical_test_host();
+        let agent_id = "startup-timer-stopped";
+        host.create_named_agent(agent_id, None).await.unwrap();
+        host.unload_runtime(agent_id).await;
+        let storage = host.agent_storage(agent_id).unwrap();
+        let mut state = storage.read_agent().unwrap().unwrap();
+        state.status = AgentStatus::Stopped;
+        storage.write_agent(&state).unwrap();
+        let overdue = Utc::now() - chrono::Duration::minutes(15);
+        host.runtime_db()
+            .timers()
+            .upsert(&startup_timer_fixture(
+                "timer-startup-stopped-1",
+                agent_id,
+                TimerStatus::Active,
+                None,
+                Some(overdue),
+            ))
+            .unwrap();
+
+        host.recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap();
+
+        assert!(host.try_get_loaded_runtime(agent_id).await.is_none());
+        let timer = storage
+            .latest_timer_record("timer-startup-stopped-1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(timer.status, TimerStatus::Active);
+        assert_eq!(timer.fire_count, 0);
+        assert_startup_timer_tick_count(&storage, "timer-startup-stopped-1", 0);
+        let state = storage.read_agent().unwrap().unwrap();
+        assert_eq!(state.status, AgentStatus::Stopped);
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_activates_timer_and_task_owner_once() {
+        let (_home, host) = canonical_test_host();
+        let agent_id = "startup-timer-and-task";
+        host.create_named_agent(agent_id, None).await.unwrap();
+        host.unload_runtime(agent_id).await;
+        let storage = host.agent_storage(agent_id).unwrap();
+        storage
+            .append_task(&TaskRecord {
+                id: "task-startup-timer-owner".into(),
+                agent_id: agent_id.into(),
+                kind: crate::types::TaskKind::CommandTask,
+                status: TaskStatus::Running,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                parent_message_id: None,
+                work_item_id: None,
+                summary: Some("startup timer owner task".into()),
+                detail: None,
+                recovery: None,
+            })
+            .unwrap();
+        let overdue = Utc::now() - chrono::Duration::minutes(10);
+        host.runtime_db()
+            .timers()
+            .upsert(&startup_timer_fixture(
+                "timer-startup-and-task-1",
+                agent_id,
+                TimerStatus::Active,
+                None,
+                Some(overdue),
+            ))
+            .unwrap();
+
+        assert!(host.try_get_loaded_runtime(agent_id).await.is_none());
+        host.recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap();
+
+        let task = storage
+            .latest_task_record("task-startup-timer-owner")
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, TaskStatus::Interrupted);
+        let timer = storage
+            .latest_timer_record("timer-startup-and-task-1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(timer.status, TimerStatus::Completed);
+        assert_eq!(timer.fire_count, 1);
+        assert_startup_timer_tick_count(&storage, "timer-startup-and-task-1", 1);
+        assert!(host.try_get_loaded_runtime(agent_id).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_does_not_refire_persisted_one_shot_timer() {
+        let (_home, host) = canonical_test_host();
+        let config = host.config().as_ref().clone();
+        let agent_id = "startup-timer-once";
+        host.create_named_agent(agent_id, None).await.unwrap();
+        host.unload_runtime(agent_id).await;
+        let storage = host.agent_storage(agent_id).unwrap();
+        let overdue = Utc::now() - chrono::Duration::minutes(20);
+        host.runtime_db()
+            .timers()
+            .upsert(&startup_timer_fixture(
+                "timer-startup-once-1",
+                agent_id,
+                TimerStatus::Active,
+                None,
+                Some(overdue),
+            ))
+            .unwrap();
+        drop(storage);
+        drop(host);
+
+        let second_host =
+            RuntimeHost::new_with_provider(config.clone(), Arc::new(StubProvider::new("done")))
+                .unwrap();
+        second_host
+            .recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap();
+        let storage = second_host.agent_storage(agent_id).unwrap();
+        let timer = storage
+            .latest_timer_record("timer-startup-once-1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(timer.status, TimerStatus::Completed);
+        assert_eq!(timer.fire_count, 1);
+        assert_startup_timer_tick_count(&storage, "timer-startup-once-1", 1);
+        drop(storage);
+        tokio::time::timeout(Duration::from_secs(5), second_host.shutdown())
+            .await
+            .expect("second host shutdown")
+            .unwrap();
+        drop(second_host);
+
+        let third_host =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
+        third_host
+            .recover_orphaned_queue_claims_at_startup()
+            .await
+            .unwrap();
+        assert!(third_host.try_get_loaded_runtime(agent_id).await.is_none());
+        let storage = third_host.agent_storage(agent_id).unwrap();
+        let timer = storage
+            .latest_timer_record("timer-startup-once-1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(timer.status, TimerStatus::Completed);
+        assert_eq!(timer.fire_count, 1);
+        assert_startup_timer_tick_count(&storage, "timer-startup-once-1", 1);
     }
 
     #[tokio::test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5917,4 +5917,4 @@ pub(crate) fn retryable_enqueue_conflict(error: &anyhow::Error, agent_id: &str) 
 }
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -2211,6 +2211,30 @@ impl TimerRepository<'_> {
         .transpose()
     }
 
+    pub fn active_owner_agent_ids(&self) -> Result<Vec<String>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT DISTINCT t.agent_id
+             FROM timers t
+             JOIN agent_identities i
+               ON i.agent_id = t.agent_id
+              AND i.status = 'active'
+             WHERE t.status IN ('active', 'scheduled')
+             UNION
+             SELECT DISTINCT t.agent_id
+             FROM timer_wakes w
+             JOIN timers t ON t.timer_id = w.timer_id
+             JOIN agent_identities i
+               ON i.agent_id = t.agent_id
+              AND i.status = 'active'
+             WHERE w.status = 'pending'
+             ORDER BY 1 ASC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
     pub fn normalize_wakes_for_recovery(&self, agent_id: &str) -> Result<TimerWakeRecoveryResult> {
         self.db.transaction(|tx| {
             let live_messages = {

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -105,6 +105,7 @@ mod tests {
         types::{
             ActiveWorkspaceEntry, AgentDeletionJob, AgentDeletionStatus, AgentKind, AgentOwnership,
             AgentProfilePreset, AgentRegistryStatus, AgentStatus, AgentVisibility, BriefKind,
+            TimerStatus,
         },
     };
     use rusqlite::OptionalExtension;
@@ -4770,6 +4771,211 @@ CREATE TABLE working_memory_deltas (
         assert!(!db
             .queue_entries()
             .has_interrupted_for_agent("agent-dequeued")?);
+        Ok(())
+    }
+
+    fn timer_record_fixture(
+        id: &str,
+        agent_id: &str,
+        status: TimerStatus,
+        next_fire_at: Option<chrono::DateTime<Utc>>,
+    ) -> crate::types::TimerRecord {
+        crate::types::TimerRecord {
+            id: id.into(),
+            agent_id: agent_id.into(),
+            created_at: Utc::now(),
+            duration_ms: 60_000,
+            interval_ms: None,
+            repeat: false,
+            status,
+            summary: None,
+            next_fire_at,
+            last_fired_at: None,
+            fire_count: 0,
+        }
+    }
+
+    #[test]
+    fn timer_active_owner_agent_ids_dedupes_owners_and_filters_terminal_rows() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+        for agent_id in [
+            "timer-agent-a",
+            "timer-agent-b",
+            "timer-agent-terminal",
+            "timer-agent-deleting",
+            "timer-agent-deleted",
+            "timer-agent-ghost",
+        ] {
+            db.agent_identities().upsert(&agent_identity(agent_id, 0))?;
+        }
+        let mut deleting_identity = agent_identity("timer-agent-deleting", 0);
+        deleting_identity.status = AgentRegistryStatus::Deleting;
+        db.agent_identities().upsert(&deleting_identity)?;
+        let mut deleted_identity = agent_identity("timer-agent-deleted", 0);
+        deleted_identity.status = AgentRegistryStatus::Deleted;
+        deleted_identity.deleted_at = Some(now);
+        db.agent_identities().upsert(&deleted_identity)?;
+        // Remove the ghost identity so its timer exercises the missing-identity join.
+        db.connection()?.execute(
+            "DELETE FROM agent_identities WHERE agent_id = 'timer-agent-ghost'",
+            [],
+        )?;
+
+        let future = Some(now + chrono::Duration::seconds(60));
+        db.timers().upsert(&timer_record_fixture(
+            "timer-a-1",
+            "timer-agent-a",
+            TimerStatus::Active,
+            future,
+        ))?;
+        db.timers().upsert(&timer_record_fixture(
+            "timer-a-2",
+            "timer-agent-a",
+            TimerStatus::Active,
+            future,
+        ))?;
+        db.timers().upsert(&timer_record_fixture(
+            "timer-b-1",
+            "timer-agent-b",
+            TimerStatus::Active,
+            future,
+        ))?;
+        db.timers().upsert(&timer_record_fixture(
+            "timer-terminal-done",
+            "timer-agent-terminal",
+            TimerStatus::Completed,
+            None,
+        ))?;
+        db.timers().upsert(&timer_record_fixture(
+            "timer-terminal-cancelled",
+            "timer-agent-terminal",
+            TimerStatus::Cancelled,
+            future,
+        ))?;
+        for (timer_id, agent_id) in [
+            ("timer-deleting-1", "timer-agent-deleting"),
+            ("timer-deleted-1", "timer-agent-deleted"),
+            ("timer-ghost-1", "timer-agent-ghost"),
+        ] {
+            db.timers().upsert(&timer_record_fixture(
+                timer_id,
+                agent_id,
+                TimerStatus::Active,
+                future,
+            ))?;
+        }
+
+        assert_eq!(
+            db.timers().active_owner_agent_ids()?,
+            vec!["timer-agent-a", "timer-agent-b"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn timer_active_owner_agent_ids_covers_fire_times_legacy_status_and_pending_wakes() -> Result<()>
+    {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+        for agent_id in [
+            "timer-future",
+            "timer-overdue",
+            "timer-missing-next",
+            "timer-legacy",
+            "timer-pending-wake",
+            "timer-cancelled-wake",
+            "timer-stopped-identity",
+        ] {
+            db.agent_identities().upsert(&agent_identity(agent_id, 0))?;
+        }
+        let mut stopped_identity = agent_identity("timer-stopped-identity", 0);
+        stopped_identity.status = AgentRegistryStatus::Deleted;
+        stopped_identity.deleted_at = Some(now);
+        db.agent_identities().upsert(&stopped_identity)?;
+
+        db.timers().upsert(&timer_record_fixture(
+            "timer-future-1",
+            "timer-future",
+            TimerStatus::Active,
+            Some(now + chrono::Duration::seconds(600)),
+        ))?;
+        db.timers().upsert(&timer_record_fixture(
+            "timer-overdue-1",
+            "timer-overdue",
+            TimerStatus::Active,
+            Some(now - chrono::Duration::seconds(600)),
+        ))?;
+        db.timers().upsert(&timer_record_fixture(
+            "timer-missing-next-1",
+            "timer-missing-next",
+            TimerStatus::Active,
+            None,
+        ))?;
+        db.timers().upsert(&timer_record_fixture(
+            "timer-legacy-1",
+            "timer-legacy",
+            TimerStatus::Active,
+            Some(now + chrono::Duration::seconds(600)),
+        ))?;
+        db.connection()?.execute(
+            "UPDATE timers SET status = 'scheduled' WHERE timer_id = 'timer-legacy-1'",
+            [],
+        )?;
+
+        // #2894 late-bind shape: one-shot timer already done, durable wake still pending.
+        db.timers().upsert(&timer_record_fixture(
+            "timer-wake-done",
+            "timer-pending-wake",
+            TimerStatus::Completed,
+            None,
+        ))?;
+        // Cancelled wake must not keep the owner a recovery candidate.
+        db.timers().upsert(&timer_record_fixture(
+            "timer-wake-cancelled",
+            "timer-cancelled-wake",
+            TimerStatus::Completed,
+            None,
+        ))?;
+        // Pending wake owned by a non-active identity must be filtered out.
+        db.timers().upsert(&timer_record_fixture(
+            "timer-wake-stopped",
+            "timer-stopped-identity",
+            TimerStatus::Completed,
+            None,
+        ))?;
+
+        let created_at = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        for (timer_id, status) in [
+            ("timer-wake-done", "pending"),
+            ("timer-wake-cancelled", "cancelled"),
+            ("timer-wake-stopped", "pending"),
+        ] {
+            db.connection()?.execute(
+                "INSERT INTO timer_wakes
+                 (timer_id, message_id, fire_count, status, created_at, updated_at)
+                 VALUES (?1, ?2, 1, ?3, ?4, ?4)",
+                params![
+                    timer_id,
+                    format!("message:wake:{timer_id}"),
+                    status,
+                    created_at
+                ],
+            )?;
+        }
+
+        assert_eq!(
+            db.timers().active_owner_agent_ids()?,
+            vec![
+                "timer-future",
+                "timer-legacy",
+                "timer-missing-next",
+                "timer-overdue",
+                "timer-pending-wake"
+            ]
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- **Root cause**: startup recovery only merged queue-recovery candidates and active-task owners into the activation candidate set. An unloaded agent whose only durable signal was a timer never entered bootstrap recovery, so its overdue timers were never caught up (#2881).
- **Fix**: `TimerRepository::active_owner_agent_ids()` reads timer owners directly from the shared runtime database (non-terminal timers `active`/`scheduled` ∪ pending `timer_wakes` admissions, active agent identities only). Host startup recovery merges this set with the existing queue/task candidates, deduplicates, and still waits for the one-shot bootstrap result, which performs the overdue catch-up fire and wait-condition resolution.
- **Stopped-owner gate preserved**: timer ownership alone does not activate a lifecycle-stopped agent.
- **Test visibility**: `src/runtime.rs` test module is now `pub(crate)` so host-level tests can use the existing `seed_waiting_work_execution` support helper to seed execution-protocol waiting authority.
- **RFC**: `docs/rfcs/runtime-host-activation-admission-and-read-projections.md` startup-recovery section now documents timer-owner discovery, candidate merging, and the stopped-owner boundary.

## Verification

- `cargo test --lib host::tests::startup_recovery` — 11/11 (7 new timer-recovery cases incl. timer-only owner activation with overdue catch-up fire and waiting-condition resolution)
- `cargo test --lib runtime_db::tests` — 146/146 (new repository-level owner-query cases)
- `cargo test --lib runtime::tests::timers` — 9/9
- `cargo fmt --all` + `RUSTFLAGS="-D warnings" cargo check --all-targets` — clean

Closes #2881
