### PR TITLE
fix(runtime): honor durable wait resume obligations

### DIFF
--- a/docs/implementation-decisions/128-durable-wait-obligation-selection.md
+++ b/docs/implementation-decisions/128-durable-wait-obligation-selection.md
@@ -1,0 +1,16 @@
+# Durable wait obligations use derived queue selection
+
+When a durable wait record is `Triggered` or `Resolved`, its matching queued
+message is selected ahead of ordinary non-`Interject` backlog. The scheduler
+derives this obligation from persisted wait evidence and uses the same
+selection rule for planning, optimistic-concurrency revalidation, and removal
+from the queue.
+
+This does not add a public priority and does not rewrite the queued message's
+declared priority. `Interject` remains strictly first, while unrelated messages
+retain their normal priority and FIFO behavior. A queued `TaskRejoin` also
+remains a protocol barrier until canonical admission either accepts or
+terminalizes it; it is not ordinary backlog that a later obligation may bypass.
+The choice keeps delivery correctness attached to the durable wait lifecycle
+instead of encoding a temporary scheduler obligation into the public message
+envelope.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -119,3 +119,4 @@ Current decision notes:
 - [124 Ollama Tool-Only Round Placeholder User Text](./124-ollama-tool-only-round-placeholder-user-text.md)
 - [125 Agent Id Reincarnation Same Row](./125-agent-id-reincarnation-same-row.md)
 - [126 Current-Run Abort Modes](./126-current-run-abort-modes.md)
+- [128 Durable Wait Obligation Selection](./128-durable-wait-obligation-selection.md)

--- a/docs/rfcs/waiting-plane-and-reactivation.md
+++ b/docs/rfcs/waiting-plane-and-reactivation.md
@@ -100,6 +100,10 @@ The waiting plane should own:
 - cancellation of obsolete waits
 - prompt-level guidance for when waiting is appropriate
 
+It must also preserve delivery evidence once a wait has triggered. Replacing a
+wait for the same scope may cancel an older active intent, but it must not erase
+the fact that an already-triggered message is still owed resolution.
+
 The waiting plane should not own:
 
 - shell process lifecycle
@@ -155,6 +159,16 @@ The runtime therefore preserves these invariants:
   a running turn and one future wake can coexist
 - different timers are never coalesced with each other
 - `fire_count` counts actual timer fires, not queued messages or model turns
+
+The same durable-obligation rule applies to `WaitFor` rechecks:
+
+- an agent-scope wait with `recheck_at` has a runtime-owned deadline executor
+- the executor emits one deterministic recheck message for the wait and
+  deadline, so repeated scans are idempotent
+- the recheck message matches only that exact active wait and may authorize
+  model re-entry without pretending to be external input
+- once a wait trigger is durably recorded, its matching message may overtake
+  ordinary queued backlog, but it never overtakes an `Interject`
 
 Timer cancellation and execution admission compete through one durable wake
 fence. If cancellation wins, pending wakes for that timer become invalid and

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -24,6 +24,16 @@ pub fn message_id() -> String {
     runtime_id("msg")
 }
 
+pub(crate) fn wait_recheck_message_id(wait_id: &str, recheck_at: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"holon.wait-recheck-message.v1\x00");
+    hasher.update(wait_id.as_bytes());
+    hasher.update(b"\x00");
+    hasher.update(recheck_at.as_bytes());
+    let digest = hasher.finalize();
+    format!("msg_recheck1_{}", hex(&digest[..16]))
+}
+
 pub fn agent_message_delivery_id(idempotency_scope: &str, idempotency_key_digest: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"holon.agent-message-delivery.v1\x00");

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -75,6 +75,17 @@ impl RuntimeQueue {
             .or_else(|| self.background.iter().find(|message| predicate(message)))
     }
 
