### PR TITLE
fix: prevent provider fallback network storms

### DIFF
--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -10,7 +10,8 @@ use super::{
     provider_error_token_usage, provider_transport_diagnostics, provider_turn_error,
     retry::{
         classify_provider_error, format_provider_failure, provider_error_retry_after,
-        provider_max_attempts, provider_retry_delay, ProviderRetryDelay, RetryDisposition,
+        provider_fallback_disposition, provider_max_attempts, provider_retry_delay,
+        ProviderRetryDelay, RetryDisposition,
     },
     AgentProvider, PromptContentBlock, ProviderAttemptOutcome, ProviderAttemptRecord,
     ProviderAttemptTimeline, ProviderBuiltinWebSearchCapability, ProviderContextManagementPolicy,
@@ -606,6 +607,10 @@ mod tests {
             timeline.pending_fallback_model_ref.as_deref(),
             Some("anthropic/claude-sonnet-4-6")
         );
+        assert_eq!(
+            timeline.pending_fallback_disposition,
+            Some(crate::provider::ProviderFallbackDisposition::Immediate)
+        );
         assert_eq!(timeline.attempts.len(), 1);
         assert!(timeline.attempts[0].advanced_to_fallback);
     }
@@ -691,12 +696,14 @@ impl AgentProvider for FallbackProvider {
                     active_model_ref: None,
                     winning_model_ref: None,
                     pending_fallback_model_ref: None,
+                    pending_fallback_disposition: None,
                 },
                 source,
             ));
         };
         let max_attempts = provider_max_attempts();
         let mut last_error = None;
+        let mut pending_fallback_disposition = None;
         for attempt in 1..=max_attempts {
             let attempt_request =
                 request_for_model_attempt(&request, &requested_model_ref, &candidate.model_ref);
@@ -733,6 +740,7 @@ impl AgentProvider for FallbackProvider {
                         active_model_ref: Some(candidate.model_ref.clone()),
                         winning_model_ref: Some(candidate.model_ref.clone()),
                         pending_fallback_model_ref: None,
+                        pending_fallback_disposition: None,
                     };
                     return Ok((response, Some(diagnostics)));
                 }
@@ -785,7 +793,10 @@ impl AgentProvider for FallbackProvider {
                         last_error = Some(error);
                         continue;
                     }
