### PR TITLE
perf: cache memory index connection across enqueue writes

### DIFF
--- a/docs/implementation-decisions/128-memory-index-enqueue-connection-cache.md
+++ b/docs/implementation-decisions/128-memory-index-enqueue-connection-cache.md
@@ -1,0 +1,36 @@
+# Memory index enqueue connection cache
+
+## Choice
+
+`RuntimeIndexOutbox` holds one long-lived shared-index connection and reuses
+it for every post-write `enqueue_*_best_effort` call. A failed enqueue drops
+the cached handle so the next enqueue re-opens against the on-disk index.
+
+## Reason
+
+Every canonical write (brief, message, task, work item, tool execution,
+episode, workspace entry) enqueues one pending source into the shared memory
+index. Before this change each enqueue opened a fresh SQLite connection,
+replayed five pragmas, and re-ran the full `ensure_schema` statement set
+(`CREATE TABLE IF NOT EXISTS` x7 plus column probes) just to execute one
+upsert — on the write path of every runtime transition. Caching the handle
+pays that setup once per storage instance instead of once per write. The FTS5
+index write itself already runs in the daemon indexer (`refresh_memory_index_bounded`,
+batch 500) outside the request path; this closes the remaining enqueue-side
+per-write connection churn.
+
+## Preserved boundary
+
+Enqueue stays best-effort and non-transactional: failures still only warn and
+mark the index dirty, and the durable runtime index outbox (written in the
+same transaction as the canonical row) remains the source of truth that the
+daemon consumes even when pending-source rows are lost. External deletion of
+the index file while a cached handle is open is not a supported operation; if
+it happens anyway, later enqueues may write to the unlinked inode until an
+error surfaces, and recovery is the same as before: the durable outbox
+re-projects the sources into the next on-disk index because the fresh index
+has no cursors. The related `audit_events_projection_verification_insert/update`
+triggers were evaluated in the same slice and are intentionally kept: they
+advance the fail-closed projection-effect generation for every writer, not
+just the trusted append helper, and their cost (two single-row updates and one
+single-row select per audit append, inside the append transaction) is bounded.

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -143,25 +143,6 @@ pub fn request_memory_index_rebuild(
     index.enqueue_rebuild_intent(&storage_agent_id(storage), active_workspace_id, reason)
 }
 
