### PR TITLE
fix: make control auth transport-aware

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -422,7 +422,13 @@ impl AppConfig {
             ControlAuthMode::Required => true,
             ControlAuthMode::Auto => match transport {
                 ControlTransportKind::Unix => false,
-                ControlTransportKind::Tcp => !self.tcp_listener_is_local(),
+                ControlTransportKind::Tcp => {
+                    !self.tcp_listener_is_local()
+                        || self
+                            .control_token
+                            .as_deref()
+                            .is_some_and(|token| !token.trim().is_empty())
+                }
             },
         }
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -22,9 +22,9 @@ use crate::config::{
     provider_registry_for_tests, resolve_anthropic_context_management_config,
     save_persisted_config_at, set_config_key, set_credential_profile_at, unset_config_key,
     validate_provider_config, AnthropicCacheStrategy, AnthropicContextManagementConfig, AppConfig,
-    ControlAuthMode, CredentialKind, CredentialSource, CredentialStoreFile, HolonConfigFile,
-    ModelConfigFile, ModelRef, ModelRouteCapability, ModelRouteRef, ModelsConfigFile,
-    ProviderAuthConfig, ProviderBuiltinWebSearchConfig, ProviderConfigFile,
+    ControlAuthMode, ControlTransportKind, CredentialKind, CredentialSource, CredentialStoreFile,
+    HolonConfigFile, ModelConfigFile, ModelRef, ModelRouteCapability, ModelRouteRef,
+    ModelsConfigFile, ProviderAuthConfig, ProviderBuiltinWebSearchConfig, ProviderConfigFile,
     ProviderEndpointConfigFile, ProviderEndpointId, ProviderId, ProviderPlanConfigFile,
     ProviderRegistry, ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog,
     XSearchRuntimeConfig, DEFAULT_LOCAL_AGENT_ID, DEFAULT_X_SEARCH_MODEL,
@@ -477,6 +477,28 @@ fn control_auth_mode_parses_known_values() {
         ControlAuthMode::parse("disabled").unwrap(),
         ControlAuthMode::Disabled
     );
+}
+
+#[test]
+fn control_token_auto_mode_trusts_only_unix_transport() {
+    let mut fixture = test_app_config("openai/gpt-5.4", &[]);
+
+    assert!(fixture
+        .config
+        .control_token_required(ControlTransportKind::Tcp));
+    assert!(!fixture
+        .config
+        .control_token_required(ControlTransportKind::Unix));
+
+    fixture.config.control_token = None;
+    assert!(!fixture
+        .config
+        .control_token_required(ControlTransportKind::Tcp));
+
+    fixture.config.http_addr = "0.0.0.0:7878".into();
+    assert!(fixture
+        .config
+        .control_token_required(ControlTransportKind::Tcp));
 }
 
 #[test]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -193,6 +193,7 @@ fn decrement_http_in_flight_requests() -> usize {
 pub struct AppState {
     pub host: RuntimeHost,
     pub require_control_token: bool,
+    transport: ControlTransportKind,
     pub runtime_service: Option<RuntimeServiceHandle>,
     pub advertise_url: Option<String>,
     pub web_dist: Option<Arc<PathBuf>>,
@@ -311,6 +312,7 @@ impl AppState {
         Self {
             host,
             require_control_token,
+            transport: ControlTransportKind::Tcp,
             runtime_service,
             advertise_url: None,
             web_dist: None,
@@ -345,6 +347,7 @@ impl AppState {
         Self {
             host,
             require_control_token: false,
+            transport: ControlTransportKind::Unix,
             runtime_service,
             advertise_url: None,
             web_dist: None,
@@ -361,6 +364,10 @@ impl AppState {
     pub fn with_advertise_url(mut self, advertise_url: Option<String>) -> Self {
         self.advertise_url = advertise_url;
         self
+    }
+
+    fn uses_trusted_local_admission(&self) -> bool {
+        self.transport == ControlTransportKind::Unix
     }
 
     pub fn with_web_dist(mut self, web_dist: Option<PathBuf>) -> Self {
@@ -916,6 +923,9 @@ pub(crate) fn projection_gate_error_response(error: ProjectionGateError) -> Axum
     }
 }
 pub(crate) fn authorize_control(headers: &HeaderMap, state: &AppState) -> Result<()> {
+    if state.uses_trusted_local_admission() {
+        return Ok(());
+    }
     if state.host.config().auth.mode == crate::authentication::AuthenticationMode::Oidc {
         return authenticate_session(headers, state).map(|_| ());
     }
@@ -944,6 +954,9 @@ pub(crate) fn authorize_control(headers: &HeaderMap, state: &AppState) -> Result
 }
 
 pub(crate) fn authorize_remote_access(headers: &HeaderMap, state: &AppState) -> Result<()> {
+    if state.uses_trusted_local_admission() {
+        return Ok(());
+    }
     if state.require_control_token
         || state.host.config().auth.mode == crate::authentication::AuthenticationMode::Oidc
     {
@@ -1095,6 +1108,9 @@ impl ControlActor {
 /// `authorize_control` remains the gate; this answers *who* is acting so the
 /// enqueued message can carry user-level attribution.
 pub(crate) fn control_actor(headers: &HeaderMap, state: &AppState) -> Result<ControlActor> {
+    if state.uses_trusted_local_admission() {
+        return Ok(ControlActor::LocalControl);
+    }
     if state.host.config().auth.mode == crate::authentication::AuthenticationMode::Oidc {
         let session = authenticate_session(headers, state)?;
         let user = state
@@ -1129,7 +1145,8 @@ async fn session_auth_middleware(
     ) || api_path.starts_with("/callbacks/")
         || api_path.starts_with("/webhooks/");
 
-    if state.host.config().auth.mode == crate::authentication::AuthenticationMode::Oidc
+    if !state.uses_trusted_local_admission()
+        && state.host.config().auth.mode == crate::authentication::AuthenticationMode::Oidc
         && !anonymous
     {
         if let Err(error) = authenticate_session(request.headers(), &state) {

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -12,7 +12,8 @@ macro_rules! http_async_tests {
 }
 
 http_async_tests!(
-    control_prompt_is_open_on_loopback_auto,
+    control_prompt_is_open_on_loopback_auto_without_token,
+    control_prompt_requires_configured_token_on_loopback_auto,
     control_agent_create_returns_degraded_receipt_and_repairs,
     agent_state_route_returns_aggregated_snapshot,
     unloaded_agent_state_route_uses_storage_without_starting_runtime,
@@ -70,6 +71,7 @@ http_async_tests!(
 #[cfg(unix)]
 http_async_tests!(
     control_prompt_is_open_over_unix_socket_auto,
+    oidc_unix_socket_uses_trusted_local_admission_and_identity,
     control_runtime_status_is_open_over_unix_socket_when_auth_required,
     control_runtime_readiness_is_open_over_unix_socket_when_auth_required,
     control_agent_delete_fails_closed_when_home_is_symlink,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -40,7 +40,7 @@ use super::{
     wait_until, RuntimeFailureProvider, TestConfigBuilder,
 };
 
-pub async fn control_prompt_is_open_on_loopback_auto() -> Result<()> {
+pub async fn control_prompt_is_open_on_loopback_auto_without_token() -> Result<()> {
     let (_host, base, server) = spawn_server().await?;
     let client = reqwest::Client::new();
     let response = client
@@ -49,6 +49,32 @@ pub async fn control_prompt_is_open_on_loopback_auto() -> Result<()> {
         .send()
         .await?;
     assert!(response.status().is_success());
+    server.abort();
+    Ok(())
+}
+
+pub async fn control_prompt_requires_configured_token_on_loopback_auto() -> Result<()> {
+    let config = TestConfigBuilder::new()
+        .with_control_token("secret")
+        .build_retained();
+    let (_host, base, server) = spawn_server_with_config(config).await?;
+    let client = reqwest::Client::new();
+
+    let denied = client
+        .post(format!("{base}/api/control/agents/default/prompt"))
+        .json(&serde_json::json!({ "text": "hello" }))
+        .send()
+        .await?;
+    assert_eq!(denied.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let allowed = client
+        .post(format!("{base}/api/control/agents/default/prompt"))
+        .bearer_auth("secret")
+        .json(&serde_json::json!({ "text": "hello" }))
+        .send()
+        .await?;
+    assert!(allowed.status().is_success());
+
     server.abort();
     Ok(())
 }
@@ -487,6 +513,68 @@ pub async fn control_prompt_is_open_over_unix_socket_auto() -> Result<()> {
     )
     .await?;
     assert_eq!(response.status, 200);
+    server.abort();
+    Ok(())
+}
+
+#[cfg(unix)]
+pub async fn oidc_unix_socket_uses_trusted_local_admission_and_identity() -> Result<()> {
+    let mut config = TestConfigBuilder::new().build_retained();
+    config.auth.mode = holon::authentication::AuthenticationMode::Oidc;
+    config.auth.oidc = Some(holon::authentication::OidcProviderConfig {
+        issuer_url: "https://issuer.example.com".to_string(),
+        client_id: "holon-test".to_string(),
+        client_secret_env: None,
+        redirect_uri: None,
+    });
+    let (host, socket_path, server) = spawn_unix_server(config).await?;
+    let runtime = host.default_runtime().await?;
+
+    let list = unix_request(
+        &socket_path,
+        "GET",
+        "/api/agents/list",
+        &[
+            ("authorization", "Bearer stale-remote-credential"),
+            ("cookie", "holon_session=stale-session"),
+        ],
+        None,
+    )
+    .await?;
+    assert_eq!(list.status, 200);
+
+    let prompt = unix_request(
+        &socket_path,
+        "POST",
+        "/api/control/agents/default/prompt",
+        &[
+            ("authorization", "Bearer stale-remote-credential"),
+            ("cookie", "holon_session=stale-session"),
+            ("content-type", "application/json"),
+        ],
+        Some(br#"{ "text": "trusted unix oidc" }"#),
+    )
+    .await?;
+    assert_eq!(prompt.status, 200);
+
+    wait_until(|| {
+        Ok(runtime
+            .storage()
+            .read_recent_messages(10)?
+            .iter()
+            .any(|message| {
+                matches!(
+                    &message.body,
+                    MessageBody::Text { text } if text == "trusted unix oidc"
+                ) && message.origin
+                    == MessageOrigin::Operator {
+                        actor_id: Some("control".into()),
+                        actor_display_name: None,
+                    }
+            }))
+    })
+    .await?;
+
     server.abort();
     Ok(())
 }
@@ -2275,12 +2363,13 @@ pub async fn control_wake_records_contentful_system_tick_on_loopback_auto() -> R
 }
 
 pub async fn control_prompt_requires_bearer_token_for_non_loopback_auto() -> Result<()> {
-    let config = test_config_with_paths(
+    let mut config = test_config_with_paths(
         tempdir().unwrap().keep(),
         tempdir().unwrap().keep(),
         "0.0.0.0:0".into(),
         ControlAuthMode::Auto,
     );
+    config.control_token = Some("secret".into());
     let (_host, base, server) = spawn_server_with_config(config).await?;
     let client = reqwest::Client::new();
     let denied = client
@@ -2682,7 +2771,10 @@ pub async fn runtime_status_route_reports_runtime_metadata() -> Result<()> {
         payload["startup_surface"]["callback_base_url"],
         config.callback_base_url
     );
-    assert_eq!(payload["startup_surface"]["control_token_configured"], true);
+    assert_eq!(
+        payload["startup_surface"]["control_token_configured"],
+        config.control_token.is_some()
+    );
     assert_eq!(payload["startup_surface"]["control_auth_mode"], "auto");
     assert_eq!(
         payload["runtime_surface"]["model_default"],

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -39,6 +39,7 @@ pub struct TestConfigBuilder {
     data_dir: Option<PathBuf>,
     workspace_dir: Option<PathBuf>,
     http_addr: String,
+    control_token: Option<String>,
     control_auth_mode: ControlAuthMode,
     compaction_trigger_messages: usize,
     compaction_keep_recent_messages: usize,
@@ -120,6 +121,7 @@ impl TestConfigBuilder {
             data_dir: None,
             workspace_dir: None,
             http_addr: "127.0.0.1:0".into(),
+            control_token: None,
             control_auth_mode: ControlAuthMode::Auto,
             compaction_trigger_messages: 10,
             compaction_keep_recent_messages: 4,
@@ -146,6 +148,11 @@ impl TestConfigBuilder {
 
     pub fn with_control_auth_mode(mut self, control_auth_mode: ControlAuthMode) -> Self {
         self.control_auth_mode = control_auth_mode;
+        self
+    }
+
+    pub fn with_control_token(mut self, control_token: impl Into<String>) -> Self {
+        self.control_token = Some(control_token.into());
         self
     }
 
@@ -198,7 +205,7 @@ impl TestConfigBuilder {
             compaction_keep_recent_estimated_tokens: self.compaction_keep_recent_estimated_tokens,
             recent_episode_candidates: 12,
             max_relevant_episodes: 3,
-            control_token: Some("secret".into()),
+            control_token: self.control_token,
             control_auth_mode: self.control_auth_mode,
             auth: Default::default(),
             api_cors: Default::default(),
@@ -735,12 +742,16 @@ pub fn test_config_with_paths(
     http_addr: String,
     control_auth_mode: ControlAuthMode,
 ) -> AppConfig {
-    TestConfigBuilder::new()
+    let builder = TestConfigBuilder::new()
         .with_data_dir(data_dir)
         .with_workspace_dir(workspace_dir)
         .with_http_addr(http_addr)
-        .with_control_auth_mode(control_auth_mode)
-        .build_retained()
+        .with_control_auth_mode(control_auth_mode);
+    if control_auth_mode == ControlAuthMode::Required {
+        builder.with_control_token("secret").build_retained()
+    } else {
+        builder.build_retained()
+    }
 }
 
 pub async fn spawn_server() -> Result<(RuntimeHost, String, TestServerHandle)> {


### PR DESCRIPTION
## Summary

- make the control HTTP transport explicit in `AppState`
- preserve Unix socket admission as trusted local IPC under OIDC and always attribute it to `LocalControl`
- require a configured static control token on localhost TCP in `auto` mode while retaining the non-loopback fail-closed rule
- make HTTP test fixtures opt into control tokens explicitly and add the Unix/TCP auth regression matrix

## Runtime contract

- Unix control socket admission is bounded by filesystem permissions and ignores stale remote session or bearer credentials.
- TCP HTTP never inherits the Unix trusted-local exemption: OIDC requires a valid session, and a configured static token is required on both loopback and remote TCP.
- Existing anonymous OIDC bootstrap, callback, and webhook paths are unchanged.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --test http_control` (60 passed)
- `cargo test http --lib`
- targeted config, loopback token, non-loopback token, and real Unix OIDC tests
- `cargo test --all-targets` attempted twice: 3138 passed, 4 ignored; both runs timed out only in the unrelated `runtime::tests::work_items::complete_work_item_uses_followup_report_after_text_before_other_tool`, which passed when rerun alone

Closes #2913
Closes #2916