-                    let has_fallback = pending_fallback_model_ref.is_some();
+                    pending_fallback_disposition = pending_fallback_model_ref
+                        .as_ref()
+                        .map(|_| provider_fallback_disposition(classification.kind));
+                    let has_fallback = pending_fallback_disposition.is_some();
                     if matches!(retry_delay, Some(ProviderRetryDelay::SkipToFallback)) {
                         warn!(
                             model_ref = %candidate.model_ref,
@@ -823,6 +834,7 @@ impl AgentProvider for FallbackProvider {
                         max_attempts,
                         failure_kind = classification.kind.as_str(),
                         disposition = classification.disposition.as_str(),
+                        fallback_disposition = ?pending_fallback_disposition,
                         has_fallback,
                         "provider turn failed; {}", if has_fallback { "deferring fallback to next turn" } else { "no fallback remaining" }
                     );
@@ -847,6 +859,7 @@ impl AgentProvider for FallbackProvider {
                 active_model_ref: None,
                 winning_model_ref: None,
                 pending_fallback_model_ref,
+                pending_fallback_disposition,
             },
             source,
         ))

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -682,6 +682,13 @@ pub enum ProviderAttemptOutcome {
     Succeeded,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderFallbackDisposition {
+    Immediate,
+    Deferred,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProviderAttemptRecord {
     pub provider: String,
@@ -721,6 +728,8 @@ pub struct ProviderAttemptTimeline {
     pub winning_model_ref: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_fallback_model_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_fallback_disposition: Option<ProviderFallbackDisposition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub aggregated_token_usage: Option<TokenUsage>,
 }
@@ -840,7 +849,10 @@ pub(crate) fn aggregate_attempt_token_usage(
 pub(crate) use catalog::build_candidate;
 #[cfg(test)]
 pub(crate) use retry::provider_max_attempts;
-pub(crate) use retry::{classify_provider_error, ProviderTransportError};
+pub(crate) use retry::{
+    classify_provider_error, ProviderTransportError, PROVIDER_RECOVERY_BASE_BACKOFF_MS,
+    PROVIDER_RECOVERY_MAX_BACKOFF_MS, PROVIDER_RECOVERY_MAX_FALLBACKS,
+};
 #[cfg(test)]
 pub(crate) use retry::{
     provider_transport_error, provider_transport_error_with_code, ProviderFailureClassification,

--- a/src/provider/retry.rs
+++ b/src/provider/retry.rs
@@ -7,13 +7,17 @@ use thiserror::Error;
 use tokio::time::Duration;
 
 use super::{
-    http_trace::ProviderHttpTraceRequest, ProviderTransportDiagnostics, ReqwestTransportDiagnostics,
+    http_trace::ProviderHttpTraceRequest, ProviderFallbackDisposition,
+    ProviderTransportDiagnostics, ReqwestTransportDiagnostics,
 };
 use crate::types::TokenUsage;
 
 pub(crate) const PROVIDER_MAX_RETRIES: usize = 2;
 const PROVIDER_RETRY_BASE_BACKOFF_MS: u64 = 200;
 pub(crate) const PROVIDER_RETRY_SERVER_HINT_CAP_MS: u64 = 30_000;
+pub(crate) const PROVIDER_RECOVERY_BASE_BACKOFF_MS: u64 = 2_000;
+pub(crate) const PROVIDER_RECOVERY_MAX_BACKOFF_MS: u64 = 30_000;
+pub(crate) const PROVIDER_RECOVERY_MAX_FALLBACKS: usize = 2;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -105,6 +109,17 @@ impl RetryDisposition {
     }
 }
 
+pub(crate) fn provider_fallback_disposition(
+    kind: ProviderFailureKind,
+) -> ProviderFallbackDisposition {
+    match kind {
+        ProviderFailureKind::Timeout | ProviderFailureKind::Connection => {
+            ProviderFallbackDisposition::Deferred
+        }
+        _ => ProviderFallbackDisposition::Immediate,
+    }
+}
+
 pub(crate) fn provider_retry_policy_json() -> Value {
     json!({
         "max_retries_per_provider": PROVIDER_MAX_RETRIES,
@@ -126,6 +141,15 @@ pub(crate) fn provider_retry_policy_json() -> Value {
             ProviderFailureKind::UnsupportedTransport.as_str(),
             ProviderFailureKind::Unknown.as_str(),
         ],
+        "fallback": {
+            "max_lineage_fallbacks": PROVIDER_RECOVERY_MAX_FALLBACKS,
+            "deferred_base_backoff_ms": PROVIDER_RECOVERY_BASE_BACKOFF_MS,
+            "deferred_max_backoff_ms": PROVIDER_RECOVERY_MAX_BACKOFF_MS,
+            "deferred_failure_kinds": [
+                ProviderFailureKind::Timeout.as_str(),
+                ProviderFailureKind::Connection.as_str(),
+            ],
+        },
     })
 }
 
@@ -656,9 +680,30 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        classify_status_error_with_trace, provider_retry_delay, ProviderFailureKind,
-        ProviderRetryDelay, ProviderRetryDelaySource, ProviderTransportError,
+        classify_status_error_with_trace, provider_fallback_disposition, provider_retry_delay,
+        ProviderFailureKind, ProviderRetryDelay, ProviderRetryDelaySource, ProviderTransportError,
     };
+    use crate::provider::ProviderFallbackDisposition;
+
+    #[test]
+    fn network_failures_defer_fallback_but_other_failures_remain_immediate() {
+        assert_eq!(
+            provider_fallback_disposition(ProviderFailureKind::Timeout),
+            ProviderFallbackDisposition::Deferred
+        );
+        assert_eq!(
+            provider_fallback_disposition(ProviderFailureKind::Connection),
+            ProviderFallbackDisposition::Deferred
+        );
+        assert_eq!(
+            provider_fallback_disposition(ProviderFailureKind::ServerError),
+            ProviderFallbackDisposition::Immediate
+        );
+        assert_eq!(
+            provider_fallback_disposition(ProviderFailureKind::RateLimited),
+            ProviderFallbackDisposition::Immediate
+        );
+    }
 
     fn retry_after_headers(value: &str) -> reqwest::header::HeaderMap {
         let mut headers = reqwest::header::HeaderMap::new();

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -522,6 +522,8 @@ pub(crate) struct ContextLengthExceededProvider;
 
 pub(crate) struct DeferredFallbackProvider;
 
+pub(crate) struct DeferredNetworkFallbackProvider;
+
 pub(crate) struct TextThenFailingFallbackProvider {
     pub(crate) calls: Mutex<usize>,
 }
@@ -715,6 +717,7 @@ impl AgentProvider for TimelineProvider {
                 active_model_ref: Some("anthropic/claude-sonnet-4-6".into()),
                 winning_model_ref: Some("anthropic/claude-sonnet-4-6".into()),
                 pending_fallback_model_ref: None,
+                pending_fallback_disposition: None,
             }),
         ))
     }
