### PR TITLE
test: accept canonical relation databases in the release upgrade E2E

### DIFF
--- a/scripts/docker_e2e/runner.py
+++ b/scripts/docker_e2e/runner.py
@@ -1886,6 +1886,10 @@ class CaseHarness:
                 "SELECT EXISTS(SELECT 1 FROM sqlite_master "
                 "WHERE type = 'table' AND name = 'schema_migration_baselines')"
             ).fetchone()[0]
+            has_canonical_relations = connection.execute(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master "
+                "WHERE type = 'table' AND name = 'agent_durability_records')"
+            ).fetchone()[0]
             snapshot = {
                 "integrity_check": connection.execute(
                     "PRAGMA integrity_check"
@@ -1899,6 +1903,17 @@ class CaseHarness:
                         "SELECT agent_id FROM agent_states ORDER BY agent_id"
                     )
                 ],
+                "canonical_relation_agents": (
+                    [
+                        row[0]
+                        for row in connection.execute(
+                            "SELECT DISTINCT agent_id FROM agent_durability_records "
+                            "ORDER BY agent_id"
+                        )
+                    ]
+                    if has_canonical_relations
+                    else []
+                ),
                 "messages": sqlite_rows(
                     connection,
                     "SELECT evidence_id, message_id, turn_id, payload_json "
@@ -2681,6 +2696,12 @@ def run_runtime_upgrade_previous_release_case(
     )
 
     harness.stop()
+    # Releases at or after the relation-write cutover (#2825, first shipped
+    # in v0.38.0) persist canonical relations at agent creation, so upgrades
+    # from those databases must report no legacy migration work.
+    previous_writes_canonical_relations = bool(
+        set(old_snapshot["canonical_relation_agents"]) & old_agent_ids
+    )
     relation_report = harness.offline_debug(
         "upgrade-v030-agent-relations-report",
         "runtime-db",
@@ -2688,12 +2709,24 @@ def run_runtime_upgrade_previous_release_case(
         "--diagnostic-sample-limit",
         "100",
     )
-    require(
-        relation_report["apply"] is False
-        and relation_report["scanned_agents"] >= len(old_agent_ids)
-        and relation_report["changed_agents"] > 0,
-        f"legacy agent relation report did not find migration work: {relation_report}",
-    )
+    if previous_writes_canonical_relations:
+        require(
+            relation_report["apply"] is False
+            and relation_report["scanned_agents"] >= len(old_agent_ids)
+            and relation_report["changed_agents"] == 0
+            and relation_report["unchanged_agents"] >= len(old_agent_ids)
+            and relation_report["diagnostic_agents"] == 0,
+            "agent relation report found unexpected migration work on a "
+            f"canonical database: {relation_report}",
+        )
+    else:
+        require(
+            relation_report["apply"] is False
+            and relation_report["scanned_agents"] >= len(old_agent_ids)
+            and relation_report["changed_agents"] > 0,
+            "legacy agent relation report did not find migration work: "
+            f"{relation_report}",
+        )
     require(
         legacy_agent_id
         not in {
@@ -2710,11 +2743,16 @@ def run_runtime_upgrade_previous_release_case(
         "--diagnostic-sample-limit",
         "100",
     )
+    expected_backfill_changes = (
+        0
+        if previous_writes_canonical_relations
+        else relation_report["changed_agents"]
+    )
     require(
         relation_apply["apply"] is True
         and relation_apply["run_id"]
         and relation_apply["backup_path"]
-        and relation_apply["changed_agents"] > 0,
+        and relation_apply["changed_agents"] == expected_backfill_changes,
         f"legacy agent relation backfill did not apply: {relation_apply}",
     )
     relation_retry = harness.offline_debug(


### PR DESCRIPTION
## Summary

The Release E2E run for the v0.39.0 candidate ([run 34623756563](https://github.com/holon-run/holon/actions/runs/34623756563)) failed deterministically in `runtime-upgrade-v030`:

```
FAIL runtime-upgrade-v030: legacy agent relation report did not find migration work:
{'apply': False, 'changed_agents': 0, 'scanned_agents': 2, 'unchanged_agents': 2, ...}
```

This is a stale assertion, not a runtime regression. Since the relation-write cutover (#2825, first shipped in v0.38.0), the previous release already persists the canonical relation record set at agent creation. The release contract upgrades from the previous release (`previous_ref=v0.38.0`), so the upgraded database correctly contains no legacy relation work and the backfill report returns `changed_agents=0`.

## Changes

- `upgrade_db_snapshot` now reports `canonical_relation_agents` (guarded by a `sqlite_master` existence check, so pre-canonical previous releases yield an empty list).
- `runtime-upgrade-v030` branches the migration assertions on whether the old database already contains canonical relation records for the old agents:
  - **Post-cutover previous release:** the report must be a clean no-op (`changed_agents == 0`, `unchanged_agents` covers the old agents, no diagnostic agents), and `--apply` must report the same zero-change result while still producing `run_id` and `backup_path`.
  - **Pre-cutover previous release:** unchanged behavior — the report must find migration work and `--apply` must apply exactly what the report found.
- The ambiguity guard (legacy agent must not appear in diagnostics), idempotent-retry check, canonical-table presence checks, and the post-upgrade turn assertions apply to both branches.

## Verification

- `python3 -m unittest tests.test_docker_e2e_runner`: 88 tests pass.
- `python3 scripts/docker-e2e.py --validate-manifest`: valid.
- The real E2E coverage for this path is the Release E2E workflow itself; after merge this PR's merge commit becomes the new v0.39.0 candidate and will re-run the suite.