+    pub fn pop_selected(
+        &mut self,
+        message_id: &str,
+        allow_non_head: bool,
+    ) -> Option<MessageEnvelope> {
+        if !allow_non_head {
+            return self.pop_if_next(message_id);
+        }
+        self.pop_next_matching(|message| message.id == message_id)
+    }
+
     pub fn len(&self) -> usize {
         self.interject.len() + self.next.len() + self.normal.len() + self.background.len()
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1220,6 +1220,43 @@ fn exact_agent_scope_task_result_wait(
     Ok(Some(wait.clone()))
 }
 
+fn exact_agent_scope_wait_recheck(
+    storage: &AppStorage,
+    message: &MessageEnvelope,
+) -> Result<Option<WaitConditionRecord>> {
+    let MessageOrigin::System { subsystem } = &message.origin else {
+        return Ok(None);
+    };
+    if message.kind != MessageKind::SystemTick
+        || subsystem != "wait_condition_recheck"
+        || message.authority_class != AuthorityClass::RuntimeInstruction
+        || message.admission_context != Some(AdmissionContext::RuntimeOwned)
+        || message.delivery_surface != Some(MessageDeliverySurface::RuntimeSystem)
+    {
+        return Ok(None);
+    }
+    let Some(wait_id) = message.source_refs.get("wait_id") else {
+        return Ok(None);
+    };
+    let matching_waits = storage
+        .latest_wait_conditions_for_agent(&message.agent_id)?
+        .into_iter()
+        .filter(|wait| {
+            wait.id == *wait_id
+                && wait.work_item_id.is_none()
+                && matches!(
+                    wait.status,
+                    WaitConditionStatus::Triggered | WaitConditionStatus::Resolved
+                )
+                && wait.trigger_message_id() == Some(message.id.as_str())
+        })
+        .collect::<Vec<_>>();
+    let [wait] = matching_waits.as_slice() else {
+        return Ok(None);
+    };
+    Ok(Some(wait.clone()))
+}
+
 enum TaskResultClaimRecovery {
     Replayable {
         transition: crate::runtime_db::transitions::ExecutionProtocolTransition,
@@ -4833,6 +4870,9 @@ impl RuntimeHandle {
         bootstrap?;
 
         loop {
+            if self.emit_due_agent_wait_recheck().await? {
+                continue;
+            }
             let poll = scheduler_executor::SchedulerDecisionExecutor::new(&self)
                 .poll()
                 .await?;
@@ -4901,7 +4941,13 @@ impl RuntimeHandle {
                             &decision,
                         )?;
                     }
-                    let next_recheck_at = self.next_blocked_work_item_recheck_at().await?;
+                    let next_recheck_at = match (
+                        self.next_blocked_work_item_recheck_at().await?,
+                        self.next_agent_wait_recheck_at().await?,
+                    ) {
+                        (Some(left), Some(right)) => Some(left.min(right)),
+                        (left, right) => left.or(right),
+                    };
                     let idle_state = scheduler_executor::SchedulerDecisionExecutor::new(&self)
                         .transition_run_loop_idle_to_sleep(next_recheck_at)
                         .await?;

--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -17,6 +17,9 @@ pub(super) struct ContinuationTrigger {
     /// task result reentry even when the prior closure waiting_reason was
     /// polluted by unrelated waits.
     pub(super) exact_task_wait: bool,
+    /// Durable evidence that this runtime-owned SystemTick is the exact
+    /// recheck event for an agent-scope WaitFor condition.
+    pub(super) exact_wait_recheck: bool,
 }
 
 impl ContinuationTrigger {
@@ -32,6 +35,7 @@ impl ContinuationTrigger {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             }),
             MessageKind::WebhookEvent | MessageKind::CallbackEvent | MessageKind::ChannelEvent => {
                 Some(Self {
@@ -41,6 +45,7 @@ impl ContinuationTrigger {
                     wake_hint_source: None,
                     task_work_item_id: None,
                     exact_task_wait: false,
+                    exact_wait_recheck: false,
                 })
             }
             MessageKind::TimerTick => Some(Self {
@@ -50,6 +55,7 @@ impl ContinuationTrigger {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             }),
             MessageKind::InternalFollowup => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
@@ -58,6 +64,7 @@ impl ContinuationTrigger {
                 task_work_item_id: None,
                 wake_hint_source: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             }),
             MessageKind::SystemTick => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
@@ -72,6 +79,7 @@ impl ContinuationTrigger {
                     .map(ToString::to_string),
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             }),
             MessageKind::TaskResult => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
@@ -89,6 +97,7 @@ impl ContinuationTrigger {
                 // Filled by the dispatch plan builder from durable wait
                 // evidence; from_message alone cannot see wait conditions.
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             }),
             MessageKind::TaskStatus
             | MessageKind::Control
@@ -117,14 +126,22 @@ pub(super) fn resolve_continuation(
         }
         (Some(t), Some(a)) => t == a,
     };
-    let authorization = resolve_resume_authorization(
-        prior.outcome,
-        prior_waiting_reason,
-        trigger.kind,
-        trigger.contentful,
-        trigger.task_result_outcome,
-        same_work_item,
-    );
+    let authorization = if trigger.exact_wait_recheck && trigger.contentful {
+        super::wake_matching::ResumeDecision {
+            authorization: ResumeAuthorization::ExpectedWait,
+            model_reentry: true,
+            matched_waiting_reason: false,
+        }
+    } else {
+        resolve_resume_authorization(
+            prior.outcome,
+            prior_waiting_reason,
+            trigger.kind,
+            trigger.contentful,
+            trigger.task_result_outcome,
+            same_work_item,
+        )
+    };
     let mut evidence = Vec::new();
     evidence.push(format!("trigger_kind={}", enum_label(trigger.kind)));
     if trigger.contentful {
@@ -138,6 +155,9 @@ pub(super) fn resolve_continuation(
     }
     if trigger.exact_task_wait {
         evidence.push("exact_task_wait".to_string());
+    }
+    if trigger.exact_wait_recheck {
+        evidence.push("exact_wait_recheck".to_string());
     }
     if authorization.matched_waiting_reason {
         evidence.push("matches_waiting_reason".to_string());
@@ -263,6 +283,7 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             None,
         );
@@ -281,6 +302,7 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             None,
         );
@@ -305,6 +327,7 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: Some("other-work".into()),
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             Some("active-work"),
         );
@@ -325,6 +348,7 @@ mod tests {
                 wake_hint_source: Some("callback".into()),
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             None,
         );
@@ -343,6 +367,7 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             None,
         );