@@ -1152,7 +1155,8 @@ impl AgentProvider for FailingTimelineProvider {
                 requested_model_ref: "openai/gpt-5.4".into(),
                 active_model_ref: None,
                 winning_model_ref: None,
-                pending_fallback_model_ref: None
+                pending_fallback_model_ref: None,
+                pending_fallback_disposition: None,
             },
             anyhow!("bad request"),
         ))
@@ -1227,7 +1231,8 @@ impl AgentProvider for ContextLengthExceededProvider {
                 requested_model_ref: "openai-codex/gpt-5.3-codex-spark".into(),
                 active_model_ref: None,
                 winning_model_ref: None,
-                pending_fallback_model_ref: None
+                pending_fallback_model_ref: None,
+                pending_fallback_disposition: None,
             },
             provider_transport_error_with_code(
                 ProviderFailureClassification {
@@ -1271,8 +1276,48 @@ impl AgentProvider for DeferredFallbackProvider {
                 active_model_ref: None,
                 winning_model_ref: None,
                 pending_fallback_model_ref: Some("anthropic/claude-sonnet-4-6".into()),
+                pending_fallback_disposition: Some(
+                    crate::provider::ProviderFallbackDisposition::Immediate,
+                ),
             },
             anyhow!("server unavailable"),
+        ))
+    }
+}
+
+#[async_trait]
+impl AgentProvider for DeferredNetworkFallbackProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        Err(provider_turn_error(
+            "all configured providers failed for this turn: openai/gpt-5.4: retryable exhausted",
+            ProviderAttemptTimeline {
+                attempts: vec![ProviderAttemptRecord {
+                    provider: "openai".into(),
+                    model_ref: "openai/gpt-5.4".into(),
+                    attempt: 3,
+                    max_attempts: 3,
+                    started_at: None,
+                    completed_at: None,
+                    duration_ms: Some(125),
+                    failure_kind: Some("connection".into()),
+                    disposition: Some("retryable".into()),
+                    outcome: ProviderAttemptOutcome::RetriesExhausted,
+                    advanced_to_fallback: true,
+                    backoff_ms: None,
+                    backoff_source: None,
+                    token_usage: None,
+                    transport_diagnostics: None,
+                }],
+                aggregated_token_usage: None,
+                requested_model_ref: "openai/gpt-5.4".into(),
+                active_model_ref: None,
+                winning_model_ref: None,
+                pending_fallback_model_ref: Some("anthropic/claude-sonnet-4-6".into()),
+                pending_fallback_disposition: Some(
+                    crate::provider::ProviderFallbackDisposition::Deferred,
+                ),
+            },
+            anyhow!("network unavailable"),
         ))
     }
 }
