### PR TITLE
perf(runtime): jemalloc on Linux and capped tokio workers for the daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3073,6 +3074,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,11 @@ tempfile = "3.14"
 proptest = "1.6"
 tokio = { version = "1.43", features = ["test-util"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Linux daemons use jemalloc so freed pages are purged back to the OS instead
+# of accumulating per-arena high-watermark RSS (#2931).
+tikv-jemallocator = { version = "0.7", features = ["background_threads"] }
+
 [lib]
 name = "holon"
 path = "src/lib.rs"

--- a/docs/implementation-decisions/129-linux-jemalloc-and-worker-cap.md
+++ b/docs/implementation-decisions/129-linux-jemalloc-and-worker-cap.md
@@ -1,0 +1,37 @@
+# Linux jemalloc and tokio worker cap
+
+## Choice
+
+The `holon` binary installs `tikv-jemallocator` as the global allocator on
+Linux only (`#[cfg(target_os = "linux")]` in `src/main.rs`); macOS and Windows
+keep the platform allocator. At startup the binary also applies
+`mallopt(M_ARENA_MAX, 8)` for remaining libc-side malloc users and caps its
+tokio worker threads at `min(available_parallelism, 8)`, overridable with
+`HOLON_TOKIO_WORKER_THREADS`. `holon serve` prints the effective policy in
+its startup summary next to the fd-limit line.
+
+## Reason
+
+glibc gives each allocating thread its own arena and only trims the arena top
+on `free`, so each arena's RSS is a historical high-watermark. A long-lived
+daemon with tens of tokio workers therefore grows RSS without bound even
+when live data is stable (#2931: ~8.4 GiB `Private_Dirty` after 2.5 h on a
+64-core host, dominated by 64 MB-aligned arena mappings). jemalloc's
+decay-based purging (default `dirty_decay_ms`/`muzzy_decay_ms` = 10 s, plus
+the `background_threads` feature) returns freed pages to the OS, so RSS
+tracks live data instead of arena peaks. `mallopt(M_ARENA_MAX, 8)` still
+bounds glibc arenas for C code (bundled SQLite) that a Rust global allocator
+cannot intercept. The worker cap is orthogonal hygiene: agent-runtime load
+is I/O-bound, and CPU-heavy work runs on tokio's blocking pool, which is not
+capped.
+
+## Preserved boundary
+
+The allocator declaration lives in the bin crate only, so library consumers,
+integration tests, and benchmarks keep the platform allocator and benchmark
+comparability is preserved (bench harnesses also build their own uncapped
+runtimes). The dependency is target-gated to Linux, so darwin and Windows
+builds are unchanged. jemalloc can still be tuned at runtime through
+`_RJEM_MALLOC_CONF` (for example `dirty_decay_ms`), and the worker cap can be
+raised per deployment without a rebuild. Reverting or replacing the allocator
+is a one-line change in `src/main.rs`.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -120,3 +120,4 @@ Current decision notes:
 - [125 Agent Id Reincarnation Same Row](./125-agent-id-reincarnation-same-row.md)
 - [126 Current-Run Abort Modes](./126-current-run-abort-modes.md)
 - [128 Durable Wait Obligation Selection](./128-durable-wait-obligation-selection.md)
+- [129 Linux Jemalloc And Tokio Worker Cap](./129-linux-jemalloc-and-worker-cap.md)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod projection_eval;
 pub mod prompt;
 pub mod provider;
 pub mod queue;
+pub mod resource_policy;
 pub mod run_once;
 pub mod runtime;
 pub mod runtime_db;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ use holon::{
     },
     onboarding_tui::run_onboarding_tui,
     provider::{provider_doctor, resolved_model_availability},
+    resource_policy::{apply_startup_policy, startup_report},
     run_once::{run_once, RunOnceRequest},
     runtime::{maybe_enqueue_first_run_intro, seed_scheduler_terminal_recovery_fixture},
     runtime_db::{
@@ -68,11 +69,34 @@ use holon::cli::{
     ServeOptions, SkillsCommands, TaskCommands, TimerCommands, TimerCreateArgs, WorkItemCommands,
     WorkspaceCommands,
 };
-#[tokio::main]
-async fn main() -> Result<()> {
-    init_tracing();
-    let cli = Cli::parse();
 
+// Linux daemons swap in jemalloc so freed pages are purged back to the OS
+// instead of accumulating per-arena high-watermark RSS (#2931). Keep
+// `allocator_label` below in sync with this declaration.
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+fn allocator_label() -> &'static str {
+    if cfg!(target_os = "linux") {
+        "jemalloc"
+    } else {
+        "system"
+    }
+}
+
+fn main() -> Result<()> {
+    init_tracing();
+    let policy = apply_startup_policy(allocator_label());
+    let cli = Cli::parse();
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(policy.tokio_worker_threads)
+        .enable_all()
+        .build()?
+        .block_on(run(cli))
+}
+
+async fn run(cli: Cli) -> Result<()> {
     match cli.command {
         Commands::Config { command } => handle_config_command(command).await,
         Commands::Run {
@@ -853,6 +877,9 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
         "{}",
         apply_nofile_limit_policy(DEFAULT_NOFILE_TARGET).startup_summary()
     );
+    if let Some(report) = startup_report() {
+        println!("{}", report.startup_summary());
+    }
     ensure_serve_preflight(&config).await?;
     if std::env::var_os(PRE_SERVER_PREPARED_ENV).is_none() {
         prepare_runtime_before_server(&config)?;

--- a/src/resource_policy.rs
+++ b/src/resource_policy.rs
@@ -78,7 +78,10 @@ impl ResourcePolicyReport {
             ),
             None => "glibc arena cap n/a".to_string(),
         };
-        format!("runtime resources: allocator {}; tokio workers {workers}; {glibc}", self.allocator)
+        format!(
+            "runtime resources: allocator {}; tokio workers {workers}; {glibc}",
+            self.allocator
+        )
     }
 }
 

--- a/src/resource_policy.rs
+++ b/src/resource_policy.rs
@@ -1,0 +1,221 @@
+//! Startup resource policy for long-lived holon processes.
+//!
+//! With glibc, each allocating thread can get its own arena, and an arena's
+//! RSS is a high-watermark: `free` only trims the arena top, so fragmented
+//! pages inside the heap are never returned to the OS. A daemon with many
+//! tokio workers and blocking-pool threads therefore grows RSS without bound
+//! even when live data is stable (#2931).
+//!
+//! The policy applied at process start:
+//! - the `holon` binary installs jemalloc as the global allocator on Linux,
+//!   whose decay-based purging returns freed pages to the OS;
+//! - `mallopt(M_ARENA_MAX, ..)` still bounds glibc arenas for libc-side
+//!   malloc users (bundled SQLite C code) that a Rust global allocator
+//!   cannot intercept;
+//! - tokio worker threads are capped because agent-runtime load is
+//!   I/O-bound; CPU-heavy work runs on tokio's blocking pool.
+
+use std::sync::OnceLock;
+
+/// Environment variable overriding the tokio worker-thread count.
+pub const TOKIO_WORKER_THREADS_ENV: &str = "HOLON_TOKIO_WORKER_THREADS";
+
+/// Default upper bound for tokio worker threads in the `holon` binary.
+pub const DEFAULT_TOKIO_WORKER_THREADS_CAP: usize = 8;
+
+/// Upper bound for glibc arenas still serving libc-side malloc users.
+pub const GLIBC_ARENA_MAX: i32 = 8;
+
+static STARTUP_REPORT: OnceLock<ResourcePolicyReport> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerThreadsSource {
+    DefaultCap,
+    EnvOverride,
+    InvalidEnvIgnored,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlibcArenaCapReport {
+    pub max: i32,
+    pub applied: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourcePolicyReport {
+    /// Allocator backing Rust allocations in this process, e.g. "jemalloc"
+    /// or "system". Supplied by the binary crate so it stays in sync with
+    /// its `#[global_allocator]` declaration.
+    pub allocator: &'static str,
+    /// Resolved tokio worker-thread count.
+    pub tokio_worker_threads: usize,
+    /// Where the worker-thread count came from.
+    pub worker_threads_source: WorkerThreadsSource,
+    /// Result of the glibc arena cap attempt (glibc platforms only).
+    pub glibc_arena_cap: Option<GlibcArenaCapReport>,
+}
+
+impl ResourcePolicyReport {
+    pub fn startup_summary(&self) -> String {
+        let workers = match self.worker_threads_source {
+            WorkerThreadsSource::DefaultCap => format!(
+                "{} (default cap {DEFAULT_TOKIO_WORKER_THREADS_CAP}; override with {TOKIO_WORKER_THREADS_ENV})",
+                self.tokio_worker_threads
+            ),
+            WorkerThreadsSource::EnvOverride => {
+                format!("{} (from {TOKIO_WORKER_THREADS_ENV})", self.tokio_worker_threads)
+            }
+            WorkerThreadsSource::InvalidEnvIgnored => format!(
+                "{} (ignored invalid {TOKIO_WORKER_THREADS_ENV})",
+                self.tokio_worker_threads
+            ),
+        };
+        let glibc = match &self.glibc_arena_cap {
+            Some(cap) if cap.applied => format!("glibc arena cap {}", cap.max),
+            Some(cap) => format!(
+                "glibc arena cap not applied (mallopt(M_ARENA_MAX, {}) failed)",
+                cap.max
+            ),
+            None => "glibc arena cap n/a".to_string(),
+        };
+        format!("runtime resources: allocator {}; tokio workers {workers}; {glibc}", self.allocator)
+    }
+}
+
+/// Apply the process-start resource policy and remember the result so
+/// `holon serve` can report it later. The allocator label is provided by the
+/// binary crate because only it knows which global allocator was linked in.
+pub fn apply_startup_policy(allocator: &'static str) -> ResourcePolicyReport {
+    let (tokio_worker_threads, worker_threads_source) = resolve_worker_threads();
+    let report = ResourcePolicyReport {
+        allocator,
+        tokio_worker_threads,
+        worker_threads_source,
+        glibc_arena_cap: cap_glibc_arenas(),
+    };
+    let _ = STARTUP_REPORT.set(report.clone());
+    report
+}
+
+/// The report recorded by [`apply_startup_policy`], if this process applied
+/// the startup policy.
+pub fn startup_report() -> Option<&'static ResourcePolicyReport> {
+    STARTUP_REPORT.get()
+}
+
+fn resolve_worker_threads() -> (usize, WorkerThreadsSource) {
+    match std::env::var_os(TOKIO_WORKER_THREADS_ENV) {
+        Some(value) => {
+            let parsed = value
+                .to_str()
+                .and_then(|raw| raw.trim().parse::<usize>().ok())
+                .filter(|threads| *threads > 0);
+            match parsed {
+                Some(threads) => (threads, WorkerThreadsSource::EnvOverride),
+                None => (
+                    default_worker_threads(),
+                    WorkerThreadsSource::InvalidEnvIgnored,
+                ),
+            }
+        }
+        None => (default_worker_threads(), WorkerThreadsSource::DefaultCap),
+    }
+}
+
+fn default_worker_threads() -> usize {
+    let parallelism = std::thread::available_parallelism()
+        .map(|cpus| cpus.get())
+        .unwrap_or(1);
+    parallelism.min(DEFAULT_TOKIO_WORKER_THREADS_CAP).max(1)
+}
+
+// M_ARENA_MAX only exists on glibc; musl and non-Linux libc malloc has no
+// per-thread arenas to cap.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+fn cap_glibc_arenas() -> Option<GlibcArenaCapReport> {
+    // SAFETY: mallopt only flips the arena-limit tunable for this process.
+    let applied = unsafe { libc::mallopt(libc::M_ARENA_MAX, GLIBC_ARENA_MAX) } == 1;
+    Some(GlibcArenaCapReport {
+        max: GLIBC_ARENA_MAX,
+        applied,
+    })
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+fn cap_glibc_arenas() -> Option<GlibcArenaCapReport> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_env::lock_env;
+
+    #[test]
+    fn default_worker_threads_is_bounded() {
+        let threads = default_worker_threads();
+        assert!(threads >= 1);
+        assert!(threads <= DEFAULT_TOKIO_WORKER_THREADS_CAP);
+    }
+
+    #[test]
+    fn worker_threads_env_override_is_parsed() {
+        let _guard = lock_env();
+        std::env::set_var(TOKIO_WORKER_THREADS_ENV, "3");
+        let (threads, source) = resolve_worker_threads();
+        std::env::remove_var(TOKIO_WORKER_THREADS_ENV);
+        assert_eq!(threads, 3);
+        assert_eq!(source, WorkerThreadsSource::EnvOverride);
+    }
+
+    #[test]
+    fn invalid_worker_threads_env_falls_back_to_default() {
+        let _guard = lock_env();
+        std::env::set_var(TOKIO_WORKER_THREADS_ENV, "not-a-number");
+        let (threads, source) = resolve_worker_threads();
+        std::env::remove_var(TOKIO_WORKER_THREADS_ENV);
+        assert_eq!(threads, default_worker_threads());
+        assert_eq!(source, WorkerThreadsSource::InvalidEnvIgnored);
+    }
+
+    #[test]
+    fn zero_worker_threads_env_is_rejected() {
+        let _guard = lock_env();
+        std::env::set_var(TOKIO_WORKER_THREADS_ENV, "0");
+        let (threads, source) = resolve_worker_threads();
+        std::env::remove_var(TOKIO_WORKER_THREADS_ENV);
+        assert_eq!(threads, default_worker_threads());
+        assert_eq!(source, WorkerThreadsSource::InvalidEnvIgnored);
+    }
+
+    #[test]
+    fn startup_summary_mentions_allocator_and_worker_policy() {
+        let report = ResourcePolicyReport {
+            allocator: "jemalloc",
+            tokio_worker_threads: DEFAULT_TOKIO_WORKER_THREADS_CAP,
+            worker_threads_source: WorkerThreadsSource::DefaultCap,
+            glibc_arena_cap: Some(GlibcArenaCapReport {
+                max: GLIBC_ARENA_MAX,
+                applied: true,
+            }),
+        };
+        let summary = report.startup_summary();
+        assert!(summary.contains("allocator jemalloc"));
+        assert!(summary.contains(&format!(
+            "tokio workers {DEFAULT_TOKIO_WORKER_THREADS_CAP} (default cap"
+        )));
+        assert!(summary.contains("glibc arena cap"));
+    }
+
+    #[test]
+    fn apply_startup_policy_records_report_for_binary_allocator() {
+        let _guard = lock_env();
+        std::env::remove_var(TOKIO_WORKER_THREADS_ENV);
+        let report = apply_startup_policy("allocator-under-test");
+        assert_eq!(report.tokio_worker_threads, default_worker_threads());
+        assert_eq!(
+            startup_report().map(|recorded| recorded.allocator),
+            Some("allocator-under-test")
+        );
+    }
+}


### PR DESCRIPTION
Fixes #2931

## What changed

Long-running daemons on glibc grew RSS without bound (measured ~8.4 GiB `Private_Dirty` after 2.5 h on a 64-core host, dominated by 64 MB-aligned arena mappings): glibc gives each allocating thread its own arena and only trims the arena top on `free`, so each arena's RSS is a historical high-watermark that only climbs.

- **jemalloc on Linux** (`src/main.rs`): the `holon` binary installs `tikv-jemallocator` as the global allocator, gated to `target_os = "linux"` (darwin/Windows keep the platform allocator; release builds are linux-gnu + darwin). jemalloc's decay-based purging (`dirty_decay_ms`/`muzzy_decay_ms` = 10 s defaults, plus the `background_threads` feature) returns freed pages to the OS, so RSS tracks live data instead of arena peaks.
- **glibc arena cap as defense-in-depth** (`src/resource_policy.rs`): `mallopt(M_ARENA_MAX, 8)` at startup bounds arenas for the libc-side malloc users a Rust global allocator cannot intercept (bundled SQLite C code).
- **Tokio worker cap**: the binary's runtime now uses `min(available_parallelism, 8)` worker threads instead of one per CPU (65 on the reporting host), overridable per deployment via `HOLON_TOKIO_WORKER_THREADS`. Agent-runtime load is I/O-bound; CPU-heavy work runs on tokio's blocking pool, which is not capped. Invalid env values fall back to the default and are surfaced in the startup summary.
- **Startup visibility**: `holon serve` prints the effective policy next to the existing fd-limit line:
  ```
  runtime resources: allocator jemalloc; tokio workers 8 (default cap 8; override with HOLON_TOKIO_WORKER_THREADS); glibc arena cap 8
  ```
- Docs: `docs/implementation-decisions/129-linux-jemalloc-and-worker-cap.md` records why Linux-only, why the allocator lives in the bin crate (library/tests/benches keep the platform allocator and bench comparability), and how to tune at runtime via `_RJEM_MALLOC_CONF`.

## Runtime concept

Process resource policy, not a scheduling/message-plane change: allocator selection, glibc arena bound, and worker-thread budget are computed once at startup in the binary, kept in `resource_policy`, and reported through the serve startup summary.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib resource_policy` ✅ (6 tests: env override parse, invalid/zero fallback, default bound, summary, report recording)
- Release build on 64-core Linux: `nm target/release/holon | grep -c _rjem_je_` = 570 → jemalloc statically linked and active; `_RJEM_MALLOC_CONF` runtime tunable present.
- Serve smoke on an isolated `HOLON_HOME` (this 64-core host): startup line shows `allocator jemalloc; tokio workers 8 ... glibc arena cap 8`; `HOLON_TOKIO_WORKER_THREADS=3` yields `tokio workers 3 (from HOLON_TOKIO_WORKER_THREADS)`; daemon reaches "Holon listening on ..." normally.
- One-shot CLI paths (`--version`, `config`) work under the explicit runtime builder.

## Not covered here

The multi-hour RSS A/B on the real daemon tailnet deployment is ops-side validation after rollout (acceptance in #2931). A jemalloc stats endpoint is possible later via `_RJEM_MALLOC_CONF=stats_print` or `tikv-jemalloc-ctl`; deliberately left out to keep this change minimal.