@@ -363,6 +388,7 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             None,
         );
@@ -387,6 +413,7 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             None,
         );
@@ -417,6 +444,7 @@ mod tests {
                     wake_hint_source: None,
                     task_work_item_id: None,
                     exact_task_wait: false,
+                    exact_wait_recheck: false,
                 },
                 None,
             );
@@ -442,6 +470,7 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             None,
         );
@@ -460,6 +489,7 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             None,
         );
@@ -478,6 +508,7 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             None,
         );
@@ -496,6 +527,7 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             None,
         );
@@ -515,6 +547,7 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
                 exact_task_wait: false,
+                exact_wait_recheck: false,
             },
             None,
         );
@@ -571,6 +604,7 @@ mod tests {
             wake_hint_source: None,
             task_work_item_id: None,
             exact_task_wait: true,
+            exact_wait_recheck: false,
         };
         let resolution = resolve_continuation(
             &waiting(WaitingReason::AwaitingOperatorInput),
@@ -594,6 +628,7 @@ mod tests {
             wake_hint_source: None,
             task_work_item_id: None,
             exact_task_wait: false,
+            exact_wait_recheck: false,
         };
         let resolution = resolve_continuation(
             &waiting(WaitingReason::AwaitingOperatorInput),

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -355,6 +355,113 @@ impl RuntimeHandle {
             .next_blocked_work_item_recheck_at(&agent_id)
     }
 
+    pub(super) async fn next_agent_wait_recheck_at(
+        &self,
+    ) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
+        let agent_id = self.agent_id().await?;
+        Ok(self
+            .inner
+            .storage
+            .raw_unresolved_wait_conditions_for_agent(&agent_id)?
+            .into_iter()
+            .filter(|condition| {
+                condition.work_item_id.is_none()
+                    && condition.status == crate::types::WaitConditionStatus::Active
+            })
+            .filter_map(|condition| condition.recheck_at())
+            .min())
+    }
+
+    pub(super) async fn emit_due_agent_wait_recheck(&self) -> Result<bool> {
+        let agent_id = self.agent_id().await?;
+        let now = self.now();
+        let Some(condition) = self
+            .inner
+            .storage
+            .raw_unresolved_wait_conditions_for_agent(&agent_id)?
+            .into_iter()
+            .filter(|condition| {
+                condition.work_item_id.is_none()
+                    && condition.status == crate::types::WaitConditionStatus::Active
+                    && condition
+                        .recheck_at()
+                        .is_some_and(|deadline| deadline <= now)
+            })
+            .min_by_key(|condition| condition.recheck_at())
+        else {
+            return Ok(false);
+        };
+        let recheck_at = condition
+            .recheck_at()
+            .expect("due agent wait must have a recheck deadline");
+        let recheck_at_key = recheck_at.to_rfc3339();
+        let wake = condition
+            .continuation
+            .as_ref()
+            .and_then(|value| value.get("wake"))
+            .cloned();
+        let resource = condition
+            .continuation
+            .as_ref()
+            .and_then(|value| value.get("resource"))
+            .cloned();
+        let mut message = MessageEnvelope::new(
+            agent_id.clone(),
+            MessageKind::SystemTick,
+            MessageOrigin::System {
+                subsystem: "wait_condition_recheck".into(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Next,
+            MessageBody::Text {
+                text: format!(
+                    "WaitFor recheck deadline reached for wait {}.",
+                    condition.id
+                ),
+            },
+        )
+        .with_admission(
+            MessageDeliverySurface::RuntimeSystem,
+            AdmissionContext::RuntimeOwned,
+        );
+        message.id = crate::ids::wait_recheck_message_id(&condition.id, &recheck_at_key);
+        message
+            .source_refs
+            .insert("wait_id".into(), condition.id.clone());
+        message.metadata = Some(serde_json::json!({
+            "wait_condition_recheck": {
+                "wait_id": condition.id,
+                "recheck_at": recheck_at,
+                "wake": wake,
+                "resource": resource,
+                "waiting_for": condition.waiting_for,
+            }
+        }));
+        self.inner.storage.append_event(&AuditEvent::legacy(
+            "wait_condition_recheck_due",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "wait_id": message.source_refs.get("wait_id"),
+                "message_id": message.id,
+                "recheck_at": recheck_at,
+            }),
+        ))?;
+        let _ = self.enqueue(message).await?;
+        self.inner.storage.append_event(&AuditEvent::legacy(
+            "wait_condition_recheck_enqueued",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "wait_id": condition.id,
+                "message_id": crate::ids::wait_recheck_message_id(
+                    &condition.id,
+                    &recheck_at_key,
+                ),
+                "recheck_at": recheck_at,
+            }),
+        ))?;
+        Ok(true)
+    }
+
     fn duplicate_queued_available_message_id(
         &self,
         work_item: &crate::types::WorkItemRecord,
@@ -999,6 +1106,84 @@ mod tests {
             _dir: dir,
             _workspace: workspace,
         }
+    }
+
+    #[test]
+    fn due_agent_wait_recheck_is_exact_idempotent_and_model_reentering() {
+        let test_runtime = test_runtime();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let registration = rt
+            .block_on(test_runtime.runtime.register_wait_for(
+                "default",
+                None,
+                WaitForWakeKind::OperatorInput,
+                None,
+                "recheck operator wait".into(),
+                Some(0),
+            ))
+            .unwrap();
+        let recheck_at = registration.condition.recheck_at().unwrap();
+        let expected_message_id = crate::ids::wait_recheck_message_id(
+            &registration.condition.id,
+            &recheck_at.to_rfc3339(),
+        );
+        let persisted = test_runtime
+            .runtime
+            .storage()
+            .raw_unresolved_wait_conditions_for_agent("default")
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .expect("agent wait should remain unresolved before its recheck");
+        assert_eq!(persisted.status, crate::types::WaitConditionStatus::Active);
+        assert_eq!(persisted.work_item_id, None);
+        assert!(
+            persisted.recheck_at().unwrap() <= test_runtime.runtime.now(),
+            "zero-delay agent wait should already be due: persisted={:?}, now={:?}",
+            persisted.recheck_at(),
+            test_runtime.runtime.now(),
+        );
+
+        assert!(rt
+            .block_on(test_runtime.runtime.emit_due_agent_wait_recheck())
+            .unwrap());
+        assert!(!rt
+            .block_on(test_runtime.runtime.emit_due_agent_wait_recheck())
+            .unwrap());
+
+        let triggered = test_runtime
+            .runtime
+            .storage()
+            .latest_wait_conditions_for_agent("default")
+            .unwrap()
+            .into_iter()
+            .find(|condition| condition.id == registration.condition.id)
+            .unwrap();
+        assert_eq!(
+            triggered.status,
+            crate::types::WaitConditionStatus::Triggered
+        );
+        assert_eq!(
+            triggered.trigger_message_id(),
+            Some(expected_message_id.as_str())
+        );
+
+        let poll = rt
+            .block_on(
+                super::scheduler_executor::SchedulerDecisionExecutor::new(&test_runtime.runtime)
+                    .poll(),
+            )
+            .unwrap();
+        let super::scheduler_executor::RunLoopPoll::Message(scheduled) = poll else {
+            panic!("due agent wait recheck should be scheduled");
+        };
+        assert_eq!(scheduled.message.id, expected_message_id);
+        assert!(scheduled.dispatch_plan.model_turn_allowed);
+        assert!(scheduled
+            .dispatch_plan
+            .continuation_trigger
+            .as_ref()
+            .is_some_and(|trigger| trigger.exact_wait_recheck));
     }
 
     fn set_agent_idle(test_runtime: &TestRuntime) {

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -81,6 +81,10 @@ impl RuntimeHandle {
         let mut continuation_trigger =
             ContinuationTrigger::from_message(message, task.as_ref().ok().and_then(Option::as_ref));
         if let Some(trigger) = continuation_trigger.as_mut() {
+            if trigger.kind == crate::types::ContinuationTriggerKind::SystemTick {
+                trigger.exact_wait_recheck =
+                    exact_agent_scope_wait_recheck(&self.inner.storage, message)?.is_some();
+            }
             // An explicit agent-scope WaitFor that targeted this exact task
             // authorizes terminal task result reentry even when the prior
             // closure waiting_reason was polluted by unrelated waits.

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1636,6 +1636,20 @@ pub(super) fn message_matches_wait_condition(
     message: &MessageEnvelope,
     condition: &WaitConditionRecord,
 ) -> bool {
+    if matches!(
+        (&message.kind, &message.origin),
+        (
+            MessageKind::SystemTick,
+            MessageOrigin::System { subsystem }
+        ) if subsystem == "wait_condition_recheck"
+    ) && message.authority_class == AuthorityClass::RuntimeInstruction
+        && message.delivery_surface == Some(MessageDeliverySurface::RuntimeSystem)
+        && message.admission_context == Some(AdmissionContext::RuntimeOwned)
+        && condition.work_item_id.is_none()
+        && message.source_refs.get("wait_id") == Some(&condition.id)
+    {
+        return true;
+    }
     match (&message.kind, &message.origin) {
         (MessageKind::TaskResult, MessageOrigin::Task { task_id }) => {
             condition.wake_sources.iter().any(

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -5,6 +5,33 @@ use crate::types::ExecutionAdmissionProvenance;
 
 const QUEUE_HEAD_NO_PROGRESS_MAX_ATTEMPTS: u32 = 3;
 
+fn select_queue_message<'a>(
+    queue: &'a crate::queue::RuntimeQueue,
+    wait_trigger_message_ids: &std::collections::BTreeSet<String>,
+) -> (Option<&'a MessageEnvelope>, bool) {
+    let head = queue.peek();
+    if head.is_some_and(|message| {
+        message.priority == Priority::Interject
+            || message.delivery_surface == Some(crate::types::MessageDeliverySurface::TaskRejoin)
+    }) {
+        return (head, false);
+    }
+    let mut task_rejoin_barrier_reached = false;
+    if let Some(message) = queue.peek_next_matching(|message| {
+        if task_rejoin_barrier_reached {
+            return false;
+        }
+        if message.delivery_surface == Some(crate::types::MessageDeliverySurface::TaskRejoin) {
+            task_rejoin_barrier_reached = true;
+            return false;
+        }
+        wait_trigger_message_ids.contains(&message.id)
+    }) {
+        return (Some(message), true);
+    }
+    (head, false)
+}
+
 pub(super) enum RunLoopPoll {
     Shutdown,
     Stopped(AgentState, usize),
@@ -145,6 +172,7 @@ struct QueueCandidate {
     message: MessageEnvelope,
     prior_state: AgentState,
     queue_len: usize,
+    wait_obligation: bool,
 }
 
 enum PrepareMessageOutcome {
@@ -382,7 +410,25 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     );
                     return Ok(poll);
                 }
-                let Some(message) = guard.queue.peek().cloned() else {
+                let wait_trigger_message_ids = self
+                    .runtime
+                    .inner
+                    .storage
+                    .latest_wait_conditions_for_agent(&guard.state.id)?
+                    .into_iter()
+                    .filter(|condition| {
+                        matches!(
+                            condition.status,
+                            crate::types::WaitConditionStatus::Triggered
+                                | crate::types::WaitConditionStatus::Resolved
+                        )
+                    })
+                    .filter_map(|condition| condition.trigger_message_id)
+                    .collect::<std::collections::BTreeSet<_>>();
+                let (message, wait_obligation) =
+                    select_queue_message(&guard.queue, &wait_trigger_message_ids);
+                let message = message.cloned();
+                let Some(message) = message else {
                     let poll = RunLoopPoll::Idle;
                     crate::diagnostics::record_scheduler_poll(
                         poll.outcome_name(),
@@ -394,6 +440,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                     message,
                     prior_state: guard.state.clone(),
                     queue_len: guard.queue.len(),
+                    wait_obligation,
                 }
             };
 
@@ -651,10 +698,25 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                         guard.queue.len(),
                     )));
                 }
-                if !guard
-                    .queue
-                    .peek()
-                    .is_some_and(|message| message.id == candidate.message.id)
+                let wait_trigger_message_ids = self
+                    .runtime
+                    .inner
+                    .storage
+                    .latest_wait_conditions_for_agent(&guard.state.id)?
+                    .into_iter()
+                    .filter(|condition| {
+                        matches!(
+                            condition.status,
+                            crate::types::WaitConditionStatus::Triggered
+                                | crate::types::WaitConditionStatus::Resolved
+                        )
+                    })
+                    .filter_map(|condition| condition.trigger_message_id)
+                    .collect::<std::collections::BTreeSet<_>>();
+                let (selected_message, selected_wait_obligation) =
+                    select_queue_message(&guard.queue, &wait_trigger_message_ids);
+                if !selected_message.is_some_and(|message| message.id == candidate.message.id)
+                    || selected_wait_obligation != candidate.wait_obligation
                 {
                     return Ok(PrepareMessageOutcome::Poll(RunLoopPoll::Idle));
                 }
@@ -757,8 +819,8 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 }
                 let queued_message = guard
                     .queue
-                    .pop_if_next(&candidate.message.id)
-                    .expect("queue head was just checked");
+                    .pop_selected(&candidate.message.id, candidate.wait_obligation)
+                    .expect("selected queue message was just checked");
                 debug_assert_eq!(queued_message.id, persisted_message.id);
                 guard.state = running_state.clone();
                 guard.last_persisted_state = running_state.clone();
@@ -2362,6 +2424,92 @@ pub(super) fn apply_bootstrap_recovered_projection(
 mod tests {
     use super::*;
 
+    fn queued_message(priority: Priority, id: &str) -> MessageEnvelope {
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("test".into()),
+                actor_display_name: None,
+            },
+            AuthorityClass::OperatorInstruction,
+            priority,
+            MessageBody::Text { text: id.into() },
+        );
+        message.id = id.into();
+        message
+    }
+
+    #[test]
+    fn durable_wait_obligation_overtakes_non_interject_backlog() {
+        let mut queue = crate::queue::RuntimeQueue::default();
+        queue.push(queued_message(Priority::Next, "backlog"));
+        queue.push(queued_message(Priority::Normal, "wait-trigger"));
+        let wait_trigger_message_ids =
+            std::collections::BTreeSet::from(["wait-trigger".to_string()]);
+
+        let (selected, wait_obligation) = select_queue_message(&queue, &wait_trigger_message_ids);
+
+        assert_eq!(
+            selected.map(|message| message.id.as_str()),
+            Some("wait-trigger")
+        );
+        assert!(wait_obligation);
+    }
+
+    #[test]
+    fn interject_remains_ahead_of_durable_wait_obligation() {
+        let mut queue = crate::queue::RuntimeQueue::default();
+        queue.push(queued_message(Priority::Interject, "interject"));
+        queue.push(queued_message(Priority::Next, "wait-trigger"));
+        let wait_trigger_message_ids =
+            std::collections::BTreeSet::from(["wait-trigger".to_string()]);
+
+        let (selected, wait_obligation) = select_queue_message(&queue, &wait_trigger_message_ids);
+
+        assert_eq!(
+            selected.map(|message| message.id.as_str()),
+            Some("interject")
+        );
+        assert!(!wait_obligation);
+    }
+
+    #[test]
+    fn task_rejoin_remains_ahead_of_durable_wait_obligation() {
+        let mut queue = crate::queue::RuntimeQueue::default();
+        let mut task_rejoin = queued_message(Priority::Next, "task-rejoin");
+        task_rejoin.delivery_surface = Some(crate::types::MessageDeliverySurface::TaskRejoin);
+        queue.push(task_rejoin);
+        queue.push(queued_message(Priority::Normal, "wait-trigger"));
+        let wait_trigger_message_ids =
+            std::collections::BTreeSet::from(["wait-trigger".to_string()]);
+
+        let (selected, wait_obligation) = select_queue_message(&queue, &wait_trigger_message_ids);
+
+        assert_eq!(
+            selected.map(|message| message.id.as_str()),
+            Some("task-rejoin")
+        );
+        assert!(!wait_obligation);
+    }
+
+    #[test]
+    fn durable_wait_obligation_does_not_cross_non_head_task_rejoin() {
+        let mut queue = crate::queue::RuntimeQueue::default();
+        queue.push(queued_message(Priority::Next, "backlog"));
+        let mut task_rejoin = queued_message(Priority::Next, "task-rejoin");
+        task_rejoin.delivery_surface = Some(crate::types::MessageDeliverySurface::TaskRejoin);
+        queue.push(task_rejoin);
+        queue.push(queued_message(Priority::Normal, "wait-trigger"));
+        let wait_trigger_message_ids =
+            std::collections::BTreeSet::from(["wait-trigger".to_string()]);
+
+        let (selected, wait_obligation) = select_queue_message(&queue, &wait_trigger_message_ids);
+
+        assert_eq!(selected.map(|message| message.id.as_str()), Some("backlog"));
+        assert!(!wait_obligation);
+    }
+
     fn no_progress_cause(reason: &'static str) -> QueueHeadNoProgressCause {
         use crate::domain::scheduler::SchedulerScenarioClass;
 
@@ -2445,6 +2593,7 @@ mod tests {
             message: guard.queue.peek().cloned().expect("queued test message"),
             prior_state: guard.state.clone(),
             queue_len: guard.queue.len(),
+            wait_obligation: false,
         }
     }
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -15324,6 +15324,82 @@ async fn register_wait_for_agent_scoped_cancels_prior_agent_scoped_waits() {
 }
 
 #[tokio::test]
+async fn register_wait_for_agent_scoped_resolves_prior_triggered_wait() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let first = runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::OperatorInput,
+            None,
+            "first agent wait".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    let mut triggered = first.condition.clone();
+    triggered.mark_triggered("message:triggered-before-replacement", Utc::now());
+    runtime.storage().append_wait_condition(&triggered).unwrap();
+
+    let second = runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::OperatorInput,
+            None,
+            "second agent wait".into(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(second.cancelled_wait_condition_ids.is_empty());
+    let all_conditions = runtime.storage().latest_wait_conditions().unwrap();
+    let first_record = all_conditions
+        .iter()
+        .find(|condition| condition.id == first.condition.id)
+        .unwrap();
+    assert_eq!(first_record.status, WaitConditionStatus::Resolved);
+    assert_eq!(
+        first_record.trigger_message_id(),
+        Some("message:triggered-before-replacement")
+    );
+    assert!(first_record.resolved_at.is_some());
+    assert_eq!(
+        all_conditions
+            .iter()
+            .find(|condition| condition.id == second.condition.id)
+            .unwrap()
+            .status,
+        WaitConditionStatus::Active
+    );
+    assert!(runtime
+        .storage()
+        .read_recent_events(32)
+        .unwrap()
+        .iter()
+        .any(|event| {
+            event.kind == "wait_conditions_resolved"
+                && event.data["reason"] == "wait_for_replaced_after_trigger"
+                && event.data["wait_condition_ids"]
+                    .as_array()
+                    .is_some_and(|ids| ids.iter().any(|id| id == &first.condition.id))
+        }));
+}
+
+#[tokio::test]
 async fn agent_scoped_wait_replacement_preserves_work_item_scoped_waits() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -2224,6 +2224,9 @@ fn matching_wake_source(
             .then(|| ("operator_input".to_string(), actor_id.clone()))
         }
         (MessageKind::SystemTick, MessageOrigin::System { subsystem }) => {
+            if exact_wait_recheck_source(message, condition, subsystem) {
+                return Some(("wait_recheck".to_string(), Some(condition.id.clone())));
+            }
             if let Some(external) = matching_wake_hint_external_source(message, condition) {
                 return Some(external);
             }
@@ -2235,6 +2238,37 @@ fn matching_wake_source(
         }
         _ => None,
     }
+}
+
+fn exact_wait_recheck_source(
+    message: &MessageEnvelope,
+    condition: &WaitConditionRecord,
+    subsystem: &str,
+) -> bool {
+    if subsystem != "wait_condition_recheck"
+        || message.authority_class != AuthorityClass::RuntimeInstruction
+        || message.admission_context != Some(AdmissionContext::RuntimeOwned)
+        || message.delivery_surface != Some(MessageDeliverySurface::RuntimeSystem)
+        || message.source_refs.get("wait_id") != Some(&condition.id)
+    {
+        return false;
+    }
+    let Some(recheck_at) = condition.recheck_at() else {
+        return false;
+    };
+    let recheck = message
+        .metadata
+        .as_ref()
+        .and_then(|value| value.get("wait_condition_recheck"));
+    recheck
+        .and_then(|value| value.get("wait_id"))
+        .and_then(serde_json::Value::as_str)
+        == Some(condition.id.as_str())
+        && recheck
+            .and_then(|value| value.get("recheck_at"))
+            .and_then(serde_json::Value::as_str)
+            .and_then(|value| value.parse::<DateTime<Utc>>().ok())
+            == Some(recheck_at)
 }
 
 fn matching_wake_hint_external_source(

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -8,6 +8,43 @@ use crate::types::{
 };
 use chrono::{DateTime, Utc};
 
+struct ReplacedWaitConditions {
+    records: Vec<WaitConditionRecord>,
+    cancelled_ids: Vec<String>,
+    resolved_after_trigger_ids: Vec<String>,
+}
+
+fn replace_wait_conditions(
+    existing: Vec<WaitConditionRecord>,
+    now: DateTime<Utc>,
+) -> ReplacedWaitConditions {
+    let mut records = Vec::with_capacity(existing.len());
+    let mut cancelled_ids = Vec::new();
+    let mut resolved_after_trigger_ids = Vec::new();
+    for mut record in existing {
+        record.updated_at = now;
+        match record.status {
+            WaitConditionStatus::Active => {
+                record.status = WaitConditionStatus::Cancelled;
+                record.cancelled_at = Some(now);
+                cancelled_ids.push(record.id.clone());
+            }
+            WaitConditionStatus::Triggered => {
+                record.status = WaitConditionStatus::Resolved;
+                record.resolved_at = Some(now);
+                resolved_after_trigger_ids.push(record.id.clone());
+            }
+            _ => continue,
+        }
+        records.push(record);
+    }
+    ReplacedWaitConditions {
+        records,
+        cancelled_ids,
+        resolved_after_trigger_ids,
+    }
+}
+
 #[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum WaitForScope {
@@ -340,16 +377,11 @@ impl RuntimeHandle {
                 .filter(|record| record.work_item_id.is_none())
                 .collect()
         };
-        let mut wait_conditions = Vec::with_capacity(active_waits.len() + 1);
-        let mut cancelled_wait_condition_ids = Vec::with_capacity(active_waits.len());
-        for existing in active_waits {
-            let mut cancelled = existing.clone();
-            cancelled.status = WaitConditionStatus::Cancelled;
-            cancelled.updated_at = now;
-            cancelled.cancelled_at = Some(now);
-            cancelled_wait_condition_ids.push(existing.id);
-            wait_conditions.push(cancelled);
-        }
+        let replaced = replace_wait_conditions(active_waits, now);
+        let mut wait_conditions = replaced.records;
+        let cancelled_wait_condition_ids = replaced.cancelled_ids;
+        let resolved_after_trigger_wait_condition_ids = replaced.resolved_after_trigger_ids;
+        wait_conditions.reserve(1);
         let mut work_items = Vec::new();
         let mut audit_events = Vec::new();
         let mut index_changes = Vec::new();
@@ -362,6 +394,17 @@ impl RuntimeHandle {
                     "work_item_id": work_item_id,
                     "reason": "wait_for_replaced",
                     "wait_condition_ids": &cancelled_wait_condition_ids,
+                }),
+            ));
+        }
+        if !resolved_after_trigger_wait_condition_ids.is_empty() {
+            audit_events.push(AuditEvent::legacy(
+                "wait_conditions_resolved",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "work_item_id": work_item_id,
+                    "reason": "wait_for_replaced_after_trigger",
+                    "wait_condition_ids": &resolved_after_trigger_wait_condition_ids,
                 }),
             ));
         }
