### PR TITLE
fix: preserve timer wake execution fences

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3691,6 +3691,7 @@ impl RuntimeHandle {
                     .ok_or_else(|| {
                         anyhow!("canonical execution admission references an unknown attempt")
                     })?;
+                let claimed_work_revision = attempt.admitted_fences.work_item_source_revision;
                 let owner = match attempt.binding {
                     crate::domain::execution_protocol::ExecutionBinding::WorkItem {
                         work_item_id,
@@ -3705,7 +3706,7 @@ impl RuntimeHandle {
                         crate::types::TurnOwner::Command
                     }
                 };
-                Some((activation_id.clone(), owner))
+                Some((activation_id.clone(), owner, claimed_work_revision))
             }
             ExecutionAdmissionProvenance::LegacyCompat { .. } => None,
         };
@@ -3763,7 +3764,7 @@ impl RuntimeHandle {
             };
             guard.state.current_turn_id = Some(turn_id.clone());
             guard.state.last_turn_terminal = None;
-            if let Some((_, owner)) = canonical_execution_binding.as_ref() {
+            if let Some((_, owner, _)) = canonical_execution_binding.as_ref() {
                 guard.state.current_turn_work_item_id =
                     owner.work_item_id().map(ToString::to_string);
             } else if let Some((_, source_turn)) = replay_source.as_ref() {
@@ -3777,27 +3778,32 @@ impl RuntimeHandle {
                 let work_item_id = if canonical_execution_binding.is_some() {
                     canonical_execution_binding
                         .as_ref()
-                        .and_then(|(_, owner)| owner.work_item_id().map(ToString::to_string))
+                        .and_then(|(_, owner, _)| owner.work_item_id().map(ToString::to_string))
                 } else {
                     message
                         .work_item_id
                         .clone()
                         .or_else(|| guard.state.current_turn_work_item_id.clone())
                 };
-                let claimed_work_revision = work_item_id
-                    .as_deref()
-                    .and_then(|work_item_id| {
-                        self.inner
-                            .runtime_db
-                            .work_items()
-                            .latest(work_item_id)
-                            .ok()
-                            .flatten()
-                    })
-                    .map(|work_item| work_item.revision);
+                let claimed_work_revision = canonical_execution_binding
+                    .as_ref()
+                    .and_then(|(_, _, claimed_work_revision)| *claimed_work_revision)
+                    .or_else(|| {
+                        work_item_id
+                            .as_deref()
+                            .and_then(|work_item_id| {
+                                self.inner
+                                    .runtime_db
+                                    .work_items()
+                                    .latest(work_item_id)
+                                    .ok()
+                                    .flatten()
+                            })
+                            .map(|work_item| work_item.revision)
+                    });
                 let activation_id = canonical_execution_binding
                     .as_ref()
-                    .map(|(activation_id, _)| activation_id.clone());
+                    .map(|(activation_id, _, _)| activation_id.clone());
                 WorkItemExecutionBinding {
                     activation_id,
                     admission_provenance: Some(execution_admission_provenance.clone()),
@@ -3805,7 +3811,7 @@ impl RuntimeHandle {
                     turn_id,
                     owner: canonical_execution_binding
                         .as_ref()
-                        .map(|(_, owner)| owner.clone()),
+                        .map(|(_, owner, _)| owner.clone()),
                     work_item_id,
                     claimed_work_revision,
                 }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -942,6 +942,108 @@ async fn canonical_agent_lifecycle_binding_does_not_inherit_replay_or_message_wo
     );
 }
 
+#[tokio::test]
+async fn canonical_turn_binding_preserves_the_admitted_work_item_revision() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work = runtime
+        .create_work_item("preserve admitted revision".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "work_queue".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "claim work before a later durable write".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::RuntimeSystem,
+        AdmissionContext::RuntimeOwned,
+    );
+    bind_autonomous_work_queue_tick(&mut message, &work, "queued_available");
+    let message = runtime.enqueue(message).await.unwrap();
+    let poll = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .poll()
+        .await
+        .unwrap();
+    let scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+        panic!("work item wake should be claimed");
+    };
+    let activation_id = scheduler_executor::canonical_activation_id(&message.id);
+    let execution = runtime
+        .inner
+        .runtime_db
+        .transitions()
+        .load_execution_protocol_state_if_initialized("default")
+        .unwrap()
+        .unwrap();
+    let admitted_revision = execution.attempts[&activation_id]
+        .admitted_fences
+        .work_item_source_revision
+        .expect("work item attempt should carry an admitted revision");
+
+    let latest = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
+    runtime
+        .storage()
+        .append_work_item(&WorkItemRecord {
+            revision: latest.revision + 1,
+            objective: "durable write after admission".into(),
+            updated_at: Utc::now(),
+            ..latest
+        })
+        .unwrap();
+
+    runtime
+        .begin_interactive_turn_with_provenance(
+            Some(&scheduled.message),
+            None,
+            None,
+            scheduled
+                .dispatch_plan
+                .execution_admission_provenance
+                .clone(),
+        )
+        .await
+        .unwrap();
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state
+            .current_execution_binding
+            .as_ref()
+            .and_then(|binding| binding.claimed_work_revision),
+        Some(admitted_revision)
+    );
+    assert!(
+        runtime
+            .latest_work_item(&work.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .revision
+            > admitted_revision,
+        "the regression requires durable state to have advanced after admission"
+    );
+}
+
 struct OperatorInterjectionProbeProvider {
     calls: Mutex<usize>,
     requests: Mutex<Vec<ProviderTurnRequest>>,

--- a/src/runtime/tests/timers.rs
+++ b/src/runtime/tests/timers.rs
@@ -213,11 +213,12 @@ async fn timer_message_binds_the_unique_matching_wait_work_item() {
         .create_work_item("wait for timer".into(), None, None, Vec::new())
         .await
         .unwrap();
+    runtime.pick_work_item(work.id.clone()).await.unwrap();
     let timer = runtime
         .schedule_timer(100, None, Some("bound timer".into()))
         .await
         .unwrap();
-    runtime
+    let registration = runtime
         .register_wait_for(
             "default",
             Some(work.id.clone()),
@@ -242,6 +243,108 @@ async fn timer_message_binds_the_unique_matching_wait_work_item() {
         .expect("timer tick should be queued");
     assert_eq!(message.work_item_id.as_deref(), Some(work.id.as_str()));
     assert_eq!(message.source_refs.get("timer_id"), Some(&timer.id));
+    let triggered = runtime
+        .storage()
+        .latest_wait_conditions()
+        .unwrap()
+        .into_iter()
+        .find(|condition| condition.id == registration.condition.id)
+        .expect("timer wait should remain durable");
+    assert_eq!(triggered.status, WaitConditionStatus::Triggered);
+    assert_eq!(
+        triggered.trigger_message_id(),
+        Some(message.id.as_str()),
+        "timer fire must trigger the exact wait in the enqueue transaction"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn timer_fire_fault_rolls_back_the_wait_and_wake_transaction() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let clock = controlled_clock();
+    let runtime = RuntimeHandle::new_with_clock(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("timer done")),
+        "default".into(),
+        context_config(),
+        clock,
+    )
+    .unwrap();
+    let work = runtime
+        .create_work_item("atomic timer wake".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work.id.clone()).await.unwrap();
+    let mut timer = runtime
+        .schedule_timer(10_000, None, Some("atomic timer".into()))
+        .await
+        .unwrap();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work.id.clone()),
+            WaitForWakeKind::Timer,
+            Some(timer.id.clone()),
+            "waiting for atomic timer".into(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    runtime.inject_next_transition_fault(
+        crate::runtime_db::transitions::TransitionFaultPoint::AfterCanonicalWrites,
+    );
+    let error = runtime.fire_timer_record(&mut timer).await.unwrap_err();
+    assert_injected_transition_fault(&error);
+    let persisted = runtime
+        .recent_timers(10)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|record| record.id == timer.id)
+        .unwrap();
+    assert_eq!(persisted.status, TimerStatus::Active);
+    assert_eq!(persisted.fire_count, 0);
+    assert!(runtime
+        .inner
+        .runtime_db
+        .timers()
+        .pending_wake(&timer.id)
+        .unwrap()
+        .is_none());
+    assert!(!runtime
+        .storage()
+        .read_recent_messages(10)
+        .unwrap()
+        .iter()
+        .any(|message| message.kind == MessageKind::TimerTick));
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Active)
+    );
+    assert_eq!(runtime.agent_state().await.unwrap().pending, 0);
+
+    runtime.fire_timer_record(&mut timer).await.unwrap();
+    assert_eq!(
+        runtime
+            .storage()
+            .latest_wait_conditions()
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .map(|condition| condition.status),
+        Some(WaitConditionStatus::Triggered)
+    );
 }
 
 #[tokio::test(start_paused = true)]

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -1445,6 +1445,7 @@ impl RuntimeHandle {
         message.normalize_admission_fields();
 
         for attempt in 0..super::ENQUEUE_AGENT_STATE_MAX_ATTEMPTS {
+            let wait_transition = self.wait_trigger_transition_for_message(&message)?;
             let mut guard = self.inner.agent.lock().await;
             let expected_state = guard.last_persisted_state.clone();
             let mut committed_state = guard.state.clone();
@@ -1453,11 +1454,8 @@ impl RuntimeHandle {
             committed_state.total_message_count =
                 self.inner.storage.count_messages()?.saturating_add(1);
             scheduler::apply_message_wake_projection(&mut committed_state);
-            let result = self
-                .inner
-                .runtime_db
-                .timers()
-                .fire(&crate::runtime_db::TimerFire {
+            let result = self.inner.runtime_db.timers().fire_with_wait(
+                &crate::runtime_db::TimerFire {
                     expected: expected.clone(),
                     record: record.clone(),
                     message: message.clone(),
@@ -1470,7 +1468,10 @@ impl RuntimeHandle {
                         updated_at: fired_at,
                     },
                     agent_state: (expected_state, committed_state.clone()),
-                });
+                },
+                wait_transition.as_ref(),
+                self.take_transition_fault(),
+            );
             match result {
                 Ok(result) if result.advanced => {
                     if let Some(message) = result.message {
@@ -1496,6 +1497,19 @@ impl RuntimeHandle {
                             "wake_created": result.wake_created,
                         }),
                     ))?;
+                    if result.wake_created {
+                        if let Some(wait_transition) = wait_transition.as_ref() {
+                            self.inner.storage.append_event(&AuditEvent::legacy(
+                                "wait_condition_triggered",
+                                serde_json::json!({
+                                    "agent_id": message.agent_id,
+                                    "wait_condition_id": wait_transition.record.id,
+                                    "trigger_message_id": message.id,
+                                    "work_item_id": wait_transition.record.work_item_id,
+                                }),
+                            ))?;
+                        }
+                    }
                     if result.wake_created {
                         self.inner.notify.notify_one();
                     }

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -12,6 +12,10 @@ use crate::runtime_db::agent_relations::{
 };
 use crate::runtime_db::evidence::*;
 use crate::runtime_db::index_outbox::RuntimeIndexChange;
+use crate::runtime_db::transitions::{
+    apply_work_item_mutation_tx, inject_fault, validate_wait_condition_expectation_tx,
+    validate_wait_condition_tx, validate_work_item_mutation_tx,
+};
 use crate::runtime_db::types::*;
 use crate::runtime_db::write_queue::RuntimeDbWriteContext;
 use crate::runtime_db::{
@@ -2381,6 +2385,15 @@ impl TimerRepository<'_> {
     }
 
     pub fn fire(&self, command: &TimerFire) -> Result<TimerFireResult> {
+        self.fire_with_wait(command, None, None)
+    }
+
+    pub(crate) fn fire_with_wait(
+        &self,
+        command: &TimerFire,
+        wait_transition: Option<&crate::runtime_db::transitions::QueueWaitTransition>,
+        fault: Option<crate::runtime_db::transitions::TransitionFaultPoint>,
+    ) -> Result<TimerFireResult> {
         self.db.transaction(|tx| {
             if timer_tx(tx, &command.expected.id)?.as_ref() != Some(&command.expected)
                 || command.expected.status != TimerStatus::Active
@@ -2433,6 +2446,17 @@ impl TimerRepository<'_> {
             {
                 return Err(anyhow!("invalid timer wake message or queue entry"));
             }
+            if let Some(wait_transition) = wait_transition {
+                validate_wait_condition_expectation_tx(tx, &wait_transition.expected)?;
+                validate_wait_condition_tx(tx, &wait_transition.record)?;
+                if let Some(work_item) = wait_transition.work_item.as_ref() {
+                    validate_work_item_mutation_tx(tx, work_item)?;
+                }
+            }
+            inject_fault(
+                fault,
+                crate::runtime_db::transitions::TransitionFaultPoint::AfterValidation,
+            )?;
             let (message, inserted) = append_message_tx(tx, &command.message)?;
             if inserted {
                 insert_runtime_index_changes_tx(tx, &[RuntimeIndexChange::for_message(&message)])?;
@@ -2445,7 +2469,18 @@ impl TimerRepository<'_> {
                  VALUES (?1, ?2, ?3, 'pending', ?4, ?4)",
                 params![command.record.id, command.message.id, command.record.fire_count as i64, now],
             )?;
+            if let Some(wait_transition) = wait_transition {
+                upsert_wait_condition_tx(tx, &wait_transition.record)?;
+                if let Some(work_item) = wait_transition.work_item.as_ref() {
+                    apply_work_item_mutation_tx(tx, work_item)?;
+                }
+                insert_runtime_index_changes_tx(tx, &wait_transition.index_changes)?;
+            }
             upsert_agent_state_tx(tx, &command.agent_state.1)?;
+            inject_fault(
+                fault,
+                crate::runtime_db::transitions::TransitionFaultPoint::AfterCanonicalWrites,
+            )?;
             Ok(TimerFireResult {
                 advanced: true,
                 wake_created: true,

--- a/src/runtime_db/transitions.rs
+++ b/src/runtime_db/transitions.rs
@@ -1733,7 +1733,7 @@ impl RuntimeTransitionRepository<'_> {
     }
 }
 
-fn validate_wait_condition_expectation_tx(
+pub(super) fn validate_wait_condition_expectation_tx(
     tx: &Transaction<'_>,
     expected: &WaitConditionExpectation,
 ) -> Result<()> {
@@ -2229,7 +2229,10 @@ fn apply_agent_state_mutation_tx(
     Ok(true)
 }
 
-fn validate_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutation) -> Result<()> {
+pub(super) fn validate_work_item_mutation_tx(
+    tx: &Transaction<'_>,
+    mutation: &WorkItemMutation,
+) -> Result<()> {
     validate_work_item_completion_contract(mutation.record())?;
     match mutation {
         WorkItemMutation::Insert { record } => {
@@ -2360,7 +2363,10 @@ fn validate_work_item_state_transition(
     Ok(())
 }
 
-fn apply_work_item_mutation_tx(tx: &Transaction<'_>, mutation: &WorkItemMutation) -> Result<bool> {
+pub(super) fn apply_work_item_mutation_tx(
+    tx: &Transaction<'_>,
+    mutation: &WorkItemMutation,
+) -> Result<bool> {
     match mutation {
         WorkItemMutation::Insert { record } => {
             let existing = tx
@@ -2399,7 +2405,10 @@ fn validate_task_tx(tx: &Transaction<'_>, incoming: &TaskRecord) -> Result<()> {
     Ok(())
 }
 
-fn validate_wait_condition_tx(tx: &Transaction<'_>, incoming: &WaitConditionRecord) -> Result<()> {
+pub(super) fn validate_wait_condition_tx(
+    tx: &Transaction<'_>,
+    incoming: &WaitConditionRecord,
+) -> Result<()> {
     let existing = tx
         .query_row(
             "SELECT payload_json FROM wait_conditions WHERE wait_condition_id = ?1",
@@ -2633,7 +2642,7 @@ fn validate_queue_operation(command: &QueueTransitionCommand) -> Result<()> {
     Ok(())
 }
 
-fn inject_fault(
+pub(super) fn inject_fault(
     configured: Option<TransitionFaultPoint>,
     current: TransitionFaultPoint,
 ) -> Result<()> {


### PR DESCRIPTION
## Summary

- trigger the exact timer-bound wait inside the same transaction that records the timer wake, message, queue entry, and agent state
- derive canonical turn bindings from the scheduler admission attempt's captured work-item revision instead of rereading a later revision
- add regression coverage for timer wake binding, transactional rollback, admitted-fence preservation, and a complete timer-driven model turn

## Runtime contract

A timer wake now preserves one atomic path from wait trigger through scheduler claim to execution binding. Later dispatch reconciliation can no longer advance the WorkItem revision between admission and completion authority.

The broader consolidation of all wake writers behind one primitive remains scoped to #2909.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- targeted timer atomicity, binding, admitted revision, and end-to-end model-turn tests passed
- `cargo test --all-targets`: 3131 passed, 1 existing asynchronous follow-up test timed out under full-suite load; `cargo test complete_work_item_uses_followup_report_after_text_before_other_tool -- --nocapture` passed when rerun independently

Fixes #2908
