### PR TITLE
fix: bound session catch-up backfill and skip redundant stream flush work

### DIFF
--- a/web-gui/app/src/runtime/agent-session-repository.test.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   AgentSessionRepository,
+  SESSION_CATCHUP_MAX_PAGES,
   type LedgerIngestionIntegration,
   type AgentSessionRepositoryDependencies,
   type AgentSessionRepositoryState,
@@ -245,6 +246,64 @@ describe("AgentSessionRepository", () => {
       5,
       10,
     ]);
+  });
+
+  it("keeps a fresh session on the tail without backfilling retained history", async () => {
+    const harness = createHarness();
+    harness.client.getAgentEvents
+      .mockResolvedValueOnce({
+        events: [event(12), event(11)],
+        oldest_seq: 11,
+        has_older: true,
+      })
+      .mockResolvedValueOnce({
+        events: [event(12)],
+        oldest_seq: 12,
+        has_older: true,
+      });
+
+    await harness.repository.catchUpEvents("agent-a", "info");
+
+    expect(harness.client.getAgentEvents.mock.calls).toEqual([
+      ["agent-a", { limit: 100, order: "desc" }],
+      ["agent-a", { limit: 80, order: "desc", displayLevel: "info" }],
+    ]);
+  });
+
+  it("bounds gap backfill to a fixed page budget per catch-up run", async () => {
+    const harness = createHarness({
+      ...emptyAgentSession(),
+      newestSeq: 3,
+      gaps: [{ afterSeq: 3, beforeSeq: 10 }],
+    });
+    harness.client.getAgentEvents
+      .mockResolvedValueOnce({
+        events: [event(12)],
+        oldest_seq: 500,
+        has_older: true,
+      })
+      .mockResolvedValueOnce({
+        events: [event(12)],
+        oldest_seq: 12,
+        has_older: true,
+      });
+    for (let seq = 4; seq < 4 + SESSION_CATCHUP_MAX_PAGES; seq += 1) {
+      harness.client.getAgentEvents.mockResolvedValueOnce({
+        events: [event(seq)],
+        has_newer: true,
+      });
+    }
+
+    await harness.repository.catchUpEvents("agent-a", "info");
+
+    const ascCalls = harness.client.getAgentEvents.mock.calls.filter(
+      (call) => call[1]?.order === "asc",
+    );
+    expect(ascCalls).toHaveLength(SESSION_CATCHUP_MAX_PAGES);
+    expect(ascCalls[0]?.[1]?.afterSeq).toBe(3);
+    expect(ascCalls[ascCalls.length - 1]?.[1]?.afterSeq).toBe(
+      3 + SESSION_CATCHUP_MAX_PAGES - 1,
+    );
   });
 
   it("deduplicates message hydration and cancels stale generation results", async () => {

--- a/web-gui/app/src/runtime/agent-session-repository.ts
+++ b/web-gui/app/src/runtime/agent-session-repository.ts
@@ -47,6 +47,10 @@ import type {
 const BRIEF_HYDRATION_RETRY_DELAYS_MS = [1_000, 2_000] as const;
 const BRIEF_HYDRATION_MAX_ATTEMPTS = 5;
 
+// Session catch-up closes at most this many ascending pages per run; the
+// rest of the retained history stays behind the explicit load-older flow.
+export const SESSION_CATCHUP_MAX_PAGES = 10;
+
 export interface SessionCacheContext {
   remoteKey: string;
   generation: number;
@@ -853,14 +857,24 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
       );
     }
 
-    // Backfill ascending until the cursor overlaps the tail's oldest event.
+    // Fresh sessions (no cached cursor) intentionally keep only the tail:
+    // older history loads on demand through the explicit load-older flow
+    // instead of backfilling the entire retained history. Sessions with a
+    // cursor backfill ascending to close their gap, bounded per run so one
+    // catch-up cannot serially walk the whole event log.
     const hasGap =
       tailHasOlder &&
       tailOldestSeq != null &&
-      (initialAfterSeq == null || tailOldestSeq > initialAfterSeq + 1);
+      initialAfterSeq != null &&
+      tailOldestSeq > initialAfterSeq + 1;
+    let backfillCapped = false;
     if (hasGap) {
       let afterSeq = initialAfterSeq;
-      while (true) {
+      for (let backfillPages = 0; ; backfillPages += 1) {
+        if (backfillPages >= SESSION_CATCHUP_MAX_PAGES) {
+          backfillCapped = true;
+          break;
+        }
         const page = await client.getAgentEvents(agentId, {
           afterSeq,
           limit: 100,
@@ -899,6 +913,7 @@ export class AgentSessionRepository<State extends AgentSessionRepositoryState> {
       gapCount: gaps.length,
       eventCount,
       pageCount,
+      backfillCapped,
     });
   }
 

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -1259,7 +1259,21 @@ describe("brief projection and hydration", () => {
         .toBe("Background hydrated brief.");
     });
 
+    const sessionBefore = useRuntimeStore.getState().sessionsByAgentId["agent-b"];
     applyStreamEvents(useRuntimeStore.setState, "agent-b", [briefEvent]);
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Duplicate flushes neither commit a new session object nor rehydrate.
+    expect(useRuntimeStore.getState().sessionsByAgentId["agent-b"]).toBe(sessionBefore);
+
+    // A follow-up event that references no new unresolved brief id must not
+    // issue another briefs:batchGet either.
+    const followUpEvent: StreamEventEnvelopeDto = {
+      ...briefEvent,
+      id: "event-brief-b-followup",
+      event_seq: 2,
+    };
+    applyStreamEvents(useRuntimeStore.setState, "agent-b", [followUpEvent]);
     await Promise.resolve();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -4666,24 +4666,48 @@ export function applyStreamEvents(set: StoreSet, agentId: string, events: Stream
   }
   const liveStatus = globalSyncCoordinator.isRecovering(agentId) ? "recovering" : "streaming";
 
+  const currentSession = sessionForEventLogEpoch(
+    currentSnapshot ?? emptyAgentSession(),
+    incomingEpoch,
+  );
+  const uniqueEvents = incomingEvents.filter(
+    (event) => !currentSession.eventsBySeq[event.event_seq as number],
+  );
+  const offerToLedger = (): void => {
+    void agentSessionRepository
+      .ingestSessionEvents(agentId, incomingEvents)
+      .catch((error) => console.warn(`Agent ledger ingestion failed for ${agentId}.`, error));
+  };
+  // Duplicate stream events are common while gap recovery overlaps the live
+  // stream; they must not commit a new session object on every flush. The
+  // ledger is still offered every envelope so its exactness guarantees hold.
+  if (!uniqueEvents.length) {
+    if (currentSession.liveStatus !== liveStatus || currentSession.error !== undefined) {
+      set((state) => ({
+        sessionsByAgentId: {
+          ...state.sessionsByAgentId,
+          [agentId]: {
+            ...sessionForEventLogEpoch(
+              state.sessionsByAgentId[agentId] ?? emptyAgentSession(),
+              incomingEpoch,
+            ),
+            liveStatus,
+            error: undefined,
+          },
+        },
+      }));
+    }
+    offerToLedger();
+    return;
+  }
+  const unresolvedBriefIdsBefore = new Set(briefIdsForProjectionHydration(currentSession));
+  let introducedNewBriefRefs = false;
+
   set((state) => {
     const current = sessionForEventLogEpoch(
       state.sessionsByAgentId[agentId] ?? emptyAgentSession(),
       incomingEpoch,
     );
-    const uniqueEvents = incomingEvents.filter((event) => !current.eventsBySeq[event.event_seq as number]);
-    if (!uniqueEvents.length) {
-      return {
-        sessionsByAgentId: {
-          ...state.sessionsByAgentId,
-          [agentId]: {
-            ...current,
-            liveStatus,
-            error: undefined,
-          },
-        },
-      };
-    }
     const projectionEvents = uniqueEvents.filter(canApplySessionEvent);
     const rosterActivityByAgentId = projectionEvents.reduce(
       (activityByAgentId, event) =>
@@ -4702,6 +4726,9 @@ export function applyStreamEvents(set: StoreSet, agentId: string, events: Stream
       events: uniqueEvents,
       eventLogEpoch: incomingEpoch,
     }, "debug", patchedBaseDetail);
+    introducedNewBriefRefs = briefIdsForProjectionHydration(projected).some(
+      (briefId) => !unresolvedBriefIdsBefore.has(briefId),
+    );
     const timelineEvents = state.timelineEventsByAgentId[agentId];
 
     return {
@@ -4732,12 +4759,15 @@ export function applyStreamEvents(set: StoreSet, agentId: string, events: Stream
       },
     };
   });
-  void agentSessionRepository
-    .ingestSessionEvents(agentId, incomingEvents)
-    .catch((error) => console.warn(`Agent ledger ingestion failed for ${agentId}.`, error));
+  offerToLedger();
   const displayLevel = useRuntimeStore.getState().displayLevel;
   agentSessionRepository.hydrateSelectedContent(agentId, displayLevel);
-  agentSessionRepository.hydrateBriefs(agentId, displayLevel);
+  // Hydrate briefs only when this flush introduced references the store has
+  // not already seen unresolved; otherwise unrelated poll responses would
+  // issue briefs:batchGet on every tick.
+  if (introducedNewBriefRefs) {
+    agentSessionRepository.hydrateBriefs(agentId, displayLevel);
+  }
   agentSessionRepository.scheduleCacheWrite(agentId);
   if (events.some((event) => canApplySessionEvent(event) && isWorkItemCacheInvalidationEvent(event))) {
     void useRuntimeStore.getState().refreshAgentWorkItems(agentId);


### PR DESCRIPTION
## Summary

Fixes #2905. Opening a conversation with a long retained history no longer
backfills the entire event log serially, and stream flushes no longer commit
or hydrate when nothing new arrived.

## Root causes (from #2905)

1. `catchUpEventsInner` treated a missing session cursor as an unbounded gap:
   the ascending `while (true)` loop paged the whole retained history
   (measured: 47 serial pages, 51.4s) with one store commit per page.
2. `applyStreamEvents` committed a new session object on every flush even for
   duplicate events, and called `hydrateBriefs` unconditionally, so unrelated
   agents' event polls re-rendered open pages at ~15Hz and issued
   `briefs:batchGet` on every tick.

## Changes

- `agent-session-repository.ts`
  - Fresh sessions (no cached cursor) keep only the newest tail plus the
    display-filtered tail; older history loads through the existing
    `loadOlderAgentEvents` flow.
  - Gap backfill is bounded by `SESSION_CATCHUP_MAX_PAGES = 10` per run
    (matching `GLOBAL_BACKFILL_MAX_PAGES`), so one catch-up cannot serially
    walk the whole event log; the span records `backfillCapped`.
- `runtime-store.ts` (`applyStreamEvents`)
  - Duplicate stream events commit a new session object only when the live
    status or error actually changed.
  - The durable ledger is still offered every envelope (exactness preserved;
    verified by the divergence-repair e2e).
  - `hydrateBriefs` runs only when the flush introduces brief references the
    store has not already seen unresolved, so polls without new brief refs no
    longer issue `briefs:batchGet`.

## Verification

- `vitest run`: 540 tests passed (44 files), including new cases:
  fresh-session catch-up issues no ascending fetch; gap backfill stops at the
  page budget; duplicate flushes keep the session object reference stable and
  issue no extra `briefs:batchGet`.
- `npm run typecheck`: clean.
- `npm run build`: clean.
- `playwright test --project=chromium`: 7/7 passed (includes the
  divergence-repair/degraded-handle exactness spec that initially caught the
  ledger-ingestion regression and now passes with the ledger offer preserved).
