### PR TITLE
fix(memory): at-least-once memory index outbox consumption with contiguous-prefix ack

### DIFF
--- a/docs/implementation-decisions/061-memory-index-v2-outbox.md
+++ b/docs/implementation-decisions/061-memory-index-v2-outbox.md
@@ -30,7 +30,17 @@ migrating content into the new ref-discovery schema.
 
 `index_status` reports stale/incomplete results when the current projection lacks
 any required full-backfill checkpoint, even if its runtime outbox cursor is
-caught up. It also reports when bounded outbox consumption hit its limit and
-when individual outbox rows were skipped because their source could not be
-projected. A failed row advances the outbox cursor after logging so one bad
-source cannot permanently stall discovery for later refs.
+caught up. It also reports when bounded outbox consumption hit its limit
+(`consumption_was_limited`) and how many rows the current consume attempt
+failed to apply (`skipped_error_count`).
+
+Outbox consumption is at-least-once with contiguous-prefix acknowledgment: the
+applied cursor advances only inside the memory index transaction that projects
+a row, a failed row and everything after it stay in the runtime outbox as a
+durable retry queue, and the daemon backs off a persistently failing agent.
+Rows are deleted only after the cursor has covered them, so a projection
+failure can delay discovery but never silently drop refs. `index_status`
+additionally tracks a monotonic per-agent produced watermark that survives row
+GC, and counts pending rows only above the applied cursor: rows at or below it
+are acknowledged garbage awaiting GC, including rows a full rebuild jumped the
+cursor past.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -8632,6 +8632,7 @@
                 "type": "boolean"
               },
               "cursor": {
+                "description": "Highest applied contiguous runtime outbox `change_seq`.",
                 "format": "int64",
                 "type": "integer"
               },
@@ -8639,6 +8640,7 @@
                 "type": "string"
               },
               "high_watermark": {
+                "description": "Monotonic produced watermark: highest `change_seq` ever appended for\n the agent. Unlike the drained-outbox maximum, it never returns to 0.",
                 "format": "int64",
                 "type": "integer"
               },
@@ -8646,6 +8648,7 @@
                 "type": "boolean"
               },
               "lag": {
+                "description": "Sequence distance `produced - applied`. Cross-agent global\n autoincrement makes this an upper-bound hint only; `pending_count` is\n the exact backlog metric.",
                 "format": "int64",
                 "type": "integer"
               },
@@ -8656,10 +8659,24 @@
                   "null"
                 ]
               },