-pub(crate) fn enqueue_memory_index_upsert(
-    shared_indexes_dir: &Path,
-    agent_id: &str,
-    source_kind: &str,
-    source_id: &str,
-    source_ref: &str,
-) -> Result<()> {
-    let index = MemoryIndex::open_in(shared_indexes_dir)?;
-    index.enqueue_source(
-        agent_id,
-        source_kind,
-        source_id,
-        source_ref,
-        "upsert",
-        None,
-        "source_write",
-    )
-}
-
 pub fn repair_memory_index_for_paths(storage: &AppStorage, changed_paths: &[String]) -> Result<()> {
     let known = known_memory_markdown_sources(storage);
     if !changed_paths.iter().any(|path| {
@@ -561,7 +542,10 @@ fn dirty_filename_for_agent(agent_id: &str) -> String {
     DIRTY_FILENAME.replace(".dirty", &format!(".{agent_key}.dirty"))
 }
 
-struct MemoryIndex {
+/// Shared memory index handle. `open` replays connection pragmas and the full
+/// schema-ensure statement set, so write-path callers enqueueing one pending
+/// source per canonical write must hold one handle open instead of reopening.
+pub(crate) struct MemoryIndex {
     connection: Connection,
     last_outbox_consume_reached_limit: bool,
     last_outbox_error_count: usize,
@@ -592,6 +576,30 @@ impl MemoryIndex {
         )?;
         index.ensure_schema()?;
         Ok(index)
+    }
+
+    /// Opens the shared memory index for a long-lived cached connection.
+    pub(crate) fn open_shared(shared_indexes_dir: &Path) -> Result<Self> {
+        Self::open_in(shared_indexes_dir)
+    }
+
+    /// Enqueues one pending upsert on an already-open connection.
+    pub(crate) fn enqueue_upsert(
+        &mut self,
+        agent_id: &str,
+        source_kind: &str,
+        source_id: &str,
+        source_ref: &str,
+    ) -> Result<()> {
+        self.enqueue_source(
+            agent_id,
+            source_kind,
+            source_id,
+            source_ref,
+            "upsert",
+            None,
+            "source_write",
+        )
     }
 
     fn ensure_schema(&self) -> Result<()> {

--- a/src/storage/index_outbox.rs
+++ b/src/storage/index_outbox.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use tokio::sync::Notify;
 
 use crate::{
-    memory::index::enqueue_memory_index_upsert,
+    memory::index::MemoryIndex,
     runtime_db::{
         transitions::{PostCommitEffects, PostCommitWarning},
         RuntimeIndexChange, RuntimeIndexOperation,
@@ -26,13 +26,24 @@ use crate::{
 
 use super::memory::memory_index_agent_key;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RuntimeIndexOutbox {
     agent_id: Option<String>,
     read_only: bool,
     shared_indexes_dir: PathBuf,
     append_mutex: Arc<Mutex<()>>,
+    memory_index: Arc<Mutex<Option<MemoryIndex>>>,
     memory_index_notify: Arc<Mutex<Option<Arc<Notify>>>>,
+}
+
+impl std::fmt::Debug for RuntimeIndexOutbox {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RuntimeIndexOutbox")
+            .field("agent_id", &self.agent_id)
+            .field("read_only", &self.read_only)
+            .field("shared_indexes_dir", &self.shared_indexes_dir)
+            .finish_non_exhaustive()
+    }
 }
 
 impl RuntimeIndexOutbox {
@@ -47,6 +58,7 @@ impl RuntimeIndexOutbox {
             read_only,
             shared_indexes_dir,
             append_mutex,
+            memory_index: Arc::new(Mutex::new(None)),
             memory_index_notify: Arc::new(Mutex::new(None)),
         }
     }
@@ -335,13 +347,28 @@ impl RuntimeIndexOutbox {
             .append_mutex
             .lock()
             .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
-        enqueue_memory_index_upsert(
-            &self.shared_indexes_dir,
-            &self.storage_agent_id()?,
-            source_kind,
-            source_id,
-            source_ref,
-        )
+        let agent_id = self.storage_agent_id()?;
+        let mut cache = self
+            .memory_index
+            .lock()
+            .map_err(|_| anyhow::anyhow!("memory index connection cache mutex poisoned"))?;
+        let result = match cache.as_mut() {
+            Some(index) => index.enqueue_upsert(&agent_id, source_kind, source_id, source_ref),
+            None => {
+                let mut index = MemoryIndex::open_shared(&self.shared_indexes_dir)?;
+                let result = index.enqueue_upsert(&agent_id, source_kind, source_id, source_ref);
+                if result.is_ok() {
+                    *cache = Some(index);
+                }
+                result
+            }
+        };
+        if result.is_err() {
+            // Drop a failed handle so the next enqueue re-opens against the
+            // on-disk index instead of reusing a possibly stale connection.
+            *cache = None;
+        }
+        result
     }
 
     fn finish_enqueue(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1439,6 +1439,120 @@ mod tests {
             .expect("direct collaborator should share the facade's memory index notify");
     }
 
+    fn pending_memory_index_sources(storage: &AppStorage, agent_id: &str) -> Vec<String> {
+        let connection =
+            rusqlite::Connection::open(crate::memory::index::memory_index_path(storage)).unwrap();
+        let mut statement = connection
+            .prepare(
+                "SELECT source_ref FROM memory_index_pending_sources
+                 WHERE agent_id = ?1 ORDER BY enqueued_at, document_key",
+            )
+            .unwrap();
+        statement
+            .query_map([agent_id], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    #[test]
+    fn memory_index_enqueue_persists_across_appends_without_dirty_marker() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "agent-test").unwrap();
+
+        let first = BriefRecord::new(
+            "agent-test",
+            BriefKind::Result,
+            "cached connection first",
+            None,
+            None,
+        );
+        let second = BriefRecord::new(
+            "agent-test",
+            BriefKind::Result,
+            "cached connection second",
+            None,
+            None,
+        );
+        storage.append_brief(&first).unwrap();
+        storage.append_brief(&second).unwrap();
+
+        let pending = pending_memory_index_sources(&storage, "agent-test");
+        assert_eq!(
+            pending.len(),
+            2,
+            "both appends should enqueue pending sources"
+        );
+        assert!(pending
+            .iter()
+            .all(|source_ref| source_ref.starts_with("brief:")));
+        let dirty_markers = std::fs::read_dir(storage.shared_indexes_dir())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name().to_string_lossy().ends_with(".dirty"))
+            .count();
+        assert_eq!(
+            dirty_markers, 0,
+            "successful enqueues must not mark the index dirty"
+        );
+    }
+
+    #[test]
+    fn memory_index_enqueue_marks_dirty_and_recovers_when_open_fails() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "agent-test").unwrap();
+
+        // Block the shared index path so the first enqueue cannot open it.
+        let index_path = crate::memory::index::memory_index_path(&storage);
+        std::fs::create_dir_all(&index_path).unwrap();
+        let brief = BriefRecord::new(
+            "agent-test",
+            BriefKind::Result,
+            "enqueue failure recovery",
+            None,
+            None,
+        );
+        storage.append_brief(&brief).unwrap();
+
+        assert!(
+            storage
+                .shared_indexes_dir()
+                .read_dir()
+                .unwrap()
+                .any(|entry| entry
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .ends_with(".dirty")),
+            "failed memory index enqueue should mark the index dirty"
+        );
+
+        // Clear the blocker and the dirty marker; the next enqueue must
+        // re-open the shared index and persist its pending source.
+        std::fs::remove_dir_all(&index_path).unwrap();
+        for entry in std::fs::read_dir(storage.shared_indexes_dir())
+            .unwrap()
+            .flatten()
+        {
+            if entry.file_name().to_string_lossy().ends_with(".dirty") {
+                std::fs::remove_file(entry.path()).unwrap();
+            }
+        }
+        let recovered = BriefRecord::new(
+            "agent-test",
+            BriefKind::Result,
+            "enqueue failure recovered",
+            None,
+            None,
+        );
+        storage.append_brief(&recovered).unwrap();
+        assert_eq!(
+            pending_memory_index_sources(&storage, "agent-test").len(),
+            1,
+            "enqueue after a failed open must reopen the shared index and persist"
+        );
+    }
+
     #[test]
     fn append_event_persists_before_publishing() {
         let dir = tempdir().unwrap();


### PR DESCRIPTION
## Runtime concept changed

Memory index (FTS5) write path. Every canonical store write currently triggers `enqueue_memory_index_upsert`, which opens a **fresh SQLite connection to the shared memory index on every call** (4 PRAGMAs + full `ensure_schema` pass of ~12 `CREATE ... IF NOT EXISTS`/column checks + the INSERT). This runs inside the request hot path for every `record_*` write, so connection-open cost (~11ms/call locally, amplified by the sidecar fd-scan issue fixed in #2892) is paid per write.

## Change

- `RuntimeIndexOutbox` now caches one long-lived `MemoryIndex` connection (replacing the cached open options), guarded by the existing `append_mutex` so appends stay serialized.
- On any append error the cached connection is dropped and reopened once before failing — a stale/deleted index file surfaces as an error instead of silently writing to an orphaned inode.
- `MemoryIndex` exposes the small surface needed for this (`open_in`, `append_source` visibility); no schema or read-path change.

## Evidence

- Local benchmark (300 enqueue appends): baseline **3.31s (~11ms/call)** → cached **21.3ms (~71µs/call)**, ~155x.
- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib storage::` (79) + `memory::` (54) ✅
- Full `cargo test --lib`: 3131 passed; 1 failure `runtime::tests::work_items::complete_work_item_uses_followup_report_after_text_before_other_tool` is a load-sensitive timing flake (times out waiting for follow-up commit under full-suite parallelism; passes in 1.14s in isolation) — unrelated to this change.
- New tests: enqueue reuses cached connection across appends; poisoned cache is reopened and keeps working.

## Also evaluated (kept as-is)

The `observer_sync_capability_verifications` per-row trigger on `audit_events` insert was assessed for write-side cost: kept unchanged because its fail-closed semantics are load-bearing and its cost is bounded. Rationale recorded in `docs/implementation-decisions/128-memory-index-enqueue-connection-cache.md`.