### PR TITLE
feat: add core end-to-end tracing

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -7138,6 +7138,212 @@
         ],
         "type": "string"
       },
+      "RecentTrace": {
+        "properties": {
+          "completed_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "dropped_spans": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "duration_us": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "error_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "span_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "spans": {
+            "items": {
+              "properties": {
+                "attributes": {
+                  "properties": {
+                    "agent_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "message_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "provider": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "round": {
+                      "format": "uint64",
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "run_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "task_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "tool_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "turn_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "completed_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "duration_us": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "parent_span_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "span_id": {
+                  "type": "string"
+                },
+                "started_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "status": {
+                  "enum": [
+                    "ok",
+                    "error"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "span_id",
+                "started_at",
+                "completed_at",
+                "duration_us",
+                "status",
+                "attributes"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "started_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "trace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "started_at",
+          "completed_at",
+          "duration_us",
+          "span_count",
+          "dropped_spans",
+          "error_count",
+          "spans"
+        ],
+        "title": "RecentTrace",
+        "type": "object"
+      },
+      "RecentTraceSummaryList": {
+        "items": {
+          "properties": {
+            "completed_at": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "dropped_spans": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "duration_us": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "error_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "span_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "started_at": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "trace_id",
+            "started_at",
+            "completed_at",
+            "duration_us",
+            "span_count",
+            "dropped_spans",
+            "error_count"
+          ],
+          "type": "object"
+        },
+        "title": "Array_of_RecentTraceSummary",
+        "type": "array"
+      },
       "ReconcileSkillRequest": {
         "properties": {
           "name": {
@@ -16824,6 +17030,171 @@
           }
         ],
         "summary": "Runtime status",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/api/control/runtime/traces": {
+      "get": {
+        "description": "Return summaries for the bounded in-memory recent trace ring.",
+        "operationId": "runtimeTraces",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecentTraceSummaryList"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Recent runtime traces",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/api/control/runtime/traces/search": {
+      "get": {
+        "description": "Search the bounded in-memory recent trace ring by trace or span attributes.",
+        "operationId": "runtimeTraceSearch",
+        "parameters": [
+          {
+            "description": "Case-insensitive trace or span attribute search text.",
+            "in": "query",
+            "name": "query",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecentTraceSummaryList"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Search recent runtime traces",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/api/control/runtime/traces/{trace_id}": {
+      "get": {
+        "description": "Return the recorded span waterfall for one recent trace.",
+        "operationId": "runtimeTrace",
+        "parameters": [
+          {
+            "description": "Trace id.",
+            "in": "path",
+            "name": "trace_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecentTrace"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime trace waterfall",
         "tags": [
           "runtime"
         ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -683,6 +683,14 @@ pub enum DebugCommands {
         #[arg(long)]
         json: bool,
     },
+    Trace {
+        #[arg(conflicts_with = "search")]
+        trace_id: Option<String>,
+        #[arg(long, conflicts_with = "trace_id")]
+        search: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
     RuntimeDb {
         #[command(subcommand)]
         command: RuntimeDbDebugCommands,

--- a/src/client.rs
+++ b/src/client.rs
@@ -440,6 +440,26 @@ impl LocalClient {
         self.get_control_json("/control/runtime/performance").await
     }
 
+    pub async fn recent_traces(&self) -> Result<Vec<crate::observability::RecentTraceSummary>> {
+        self.get_control_json("/control/runtime/traces").await
+    }
+
+    pub async fn recent_trace(&self, trace_id: &str) -> Result<crate::observability::RecentTrace> {
+        self.get_control_json(&format!("/control/runtime/traces/{trace_id}"))
+            .await
+    }
+
+    pub async fn search_recent_traces(
+        &self,
+        query: &str,
+    ) -> Result<Vec<crate::observability::RecentTraceSummary>> {
+        let query = url::form_urlencoded::Serializer::new(String::new())
+            .append_pair("query", query)
+            .finish();
+        self.get_control_json(&format!("/control/runtime/traces/search?{query}",))
+            .await
+    }
+
     pub async fn update_runtime_config(
         &self,
         request: &RuntimeConfigUpdateRequest,

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -56,6 +56,44 @@ pub async fn runtime_performance(
     Ok(Json(diagnostics::performance_snapshot()))
 }
 
+pub async fn runtime_traces(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    Ok(Json(crate::observability::recent_trace_summaries()))
+}
+
+pub async fn runtime_trace(
+    Path(trace_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    crate::observability::recent_trace(&trace_id)
+        .map(Json)
+        .ok_or_else(|| not_found(format!("trace {trace_id} not found")))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RuntimeTraceSearchQuery {
+    pub query: String,
+}
+
+pub async fn runtime_trace_search(
+    Query(query): Query<RuntimeTraceSearchQuery>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    if query.query.trim().is_empty() {
+        return Err(bad_request("trace search query must not be empty"));
+    }
+    Ok(Json(crate::observability::search_recent_traces(
+        query.query.trim(),
+    )))
+}
+
 pub async fn scheduler_repair_inspect(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
@@ -905,6 +943,7 @@ pub async fn control_prompt(
         metadata: Some(json!({ "control": true })),
         correlation_id: None,
         causation_id: None,
+        trace_context: None,
     }
     .into_message();
     let queued = runtime.enqueue(message).await.map_err(error_response)?;
@@ -1407,6 +1446,7 @@ pub async fn operator_ingress(
         metadata: Some(metadata),
         correlation_id: request.correlation_id,
         causation_id: request.causation_id,
+        trace_context: None,
     }
     .into_message();
     let mut message = message;

--- a/src/http/ingress.rs
+++ b/src/http/ingress.rs
@@ -179,6 +179,7 @@ pub async fn generic_webhook(
     Json(payload): Json<Value>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    let trace_context = super::state::trace_context_from_headers(&headers)?;
     enqueue_internal(
         state,
         agent_id,
@@ -201,6 +202,7 @@ pub async fn generic_webhook(
             delivery_surface: MessageDeliverySurface::HttpWebhook,
             admission_context: public_admission_context(),
         },
+        trace_context,
     )
     .await
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -557,6 +557,15 @@ pub fn router(state: AppState) -> Router {
             "/control/runtime/performance",
             get(control::runtime_performance),
         )
+        .route("/control/runtime/traces", get(control::runtime_traces))
+        .route(
+            "/control/runtime/traces/search",
+            get(control::runtime_trace_search),
+        )
+        .route(
+            "/control/runtime/traces/{trace_id}",
+            get(control::runtime_trace),
+        )
         .route("/control/runtime/config", get(control::runtime_config))
         .route(
             "/control/runtime/config",
@@ -1529,6 +1538,9 @@ mod tests {
     use crate::{
         config::{AppConfig, ControlAuthMode},
         host::RuntimeHost,
+        observability::{
+            completed_span, record_span, TraceAttributes, TraceContext, TraceSpanStatus,
+        },
         provider::StubProvider,
         runtime_error::{RuntimeError, RuntimeErrorDomain},
         types::{
@@ -1617,6 +1629,105 @@ mod tests {
         let host =
             RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
         (home, host)
+    }
+
+    #[tokio::test]
+    async fn runtime_trace_queries_require_control_auth_and_return_recent_trace() {
+        let (_home, host) = control_token_test_host();
+        let app = router(AppState::for_tcp(host));
+        let context = TraceContext::new_root(true);
+        let message_id = format!("message-{}", uuid::Uuid::new_v4());
+        let started_at = chrono::Utc::now();
+        record_span(
+            &context,
+            completed_span(
+                "turn",
+                &context,
+                None,
+                started_at,
+                TraceSpanStatus::Ok,
+                TraceAttributes {
+                    message_id: Some(message_id.clone()),
+                    ..Default::default()
+                },
+            ),
+        );
+
+        let unauthorized = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/control/runtime/traces")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let authorized = |uri: &str| {
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .header(header::AUTHORIZATION, "Bearer secret")
+                .body(Body::empty())
+                .unwrap()
+        };
+        let list_response = app
+            .clone()
+            .oneshot(authorized("/api/control/runtime/traces"))
+            .await
+            .unwrap();
+        assert_eq!(list_response.status(), StatusCode::OK);
+        let list: serde_json::Value = serde_json::from_slice(
+            &to_bytes(list_response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(list
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|trace| trace["trace_id"].as_str() == Some(context.trace_id.as_str())));
+
+        let trace_response = app
+            .clone()
+            .oneshot(authorized(&format!(
+                "/api/control/runtime/traces/{}",
+                context.trace_id
+            )))
+            .await
+            .unwrap();
+        assert_eq!(trace_response.status(), StatusCode::OK);
+        let trace: serde_json::Value = serde_json::from_slice(
+            &to_bytes(trace_response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(trace["trace_id"], context.trace_id);
+        assert_eq!(trace["spans"][0]["attributes"]["message_id"], message_id);
+
+        let search_response = app
+            .oneshot(authorized(&format!(
+                "/api/control/runtime/traces/search?query={message_id}"
+            )))
+            .await
+            .unwrap();
+        assert_eq!(search_response.status(), StatusCode::OK);
+        let search: serde_json::Value = serde_json::from_slice(
+            &to_bytes(search_response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(search
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|trace| trace["trace_id"].as_str() == Some(context.trace_id.as_str())));
     }
 
     #[test]

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -9,7 +9,15 @@ pub async fn enqueue_default(
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
     let agent_id = state.host.config().default_agent_id.clone();
-    enqueue_internal(state, agent_id, request, EnqueueIngress::Public).await
+    let trace_context = trace_context_from_headers(&headers)?;
+    enqueue_internal(
+        state,
+        agent_id,
+        request,
+        EnqueueIngress::Public,
+        trace_context,
+    )
+    .await
 }
 
 pub async fn enqueue(
@@ -19,7 +27,15 @@ pub async fn enqueue(
     Json(request): Json<EnqueueRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
-    enqueue_internal(state, agent_id, request, EnqueueIngress::Public).await
+    let trace_context = trace_context_from_headers(&headers)?;
+    enqueue_internal(
+        state,
+        agent_id,
+        request,
+        EnqueueIngress::Public,
+        trace_context,
+    )
+    .await
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -77,7 +93,9 @@ pub(crate) async fn enqueue_internal(
     agent_id: String,
     request: EnqueueRequest,
     ingress: EnqueueIngress,
+    trace_context: Option<crate::observability::TraceContext>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let ingress_started_at = chrono::Utc::now();
     let kind = request.kind.unwrap_or(MessageKind::WebhookEvent);
     if matches!(kind, MessageKind::SystemTick | MessageKind::CallbackEvent) {
         return Err(forbidden(
@@ -169,6 +187,7 @@ pub(crate) async fn enqueue_internal(
         metadata: request.metadata,
         correlation_id: request.correlation_id,
         causation_id: request.causation_id,
+        trace_context,
     }
     .into_message();
 
@@ -178,12 +197,50 @@ pub(crate) async fn enqueue_internal(
         .await
         .map_err(agent_access_error)?;
     let queued = runtime.enqueue(message).await.map_err(error_response)?;
+    if let Some(parent) = queued.trace_context.as_ref() {
+        let context = parent.child();
+        crate::observability::record_span(
+            &context,
+            crate::observability::completed_span(
+                "holon.ingress.admit",
+                &context,
+                Some(parent.span_id.clone()),
+                ingress_started_at,
+                crate::observability::TraceSpanStatus::Ok,
+                crate::observability::TraceAttributes {
+                    agent_id: Some(agent_id.clone()),
+                    message_id: Some(queued.id.clone()),
+                    turn_id: queued.turn_id.clone(),
+                    ..Default::default()
+                },
+            ),
+        );
+    }
 
     Ok(Json(EnqueueResponse {
         ok: true,
         agent_id,
         message_id: queued.id,
     }))
+}
+
+pub(crate) fn trace_context_from_headers(
+    headers: &HeaderMap,
+) -> Result<Option<crate::observability::TraceContext>, (StatusCode, Json<Value>)> {
+    let Some(trace_parent) = headers.get("traceparent") else {
+        return Ok(None);
+    };
+    let trace_parent = trace_parent
+        .to_str()
+        .map_err(|_| bad_request("invalid traceparent header"))?;
+    let trace_state = headers
+        .get("tracestate")
+        .map(|value| value.to_str())
+        .transpose()
+        .map_err(|_| bad_request("invalid tracestate header"))?;
+    crate::observability::TraceContext::parse(trace_parent, trace_state)
+        .map(Some)
+        .map_err(|error| bad_request(error.to_string()))
 }
 
 pub async fn status_default(

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::observability::TraceContext;
 use crate::types::{
     AdmissionContext, AuthorityClass, MessageBody, MessageDeliverySurface, MessageEnvelope,
     MessageKind, MessageOrigin, Priority,
@@ -19,6 +20,7 @@ pub struct InboundRequest {
     pub metadata: Option<serde_json::Value>,
     pub correlation_id: Option<String>,
     pub causation_id: Option<String>,
+    pub trace_context: Option<TraceContext>,
 }
 
 impl InboundRequest {
@@ -36,6 +38,7 @@ impl InboundRequest {
         message.metadata = self.metadata;
         message.correlation_id = self.correlation_id;
         message.causation_id = self.causation_id;
+        message.trace_context = self.trace_context;
         message
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod model_discovery;
 pub mod notes_catalog;
 pub mod object_query_cache;
 pub mod object_resolver;
+pub mod observability;
 pub mod oidc;
 pub mod onboarding;
 pub mod onboarding_tui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2020,6 +2020,51 @@ mod tests {
     }
 
     #[test]
+    fn debug_trace_command_parses_query_modes() {
+        let cli = Cli::parse_from(["holon", "debug", "trace", "trace-id", "--json"]);
+        let Commands::Debug {
+            command:
+                DebugCommands::Trace {
+                    trace_id,
+                    search,
+                    json,
+                },
+        } = cli.command
+        else {
+            panic!("expected debug trace command");
+        };
+        assert_eq!(trace_id.as_deref(), Some("trace-id"));
+        assert_eq!(search, None);
+        assert!(json);
+
+        let cli = Cli::parse_from(["holon", "debug", "trace", "--search", "message-id"]);
+        let Commands::Debug {
+            command:
+                DebugCommands::Trace {
+                    trace_id,
+                    search,
+                    json,
+                },
+        } = cli.command
+        else {
+            panic!("expected debug trace search command");
+        };
+        assert_eq!(trace_id, None);
+        assert_eq!(search.as_deref(), Some("message-id"));
+        assert!(!json);
+
+        assert!(Cli::try_parse_from([
+            "holon",
+            "debug",
+            "trace",
+            "trace-id",
+            "--search",
+            "message-id",
+        ])
+        .is_err());
+    }
+
+    #[test]
     fn export_scheduler_fixture_writes_replay_harness_shape() {
         let config = test_config();
         let agent_id = "default";
@@ -2845,6 +2890,11 @@ async fn handle_debug_command(config: AppConfig, command: DebugCommands) -> Resu
             events_limit,
         } => print_latency_diagnostics(&config, agent, limit, events_limit),
         DebugCommands::Performance { json } => print_performance_diagnostics(&config, json).await,
+        DebugCommands::Trace {
+            trace_id,
+            search,
+            json,
+        } => print_trace_diagnostics(&config, trace_id, search, json).await,
         DebugCommands::RuntimeDb { command } => handle_runtime_db_debug_command(&config, command),
         DebugCommands::SchedulerFixture { agent, output } => {
             export_scheduler_fixture(&config, agent, &output)
@@ -3899,6 +3949,62 @@ async fn print_performance_diagnostics(config: &AppConfig, json: bool) -> Result
     print_metric_group("projections", &snapshot.projections);
     print_metric_group("db", &snapshot.db);
     print_metric_group("scheduler", &snapshot.scheduler);
+    Ok(())
+}
+
+async fn print_trace_diagnostics(
+    config: &AppConfig,
+    trace_id: Option<String>,
+    search: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let client = LocalClient::new(config.clone())?;
+    if let Some(query) = search {
+        let traces = client.search_recent_traces(&query).await?;
+        if json {
+            return print_json(&serde_json::to_value(traces)?);
+        }
+        for trace in traces {
+            println!(
+                "{}  {} us  {} spans  {} errors",
+                trace.trace_id, trace.duration_us, trace.span_count, trace.error_count
+            );
+        }
+        return Ok(());
+    }
+    if let Some(trace_id) = trace_id {
+        let trace = client.recent_trace(&trace_id).await?;
+        if json {
+            return print_json(&serde_json::to_value(trace)?);
+        }
+        println!(
+            "{}  {} us  {} spans  {} errors",
+            trace.trace_id, trace.duration_us, trace.span_count, trace.error_count
+        );
+        for span in trace.spans {
+            let offset_us = span
+                .started_at
+                .signed_duration_since(trace.started_at)
+                .num_microseconds()
+                .unwrap_or_default()
+                .max(0);
+            println!(
+                "{offset_us:>10} us  {:>10} us  {:<30} {:?}",
+                span.duration_us, span.name, span.status
+            );
+        }
+        return Ok(());
+    }
+    let traces = client.recent_traces().await?;
+    if json {
+        return print_json(&serde_json::to_value(traces)?);
+    }
+    for trace in traces {
+        println!(
+            "{}  {} us  {} spans  {} errors",
+            trace.trace_id, trace.duration_us, trace.span_count, trace.error_count
+        );
+    }
     Ok(())
 }
 

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1,0 +1,433 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::fmt;
+use std::sync::{Mutex, OnceLock};
+use uuid::Uuid;
+
+const TRACE_ID_HEX_LEN: usize = 32;
+const SPAN_ID_HEX_LEN: usize = 16;
+const RECENT_TRACE_LIMIT: usize = 128;
+const SPANS_PER_TRACE_LIMIT: usize = 256;
+
+static RECENT_TRACES: OnceLock<Mutex<RecentTraceStore>> = OnceLock::new();
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TraceContextError {
+    InvalidTraceParent,
+    UnsupportedVersion,
+    InvalidTraceState,
+}
+
+impl fmt::Display for TraceContextError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidTraceParent => formatter.write_str("invalid W3C traceparent"),
+            Self::UnsupportedVersion => formatter.write_str("unsupported W3C traceparent version"),
+            Self::InvalidTraceState => formatter.write_str("invalid W3C tracestate"),
+        }
+    }
+}
+
+impl std::error::Error for TraceContextError {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct TraceContext {
+    pub trace_id: String,
+    pub span_id: String,
+    pub trace_flags: u8,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct TraceAttributes {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub round: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceSpanStatus {
+    Ok,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct TraceSpan {
+    pub name: String,
+    pub span_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_span_id: Option<String>,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub completed_at: chrono::DateTime<chrono::Utc>,
+    pub duration_us: u64,
+    pub status: TraceSpanStatus,
+    pub attributes: TraceAttributes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct RecentTrace {
+    pub trace_id: String,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub completed_at: chrono::DateTime<chrono::Utc>,
+    pub duration_us: u64,
+    pub span_count: usize,
+    pub dropped_spans: u64,
+    pub error_count: usize,
+    pub spans: Vec<TraceSpan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct RecentTraceSummary {
+    pub trace_id: String,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub completed_at: chrono::DateTime<chrono::Utc>,
+    pub duration_us: u64,
+    pub span_count: usize,
+    pub dropped_spans: u64,
+    pub error_count: usize,
+}
+
+#[derive(Debug, Default)]
+struct RecentTraceStore {
+    traces: VecDeque<RecentTrace>,
+}
+
+pub fn record_span(context: &TraceContext, span: TraceSpan) {
+    let mut store = recent_traces()
+        .lock()
+        .expect("recent trace store lock poisoned");
+    let mut trace = if let Some(index) = store
+        .traces
+        .iter()
+        .position(|trace| trace.trace_id == context.trace_id)
+    {
+        store
+            .traces
+            .remove(index)
+            .expect("trace index should remain valid")
+    } else {
+        RecentTrace {
+            trace_id: context.trace_id.clone(),
+            started_at: span.started_at,
+            completed_at: span.completed_at,
+            duration_us: span.duration_us,
+            span_count: 0,
+            dropped_spans: 0,
+            error_count: 0,
+            spans: Vec::new(),
+        }
+    };
+    trace.started_at = trace.started_at.min(span.started_at);
+    trace.completed_at = trace.completed_at.max(span.completed_at);
+    trace.duration_us = elapsed_us(trace.started_at, trace.completed_at);
+    trace.span_count = trace.span_count.saturating_add(1);
+    if span.status == TraceSpanStatus::Error {
+        trace.error_count = trace.error_count.saturating_add(1);
+    }
+    if trace.spans.len() == SPANS_PER_TRACE_LIMIT {
+        trace.spans.remove(0);
+        trace.dropped_spans = trace.dropped_spans.saturating_add(1);
+    }
+    trace.spans.push(span);
+    store.traces.push_front(trace);
+    store.traces.truncate(RECENT_TRACE_LIMIT);
+}
+
+pub fn recent_trace_summaries() -> Vec<RecentTraceSummary> {
+    recent_traces()
+        .lock()
+        .expect("recent trace store lock poisoned")
+        .traces
+        .iter()
+        .map(RecentTraceSummary::from)
+        .collect()
+}
+
+pub fn recent_trace(trace_id: &str) -> Option<RecentTrace> {
+    recent_traces()
+        .lock()
+        .expect("recent trace store lock poisoned")
+        .traces
+        .iter()
+        .find(|trace| trace.trace_id == trace_id)
+        .cloned()
+}
+
+pub fn search_recent_traces(query: &str) -> Vec<RecentTraceSummary> {
+    recent_traces()
+        .lock()
+        .expect("recent trace store lock poisoned")
+        .traces
+        .iter()
+        .filter(|trace| {
+            trace.trace_id == query
+                || trace.spans.iter().any(|span| {
+                    [
+                        span.attributes.turn_id.as_deref(),
+                        span.attributes.message_id.as_deref(),
+                        span.attributes.run_id.as_deref(),
+                        span.attributes.work_item_id.as_deref(),
+                        span.attributes.task_id.as_deref(),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .any(|value| value == query)
+                })
+        })
+        .map(RecentTraceSummary::from)
+        .collect()
+}
+
+impl From<&RecentTrace> for RecentTraceSummary {
+    fn from(trace: &RecentTrace) -> Self {
+        Self {
+            trace_id: trace.trace_id.clone(),
+            started_at: trace.started_at,
+            completed_at: trace.completed_at,
+            duration_us: trace.duration_us,
+            span_count: trace.span_count,
+            dropped_spans: trace.dropped_spans,
+            error_count: trace.error_count,
+        }
+    }
+}
+
+pub fn completed_span(
+    name: impl Into<String>,
+    context: &TraceContext,
+    parent_span_id: Option<String>,
+    started_at: chrono::DateTime<chrono::Utc>,
+    status: TraceSpanStatus,
+    attributes: TraceAttributes,
+) -> TraceSpan {
+    let completed_at = chrono::Utc::now();
+    TraceSpan {
+        name: name.into(),
+        span_id: context.span_id.clone(),
+        parent_span_id,
+        started_at,
+        completed_at,
+        duration_us: elapsed_us(started_at, completed_at),
+        status,
+        attributes,
+    }
+}
+
+fn recent_traces() -> &'static Mutex<RecentTraceStore> {
+    RECENT_TRACES.get_or_init(|| Mutex::new(RecentTraceStore::default()))
+}
+
+fn elapsed_us(
+    started_at: chrono::DateTime<chrono::Utc>,
+    completed_at: chrono::DateTime<chrono::Utc>,
+) -> u64 {
+    completed_at
+        .signed_duration_since(started_at)
+        .num_microseconds()
+        .unwrap_or_default()
+        .max(0) as u64
+}
+
+impl TraceContext {
+    pub fn new_root(sampled: bool) -> Self {
+        Self {
+            trace_id: Uuid::new_v4().simple().to_string(),
+            span_id: random_span_id(),
+            trace_flags: u8::from(sampled),
+            trace_state: None,
+        }
+    }
+
+    pub fn parse(trace_parent: &str, trace_state: Option<&str>) -> Result<Self, TraceContextError> {
+        let mut parts = trace_parent.trim().split('-');
+        let version = parts.next().ok_or(TraceContextError::InvalidTraceParent)?;
+        let trace_id = parts.next().ok_or(TraceContextError::InvalidTraceParent)?;
+        let span_id = parts.next().ok_or(TraceContextError::InvalidTraceParent)?;
+        let trace_flags = parts.next().ok_or(TraceContextError::InvalidTraceParent)?;
+        if parts.next().is_some() || version.len() != 2 || !is_lower_hex(version) || version == "ff"
+        {
+            return Err(TraceContextError::InvalidTraceParent);
+        }
+        if version != "00" {
+            return Err(TraceContextError::UnsupportedVersion);
+        }
+        if !valid_nonzero_hex(trace_id, TRACE_ID_HEX_LEN)
+            || !valid_nonzero_hex(span_id, SPAN_ID_HEX_LEN)
+            || trace_flags.len() != 2
+            || !is_lower_hex(trace_flags)
+        {
+            return Err(TraceContextError::InvalidTraceParent);
+        }
+        let trace_flags = u8::from_str_radix(trace_flags, 16)
+            .map_err(|_| TraceContextError::InvalidTraceParent)?;
+        let trace_state = trace_state
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(validate_trace_state)
+            .transpose()?;
+        Ok(Self {
+            trace_id: trace_id.to_owned(),
+            span_id: span_id.to_owned(),
+            trace_flags,
+            trace_state,
+        })
+    }
+
+    pub fn trace_parent(&self) -> String {
+        format!(
+            "00-{}-{}-{:02x}",
+            self.trace_id, self.span_id, self.trace_flags
+        )
+    }
+
+    pub fn child(&self) -> Self {
+        Self {
+            trace_id: self.trace_id.clone(),
+            span_id: random_span_id(),
+            trace_flags: self.trace_flags,
+            trace_state: self.trace_state.clone(),
+        }
+    }
+
+    pub fn sampled(&self) -> bool {
+        self.trace_flags & 1 == 1
+    }
+}
+
+fn random_span_id() -> String {
+    Uuid::new_v4().as_bytes()[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn valid_nonzero_hex(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && is_lower_hex(value)
+        && value.as_bytes().iter().any(|byte| *byte != b'0')
+}
+
+fn is_lower_hex(value: &str) -> bool {
+    value
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn validate_trace_state(value: &str) -> Result<String, TraceContextError> {
+    if value.len() > 512 || value.bytes().any(|byte| byte.is_ascii_control()) {
+        return Err(TraceContextError::InvalidTraceState);
+    }
+    Ok(value.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_context_round_trips_w3c_headers() {
+        let context = TraceContext::parse(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+            Some("vendor=value"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            context.trace_parent(),
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        );
+        assert_eq!(context.trace_state.as_deref(), Some("vendor=value"));
+        assert!(context.sampled());
+    }
+
+    #[test]
+    fn child_preserves_trace_and_changes_span() {
+        let parent = TraceContext::new_root(true);
+        let child = parent.child();
+
+        assert_eq!(child.trace_id, parent.trace_id);
+        assert_ne!(child.span_id, parent.span_id);
+        assert_eq!(child.trace_flags, parent.trace_flags);
+    }
+
+    #[test]
+    fn rejects_invalid_or_unsupported_traceparent() {
+        assert_eq!(
+            TraceContext::parse(
+                "00-00000000000000000000000000000000-00f067aa0ba902b7-01",
+                None
+            ),
+            Err(TraceContextError::InvalidTraceParent)
+        );
+        assert_eq!(
+            TraceContext::parse(
+                "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                None
+            ),
+            Err(TraceContextError::UnsupportedVersion)
+        );
+    }
+
+    #[test]
+    fn recent_trace_ring_aggregates_searches_and_bounds_spans() {
+        let root = TraceContext::new_root(true);
+        let message_id = format!("message-{}", Uuid::new_v4());
+        let started_at = chrono::Utc::now();
+
+        for index in 0..(SPANS_PER_TRACE_LIMIT + 2) {
+            let context = root.child();
+            record_span(
+                &context,
+                TraceSpan {
+                    name: format!("span-{index}"),
+                    span_id: context.span_id.clone(),
+                    parent_span_id: Some(root.span_id.clone()),
+                    started_at,
+                    completed_at: started_at,
+                    duration_us: 0,
+                    status: if index == SPANS_PER_TRACE_LIMIT + 1 {
+                        TraceSpanStatus::Error
+                    } else {
+                        TraceSpanStatus::Ok
+                    },
+                    attributes: TraceAttributes {
+                        message_id: Some(message_id.clone()),
+                        ..Default::default()
+                    },
+                },
+            );
+        }
+
+        let trace = recent_trace(&root.trace_id).expect("trace should be retained");
+        assert_eq!(trace.span_count, SPANS_PER_TRACE_LIMIT + 2);
+        assert_eq!(trace.spans.len(), SPANS_PER_TRACE_LIMIT);
+        assert_eq!(trace.dropped_spans, 2);
+        assert_eq!(trace.error_count, 1);
+        assert_eq!(trace.spans[0].name, "span-2");
+        assert_eq!(
+            search_recent_traces(&message_id)
+                .into_iter()
+                .map(|summary| summary.trace_id)
+                .collect::<Vec<_>>(),
+            vec![root.trace_id]
+        );
+    }
+}

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -18,6 +18,7 @@ use crate::{
     http_dto::{AgentStateSnapshotDto, SlimTaskDto, SlimWorkItemDto},
     memory::MemoryGetResult,
     model_config_migration::ModelConfigMigrationReport,
+    observability::{RecentTrace, RecentTraceSummary},
     runtime::{SchedulerRepairInspection, SchedulerRepairRequest, SchedulerRepairResult},
     types::{
         AddSkillRequest, BriefRecord, CheckSkillRequest, ReconcileSkillRequest,
@@ -155,6 +156,9 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/control/runtime/readiness", "runtimeReadiness", "runtime", "Runtime readiness", "Return daemon readiness metadata.", None, AuthKind::Control),
     route("get", "/control/runtime/status", "runtimeStatus", "runtime", "Runtime status", "Return daemon status and runtime activity metadata.", None, AuthKind::Control),
     route_with_response("get", "/control/runtime/performance", "runtimePerformance", "runtime", "Runtime performance diagnostics", "Return bounded in-process performance diagnostics for HTTP, projections, DB, and scheduler activity.", None, "PerformanceDiagnosticsSnapshot", AuthKind::Control),
+    route_with_response("get", "/control/runtime/traces", "runtimeTraces", "runtime", "Recent runtime traces", "Return summaries for the bounded in-memory recent trace ring.", None, "RecentTraceSummaryList", AuthKind::Control),
+    route_with_response("get", "/control/runtime/traces/search", "runtimeTraceSearch", "runtime", "Search recent runtime traces", "Search the bounded in-memory recent trace ring by trace or span attributes.", None, "RecentTraceSummaryList", AuthKind::Control),
+    route_with_response("get", "/control/runtime/traces/{trace_id}", "runtimeTrace", "runtime", "Runtime trace waterfall", "Return the recorded span waterfall for one recent trace.", None, "RecentTrace", AuthKind::Control),
     route_with_response("get", "/control/runtime/config", "runtimeConfig", "runtime", "Runtime config", "Return the daemon effective runtime configuration surface.", None, "RuntimeConfigReadResponse", AuthKind::Control),
     route_with_response("patch", "/control/runtime/config", "runtimeConfigUpdate", "runtime", "Update runtime config", "Persist runtime-mutable config updates and classify their effect as restart/reload-required or rejected.", Some("RuntimeConfigUpdateRequest"), "RuntimeConfigUpdateResponse", AuthKind::Control),
     route_with_response("post", "/control/runtime/config/migrate-model-routes", "migrateModelConfigRoutes", "runtime", "Migrate model config routes", "Inspect legacy model route references or persist a complete canonical migration across config.json and agent state.", Some("ModelConfigMigrationRequest"), "ModelConfigMigrationReport", AuthKind::Control),
@@ -395,12 +399,22 @@ fn aide_operation(spec: &RouteSpec) -> Operation {
 }
 
 fn operation(spec: &RouteSpec) -> Value {
+    let mut parameters = path_parameters(spec.path);
+    if spec.operation_id == "runtimeTraceSearch" {
+        parameters.push(json!({
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "Case-insensitive trace or span attribute search text.",
+            "schema": { "type": "string", "minLength": 1 }
+        }));
+    }
     let mut op = json!({
         "operationId": spec.operation_id,
         "tags": [spec.tag],
         "summary": spec.summary,
         "description": spec.description,
-        "parameters": path_parameters(spec.path),
+        "parameters": parameters,
         "responses": responses(spec.response_kind, spec.response_schema),
     });
     if let Some(schema) = spec.request_schema {
@@ -451,6 +465,9 @@ fn path_parameters(path: &str) -> Vec<Value> {
     }
     if path.contains("{message_id}") {
         params.push(path_param("message_id", "Message id."));
+    }
+    if path.contains("{trace_id}") {
+        params.push(path_param("trace_id", "Trace id."));
     }
     if path.contains("{skill_id}") {
         params.push(path_param("skill_id", "Root-qualified skill id."));
@@ -658,6 +675,11 @@ fn component_schemas() -> Value {
         "PerformanceDiagnosticsSnapshot".into(),
         component_schema::<PerformanceDiagnosticsSnapshot>(),
     );
+    schemas.insert(
+        "RecentTraceSummaryList".into(),
+        component_schema::<Vec<RecentTraceSummary>>(),
+    );
+    schemas.insert("RecentTrace".into(), component_schema::<RecentTrace>());
     schemas.insert(
         "RuntimeConfigUpdateRequest".into(),
         component_schema::<RuntimeConfigUpdateRequest>(),

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -250,6 +250,7 @@ async fn run_once_with_host_inner(
         metadata: None,
         correlation_id: None,
         causation_id: None,
+        trace_context: None,
     };
     // Set turn budget before enqueueing the message so the turn execution
     // pipeline can inject a budget warning on the last allowed turn.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4124,6 +4124,10 @@ impl RuntimeHandle {
         if message.turn_id.is_none() {
             message.turn_id = Some(crate::ids::turn_id());
         }
+        if message.trace_context.is_none() {
+            message.trace_context = Some(crate::observability::TraceContext::new_root(true));
+        }
+        let enqueue_started_at = chrono::Utc::now();
         for attempt in 0..ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
             match self.enqueue_attempt(&message, delivery).await {
                 Ok(mut commit) => {
@@ -4134,6 +4138,27 @@ impl RuntimeHandle {
                         });
                     let receipt = commit.delivery_receipt.clone();
                     self.apply_transition_commit(commit).await;
+                    if let Some(parent) = message.trace_context.as_ref() {
+                        let span_context = parent.child();
+                        crate::observability::record_span(
+                            &span_context,
+                            crate::observability::completed_span(
+                                "holon.message.enqueue",
+                                &span_context,
+                                Some(parent.span_id.clone()),
+                                enqueue_started_at,
+                                crate::observability::TraceSpanStatus::Ok,
+                                crate::observability::TraceAttributes {
+                                    agent_id: Some(message.agent_id.clone()),
+                                    message_id: Some(message.id.clone()),
+                                    turn_id: message.turn_id.clone(),
+                                    work_item_id: message.work_item_id.clone(),
+                                    task_id: message.task_id.clone(),
+                                    ..Default::default()
+                                },
+                            ),
+                        );
+                    }
                     return Ok((message, receipt));
                 }
                 Err(error) => {
@@ -4951,11 +4976,17 @@ impl RuntimeHandle {
             }
             self.append_state_changed_events(&scheduled.running_state)?;
 
+            let turn_trace_context = scheduled
+                .message
+                .trace_context
+                .as_ref()
+                .map(crate::observability::TraceContext::child);
             let terminal_transition = match self
                 .process_message_with_plan_deferred(
                     scheduled.message,
                     scheduled.dispatch_plan,
                     &scheduled.scheduler_decision,
+                    turn_trace_context,
                 )
                 .await
             {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4976,17 +4976,11 @@ impl RuntimeHandle {
             }
             self.append_state_changed_events(&scheduled.running_state)?;
 
-            let turn_trace_context = scheduled
-                .message
-                .trace_context
-                .as_ref()
-                .map(crate::observability::TraceContext::child);
             let terminal_transition = match self
                 .process_message_with_plan_deferred(
                     scheduled.message,
                     scheduled.dispatch_plan,
                     &scheduled.scheduler_decision,
-                    turn_trace_context,
                 )
                 .await
             {

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -187,11 +187,65 @@ impl RuntimeHandle {
         plan: MessageDispatchPlan,
         scheduler_decision: &scheduler::SchedulerDecision,
     ) -> Result<()> {
-        let transition = self
-            .process_message_with_plan_deferred(message, plan, scheduler_decision)
-            .await?;
-        self.persist_terminal_transition(&transition).await?;
-        Ok(())
+        let trace_context = message.trace_context.clone();
+        let attributes = crate::observability::TraceAttributes {
+            agent_id: Some(message.agent_id.clone()),
+            message_id: Some(message.id.clone()),
+            turn_id: message.turn_id.clone(),
+            work_item_id: message.work_item_id.clone(),
+            task_id: message.task_id.clone(),
+            ..Default::default()
+        };
+        if let Some(parent) = trace_context.as_ref() {
+            let queue_context = parent.child();
+            crate::observability::record_span(
+                &queue_context,
+                crate::observability::completed_span(
+                    "holon.scheduler.queue_wait",
+                    &queue_context,
+                    Some(parent.span_id.clone()),
+                    message.created_at,
+                    crate::observability::TraceSpanStatus::Ok,
+                    attributes.clone(),
+                ),
+            );
+        }
+        let turn_context = trace_context
+            .as_ref()
+            .map(crate::observability::TraceContext::child);
+        let turn_started_at = chrono::Utc::now();
+        let result = async {
+            let transition = self
+                .process_message_with_plan_deferred(
+                    message,
+                    plan,
+                    scheduler_decision,
+                    turn_context.clone(),
+                )
+                .await?;
+            self.persist_terminal_transition(&transition).await?;
+            Ok(())
+        }
+        .await;
+        if let Some(context) = turn_context.as_ref() {
+            let status = if result.is_ok() {
+                crate::observability::TraceSpanStatus::Ok
+            } else {
+                crate::observability::TraceSpanStatus::Error
+            };
+            crate::observability::record_span(
+                context,
+                crate::observability::completed_span(
+                    "holon.turn",
+                    context,
+                    trace_context.as_ref().map(|parent| parent.span_id.clone()),
+                    turn_started_at,
+                    status,
+                    attributes,
+                ),
+            );
+        }
+        result
     }
 
     pub(super) async fn process_message_with_plan_deferred(
@@ -199,6 +253,7 @@ impl RuntimeHandle {
         mut message: MessageEnvelope,
         plan: MessageDispatchPlan,
         scheduler_decision: &scheduler::SchedulerDecision,
+        turn_trace_context: Option<crate::observability::TraceContext>,
     ) -> Result<turn::TurnTerminalTransition> {
         message.normalize_admission_fields();
         self.inner.storage.append_event(&AuditEvent::typed(
@@ -273,6 +328,7 @@ impl RuntimeHandle {
                             LoopControlOptions {
                                 max_tool_rounds: None,
                             },
+                            turn_trace_context,
                         )
                         .await?,
                     );

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -187,6 +187,19 @@ impl RuntimeHandle {
         plan: MessageDispatchPlan,
         scheduler_decision: &scheduler::SchedulerDecision,
     ) -> Result<()> {
+        let transition = self
+            .process_message_with_plan_deferred(message, plan, scheduler_decision)
+            .await?;
+        self.persist_terminal_transition(&transition).await?;
+        Ok(())
+    }
+
+    pub(super) async fn process_message_with_plan_deferred(
+        &self,
+        message: MessageEnvelope,
+        plan: MessageDispatchPlan,
+        scheduler_decision: &scheduler::SchedulerDecision,
+    ) -> Result<turn::TurnTerminalTransition> {
         let trace_context = message.trace_context.clone();
         let attributes = crate::observability::TraceAttributes {
             agent_id: Some(message.agent_id.clone()),
@@ -214,19 +227,14 @@ impl RuntimeHandle {
             .as_ref()
             .map(crate::observability::TraceContext::child);
         let turn_started_at = chrono::Utc::now();
-        let result = async {
-            let transition = self
-                .process_message_with_plan_deferred(
-                    message,
-                    plan,
-                    scheduler_decision,
-                    turn_context.clone(),
-                )
-                .await?;
-            self.persist_terminal_transition(&transition).await?;
-            Ok(())
-        }
-        .await;
+        let result = self
+            .process_message_with_plan_deferred_in_turn(
+                message,
+                plan,
+                scheduler_decision,
+                turn_context.clone(),
+            )
+            .await;
         if let Some(context) = turn_context.as_ref() {
             let status = if result.is_ok() {
                 crate::observability::TraceSpanStatus::Ok
@@ -248,7 +256,7 @@ impl RuntimeHandle {
         result
     }
 
-    pub(super) async fn process_message_with_plan_deferred(
+    async fn process_message_with_plan_deferred_in_turn(
         &self,
         mut message: MessageEnvelope,
         plan: MessageDispatchPlan,

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -5,6 +5,36 @@ use crate::runtime::turn::TurnTerminalTransition;
 use crate::tool::{ApplyPatchSurface, ToolSpec};
 use crate::types::ExecutionAdmissionProvenance;
 
+fn record_operator_span(
+    parent: Option<&crate::observability::TraceContext>,
+    name: &'static str,
+    started_at: chrono::DateTime<chrono::Utc>,
+    message: &MessageEnvelope,
+) {
+    let Some(parent) = parent else {
+        return;
+    };
+    let context = parent.child();
+    crate::observability::record_span(
+        &context,
+        crate::observability::completed_span(
+            name,
+            &context,
+            Some(parent.span_id.clone()),
+            started_at,
+            crate::observability::TraceSpanStatus::Ok,
+            crate::observability::TraceAttributes {
+                agent_id: Some(message.agent_id.clone()),
+                message_id: Some(message.id.clone()),
+                turn_id: message.turn_id.clone(),
+                work_item_id: message.work_item_id.clone(),
+                task_id: message.task_id.clone(),
+                ..Default::default()
+            },
+        ),
+    );
+}
+
 impl RuntimeHandle {
     #[cfg(test)]
     pub(super) async fn process_interactive_message(
@@ -19,6 +49,10 @@ impl RuntimeHandle {
                 continuation_resolution,
                 self.execution_admission_provenance(message, continuation_resolution, None)?,
                 loop_control,
+                message
+                    .trace_context
+                    .as_ref()
+                    .map(crate::observability::TraceContext::child),
             )
             .await?;
         self.persist_terminal_transition(&terminal_transition)
@@ -32,12 +66,14 @@ impl RuntimeHandle {
         continuation_resolution: Option<&ContinuationResolution>,
         execution_admission_provenance: ExecutionAdmissionProvenance,
         loop_control: LoopControlOptions,
+        trace_context: Option<crate::observability::TraceContext>,
     ) -> Result<TurnTerminalTransition> {
         let result = Box::pin(self.process_interactive_message_deferred(
             message,
             continuation_resolution,
             execution_admission_provenance,
             loop_control,
+            trace_context,
         ))
         .await;
         let cleanup = self.reconfigure_provider_for_turn(None).await;
@@ -57,6 +93,7 @@ impl RuntimeHandle {
         continuation_resolution: Option<&ContinuationResolution>,
         execution_admission_provenance: ExecutionAdmissionProvenance,
         loop_control: LoopControlOptions,
+        trace_context: Option<crate::observability::TraceContext>,
     ) -> Result<TurnTerminalTransition> {
         let (operator_binding_id, operator_reply_route_id) =
             Self::operator_transport_from_message(message);
@@ -175,10 +212,12 @@ impl RuntimeHandle {
                 built,
                 model_selection,
                 loop_control,
+                trace_context.clone(),
             )
             .await?;
         crate::diagnostics::record_turn_total(context_build_started.elapsed());
         let cleanup_started = std::time::Instant::now();
+        let cleanup_started_at = chrono::Utc::now();
 
         if outcome.prepared_work_item_completion.is_some() {
             // The completion report brief, WorkItem transition, tool execution,
@@ -195,7 +234,14 @@ impl RuntimeHandle {
                 &mut brief,
                 outcome.final_text_source_assistant_round_id.as_deref(),
             );
+            let delivery_started_at = chrono::Utc::now();
             self.persist_brief(&brief).await?;
+            record_operator_span(
+                trace_context.as_ref(),
+                "holon.delivery",
+                delivery_started_at,
+                message,
+            );
             outcome.terminal.no_brief_reason = None;
         } else if !outcome.final_text.trim().is_empty() {
             // Always generate the normal result brief (no longer suppressed for
@@ -214,7 +260,14 @@ impl RuntimeHandle {
                 &mut brief,
                 outcome.final_text_source_assistant_round_id.as_deref(),
             );
+            let delivery_started_at = chrono::Utc::now();
             self.persist_brief(&brief).await?;
+            record_operator_span(
+                trace_context.as_ref(),
+                "holon.delivery",
+                delivery_started_at,
+                message,
+            );
             outcome.terminal.no_brief_reason = None;
         }
         let mut turn_record = self.build_turn_record(&outcome.terminal).await?;
@@ -252,6 +305,12 @@ impl RuntimeHandle {
         }
 
         crate::diagnostics::record_turn_cleanup(cleanup_started.elapsed());
+        record_operator_span(
+            trace_context.as_ref(),
+            "holon.turn.cleanup",
+            cleanup_started_at,
+            message,
+        );
         Ok(TurnTerminalTransition {
             terminal: outcome.terminal,
             turn_record,

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -573,7 +573,34 @@ impl RuntimeHandle {
                 guard.state.current_turn_work_item_id = Some(work_item_id);
                 guard.persist_state(&self.inner.storage)?;
             }
-            let transition = self
+            let trace_context = message.trace_context.clone();
+            let attributes = crate::observability::TraceAttributes {
+                agent_id: Some(message.agent_id.clone()),
+                message_id: Some(message.id.clone()),
+                turn_id: message.turn_id.clone(),
+                work_item_id: message.work_item_id.clone(),
+                task_id: message.task_id.clone(),
+                ..Default::default()
+            };
+            if let Some(parent) = trace_context.as_ref() {
+                let queue_context = parent.child();
+                crate::observability::record_span(
+                    &queue_context,
+                    crate::observability::completed_span(
+                        "holon.scheduler.queue_wait",
+                        &queue_context,
+                        Some(parent.span_id.clone()),
+                        message.created_at,
+                        crate::observability::TraceSpanStatus::Ok,
+                        attributes.clone(),
+                    ),
+                );
+            }
+            let turn_context = trace_context
+                .as_ref()
+                .map(crate::observability::TraceContext::child);
+            let turn_started_at = chrono::Utc::now();
+            let result = self
                 .process_interactive_message_deferred_with_cleanup(
                     message,
                     continuation_resolution,
@@ -581,13 +608,28 @@ impl RuntimeHandle {
                     LoopControlOptions {
                         max_tool_rounds: None,
                     },
-                    message
-                        .trace_context
-                        .as_ref()
-                        .map(crate::observability::TraceContext::child),
+                    turn_context.clone(),
                 )
-                .await?;
-            return Ok(transition);
+                .await;
+            if let Some(context) = turn_context.as_ref() {
+                let status = if result.is_ok() {
+                    crate::observability::TraceSpanStatus::Ok
+                } else {
+                    crate::observability::TraceSpanStatus::Error
+                };
+                crate::observability::record_span(
+                    context,
+                    crate::observability::completed_span(
+                        "holon.turn",
+                        context,
+                        trace_context.as_ref().map(|parent| parent.span_id.clone()),
+                        turn_started_at,
+                        status,
+                        attributes,
+                    ),
+                );
+            }
+            return result;
         } else if !model_reentry {
             if emit_result_brief {
                 let brief = brief::make_result(&message.agent_id, message, result_text);

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -581,6 +581,10 @@ impl RuntimeHandle {
                     LoopControlOptions {
                         max_tool_rounds: None,
                     },
+                    message
+                        .trace_context
+                        .as_ref()
+                        .map(crate::observability::TraceContext::child),
                 )
                 .await?;
             return Ok(transition);

--- a/src/runtime/tests/message_dispatch.rs
+++ b/src/runtime/tests/message_dispatch.rs
@@ -299,12 +299,15 @@ async fn dispatch_brief_ack_is_noop() {
 #[tokio::test]
 async fn dispatch_brief_result_is_noop() {
     let (_dir, _ws, runtime) = fresh_runtime().await;
-    let msg = message_of_kind(
+    let mut msg = message_of_kind(
         MessageKind::BriefResult,
         MessageBody::Text {
             text: "result".into(),
         },
     );
+    let trace_context = crate::observability::TraceContext::new_root(true);
+    msg.trace_context = Some(trace_context.clone());
+    let message_id = msg.id.clone();
     let plan = runtime
         .build_message_dispatch_plan(
             &msg,
@@ -320,6 +323,24 @@ async fn dispatch_brief_result_is_noop() {
         .process_message_with_plan(msg, plan, &decision)
         .await
         .expect("BriefResult dispatch should not error");
+
+    let trace = crate::observability::recent_trace(&trace_context.trace_id)
+        .expect("dispatch trace should be retained");
+    for span_name in ["holon.scheduler.queue_wait", "holon.turn"] {
+        let span = trace
+            .spans
+            .iter()
+            .find(|span| span.name == span_name)
+            .unwrap_or_else(|| panic!("{span_name} span should be recorded"));
+        assert_eq!(
+            span.parent_span_id.as_deref(),
+            Some(trace_context.span_id.as_str())
+        );
+        assert_eq!(
+            span.attributes.message_id.as_deref(),
+            Some(message_id.as_str())
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2903,6 +2903,10 @@ async fn standalone_turn_writer_rejects_prepared_completion() {
             LoopControlOptions {
                 max_tool_rounds: None,
             },
+            message
+                .trace_context
+                .as_ref()
+                .map(crate::observability::TraceContext::child),
         )
         .await
         .unwrap();

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -865,6 +865,7 @@ impl RuntimeHandle {
                 model_selection: TurnModelSelection::default(),
                 loop_control,
                 persist_terminal: false,
+                trace_context: None,
             }
             .run(),
         )
@@ -956,6 +957,7 @@ impl RuntimeHandle {
         effective_prompt: EffectivePrompt,
         model_selection: TurnModelSelection,
         loop_control: LoopControlOptions,
+        trace_context: Option<crate::observability::TraceContext>,
     ) -> Result<AgentLoopOutcome> {
         Box::pin(
             TurnExecution {
@@ -966,11 +968,44 @@ impl RuntimeHandle {
                 model_selection,
                 loop_control,
                 persist_terminal: false,
+                trace_context,
             }
             .run(),
         )
         .await
     }
+}
+
+fn record_provider_round_span(
+    parent: Option<&crate::observability::TraceContext>,
+    agent_id: &str,
+    round: usize,
+    started_at: chrono::DateTime<chrono::Utc>,
+    succeeded: bool,
+) {
+    let Some(parent) = parent else {
+        return;
+    };
+    let context = parent.child();
+    crate::observability::record_span(
+        &context,
+        crate::observability::completed_span(
+            "holon.provider.round",
+            &context,
+            Some(parent.span_id.clone()),
+            started_at,
+            if succeeded {
+                crate::observability::TraceSpanStatus::Ok
+            } else {
+                crate::observability::TraceSpanStatus::Error
+            },
+            crate::observability::TraceAttributes {
+                agent_id: Some(agent_id.to_string()),
+                round: Some(round as u64),
+                ..Default::default()
+            },
+        ),
+    );
 }
 
 pub(super) const TOOL_AUDIT_INPUT_STRING_LIMIT: usize = 4_096;
@@ -1094,6 +1129,7 @@ pub(super) struct TurnExecution<'a> {
     pub(super) model_selection: TurnModelSelection,
     pub(super) loop_control: LoopControlOptions,
     pub(super) persist_terminal: bool,
+    pub(super) trace_context: Option<crate::observability::TraceContext>,
 }
 
 impl TurnExecution<'_> {
@@ -1106,6 +1142,7 @@ impl TurnExecution<'_> {
             model_selection,
             loop_control,
             persist_terminal,
+            trace_context,
         } = self;
         let mut completed_rounds = Vec::<TurnRoundRecord>::new();
         let turn_started_at = Instant::now();
@@ -1341,6 +1378,13 @@ impl TurnExecution<'_> {
                     runtime
                         .complete_turn_with_timing(provider.clone(), request)
                         .await;
+                record_provider_round_span(
+                    trace_context.as_ref(),
+                    agent_id,
+                    round,
+                    provider_started_at,
+                    result.is_ok(),
+                );
                 match result {
                     Ok((response, attempt_timeline)) => (
                         response,
@@ -1660,6 +1704,13 @@ impl TurnExecution<'_> {
                     runtime
                         .complete_turn_with_timing(provider.clone(), request)
                         .await;
+                record_provider_round_span(
+                    trace_context.as_ref(),
+                    agent_id,
+                    round,
+                    provider_started_at,
+                    result.is_ok(),
+                );
                 match result {
                     Ok((response, attempt_timeline)) => (
                         response,
@@ -2773,6 +2824,7 @@ impl TurnExecution<'_> {
                         ),
                     effective_work_item_id: pre_tool_work_item_id.clone(),
                 };
+                let tool_started_at = chrono::Utc::now();
                 let tool_exec_started = std::time::Instant::now();
                 let tool_execution = if let Some(snapshot) = runtime.current_run_abort_token().await
                 {
@@ -2797,6 +2849,30 @@ impl TurnExecution<'_> {
                         .await
                 };
                 crate::diagnostics::record_turn_tool_execution(tool_exec_started.elapsed());
+                if let Some(parent) = trace_context.as_ref() {
+                    let tool_context = parent.child();
+                    crate::observability::record_span(
+                        &tool_context,
+                        crate::observability::completed_span(
+                            "holon.tool.execute",
+                            &tool_context,
+                            Some(parent.span_id.clone()),
+                            tool_started_at,
+                            if tool_execution.is_ok() {
+                                crate::observability::TraceSpanStatus::Ok
+                            } else {
+                                crate::observability::TraceSpanStatus::Error
+                            },
+                            crate::observability::TraceAttributes {
+                                agent_id: Some(agent_id.to_string()),
+                                work_item_id: pre_tool_work_item_id.clone(),
+                                tool_name: Some(tool_name.clone()),
+                                round: Some(round as u64),
+                                ..Default::default()
+                            },
+                        ),
+                    );
+                }
                 match tool_execution {
                     Ok((mut result, mut record)) => {
                         let result_content =

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,6 +12,7 @@ use crate::domain::scheduler::{ScenarioMode, SchedulerScenarioClass};
 pub use crate::domain::{agent::*, agent_home_workspace_id, work_item::*, AGENT_HOME_WORKSPACE_ID};
 use crate::ids;
 use crate::model_catalog::ResolvedRuntimeModelPolicy;
+use crate::observability::TraceContext;
 use crate::runtime_error::{RuntimeErrorContext, RuntimeErrorDomain};
 use crate::system::{
     ExecutionProfile, ExecutionSnapshot, WorkspaceAccessMode, WorkspaceProjectionKind,
@@ -48,6 +49,8 @@ impl<'de> Deserialize<'de> for MessageEnvelope {
             task_id: Option<String>,
             #[serde(default)]
             source_refs: BTreeMap<String, String>,
+            #[serde(default)]
+            trace_context: Option<TraceContext>,
             body: MessageBody,
             #[serde(default)]
             delivery_surface: Option<MessageDeliverySurface>,
@@ -77,6 +80,7 @@ impl<'de> Deserialize<'de> for MessageEnvelope {
             work_item_id: compat.work_item_id,
             task_id: compat.task_id,
             source_refs: compat.source_refs,
+            trace_context: compat.trace_context,
             body: compat.body,
             delivery_surface: compat.delivery_surface,
             admission_context: compat.admission_context,
@@ -1895,6 +1899,8 @@ pub struct MessageEnvelope {
     pub task_id: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub source_refs: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_context: Option<TraceContext>,
     pub body: MessageBody,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delivery_surface: Option<MessageDeliverySurface>,
@@ -1928,6 +1934,7 @@ impl MessageEnvelope {
             work_item_id: None,
             task_id: None,
             source_refs: BTreeMap::new(),
+            trace_context: None,
             body,
             delivery_surface: None,
             admission_context: None,
@@ -6093,6 +6100,35 @@ mod tests {
         let message: MessageEnvelope = serde_json::from_value(legacy).unwrap();
 
         assert_eq!(message.authority_class, AuthorityClass::RuntimeInstruction);
+        assert_eq!(message.trace_context, None);
+    }
+
+    #[test]
+    fn message_trace_context_round_trips_without_changing_legacy_shape() {
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::SystemTick,
+            MessageOrigin::System {
+                subsystem: "runtime".into(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "resume".into(),
+            },
+        );
+        message.trace_context = Some(
+            TraceContext::parse(
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                Some("vendor=value"),
+            )
+            .unwrap(),
+        );
+
+        let serialized = serde_json::to_value(&message).unwrap();
+        let decoded: MessageEnvelope = serde_json::from_value(serialized).unwrap();
+
+        assert_eq!(decoded.trace_context, message.trace_context);
     }
 
     #[test]

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -93,7 +93,7 @@ fn render_live_inventory() -> String {
             route
         })
         .collect();
-    assert_eq!(routes.len(), 115, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 118, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -1163,6 +1163,37 @@
     "aliases": []
   },
   {
+    "path": "debug.trace",
+    "positionals": [
+      {
+        "name": "trace_id",
+        "value_name": "TRACE_ID",
+        "index": null,
+        "required": false
+      }
+    ],
+    "flags": [
+      {
+        "long": "json",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      },
+      {
+        "long": "search",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "events",
     "positionals": [],
     "flags": [],

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -850,6 +850,66 @@
   },
   {
     "method": "get",
+    "path": "/api/control/runtime/traces",
+    "handler": "runtime_traces",
+    "operation_id": "runtimeTraces",
+    "tag": "runtime",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/control/runtime/traces/search",
+    "handler": "runtime_trace_search",
+    "operation_id": "runtimeTraceSearch",
+    "tag": "runtime",
+    "parameters": [
+      {
+        "name": "query",
+        "location": "query",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/control/runtime/traces/{trace_id}",
+    "handler": "runtime_trace",
+    "operation_id": "runtimeTrace",
+    "tag": "runtime",
+    "parameters": [
+      {
+        "name": "trace_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/api/events/stream",
     "handler": "global_events_stream",
     "operation_id": "eventsStream",


### PR DESCRIPTION
## Summary

- add strict W3C-compatible `TraceContext` propagation through ingress, persisted message envelopes, activation/turn execution, and follow-up messages
- record bounded in-memory recent spans for HTTP ingress, enqueue, queue wait, turn, provider, tool, cleanup, and delivery boundaries
- expose authenticated control API list/get/search endpoints and `holon debug trace` waterfall output
- preserve backward compatibility for persisted envelopes that predate trace fields

This implements Phase 1 of the end-to-end tracing RFC introduced in #2906. Persistent diagnostics storage, sampling/retention, histograms, OTLP, and OpenMetrics remain in later phases.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --locked --all-targets`
- `cargo test --locked observability::tests --lib`
- `cargo test --locked types::tests --lib`
- targeted authenticated HTTP trace query tests
- targeted CLI trace argument tests and `holon debug trace --help` smoke
- existing timing-sensitive test `runtime::tests::work_items::complete_work_item_uses_followup_report_after_text_before_other_tool` passed 5 consecutive exact reruns

A full `RUSTFLAGS="-D warnings" cargo test --locked --all-targets` run reached the same pre-existing timing-sensitive test timeout previously observed on Phase 0; no trace tests failed, and the exact test passed 5/5 reruns.