+              "oldest_pending_age_ms": {
+                "description": "Age of the oldest pending outbox row, the real propagation delay.",
+                "format": "int64",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "pending_count": {
+                "description": "Exact pending outbox row count for this agent.",
+                "format": "int64",
+                "type": "integer"
+              },
               "results_may_be_incomplete": {
                 "type": "boolean"
               },
               "skipped_error_count": {
+                "description": "Failures hit by this index handle's current consume pass. Transient\n by design; not a durable health history.",
                 "format": "uint",
                 "minimum": 0,
                 "type": "integer"

--- a/src/host.rs
+++ b/src/host.rs
@@ -1210,9 +1210,19 @@ impl RuntimeHost {
 
     const DAEMON_INDEXER_BATCH: usize = 500;
     const DAEMON_INDEXER_FALLBACK_POLL: Duration = Duration::from_secs(60);
+    /// First retry delay for a failing memory-index agent before exponential
+    /// growth.
+    const MEMORY_INDEXER_RETRY_BASE: Duration = Duration::from_millis(500);
+    /// Upper bound for a failing agent's retry delay.
+    const MEMORY_INDEXER_RETRY_MAX: Duration = Duration::from_secs(30);
 
     async fn run_daemon_memory_indexer(self) {
         use crate::memory::{memory_index_agent_ids_with_pending, refresh_memory_index_bounded};
+        // Process-local per-agent retry backoff. A persistently failing agent
+        // (for example a locked index) must not be retried on every global
+        // notify driven by other agents' writes.
+        let mut agent_retry_not_before: HashMap<String, (tokio::time::Instant, u32)> =
+            HashMap::new();
         loop {
             if self.inner.daemon_indexer_token.is_cancelled() {
                 break;
@@ -1226,7 +1236,7 @@ impl RuntimeHost {
                 Ok(ids) => ids,
                 Err(error) => {
                     tracing::warn!(error = %error, "daemon memory indexer: failed to query pending agents");
-                    self.wait_daemon_indexer_round().await;
+                    self.wait_daemon_indexer_round(None).await;
                     continue;
                 }
             };
@@ -1234,7 +1244,7 @@ impl RuntimeHost {
                 Ok(storage) => storage,
                 Err(error) => {
                     tracing::warn!(error = %error, "daemon memory indexer: failed to open shared index");
-                    self.wait_daemon_indexer_round().await;
+                    self.wait_daemon_indexer_round(None).await;
                     continue;
                 }
             };
@@ -1244,7 +1254,7 @@ impl RuntimeHost {
                 Ok(ids) => ids.into_iter().collect::<std::collections::BTreeSet<_>>(),
                 Err(error) => {
                     tracing::warn!(error = %error, "daemon memory indexer: failed to query pending source agents");
-                    self.wait_daemon_indexer_round().await;
+                    self.wait_daemon_indexer_round(None).await;
                     continue;
                 }
             };
@@ -1255,6 +1265,11 @@ impl RuntimeHost {
 
             let mut did_work = false;
             for agent_id in &agent_ids {
+                if let Some((not_before, _)) = agent_retry_not_before.get(agent_id) {
+                    if tokio::time::Instant::now() < *not_before {
+                        continue;
+                    }
+                }
                 let storage = match self.agent_storage(agent_id) {
                     Ok(storage) => storage,
                     Err(error) => {
@@ -1272,6 +1287,7 @@ impl RuntimeHost {
                 .await;
                 match result {
                     Ok(Ok(status)) => {
+                        agent_retry_not_before.remove(agent_id);
                         did_work |= status.lag > 0
                             || status.consumption_was_limited
                             // A successful rebuild consumes every pending source
@@ -1286,18 +1302,34 @@ impl RuntimeHost {
                         );
                     }
                     Ok(Err(error)) => {
+                        let delay = Self::memory_indexer_retry_delay(
+                            agent_retry_not_before
+                                .get(agent_id)
+                                .map(|(_, attempts)| *attempts)
+                                .unwrap_or(0),
+                        );
                         tracing::warn!(
                             agent_id = %agent_id,
+                            retry_in_ms = delay.as_millis() as u64,
                             error = %error,
-                            "daemon memory indexer: refresh failed"
+                            "daemon memory indexer: refresh failed; backing off agent"
                         );
+                        Self::back_off_memory_indexer_agent(&mut agent_retry_not_before, agent_id);
                     }
                     Err(error) => {
+                        let delay = Self::memory_indexer_retry_delay(
+                            agent_retry_not_before
+                                .get(agent_id)
+                                .map(|(_, attempts)| *attempts)
+                                .unwrap_or(0),
+                        );
                         tracing::warn!(
                             agent_id = %agent_id,
+                            retry_in_ms = delay.as_millis() as u64,
                             error = %error,
-                            "daemon memory indexer: task failed"
+                            "daemon memory indexer: task failed; backing off agent"
                         );
+                        Self::back_off_memory_indexer_agent(&mut agent_retry_not_before, agent_id);
                     }
                 }
             }
@@ -1305,16 +1337,57 @@ impl RuntimeHost {
             if did_work {
                 tokio::task::yield_now().await;
             } else {
-                self.wait_daemon_indexer_round().await;
+                let next_retry_at = agent_retry_not_before
+                    .values()
+                    .map(|(not_before, _)| *not_before)
+                    .min();
+                self.wait_daemon_indexer_round(next_retry_at).await;
             }
         }
     }
 
-    async fn wait_daemon_indexer_round(&self) {
+    /// Exponential retry delay with a cap and ±25% jitter so concurrent
+    /// failing agents do not retry in lockstep.
+    fn memory_indexer_retry_delay(attempts: u32) -> Duration {
+        let shift = attempts.min(8);
+        let exponential = Self::MEMORY_INDEXER_RETRY_BASE
+            .saturating_mul(1u32.checked_shl(shift).unwrap_or(u32::MAX));
+        let capped = exponential.min(Self::MEMORY_INDEXER_RETRY_MAX);
+        let jitter_unit = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|elapsed| elapsed.subsec_nanos() % 1000)
+            .unwrap_or(0) as f64;
+        let factor = 0.75 + jitter_unit / 2000.0;
+        Duration::from_secs_f64(capped.as_secs_f64() * factor)
+    }
+
+    fn back_off_memory_indexer_agent(
+        agent_retry_not_before: &mut HashMap<String, (tokio::time::Instant, u32)>,
+        agent_id: &str,
+    ) {
+        let attempts = agent_retry_not_before
+            .get(agent_id)
+            .map(|(_, attempts)| *attempts)
+            .unwrap_or(0);
+        let delay = Self::memory_indexer_retry_delay(attempts);
+        agent_retry_not_before.insert(
+            agent_id.to_string(),
+            (tokio::time::Instant::now() + delay, attempts + 1),
+        );
+    }
+
+    async fn wait_daemon_indexer_round(&self, next_retry_at: Option<tokio::time::Instant>) {
+        let retry_wait = async {
+            match next_retry_at {
+                Some(at) => tokio::time::sleep_until(at).await,
+                None => std::future::pending::<()>().await,
+            }
+        };
         tokio::select! {
             _ = self.inner.daemon_indexer_token.cancelled() => {}
             _ = self.inner.memory_index_notify.notified() => {}
             _ = tokio::time::sleep(Self::DAEMON_INDEXER_FALLBACK_POLL) => {}
+            _ = retry_wait => {}
         }
     }
 
@@ -5998,6 +6071,31 @@ fn child_has_active_lifecycle_blockers(storage: &AppStorage, child_agent_id: &st
             condition.status == crate::types::WaitConditionStatus::Active
                 && condition.kind == crate::types::WaitConditionKind::Task
         }))
+}
+
+#[cfg(test)]
+mod memory_indexer_retry_tests {
+    use super::*;
+
+    #[test]
+    fn memory_indexer_retry_delay_stays_within_jittered_bounds() {
+        for attempts in 0..12u32 {
+            let delay = RuntimeHost::memory_indexer_retry_delay(attempts);
+            let exponential_ms =
+                500u64.saturating_mul(1u64.checked_shl(attempts).unwrap_or(u64::MAX));
+            let expected_ms = exponential_ms.min(30_000);
+            assert!(
+                delay.as_millis() as u64 >= expected_ms * 3 / 4,
+                "attempt {attempts}: delay {:?} below lower bound {expected_ms}ms",
+                delay
+            );
+            assert!(
+                delay.as_millis() as u64 <= expected_ms * 5 / 4 + 1,
+                "attempt {attempts}: delay {:?} above upper bound {expected_ms}ms",
+                delay
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -66,15 +66,29 @@ pub struct MemorySearchResult {
 #[serde(rename_all = "snake_case")]
 pub struct MemorySearchIndexStatus {
     pub freshness: String,
+    /// Highest applied contiguous runtime outbox `change_seq`.
     pub cursor: i64,
+    /// Monotonic produced watermark: highest `change_seq` ever appended for
+    /// the agent. Unlike the drained-outbox maximum, it never returns to 0.
     pub high_watermark: i64,
+    /// Sequence distance `produced - applied`. Cross-agent global
+    /// autoincrement makes this an upper-bound hint only; `pending_count` is
+    /// the exact backlog metric.
     pub lag: i64,
+    /// Exact pending outbox row count for this agent.
+    #[serde(default, skip_serializing_if = "is_zero_i64")]
+    pub pending_count: i64,
+    /// Age of the oldest pending outbox row, the real propagation delay.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oldest_pending_age_ms: Option<i64>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub indexing_needed: bool,
     #[serde(default, skip_serializing_if = "is_false")]
     pub results_may_be_incomplete: bool,
     #[serde(default, skip_serializing_if = "is_false")]
     pub consumption_was_limited: bool,
+    /// Failures hit by this index handle's current consume pass. Transient
+    /// by design; not a durable health history.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub skipped_error_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -367,7 +381,20 @@ fn get_memory_with_limit(
         return Ok(Some(memory_get_result(document, max_chars)));
     }
 
-    let index = ensure_memory_index_current(storage, active_workspace_id)?;
+    let index = match ensure_memory_index_current(storage, active_workspace_id) {
+        Ok(index) => index,
+        Err(error) => {
+            // Point lookups must not fail hard because the pre-read refresh
+            // hit a transient failure (for example a locked index). Query the
+            // current snapshot; search status surfaces the retained backlog.
+            tracing::warn!(
+                source_ref,
+                error = %error,
+                "memory index refresh failed before lookup; querying current index snapshot"
+            );
+            MemoryIndex::open(storage)?
+        }
+    };
     index.get(source_ref, max_chars, &agent_id, active_workspace_id)
 }
 
@@ -412,22 +439,30 @@ fn ensure_memory_indexes_current(
     log_legacy_index_deprecation(storage);
     let mut index = MemoryIndex::open(storage)?;
     let mut refreshed_agent_ids = BTreeSet::new();
-    refresh_memory_index_for_storage(
-        &mut index,
-        storage,
-        active_workspace_id,
-        MEMORY_INDEX_OUTBOX_CONSUME_LIMIT,
-    )?;
+    let mut first_error: Option<anyhow::Error> = None;
+    let mut refresh = |index: &mut MemoryIndex, agent_storage: &AppStorage| {
+        if let Err(error) = refresh_memory_index_for_storage(
+            index,
+            agent_storage,
+            active_workspace_id,
+            MEMORY_INDEX_OUTBOX_CONSUME_LIMIT,
+        ) {
+            // One agent's failed consume must not block refreshing the other
+            // agents in this read path; report the first failure after all.
+            if first_error.is_none() {
+                first_error = Some(error);
+            }
+        }
+    };
+    refresh(&mut index, storage);
     refreshed_agent_ids.insert(storage_agent_id(storage));
     for agent_storage in agent_storages {
         if refreshed_agent_ids.insert(storage_agent_id(agent_storage)) {
-            refresh_memory_index_for_storage(
-                &mut index,
-                agent_storage,
-                active_workspace_id,
-                MEMORY_INDEX_OUTBOX_CONSUME_LIMIT,
-            )?;
+            refresh(&mut index, agent_storage);
         }
+    }
+    if let Some(error) = first_error {
+        return Err(error);
     }
     Ok(index)
 }
@@ -782,6 +817,26 @@ impl MemoryIndex {
         upsert_index_meta_tx(&transaction, &agent_id, Some(Utc::now()))?;
         transaction.commit()?;
         clear_memory_index_dirty(storage)?;
+        if runtime_high_watermark > 0 {
+            // The rebuild re-collected every source up to this watermark, so
+            // outbox rows at or below it are acknowledged. Deleting them is
+            // best-effort: a failure or crash here leaves rows the consume
+            // loop's compensating GC removes later, and pending metrics
+            // already exclude them because the cursor jumped past them.
+            if let Some(runtime_db) = runtime_db.as_ref() {
+                if let Err(error) = runtime_db
+                    .runtime_index_outbox()
+                    .delete_acknowledged_through(&agent_id, runtime_high_watermark)
+                {
+                    tracing::warn!(
+                        agent_id = %agent_id,
+                        through_change_seq = runtime_high_watermark,
+                        error = %error,
+                        "failed to delete memory index outbox rows acknowledged by rebuild"
+                    );
+                }
+            }
+        }
         Ok(())
     }
 
@@ -951,47 +1006,74 @@ impl MemoryIndex {
             .runtime_index_outbox()
             .read_after(&agent_id, cursor, limit)?;
         let row_count = rows.len();
-        let mut last_change_seq = cursor;
+        // The cursor only advances over the contiguous acknowledged prefix:
+        // each row must apply successfully and advance the cursor inside one
+        // index transaction before it counts as consumed.
+        let mut last_successful_seq = cursor;
+        let mut consume_error: Option<anyhow::Error> = None;
         for row in rows {
-            last_change_seq = last_change_seq.max(row.change_seq);
             let source = pending_source_from_outbox_row(&row);
             let transaction = self.connection.transaction()?;
-            if let Err(error) = apply_pending_source_tx(&transaction, storage, &source) {
-                self.last_outbox_error_count += 1;
-                tracing::warn!(
-                    agent_id = %row.agent_id,
-                    change_seq = row.change_seq,
-                    source_kind = %row.source_kind,
-                    source_ref = %row.source_ref,
-                    error = %error,
-                    "skipping failed memory index outbox row"
-                );
+            let applied = apply_pending_source_tx(&transaction, storage, &source).and_then(|()| {
+                upsert_cursor_tx(
+                    &transaction,
+                    &runtime_id,
+                    &agent_id,
+                    MEMORY_INDEX_OUTBOX_CURSOR,
+                    row.change_seq,
+                )
+            });
+            match applied {
+                Ok(()) => match transaction.commit() {
+                    Ok(()) => {
+                        last_successful_seq = row.change_seq;
+                    }
+                    Err(error) => {
+                        consume_error = Some(error.into());
+                        break;
+                    }
+                },
+                Err(error) => {
+                    consume_error = Some(error.context(format!(
+                        "agent_id={} change_seq={} source_kind={} source_ref={}",
+                        row.agent_id, row.change_seq, row.source_kind, row.source_ref
+                    )));
+                    break;
+                }
             }
-            upsert_cursor_tx(
-                &transaction,
-                &runtime_id,
-                &agent_id,
-                MEMORY_INDEX_OUTBOX_CURSOR,
-                last_change_seq,
-            )?;
-            transaction.commit()?;
         }
 
-        // Delete consumed outbox rows to keep the table bounded.  The cursor
-        // already advanced past every row we processed (including failures
-        // which are skipped), so deleting through `last_change_seq` is safe.
-        if last_change_seq > cursor {
+        // Acknowledged rows are those at or below the committed cursor: rows
+        // applied this round, plus any rows a crash between apply and delete
+        // or a full rebuild cursor jump left behind. A failed row and
+        // everything after it stay in the runtime outbox as a durable retry
+        // queue; only rows at or below `last_successful_seq` are ever
+        // deleted.
+        if last_successful_seq > 0 {
             if let Err(error) = runtime_db
                 .runtime_index_outbox()
-                .delete_through(&agent_id, last_change_seq)
+                .delete_acknowledged_through(&agent_id, last_successful_seq)
             {
                 tracing::warn!(
                     agent_id = %agent_id,
-                    through_change_seq = last_change_seq,
+                    through_change_seq = last_successful_seq,
                     error = %error,
                     "failed to delete consumed memory index outbox rows"
                 );
             }
+        }
+        if let Some(error) = &consume_error {
+            self.last_outbox_error_count += 1;
+            tracing::warn!(
+                agent_id = %agent_id,
+                through_change_seq = last_successful_seq,
+                error = %(error as &dyn std::fmt::Display),
+                "memory index outbox apply failed; retaining rows for ordered retry"
+            );
+            // Head-of-line blocking is intentional: the consumer stops at the
+            // first failure so the applied cursor never crosses an unapplied
+            // row and no row is dropped before it is proven applied.
+            return Err(consume_error.unwrap());
         }
         self.last_outbox_consume_reached_limit = limit > 0 && row_count >= limit;
         Ok(())
@@ -1049,6 +1131,8 @@ impl MemoryIndex {
                 cursor: 0,
                 high_watermark: 0,
                 lag: 0,
+                pending_count: 0,
+                oldest_pending_age_ms: None,
                 indexing_needed,
                 results_may_be_incomplete: indexing_needed,
                 consumption_was_limited: false,
@@ -1060,12 +1144,25 @@ impl MemoryIndex {
         let cursor = self.cursor(&runtime_id, agent_id, MEMORY_INDEX_OUTBOX_CURSOR)?;
         let high_watermark = runtime_db
             .runtime_index_outbox()
-            .high_watermark_for_agent(agent_id)?;
+            .produced_watermark_for_agent(agent_id)?;
+        let pending_count = runtime_db
+            .runtime_index_outbox()
+            .pending_count_for_agent(agent_id, cursor)?;
+        let oldest_pending_age_ms = match runtime_db
+            .runtime_index_outbox()
+            .oldest_pending_created_at_for_agent(agent_id, cursor)?
+        {
+            Some(oldest_pending_at) if pending_count > 0 => {
+                Some((Utc::now() - oldest_pending_at).num_milliseconds().max(0))
+            }
+            _ => None,
+        };
         let lag = (high_watermark - cursor).max(0);
         let freshness = if !memory_index_path(storage).exists() {
             "missing"
         } else if memory_index_is_dirty(storage)
             || lag > 0
+            || pending_count > 0
             || has_stale_projection
             || has_pending_sources
             || lacks_full_backfill
@@ -1080,6 +1177,8 @@ impl MemoryIndex {
             cursor,
             high_watermark,
             lag,
+            pending_count,
+            oldest_pending_age_ms,
             indexing_needed,
             results_may_be_incomplete: indexing_needed,
             consumption_was_limited: self.last_outbox_consume_reached_limit && lag > 0,
@@ -3107,6 +3206,10 @@ fn is_zero(value: &usize) -> bool {
     *value == 0
 }
 
+fn is_zero_i64(value: &i64) -> bool {
+    *value == 0
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
@@ -3982,6 +4085,178 @@ mod tests {
                 .unwrap(),
             0
         );
+    }
+
+    #[test]
+    fn consume_runtime_outbox_stops_at_failed_row_and_retains_backlog() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+
+        // The middle row must fail projection: `agent_memory:self` points at
+        // a directory, so reading the source document returns a real error.
+        let self_memory_dir = agent_memory_self_path(storage.data_dir());
+        std::fs::create_dir_all(&self_memory_dir).unwrap();
+
+        let noop = |id: String| RuntimeIndexChange {
+            agent_id: "default".into(),
+            source_kind: "brief".into(),
+            source_id: id.clone(),
+            source_ref: format!("brief:{id}"),
+            operation: RuntimeIndexOperation::Upsert,
+            source_updated_at: Some(Utc::now()),
+            reason: "test_outbox_retry".into(),
+        };
+        let failing = RuntimeIndexChange {
+            agent_id: "default".into(),
+            source_kind: "agent_memory_markdown".into(),
+            source_id: "self".into(),
+            source_ref: "agent_memory:self".into(),
+            operation: RuntimeIndexOperation::Upsert,
+            source_updated_at: Some(Utc::now()),
+            reason: "test_outbox_retry".into(),
+        };
+        runtime_db
+            .runtime_index_outbox()
+            .append_changes(&[noop("noop-1".into()), failing, noop("noop-2".into())])
+            .unwrap();
+
+        let mut index = MemoryIndex::open(&storage).unwrap();
+        let error = index
+            .consume_runtime_outbox(&storage, 10)
+            .expect_err("middle row apply must fail");
+        assert!(error.to_string().contains("agent_memory:self"));
+
+        // The cursor stops at the acknowledged contiguous prefix.
+        let runtime_id = runtime_index_runtime_id(&runtime_db);
+        let cursor = index
+            .cursor(&runtime_id, "default", MEMORY_INDEX_OUTBOX_CURSOR)
+            .unwrap();
+        assert_eq!(cursor, 1);
+
+        // The failed row and its successor stay pending for ordered retry.
+        let outbox = runtime_db.runtime_index_outbox();
+        let remaining: Vec<i64> = outbox
+            .read_after("default", 0, 10)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.change_seq)
+            .collect();
+        assert_eq!(remaining, vec![2, 3]);
+        assert_eq!(
+            outbox.pending_count_for_agent("default", cursor).unwrap(),
+            2
+        );
+        assert_eq!(outbox.produced_watermark_for_agent("default").unwrap(), 3);
+        assert!(outbox
+            .oldest_pending_created_at_for_agent("default", cursor)
+            .unwrap()
+            .is_some());
+
+        // Clear the failure and retry: replay resumes at the failed row, the
+        // applied prefix is not re-processed, and the backlog fully drains.
+        std::fs::remove_dir(&self_memory_dir).unwrap();
+        index.consume_runtime_outbox(&storage, 10).unwrap();
+        let status = index.index_status(&storage, "default").unwrap();
+        assert_eq!(status.cursor, 3);
+        assert_eq!(status.high_watermark, 3);
+        assert_eq!(status.lag, 0);
+        assert_eq!(status.pending_count, 0);
+        assert_eq!(
+            outbox
+                .pending_count_for_agent("default", status.cursor)
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            outbox
+                .oldest_pending_created_at_for_agent("default", status.cursor)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn memory_search_status_keeps_produced_watermark_after_drain() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        let changes: Vec<_> = (0..2)
+            .map(|i| RuntimeIndexChange {
+                agent_id: "default".into(),
+                source_kind: "brief".into(),
+                source_id: format!("wm-{i}"),
+                source_ref: format!("brief:wm-{i}"),
+                operation: RuntimeIndexOperation::Upsert,
+                source_updated_at: Some(Utc::now()),
+                reason: "test_watermark".into(),
+            })
+            .collect();
+        runtime_db
+            .runtime_index_outbox()
+            .append_changes(&changes)
+            .unwrap();
+
+        let status = refresh_memory_index_bounded(&storage, None, 100).unwrap();
+        // Draining the outbox must not reset the watermark to 0: `lag` and
+        // freshness stay meaningful after row GC.
+        assert_eq!(status.cursor, 2);
+        assert_eq!(status.high_watermark, 2);
+        assert_eq!(status.lag, 0);
+        assert_eq!(status.pending_count, 0);
+        assert!(status.oldest_pending_age_ms.is_none());
+    }
+
+    #[test]
+    fn memory_search_status_reports_exact_pending_backlog() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        let consume_limit = 2;
+        let changes = (0..=consume_limit)
+            .map(|index| RuntimeIndexChange {
+                agent_id: "default".into(),
+                source_kind: "brief".into(),
+                source_id: format!("pending-{index}"),
+                source_ref: format!("brief:pending-{index}"),
+                operation: RuntimeIndexOperation::Upsert,
+                source_updated_at: Some(Utc::now()),
+                reason: "test_pending_backlog".into(),
+            })
+            .collect::<Vec<_>>();
+        runtime_db
+            .runtime_index_outbox()
+            .append_changes(&changes)
+            .unwrap();
+
+        let mut index = MemoryIndex::open(&storage).unwrap();
+        index
+            .consume_runtime_outbox(&storage, consume_limit)
+            .unwrap();
+        let status = index.index_status(&storage, "default").unwrap();
+
+        assert_eq!(status.cursor, consume_limit as i64);
+        assert_eq!(status.high_watermark, (consume_limit + 1) as i64);
+        assert_eq!(status.lag, 1);
+        assert_eq!(status.pending_count, 1);
+        let oldest_pending_age_ms = status.oldest_pending_age_ms.expect("one pending row");
+        assert!(oldest_pending_age_ms >= 0);
+        assert!(status.consumption_was_limited);
     }
 
     #[test]

--- a/src/runtime_db/agent_relations/tests.rs
+++ b/src/runtime_db/agent_relations/tests.rs
@@ -682,7 +682,7 @@ fn backfill_report_does_not_migrate_and_apply_can_record_pre_migration_backup() 
         5,
         Some(backup_path.clone()),
     )?;
-    assert_eq!(migrated.current_schema_version()?, 62);
+    assert_eq!(migrated.current_schema_version()?, 63);
     assert_eq!(applied.backup_path.as_deref(), Some(backup_path.as_str()));
     Ok(())
 }

--- a/src/runtime_db/evidence.rs
+++ b/src/runtime_db/evidence.rs
@@ -648,7 +648,10 @@ pub(crate) fn insert_runtime_index_changes_tx(
     tx: &Transaction<'_>,
     changes: &[RuntimeIndexChange],
 ) -> Result<()> {
+    let mut agent_ids = Vec::new();
     for change in changes {
+        // Outbox inserts and the produced watermark advance below share one
+        // transaction, so a committed append always advances its watermark.
         tx.execute(
             "INSERT INTO runtime_index_outbox (
                 agent_id, source_kind, source_id, source_ref, operation,
@@ -665,7 +668,37 @@ pub(crate) fn insert_runtime_index_changes_tx(
                 timestamp(Utc::now()),
             ],
         )?;
+        if !agent_ids.contains(&change.agent_id) {
+            agent_ids.push(change.agent_id.clone());
+        }
     }
+    for agent_id in &agent_ids {
+        update_runtime_index_outbox_watermark_tx(tx, agent_id)?;
+    }
+    Ok(())
+}
+
+/// Advance the agent's monotonic produced watermark to the highest appended
+/// `change_seq`. Deleting consumed outbox rows never lowers this value, which
+/// keeps `produced - applied` meaningful after the outbox is drained.
+fn update_runtime_index_outbox_watermark_tx(tx: &Transaction<'_>, agent_id: &str) -> Result<()> {
+    let produced: i64 = tx.query_row(
+        "SELECT COALESCE(MAX(change_seq), 0) FROM runtime_index_outbox WHERE agent_id = ?1",
+        params![agent_id],
+        |row| row.get(0),
+    )?;
+    tx.execute(
+        "INSERT INTO runtime_index_outbox_watermarks (
+            agent_id, produced_change_seq, updated_at
+         ) VALUES (?1, ?2, ?3)
+         ON CONFLICT(agent_id) DO UPDATE SET
+            produced_change_seq = MAX(
+                runtime_index_outbox_watermarks.produced_change_seq,
+                excluded.produced_change_seq
+            ),
+            updated_at = excluded.updated_at",
+        params![agent_id, produced, timestamp(Utc::now())],
+    )?;
     Ok(())
 }
 

--- a/src/runtime_db/index_outbox.rs
+++ b/src/runtime_db/index_outbox.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 
 use crate::runtime_db::evidence::insert_runtime_index_changes_tx;
 use crate::runtime_db::RuntimeDb;
@@ -122,6 +122,75 @@ impl RuntimeIndexOutboxRepository<'_> {
             .map_err(Into::into)
     }
 
+    /// Monotonic produced watermark: the highest `change_seq` ever appended
+    /// for the agent in this runtime database. Unlike
+    /// [`Self::high_watermark_for_agent`], this does not fall back to 0 when
+    /// consumed rows are deleted. Rows appended before the watermark table
+    /// existed are still covered by taking the max with the current outbox.
+    pub fn produced_watermark_for_agent(&self, agent_id: &str) -> Result<i64> {
+        let connection = self.db.connection()?;
+        let stored: Option<i64> = connection
+            .query_row(
+                "SELECT produced_change_seq
+                 FROM runtime_index_outbox_watermarks
+                 WHERE agent_id = ?1",
+                [agent_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(anyhow::Error::from)?;
+        let current = self.high_watermark_for_agent(agent_id)?;
+        Ok(stored.unwrap_or(0).max(current))
+    }
+
+    /// Exact number of pending outbox rows for the agent. Sequence distance
+    /// between cursors cannot substitute for this: `change_seq` is a global
+    /// autoincrement shared across agents. Only rows above the agent's
+    /// applied cursor count as pending; rows at or below it are already
+    /// acknowledged and merely await GC.
+    pub fn pending_count_for_agent(&self, agent_id: &str, after_change_seq: i64) -> Result<i64> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT COUNT(*) FROM runtime_index_outbox
+                 WHERE agent_id = ?1 AND change_seq > ?2",
+                params![agent_id, after_change_seq],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+    }
+
+    /// `created_at` of the oldest pending outbox row for the agent, the real
+    /// propagation-delay anchor for index lag observability.
+    pub fn oldest_pending_created_at_for_agent(
+        &self,
+        agent_id: &str,
+        after_change_seq: i64,
+    ) -> Result<Option<DateTime<Utc>>> {
+        let connection = self.db.connection()?;
+        let created_at: Option<String> = connection
+            .query_row(
+                "SELECT MIN(created_at) FROM runtime_index_outbox
+                 WHERE agent_id = ?1 AND change_seq > ?2",
+                params![agent_id, after_change_seq],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(anyhow::Error::from)?
+            .flatten();
+        created_at
+            .map(|value| DateTime::parse_from_rfc3339(&value).map(|dt| dt.with_timezone(&Utc)))
+            .transpose()
+            .map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Text,
+                    Box::new(error),
+                )
+                .into()
+            })
+    }
+
     pub fn read_after(
         &self,
         agent_id: &str,
@@ -187,5 +256,124 @@ impl RuntimeIndexOutboxRepository<'_> {
             )
             .map_err(Into::into)
         })
+    }
+
+    /// Best-effort GC for acknowledged rows at or below `through_change_seq`.
+    /// Returns the number of rows removed without opening a write transaction
+    /// when no such row exists. Callers use it after the applied cursor has
+    /// already covered those rows: either directly after consumption, after a
+    /// full rebuild jumped the cursor, or to compensate a crash between apply
+    /// and delete.
+    pub fn delete_acknowledged_through(
+        &self,
+        agent_id: &str,
+        through_change_seq: i64,
+    ) -> Result<usize> {
+        let connection = self.db.connection()?;
+        let has_acknowledged_rows: bool = connection
+            .query_row(
+                "SELECT 1 FROM runtime_index_outbox
+                 WHERE agent_id = ?1 AND change_seq <= ?2
+                 LIMIT 1",
+                params![agent_id, through_change_seq],
+                |_| Ok(true),
+            )
+            .optional()?
+            .unwrap_or(false);
+        if !has_acknowledged_rows {
+            return Ok(0);
+        }
+        self.delete_through(agent_id, through_change_seq)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn runtime_db() -> (tempfile::TempDir, RuntimeDb) {
+        let dir = tempdir().unwrap();
+        let db = RuntimeDb::open_and_migrate(
+            dir.path().join("state/runtime.sqlite"),
+            dir.path().join("state/runtime.lock"),
+        )
+        .unwrap();
+        (dir, db)
+    }
+
+    fn change(agent_id: &str, id: &str) -> RuntimeIndexChange {
+        RuntimeIndexChange {
+            agent_id: agent_id.into(),
+            source_kind: "brief".into(),
+            source_id: id.into(),
+            source_ref: format!("brief:{id}"),
+            operation: RuntimeIndexOperation::Upsert,
+            source_updated_at: Some(Utc::now()),
+            reason: "test_watermark".into(),
+        }
+    }
+
+    #[test]
+    fn produced_watermark_survives_outbox_gc_and_stays_monotonic() {
+        let (_dir, db) = runtime_db();
+        let outbox = db.runtime_index_outbox();
+        outbox
+            .append_changes(&[
+                change("agent-a", "1"),
+                change("agent-b", "2"),
+                change("agent-a", "3"),
+            ])
+            .unwrap();
+        assert_eq!(outbox.produced_watermark_for_agent("agent-a").unwrap(), 3);
+        assert_eq!(outbox.produced_watermark_for_agent("agent-b").unwrap(), 2);
+        assert_eq!(outbox.pending_count_for_agent("agent-a", 0).unwrap(), 2);
+        assert_eq!(outbox.pending_count_for_agent("agent-b", 0).unwrap(), 1);
+
+        // Draining an agent's outbox resets the row max but not the produced
+        // watermark: `produced - applied` must stay meaningful after GC.
+        outbox.delete_through("agent-a", 3).unwrap();
+        assert_eq!(outbox.high_watermark_for_agent("agent-a").unwrap(), 0);
+        assert_eq!(outbox.produced_watermark_for_agent("agent-a").unwrap(), 3);
+        assert_eq!(outbox.pending_count_for_agent("agent-a", 0).unwrap(), 0);
+
+        // Later appends only move the watermark forward.
+        outbox.append_changes(&[change("agent-a", "4")]).unwrap();
+        assert_eq!(outbox.produced_watermark_for_agent("agent-a").unwrap(), 4);
+    }
+
+    #[test]
+    fn pending_count_and_oldest_pending_track_per_agent_backlog() {
+        let (_dir, db) = runtime_db();
+        let outbox = db.runtime_index_outbox();
+        outbox
+            .append_changes(&[change("agent-a", "1"), change("agent-b", "2")])
+            .unwrap();
+
+        assert_eq!(outbox.pending_count_for_agent("agent-a", 0).unwrap(), 1);
+        assert_eq!(outbox.pending_count_for_agent("agent-c", 0).unwrap(), 0);
+        let oldest = outbox
+            .oldest_pending_created_at_for_agent("agent-a", 0)
+            .unwrap()
+            .expect("pending row has created_at");
+        assert!(oldest <= Utc::now());
+        assert_eq!(
+            outbox
+                .oldest_pending_created_at_for_agent("agent-c", 0)
+                .unwrap(),
+            None
+        );
+
+        // Rows at or below the applied cursor are acknowledged garbage, not
+        // backlog, even before GC removes them.
+        assert_eq!(outbox.pending_count_for_agent("agent-a", 1).unwrap(), 0);
+        assert_eq!(
+            outbox
+                .oldest_pending_created_at_for_agent("agent-a", 1)
+                .unwrap(),
+            None
+        );
+        assert_eq!(outbox.delete_acknowledged_through("agent-a", 1).unwrap(), 1);
+        assert_eq!(outbox.delete_acknowledged_through("agent-a", 1).unwrap(), 0);
     }
 }

--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -3474,6 +3474,17 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_timer_wakes_one_pending_per_timer
   ON timer_wakes(timer_id) WHERE status = 'pending';
 "#,
     },
+    Migration {
+        version: 63,
+        name: "runtime_index_outbox_watermarks",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS runtime_index_outbox_watermarks (
+  agent_id TEXT PRIMARY KEY,
+  produced_change_seq INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL
+);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes the memory index outbox data-loss window reported in #2901 and makes index backlog exactly observable.

- **At-least-once consumption with contiguous-prefix ack**: the applied cursor advances only inside the same memory index transaction that projects a row. A failed row and everything after it stay in `runtime_index_outbox` as a durable retry queue; rows are deleted only after the committed cursor has covered them, so a projection failure can delay discovery but never silently drop refs.
- **Bounded per-agent retry backoff** in the daemon indexer (500ms base, 30s cap, ±25% jitter): a persistently failing agent no longer retries on every global notify and no longer hammers a locked index in lockstep.
- **Monotonic produced watermark** (`runtime_index_outbox_watermarks`, migration 63): the append path advances a per-agent `produced_change_seq` in the same runtime transaction as the outbox insert, so `index_status.high_watermark` no longer falls back to 0 after rows are GC'd.
- **Exact backlog metrics**: `pending_count` counts only rows above the applied cursor (global autoincrement makes `produced - applied` an upper-bound hint only) and `oldest_pending_age_ms` reports the real propagation delay. Rows at or below the cursor are acknowledged garbage; `delete_acknowledged_through` GCs them after consumption, after a full rebuild jumps the cursor, and as crash-window compensation.
- Docs: `docs/implementation-decisions/061-memory-index-v2-outbox.md` now describes the new acknowledgment contract instead of the old skip-and-advance behavior.

## Evidence

- On the live node before the fix: 291 `skipping failed memory index outbox row` + 316 `daemon memory indexer: refresh failed` (all `database is locked`) within ~5.6h; every skipped row was a permanent index gap.
- `cargo fmt --all -- --check` and `RUSTFLAGS="-D warnings" cargo check --all-targets` pass.
- `cargo test --lib`: 3159 passed / 1 failed. The failure (`runtime::tests::work_items::complete_work_item_uses_followup_report_after_text_before_other_tool`) is a pre-existing load-sensitive flake that reproduces identically on `main` (`7234e3bc`) at module granularity and passes in isolation; it is unrelated to this change.

## Runtime concept changed

Memory index outbox acknowledgment semantics: consumption moves from skip-and-advance (lossy under transient failures such as `database is locked`) to ordered at-least-once retry with explicit GC, keeping `MemorySearch`'s `index_status` truthful about real backlog.

Fixes #2901
