### PR TITLE
fix(ci): regenerate stale web transport types after #2928

### DIFF
--- a/web-gui/app/src/runtime/generated/openapi.ts
+++ b/web-gui/app/src/runtime/generated/openapi.ts
@@ -4655,6 +4655,10 @@ export interface components {
         };
         /** SearchResponse */
         SearchResponse: {
+            /**
+             * @description Aggregate across the queried agents; per-agent detail is available in
+             *      `index_status_by_agent` when the request spanned multiple agents.
+             */
             index_status: {
                 consumption_was_limited?: boolean;
                 /**
@@ -4696,7 +4700,67 @@ export interface components {
                  *      by design; not a durable health history.
                  */
                 skipped_error_count?: number;
+                /**
+                 * @description Machine-readable reasons the index is not currently fresh:
+                 *      `index_missing`, `dirty_marker`, `backfill_incomplete`, `outbox_lag`,
+                 *      `pending_sources`, `stale_projection`, `consume_error`. Empty when
+                 *      fresh. The background daemon self-heals every reason; they are
+                 *      diagnostic, not a manual-work order.
+                 */
+                stale_reasons?: string[];
             };
+            index_status_by_agent?: {
+                [key: string]: {
+                    consumption_was_limited?: boolean;
+                    /**
+                     * Format: int64
+                     * @description Highest applied contiguous runtime outbox `change_seq`.
+                     */
+                    cursor: number;
+                    freshness: string;
+                    /**
+                     * Format: int64
+                     * @description Monotonic produced watermark: highest `change_seq` ever appended for
+                     *      the agent. Unlike the drained-outbox maximum, it never returns to 0.
+                     */
+                    high_watermark: number;
+                    indexing_needed?: boolean;
+                    /**
+                     * Format: int64
+                     * @description Sequence distance `produced - applied`. Cross-agent global
+                     *      autoincrement makes this an upper-bound hint only; `pending_count` is
+                     *      the exact backlog metric.
+                     */
+                    lag: number;
+                    /** Format: date-time */
+                    last_indexed_at?: string | null;
+                    /**
+                     * Format: int64
+                     * @description Age of the oldest pending outbox row, the real propagation delay.
+                     */
+                    oldest_pending_age_ms?: number | null;
+                    /**
+                     * Format: int64
+                     * @description Exact pending outbox row count for this agent.
+                     */
+                    pending_count?: number;
+                    results_may_be_incomplete?: boolean;
+                    /**
+                     * Format: uint
+                     * @description Failures hit by this index handle's current consume pass. Transient
+                     *      by design; not a durable health history.
+                     */
+                    skipped_error_count?: number;
+                    /**
+                     * @description Machine-readable reasons the index is not currently fresh:
+                     *      `index_missing`, `dirty_marker`, `backfill_incomplete`, `outbox_lag`,
+                     *      `pending_sources`, `stale_projection`, `consume_error`. Empty when
+                     *      fresh. The background daemon self-heals every reason; they are
+                     *      diagnostic, not a manual-work order.
+                     */
+                    stale_reasons?: string[];
+                };
+            } | null;
             /** Format: uint */
             limit: number;
             query: string;


### PR DESCRIPTION
## Summary
- #2928 updated `docs/website/reference/openapi.json` (search `index_status_by_agent` / `stale_reasons`) but did not regenerate `web-gui/app/src/runtime/generated/openapi.ts`, so the `Rust` job's `Test and build web GUI` step (`make web-ci`) fails on main (run 34699221307) with `Generated TypeScript transport types are stale`.
- This PR runs `make transport-types` on current main and commits the regenerated types. `openapi.json` is unchanged; the diff is purely the previously-missing generated output.

## Verification
- `make transport-types` applied cleanly; `web-gui/openapi-tools npm run check` passes locally.
- CI on this PR should turn the Rust job green again.