@@ -673,12 +716,39 @@ impl RuntimeHandle {
                 result_message_id,
             });
         }
+        if let Some(existing) = self
+            .inner
+            .storage
+            .latest_wait_conditions_for_agent(&task.agent_id)?
+            .into_iter()
+            .find(|record| {
+                record.work_item_id == task.work_item_id
+                    && matches!(
+                        record.status,
+                        WaitConditionStatus::Triggered | WaitConditionStatus::Resolved
+                    )
+                    && record.kind == WaitConditionKind::Task
+                    && record.trigger_message_id() == Some(result_message_id.as_str())
+                    && record.wake_sources.iter().any(|source| {
+                        matches!(
+                            source,
+                            WakeSource::TaskResult { task_id } if task_id == &task.id
+                        )
+                    })
+            })
+        {
+            return Ok(WaitForRegistrationOutcome::TaskResultQueued {
+                task_id: task.id,
+                result_message_id,
+                wait_condition_id: existing.id,
+            });
+        }
 
         let now = self.now();
         // The fast path must leave the same durable wait semantics as a
         // normal WaitFor registration: the re-queued result message is the
         // exact promised wake, so the wait condition starts Triggered and
-        // replaced same-scope waits are cancelled atomically with the queue
+        // replaced same-scope waits are retired atomically with the queue
         // admission. Without this record the terminal result can be resolved
         // as liveness_only and the agent never re-enters the model.
         let current_turn_id = self.agent_state().await?.current_turn_id.clone();