@@ -1322,6 +1367,9 @@ impl AgentProvider for TextThenFailingFallbackProvider {
                 active_model_ref: None,
                 winning_model_ref: None,
                 pending_fallback_model_ref: Some("anthropic/claude-sonnet-4-6".into()),
+                pending_fallback_disposition: Some(
+                    crate::provider::ProviderFallbackDisposition::Immediate,
+                ),
             },
             anyhow!("server unavailable"),
         ))

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -1899,6 +1899,8 @@ async fn provider_failure_before_output_defers_fallback_to_next_turn() {
         .unwrap();
 
     assert_eq!(outcome.terminal_kind, TurnTerminalKind::DeferredToFallback);
+    assert!(!outcome.should_sleep);
+    assert_eq!(outcome.sleep_duration_ms, None);
     let state = runtime.agent_state().await.unwrap();
     assert!(state.pending_fallback_model.is_none());
     assert_eq!(
@@ -1921,6 +1923,13 @@ async fn provider_failure_before_output_defers_fallback_to_next_turn() {
             .as_ref()
             .and_then(|metadata| { metadata["provider_recovery"]["fallback_model_ref"].as_str() }),
         Some("anthropic@default/claude-sonnet-4-6")
+    );
+    assert_eq!(
+        queued
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata["provider_recovery"]["fallback_attempt"].as_u64()),
+        Some(1)
     );
     assert_eq!(
         crate::runtime::turn::TurnModelSelection::from_message(&queued)
@@ -1967,6 +1976,118 @@ async fn provider_failure_before_output_defers_fallback_to_next_turn() {
     assert!(!events
         .iter()
         .any(|event| event.kind == "recovery_turn_started"));
+}
+
+#[tokio::test]
+async fn network_failure_delays_one_recovery_instead_of_immediate_fallback() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(DeferredNetworkFallbackProvider),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let outcome = runtime
+        .run_agent_loop(
+            "default",
+            AuthorityClass::OperatorInstruction,
+            test_effective_prompt(),
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.terminal_kind, TurnTerminalKind::DeferredToFallback);
+    assert!(outcome.should_sleep);
+    let delay_ms = outcome.sleep_duration_ms.expect("network recovery delay");
+    assert!((crate::provider::PROVIDER_RECOVERY_BASE_BACKOFF_MS
+        ..crate::provider::PROVIDER_RECOVERY_BASE_BACKOFF_MS * 5 / 4)
+        .contains(&delay_ms));
+
+    let queued = {
+        let guard = runtime.inner.agent.lock().await;
+        assert_eq!(guard.queue.len(), 1);
+        guard.queue.peek().cloned().expect("one fallback followup")
+    };
+    assert_eq!(
+        queued
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata["provider_recovery"]["fallback_attempt"].as_u64()),
+        Some(1)
+    );
+
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    let recovery = events
+        .iter()
+        .find(|event| event.kind == "recovery_enqueued")
+        .expect("recovery_enqueued event");
+    assert_eq!(recovery.data["recovery_delay_ms"].as_u64(), Some(delay_ms));
+}
+
+#[tokio::test]
+async fn provider_recovery_budget_exhaustion_stops_the_lineage() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("unused")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let error = DeferredNetworkFallbackProvider
+        .complete_turn(ProviderTurnRequest::plain("base", Vec::new(), Vec::new()))
+        .await
+        .expect_err("network provider failure");
+    let recovery = crate::runtime::turn::ProviderRecoveryDirective {
+        fallback_model_ref: crate::config::ModelRouteRef::parse_compatible("openai/gpt-5.4")
+            .unwrap(),
+        fallback_attempt: crate::provider::PROVIDER_RECOVERY_MAX_FALLBACKS,
+        root_message_id: "message-root".into(),
+        source_turn_id: "turn-source".into(),
+        source_message_id: "message-source".into(),
+        source_terminal_kind: TurnTerminalKind::DeferredToFallback,
+        source_round: 1,
+    };
+
+    let outcome = runtime
+        .maybe_defer_provider_lineage_failure(
+            "default",
+            2,
+            &error,
+            Some(&recovery),
+            None,
+            10,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+    assert!(outcome.is_none());
+    assert_eq!(runtime.inner.agent.lock().await.queue.len(), 0);
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    let exhausted = events
+        .iter()
+        .find(|event| event.kind == "provider_recovery_budget_exhausted")
+        .expect("provider_recovery_budget_exhausted event");
+    assert_eq!(
+        exhausted.data["fallback_attempt"].as_u64(),
+        Some(crate::provider::PROVIDER_RECOVERY_MAX_FALLBACKS as u64)
+    );
+    assert!(!events.iter().any(|event| event.kind == "recovery_enqueued"));
 }
 
 #[test]

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -12,8 +12,9 @@ use crate::config::ModelRouteRef;
 use crate::prompt::EffectivePrompt;
 use crate::provider::{
     provider_attempt_timeline, provider_error_is_context_length_exceeded, AgentProvider,
-    ModelBlock, ProviderAttemptTimeline, ProviderTurnRequest, ProviderTurnResponse,
-    ToolResultBlock,
+    ModelBlock, ProviderAttemptTimeline, ProviderFallbackDisposition, ProviderTurnRequest,
+    ProviderTurnResponse, ToolResultBlock, PROVIDER_RECOVERY_BASE_BACKOFF_MS,
+    PROVIDER_RECOVERY_MAX_BACKOFF_MS, PROVIDER_RECOVERY_MAX_FALLBACKS,
 };
 use crate::runtime::provider_turn::{
     build_continuation_request, build_initial_provider_turn_request, build_provider_prompt_frame,
@@ -297,11 +298,12 @@ impl RuntimeHandle {
         })
     }
 