@@ -712,26 +782,21 @@ impl RuntimeHandle {
             trigger_message_id: Some(result_message_id.clone()),
             triggered_at: Some(now),
         };
-        let mut wait_conditions = self
-            .inner
-            .storage
-            .raw_unresolved_wait_conditions_for_agent(&task.agent_id)?
-            .into_iter()
-            .filter(|record| match task.work_item_id.as_deref() {
-                Some(work_item_id) => record.work_item_id.as_deref() == Some(work_item_id),
-                None => record.work_item_id.is_none(),
-            })
-            .map(|mut record| {
-                record.status = WaitConditionStatus::Cancelled;
-                record.updated_at = now;
-                record.cancelled_at = Some(now);
-                record
-            })
-            .collect::<Vec<_>>();
-        let cancelled_wait_condition_ids = wait_conditions
-            .iter()
-            .map(|record| record.id.clone())
-            .collect::<Vec<_>>();
+        let replaced = replace_wait_conditions(
+            self.inner
+                .storage
+                .raw_unresolved_wait_conditions_for_agent(&task.agent_id)?
+                .into_iter()
+                .filter(|record| match task.work_item_id.as_deref() {
+                    Some(work_item_id) => record.work_item_id.as_deref() == Some(work_item_id),
+                    None => record.work_item_id.is_none(),
+                })
+                .collect(),
+            now,
+        );
+        let mut wait_conditions = replaced.records;
+        let cancelled_wait_condition_ids = replaced.cancelled_ids;
+        let resolved_after_trigger_wait_condition_ids = replaced.resolved_after_trigger_ids;
         let mut audit_events = vec![AuditEvent::legacy(
             "wait_condition_registered",
             serde_json::json!({
@@ -761,6 +826,17 @@ impl RuntimeHandle {
                     "work_item_id": task.work_item_id,
                     "reason": "wait_for_replaced",
                     "wait_condition_ids": &cancelled_wait_condition_ids,
+                }),
+            ));
+        }
+        if !resolved_after_trigger_wait_condition_ids.is_empty() {
+            audit_events.push(AuditEvent::legacy(
+                "wait_conditions_resolved",
+                serde_json::json!({
+                    "agent_id": task.agent_id,
+                    "work_item_id": task.work_item_id,
+                    "reason": "wait_for_replaced_after_trigger",
+                    "wait_condition_ids": &resolved_after_trigger_wait_condition_ids,
                 }),
             ));
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2951,6 +2951,15 @@ pub struct WaitConditionRecord {
 }
 
 impl WaitConditionRecord {
+    pub fn recheck_at(&self) -> Option<DateTime<Utc>> {
+        self.continuation
+            .as_ref()?
+            .get("recheck_at")?
+            .as_str()?
+            .parse()
+            .ok()
+    }
+
     pub fn trigger_message_id(&self) -> Option<&str> {
         self.trigger_message_id.as_deref()
     }


### PR DESCRIPTION
## 概要

修复 agent wait 的 durable resume 链路：

- 新 `WaitFor` 替换同 scope wait 时，保留已 `Triggered` wait 的 durable delivery evidence，直到触发消息被认领并解析。
- 为 agent-scope `recheck_after_ms` 增加 run-loop deadline、确定性 runtime-owned recheck tick、精确匹配与 model reentry 授权。
- scheduler 从队列中优先认领由持久化 wait 状态证明的 resume obligation，使其越过普通非 `Interject` backlog；同时保留 `Interject` 优先级和 `TaskRejoin` canonical admission 屏障。
- 更新 waiting/reactivation RFC，并记录不新增公开 priority、而由 durable wait evidence 派生选择义务的实现决策。

## 关键边界

- replacement 仍会取消未触发的旧 wait；不会抹掉已经发生但尚未派发的 trigger。
- recheck tick 使用 wait identity 派生的确定性 message id，重复刷新不会重复入队。
- durable obligation 不跨越 `Interject`，也不跨越位于其前方的 `TaskRejoin`；后者必须先完成 stale/authority canonical 判定。

## 验证

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- A/B/C 聚焦回归全部通过，包括 Triggered replacement、agent recheck 精确/幂等/model reentry、普通 backlog 越过、`Interject` 保序和非队首 `TaskRejoin` 屏障。
- `cargo test --lib` 复跑通过 3134 项，仅一个既有并行超时；该测试 `complete_work_item_uses_followup_report_after_text_before_other_tool` 隔离复跑通过。

Fixes #2907