-    pub(super) async fn maybe_defer_provider_lineage_failure(
+    pub(in crate::runtime) async fn maybe_defer_provider_lineage_failure(
         &self,
         agent_id: &str,
         round: usize,
         error: &anyhow::Error,
+        recovery: Option<&ProviderRecoveryDirective>,
         last_assistant_message: Option<String>,
         duration_ms: u64,
         side_effect_boundary_crossed: bool,
@@ -313,6 +315,23 @@ impl RuntimeHandle {
         let Some(fallback_ref) = timeline.pending_fallback_model_ref.as_deref() else {
             return Ok(None);
         };
+        let fallback_attempt = recovery
+            .map(|directive| directive.fallback_attempt)
+            .unwrap_or(0);
+        if fallback_attempt >= PROVIDER_RECOVERY_MAX_FALLBACKS {
+            self.inner.storage.append_event(&AuditEvent::legacy(
+                "provider_recovery_budget_exhausted",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "round": round,
+                    "fallback_attempt": fallback_attempt,
+                    "max_lineage_fallbacks": PROVIDER_RECOVERY_MAX_FALLBACKS,
+                    "pending_fallback_model_ref": fallback_ref,
+                    "provider_attempt_timeline": timeline,
+                }),
+            ))?;
+            return Ok(None);
+        }
         let Ok(fallback_model) = ModelRouteRef::parse_compatible(fallback_ref) else {
             return Ok(None);
         };
@@ -322,6 +341,23 @@ impl RuntimeHandle {
             TurnTerminalKind::DeferredToFallback
         };
         let error_text = error.to_string();
+        let recovery_seed = recovery
+            .and_then(|directive| {
+                (!directive.root_message_id.is_empty())
+                    .then_some(directive.root_message_id.as_str())
+                    .or_else(|| {
+                        (!directive.source_message_id.is_empty())
+                            .then_some(directive.source_message_id.as_str())
+                    })
+            })
+            .unwrap_or(agent_id);
+        let recovery_delay_ms = matches!(
+            timeline.pending_fallback_disposition,
+            Some(ProviderFallbackDisposition::Deferred)
+        )
+        .then(|| {
+            provider_recovery_delay_ms(fallback_attempt, &format!("{recovery_seed}:{fallback_ref}"))
+        });
         let provider_failure_text = provider_lineage_failure_text(&error_text);
         let operator_message = provider_lineage_operator_message(
             fallback_ref,
@@ -338,6 +374,8 @@ impl RuntimeHandle {
                 "requested_model_ref": timeline.requested_model_ref,
                 "active_model_ref": timeline.active_model_ref,
                 "pending_fallback_model_ref": fallback_ref,
+                "fallback_attempt": fallback_attempt,
+                "recovery_delay_ms": recovery_delay_ms,
                 "side_effect_boundary_crossed": side_effect_boundary_crossed,
                 "provider_attempt_timeline": timeline,
             }),
@@ -368,6 +406,8 @@ impl RuntimeHandle {
                 "error": error_text,
                 "operator_message": operator_message,
                 "fallback_model_ref": fallback_ref,
+                "fallback_attempt": fallback_attempt,
+                "recovery_delay_ms": recovery_delay_ms,
                 "side_effect_boundary_crossed": side_effect_boundary_crossed,
                 "last_assistant_preview": last_assistant_message
                     .as_deref()
@@ -410,6 +450,11 @@ impl RuntimeHandle {
                 .map(|binding| binding.source_message_id.clone())
                 .unwrap_or_else(|| terminal.turn_id.clone())
         };
+        let root_message_id = recovery
+            .map(|directive| directive.root_message_id.as_str())
+            .filter(|root| !root.is_empty())
+            .unwrap_or(&source_message_id)
+            .to_string();
         message.causation_id = Some(source_message_id.clone());
         message
             .source_refs
@@ -420,6 +465,8 @@ impl RuntimeHandle {
         message.metadata = Some(serde_json::json!({
             "provider_recovery": ProviderRecoveryDirective {
                 fallback_model_ref: fallback_model,
+                fallback_attempt: fallback_attempt + 1,
+                root_message_id,
                 source_turn_id: terminal.turn_id.clone(),
                 source_message_id,
                 source_terminal_kind: terminal_kind,
@@ -434,6 +481,8 @@ impl RuntimeHandle {
                 "agent_id": agent_id,
                 "message_id": queued.id,
                 "fallback_model_ref": fallback_ref,
+                "fallback_attempt": fallback_attempt + 1,
+                "recovery_delay_ms": recovery_delay_ms,
                 "source_terminal_kind": terminal_kind,
             }),
         ))?;
@@ -443,8 +492,8 @@ impl RuntimeHandle {
             final_text_source_assistant_round_id: None,
             turn_index: terminal.turn_index,
             terminal,
-            should_sleep: false,
-            sleep_duration_ms: None,
+            should_sleep: recovery_delay_ms.is_some(),
+            sleep_duration_ms: recovery_delay_ms,
             allow_sleep_runnable_work_override: false,
             terminal_kind,
             prepared_work_item_completion: None,
@@ -1121,6 +1170,24 @@ pub(super) fn provider_lineage_operator_message(
     format!("{prefix}: {failure} {queued} on {fallback_ref}.")
 }
 
+pub(super) fn provider_recovery_delay_ms(fallback_attempt: usize, seed: &str) -> u64 {
+    let exponent = u32::try_from(fallback_attempt).unwrap_or(u32::MAX).min(16);
+    let multiplier = 1_u64.checked_shl(exponent).unwrap_or(u64::MAX);
+    let backoff = PROVIDER_RECOVERY_BASE_BACKOFF_MS
+        .saturating_mul(multiplier)
+        .min(PROVIDER_RECOVERY_MAX_BACKOFF_MS);
+    let digest = Sha256::digest(seed.as_bytes());
+    let jitter_seed = u64::from_le_bytes(
+        digest[..8]
+            .try_into()
+            .expect("sha256 digest prefix has eight bytes"),
+    );
+    let jitter_window = (backoff / 4).max(1);
+    backoff
+        .saturating_add(jitter_seed % jitter_window)
+        .min(PROVIDER_RECOVERY_MAX_BACKOFF_MS)
+}
+
 pub(super) struct TurnExecution<'a> {
     pub(super) runtime: &'a RuntimeHandle,
     pub(super) agent_id: &'a str,
@@ -1157,6 +1224,7 @@ impl TurnExecution<'_> {
         let mut last_assistant_citations = Vec::<Citation>::new();
         let mut last_assistant_round_id: Option<String> = None;
         let mut max_output_recovery_count = 0usize;
+        let provider_recovery = model_selection.recovery.clone();
         let mut checkpoint_state = {
             let guard = runtime.inner.agent.lock().await;
             checkpoint_state_from_last_terminal(guard.state.last_turn_terminal.as_ref())
@@ -1426,6 +1494,7 @@ impl TurnExecution<'_> {
                                 agent_id,
                                 round,
                                 &err,
+                                provider_recovery.as_ref(),
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
                                 !completed_rounds.is_empty() || last_assistant_message.is_some(),
@@ -1752,6 +1821,7 @@ impl TurnExecution<'_> {
                                 agent_id,
                                 round,
                                 &err,
+                                provider_recovery.as_ref(),
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
                                 !completed_rounds.is_empty() || last_assistant_message.is_some(),

--- a/src/runtime/turn/mod.rs
+++ b/src/runtime/turn/mod.rs
@@ -66,6 +66,10 @@ pub(crate) struct LoopControlOptions {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(super) struct ProviderRecoveryDirective {
     pub(super) fallback_model_ref: ModelRouteRef,
+    #[serde(default)]
+    pub(super) fallback_attempt: usize,
+    #[serde(default)]
+    pub(super) root_message_id: String,
     pub(super) source_turn_id: String,
     pub(super) source_message_id: String,
     pub(super) source_terminal_kind: TurnTerminalKind,

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -823,6 +823,7 @@ fn normalize_provider_attempt_timing_backfills_missing_attempt_timing() {
         active_model_ref: None,
         winning_model_ref: None,
         pending_fallback_model_ref: None,
+        pending_fallback_disposition: None,
         aggregated_token_usage: None,
     };
     let single = normalize_provider_attempt_timing(single.into(), started_at, completed_at, 42)
@@ -838,6 +839,7 @@ fn normalize_provider_attempt_timing_backfills_missing_attempt_timing() {
         active_model_ref: None,
         winning_model_ref: None,
         pending_fallback_model_ref: None,
+        pending_fallback_disposition: None,
         aggregated_token_usage: None,
     };
     let multiple = normalize_provider_attempt_timing(multiple.into(), started_at, completed_at, 42)
@@ -848,6 +850,26 @@ fn normalize_provider_attempt_timing_backfills_missing_attempt_timing() {
         assert_eq!(attempt.completed_at, None);
         assert_eq!(attempt.duration_ms, None);
     }
+}
+
+#[test]
+fn provider_recovery_delay_is_bounded_exponential_and_lineage_seeded() {
+    let first = provider_recovery_delay_ms(0, "lineage-a:model");
+    let second = provider_recovery_delay_ms(1, "lineage-a:model");
+    let capped = provider_recovery_delay_ms(usize::MAX, "lineage-a:model");
+
+    assert!((crate::provider::PROVIDER_RECOVERY_BASE_BACKOFF_MS
+        ..crate::provider::PROVIDER_RECOVERY_BASE_BACKOFF_MS * 5 / 4)
+        .contains(&first));
+    assert!((crate::provider::PROVIDER_RECOVERY_BASE_BACKOFF_MS * 2
+        ..crate::provider::PROVIDER_RECOVERY_BASE_BACKOFF_MS * 5 / 2)
+        .contains(&second));
+    assert_eq!(capped, crate::provider::PROVIDER_RECOVERY_MAX_BACKOFF_MS);
+    assert_eq!(
+        first,
+        provider_recovery_delay_ms(0, "lineage-a:model"),
+        "the same lineage must retain deterministic jitter"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- separate retry and fallback decisions for provider failures
- defer recovery for connection and timeout failures instead of immediately walking every fallback model
- bound each recovery lineage with a total attempt budget and deterministic exponential backoff with jitter
- preserve immediate fallback behavior for non-network failures

## Runtime behavior

When a provider attempt ends with a connection or timeout failure, the turn now schedules one delayed recovery for the same lineage rather than immediately trying every configured fallback model. Recovery attempts share a bounded lineage budget, preventing persistent local network outages from producing an unbounded fallback storm.

## Verification

- `cargo test provider_recovery -- --nocapture`
- `cargo test network_failure -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
